### PR TITLE
fix(sandbox): update codex helper packaging

### DIFF
--- a/LICENSES/Apache-2.0.txt
+++ b/LICENSES/Apache-2.0.txt
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1.  Definitions.
+
+    "License" shall mean the terms and conditions for use, reproduction,
+    and distribution as defined by Sections 1 through 9 of this document.
+
+    "Licensor" shall mean the copyright owner or entity authorized by
+    the copyright owner that is granting the License.
+
+    "Legal Entity" shall mean the union of the acting entity and all
+    other entities that control, are controlled by, or are under common
+    control with that entity. For the purposes of this definition,
+    "control" means (i) the power, direct or indirect, to cause the
+    direction or management of such entity, whether by contract or
+    otherwise, or (ii) ownership of fifty percent (50%) or more of the
+    outstanding shares, or (iii) beneficial ownership of such entity.
+
+    "You" (or "Your") shall mean an individual or Legal Entity
+    exercising permissions granted by this License.
+
+    "Source" form shall mean the preferred form for making modifications,
+    including but not limited to software source code, documentation
+    source, and configuration files.
+
+    "Object" form shall mean any form resulting from mechanical
+    transformation or translation of a Source form, including but
+    not limited to compiled object code, generated documentation,
+    and conversions to other media types.
+
+    "Work" shall mean the work of authorship, whether in Source or
+    Object form, made available under the License, as indicated by a
+    copyright notice that is included in or attached to the work
+    (an example is provided in the Appendix below).
+
+    "Derivative Works" shall mean any work, whether in Source or Object
+    form, that is based on (or derived from) the Work and for which the
+    editorial revisions, annotations, elaborations, or other modifications
+    represent, as a whole, an original work of authorship. For the purposes
+    of this License, Derivative Works shall not include works that remain
+    separable from, or merely link (or bind by name) to the interfaces of,
+    the Work and Derivative Works thereof.
+
+    "Contribution" shall mean any work of authorship, including
+    the original version of the Work and any modifications or additions
+    to that Work or Derivative Works thereof, that is intentionally
+    submitted to Licensor for inclusion in the Work by the copyright owner
+    or by an individual or Legal Entity authorized to submit on behalf of
+    the copyright owner. For the purposes of this definition, "submitted"
+    means any form of electronic, verbal, or written communication sent
+    to the Licensor or its representatives, including but not limited to
+    communication on electronic mailing lists, source code control systems,
+    and issue tracking systems that are managed by, or on behalf of, the
+    Licensor for the purpose of discussing and improving the Work, but
+    excluding communication that is conspicuously marked or otherwise
+    designated in writing by the copyright owner as "Not a Contribution."
+
+    "Contributor" shall mean Licensor and any individual or Legal Entity
+    on behalf of whom a Contribution has been received by Licensor and
+    subsequently incorporated within the Work.
+
+2.  Grant of Copyright License. Subject to the terms and conditions of
+    this License, each Contributor hereby grants to You a perpetual,
+    worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+    copyright license to reproduce, prepare Derivative Works of,
+    publicly display, publicly perform, sublicense, and distribute the
+    Work and such Derivative Works in Source or Object form.
+
+3.  Grant of Patent License. Subject to the terms and conditions of
+    this License, each Contributor hereby grants to You a perpetual,
+    worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+    (except as stated in this section) patent license to make, have made,
+    use, offer to sell, sell, import, and otherwise transfer the Work,
+    where such license applies only to those patent claims licensable
+    by such Contributor that are necessarily infringed by their
+    Contribution(s) alone or by combination of their Contribution(s)
+    with the Work to which such Contribution(s) was submitted. If You
+    institute patent litigation against any entity (including a
+    cross-claim or counterclaim in a lawsuit) alleging that the Work
+    or a Contribution incorporated within the Work constitutes direct
+    or contributory patent infringement, then any patent licenses
+    granted to You under this License for that Work shall terminate
+    as of the date such litigation is filed.
+
+4.  Redistribution. You may reproduce and distribute copies of the
+    Work or Derivative Works thereof in any medium, with or without
+    modifications, and in Source or Object form, provided that You
+    meet the following conditions:
+
+    (a) You must give any other recipients of the Work or
+    Derivative Works a copy of this License; and
+
+    (b) You must cause any modified files to carry prominent notices
+    stating that You changed the files; and
+
+    (c) You must retain, in the Source form of any Derivative Works
+    that You distribute, all copyright, patent, trademark, and
+    attribution notices from the Source form of the Work,
+    excluding those notices that do not pertain to any part of
+    the Derivative Works; and
+
+    (d) If the Work includes a "NOTICE" text file as part of its
+    distribution, then any Derivative Works that You distribute must
+    include a readable copy of the attribution notices contained
+    within such NOTICE file, excluding those notices that do not
+    pertain to any part of the Derivative Works, in at least one
+    of the following places: within a NOTICE text file distributed
+    as part of the Derivative Works; within the Source form or
+    documentation, if provided along with the Derivative Works; or,
+    within a display generated by the Derivative Works, if and
+    wherever such third-party notices normally appear. The contents
+    of the NOTICE file are for informational purposes only and
+    do not modify the License. You may add Your own attribution
+    notices within Derivative Works that You distribute, alongside
+    or as an addendum to the NOTICE text from the Work, provided
+    that such additional attribution notices cannot be construed
+    as modifying the License.
+
+    You may add Your own copyright statement to Your modifications and
+    may provide additional or different license terms and conditions
+    for use, reproduction, or distribution of Your modifications, or
+    for any such Derivative Works as a whole, provided Your use,
+    reproduction, and distribution of the Work otherwise complies with
+    the conditions stated in this License.
+
+5.  Submission of Contributions. Unless You explicitly state otherwise,
+    any Contribution intentionally submitted for inclusion in the Work
+    by You to the Licensor shall be under the terms and conditions of
+    this License, without any additional terms or conditions.
+    Notwithstanding the above, nothing herein shall supersede or modify
+    the terms of any separate license agreement you may have executed
+    with Licensor regarding such Contributions.
+
+6.  Trademarks. This License does not grant permission to use the trade
+    names, trademarks, service marks, or product names of the Licensor,
+    except as required for reasonable and customary use in describing the
+    origin of the Work and reproducing the content of the NOTICE file.
+
+7.  Disclaimer of Warranty. Unless required by applicable law or
+    agreed to in writing, Licensor provides the Work (and each
+    Contributor provides its Contributions) on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+    implied, including, without limitation, any warranties or conditions
+    of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+    PARTICULAR PURPOSE. You are solely responsible for determining the
+    appropriateness of using or redistributing the Work and assume any
+    risks associated with Your exercise of permissions under this License.
+
+8.  Limitation of Liability. In no event and under no legal theory,
+    whether in tort (including negligence), contract, or otherwise,
+    unless required by applicable law (such as deliberate and grossly
+    negligent acts) or agreed to in writing, shall any Contributor be
+    liable to You for damages, including any direct, indirect, special,
+    incidental, or consequential damages of any character arising as a
+    result of this License or out of the use or inability to use the
+    Work (including but not limited to damages for loss of goodwill,
+    work stoppage, computer failure or malfunction, or any and all
+    other commercial damages or losses), even if such Contributor
+    has been advised of the possibility of such damages.
+
+9.  Accepting Warranty or Additional Liability. While redistributing
+    the Work or Derivative Works thereof, You may choose to offer,
+    and charge a fee for, acceptance of support, warranty, indemnity,
+    or other liability obligations and/or rights consistent with this
+    License. However, in accepting such obligations, You may act only
+    on Your own behalf and on Your sole responsibility, not on behalf
+    of any other Contributor, and only if You agree to indemnify,
+    defend, and hold each Contributor harmless for any liability
+    incurred by, or claims asserted against, such Contributor by reason
+    of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+Copyright 2025 OpenAI
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -2,6 +2,23 @@ version = 1
 
 [[annotations]]
 path = [
+    "LICENSES/Apache-2.0.txt",
+]
+precedence = "override"
+SPDX-FileCopyrightText = "Apache Software Foundation"
+SPDX-License-Identifier = "Apache-2.0"
+
+[[annotations]]
+path = [
+    "deploy/sandbox/linux-amd64/codex-linux-sandbox",
+    "deploy/sandbox/linux-arm64/codex-linux-sandbox",
+]
+precedence = "override"
+SPDX-FileCopyrightText = "2026 OpenAI"
+SPDX-License-Identifier = "Apache-2.0"
+
+[[annotations]]
+path = [
     "**",
 ]
 precedence = "aggregate"

