### PR TITLE
fix(characters): 角色图片按钮文案随是否已有图切换

### DIFF
--- a/frontend/src/routes/_app/projects.$project/characters.lazy.tsx
+++ b/frontend/src/routes/_app/projects.$project/characters.lazy.tsx
@@ -977,7 +977,9 @@ function PortraitBlock({
           ) : (
             <Sparkles className="size-3" />
           )}
-          {t("characters.summary.generateNew")}
+          {character.portrait_url
+            ? t("characters.portrait.regenerate")
+            : t("characters.summary.generateNew")}
           <CreditCostInline display={portraitCost} />
         </Button>
         <Button


### PR DESCRIPTION
## 问题

角色详情页中,角色图片已生成并显示在左侧预览区,但生图按钮仍显示「生成新图」,与实际状态不一致,也与镜头生图按钮规则不统一。

**复现**:角色管理 → 选一个已有图片的角色(如「林知微」)→ 观察图片下方按钮文案 → 仍是「生成新图」。

## 根因

`characters.lazy.tsx` 的 `PortraitBlock` 里,按钮文案写死了 `t("characters.summary.generateNew")`「生成新图」,没有根据是否已有图片做条件判断。而同页的角色 identity 图、镜头页草图都已按「有无图片」切换文案——此处漏了三元判断。

## 修复

按 `character.portrait_url` 判断(复用已存在的 i18n key `characters.portrait.regenerate`):

\`\`\`tsx
{character.portrait_url
  ? t("characters.portrait.regenerate")   // 有图 → 重新生成
  : t("characters.summary.generateNew")}  // 无图 → 生成新图
\`\`\`

文案随 `character` prop 变化,切换角色时自动更新。

## 统一规则核实

| 生图入口 | 状态 |
|---|---|
| 角色图片 | ✅ 本次修复:按 `portrait_url` 判断 |
| 镜头草图 | 已按 `hasSketch` 判断,本就正确 |
| 角色 identity 图 | 已按 `image_url` 判断,本就正确 |
| 镜头渲染图 | 该按钮仅在已有渲染图后出现(纯重生成语义),无需「生成新图」态,符合规则 |

## 验收

- [x] 已有角色图片时,按钮显示「重新生成」
- [x] 无角色图片时,按钮显示「生成新图」
- [x] 切换角色后文案按当前角色图片状态更新(派生自 `character.portrait_url` prop)
- [x] 与镜头页草图/identity 图等入口规则一致
- [x] `tsc -b && vite build` 通过;i18n key 在 zh/en 均已存在
- [x] 用户已在本地 http://localhost:5173 手动验证

🤖 Generated with [Claude Code](https://claude.com/claude-code)