--- a/license-inventory.csv
+++ b/license-inventory.csv
@@ -39,6 +39,7 @@ CONTRIBUTING.md,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate ann
 DCO,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 Dockerfile,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 GOVERNANCE.md,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
+LICENSES/Apache-2.0.txt,Apache-2.0,Apache Software Foundation,Apache License 2.0 text
 LICENSES/Elastic-2.0.txt,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 NOTICE,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 README.md,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
@@ -52,8 +53,8 @@ assets/partners/neoflying-lab.png,Elastic-2.0,2026 SuperTale contributors,REUSE.
 assets/pipeline.excalidraw,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 assets/pipeline.png,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 ce-allowlist.toml,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
-deploy/sandbox/linux-amd64/codex-linux-sandbox,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
-deploy/sandbox/linux-arm64/codex-linux-sandbox,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
+deploy/sandbox/linux-amd64/codex-linux-sandbox,Apache-2.0,2026 OpenAI,built from openai/codex codex-rs/linux-sandbox commit da4c8ca57d40b074bdc1b5b1218851100150c56b
+deploy/sandbox/linux-arm64/codex-linux-sandbox,Apache-2.0,2026 OpenAI,built from openai/codex codex-rs/linux-sandbox commit da4c8ca57d40b074bdc1b5b1218851100150c56b
 deploy/sandbox/seatbelt_base_policy.sbpl,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 deploy/sandbox/seatbelt_network_policy.sbpl,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 docker-compose.release.yml,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation

--- a/scripts/compliance/generate_p0b_artifacts.py
+++ b/scripts/compliance/generate_p0b_artifacts.py
@@ -26,6 +26,24 @@ SBOM_CREATED = "2026-06-25T00:00:00Z"
 # prefix (relative to repo root). Keep in sync with frontend/REUSE.toml.
 THIRD_PARTY_PATH_OVERRIDES: tuple[tuple[str, str, str, str], ...] = (
     (
+        "LICENSES/Apache-2.0.txt",
+        "Apache-2.0",
+        "Apache Software Foundation",
+        "Apache License 2.0 text",
+    ),
+    (
+        "deploy/sandbox/linux-amd64/codex-linux-sandbox",
+        "Apache-2.0",
+        "2026 OpenAI",
+        "built from openai/codex codex-rs/linux-sandbox commit da4c8ca57d40b074bdc1b5b1218851100150c56b",
+    ),
+    (
+        "deploy/sandbox/linux-arm64/codex-linux-sandbox",
+        "Apache-2.0",
+        "2026 OpenAI",
+        "built from openai/codex codex-rs/linux-sandbox commit da4c8ca57d40b074bdc1b5b1218851100150c56b",
+    ),
+    (
         "frontend/public/viewer-kit/quaternius/",
         "CC0-1.0",
         "Quaternius",
@@ -302,6 +320,23 @@ def write_reuse_toml() -> None:
 
 [[annotations]]
 path = [
+    "LICENSES/Apache-2.0.txt",
+]
+precedence = "override"
+SPDX-FileCopyrightText = "Apache Software Foundation"
+SPDX-License-Identifier = "Apache-2.0"
+
+[[annotations]]
+path = [
+    "deploy/sandbox/linux-amd64/codex-linux-sandbox",
+    "deploy/sandbox/linux-arm64/codex-linux-sandbox",
+]
+precedence = "override"
+SPDX-FileCopyrightText = "2026 OpenAI"
+SPDX-License-Identifier = "Apache-2.0"
+
+[[annotations]]
+path = [
     "**",
 ]
 precedence = "aggregate"
@@ -338,6 +373,7 @@ def write_license_inventory(files: list[str]) -> None:
         _inventory_row(path)
         for path in sorted(set(files + [
             "REUSE.toml",
+            "LICENSES/Apache-2.0.txt",
             "LICENSES/Elastic-2.0.txt",
             "license-inventory.csv",
             "NOTICE",

--- a/src/novelvideo/security/sandbox_wrap.py
+++ b/src/novelvideo/security/sandbox_wrap.py
@@ -13,6 +13,7 @@ macOS:  /usr/bin/sandbox-exec + dynamically composed sbpl profile
 
 from __future__ import annotations
 
+import json
 import logging
 import os
 import platform
@@ -113,12 +114,33 @@ def _wrap_linux(cmd: list[str], spec: SandboxSpec) -> list[str]:
     if not Path(binary).exists():
         return _fallback_or_raise(cmd, "codex-linux-sandbox not found on PATH")
 
-    args = [binary, "--sandbox", "workspace-write"]
-    # Only HERMES_HOME is writable. read defaults to filesystem-wide in
-    # workspace-write mode; codex-linux-sandbox does not have fine-grained
-    # read-deny per path, so unix permission + L1 toolset whitelist cover
-    # read-side defense on Linux. (macOS Seatbelt is stricter; see _wrap_macos.)
-    args.extend(["--writable-root", str(spec.resolved_hermes_home())])
+    hermes_home = spec.resolved_hermes_home()
+    permission_profile = {
+        "type": "managed",
+        "file_system": {
+            "type": "restricted",
+            "entries": [
+                {
+                    "path": {"type": "special", "value": {"kind": "root"}},
+                    "access": "read",
+                },
+                {
+                    "path": {"type": "path", "path": str(hermes_home)},
+                    "access": "write",
+                },
+            ],
+        },
+        "network": "restricted",
+    }
+    args = [
+        binary,
+        "--sandbox-policy-cwd",
+        str(hermes_home),
+        "--command-cwd",
+        str(hermes_home),
+        "--permission-profile",
+        json.dumps(permission_profile, separators=(",", ":")),
+    ]
     args.append("--")
     return args + cmd
 

--- a/tests/test_p0b_compliance_generator.py
+++ b/tests/test_p0b_compliance_generator.py
@@ -175,6 +175,29 @@ def test_third_party_dirs_with_license_file_not_marked_project_license() -> None
     )
 
 
+def test_codex_sandbox_binaries_are_not_marked_project_license() -> None:
+    rows = {
+        row["path"]: row
+        for row in csv.DictReader(Path("license-inventory.csv").open(encoding="utf-8"))
+        if row["path"].startswith("deploy/sandbox/linux-")
+    }
+
+    assert (
+        rows["deploy/sandbox/linux-amd64/codex-linux-sandbox"]["license_expression"]
+        == "Apache-2.0"
+    )
+    assert (
+        rows["deploy/sandbox/linux-arm64/codex-linux-sandbox"]["license_expression"]
+        == "Apache-2.0"
+    )
+    assert (
+        generator._inventory_row("deploy/sandbox/linux-amd64/codex-linux-sandbox")[
+            "license_expression"
+        ]
+        == "Apache-2.0"
+    )
+
+
 def test_write_sbom_is_idempotent_for_same_inputs(tmp_path: Path, monkeypatch) -> None:
     monkeypatch.setattr(generator, "ROOT", tmp_path)
     (tmp_path / "pyproject.toml").write_text(

--- a/tests/test_sandbox_roots.py
+++ b/tests/test_sandbox_roots.py
@@ -1,6 +1,13 @@
 """Sandbox data roots follow configured NOVELVIDEO_*_DIR values."""
 
-from novelvideo.security.sandbox_wrap import SUPERTALE_ROOT, SandboxSpec, _data_dir
+import json
+
+from novelvideo.security.sandbox_wrap import (
+    SUPERTALE_ROOT,
+    SandboxSpec,
+    _data_dir,
+    _wrap_linux,
+)
 
 
 def test_data_dir_prefers_env(monkeypatch, tmp_path):
@@ -35,3 +42,33 @@ def test_other_user_paths_use_configured_data_roots(monkeypatch, tmp_path):
     assert {state / "bob", output / "bob", runtime / "bob"} <= others
     assert state / "alice" not in others
     assert state / "_shared" not in others
+
+
+def test_linux_wrapper_uses_current_codex_sandbox_cli(monkeypatch, tmp_path):
+    sandbox_binary = tmp_path / "codex-linux-sandbox"
+    sandbox_binary.write_text("#!/bin/sh\n", encoding="utf-8")
+    hermes_home = tmp_path / "state" / "alice" / ".hermes"
+    hermes_home.mkdir(parents=True)
+    monkeypatch.setattr(
+        "novelvideo.security.sandbox_wrap.shutil.which",
+        lambda _name: str(sandbox_binary),
+    )
+
+    wrapped = _wrap_linux(
+        ["hermes", "run"],
+        SandboxSpec(user="alice", hermes_home=hermes_home),
+    )
+
+    assert wrapped[0] == str(sandbox_binary)
+    assert "--sandbox" not in wrapped
+    assert "--writable-root" not in wrapped
+    assert wrapped[-3:] == ["--", "hermes", "run"]
+    assert wrapped[1:3] == ["--sandbox-policy-cwd", str(hermes_home)]
+    assert wrapped[3:5] == ["--command-cwd", str(hermes_home)]
+    profile = json.loads(wrapped[wrapped.index("--permission-profile") + 1])
+    assert profile["type"] == "managed"
+    assert profile["network"] == "restricted"
+    assert {
+        "path": {"type": "path", "path": str(hermes_home)},
+        "access": "write",
+    } in profile["file_system"]["entries"]


### PR DESCRIPTION
## Summary
- update the Linux sandbox wrapper to use the current codex-linux-sandbox permission-profile CLI
- mark bundled codex-linux-sandbox binaries as Apache-2.0/OpenAI instead of project Elastic-2.0
- add regression coverage for sandbox wrapper arguments and compliance inventory generation

## Test Plan
- uv run pytest tests/test_ce_imports_lint.py tests/test_ce_port_closure.py tests/test_sandbox_roots.py tests/test_p0b_compliance_generator.py tests/test_api_model_credit_cost.py tests/test_task_credit_errors.py tests/test_image_credit_reservation.py tests/test_freezone_video_backend.py tests/test_seedance2_request.py tests/test_seedance2_models.py tests/test_task_backend_celery_metadata.py