### PR TITLE
fix(episode): 渲染图未生成时按钮显示「生成新图」而非「重新生成」

### DIFF
--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -2167,6 +2167,7 @@
         "cutFailed": "Grid cut failed"
       },
       "render": {
+        "generateNew": "Generate new",
         "switched": "Render switched",
         "switchFailed": "Switch failed",
         "forcedUse": "Force-applied this render",

--- a/frontend/public/locales/zh/translation.json
+++ b/frontend/public/locales/zh/translation.json
@@ -2167,6 +2167,7 @@
         "cutFailed": "网格 切割失败"
       },
       "render": {
+        "generateNew": "生成新图",
         "switched": "已切换渲染图",
         "switchFailed": "切换失败",
         "forcedUse": "已强制使用该渲染图",

--- a/frontend/src/components/episode/beat-workbench/render-section.tsx
+++ b/frontend/src/components/episode/beat-workbench/render-section.tsx
@@ -474,7 +474,9 @@ export function RenderSection({
                 className={MEDIA_PRIMARY_ACTION_BUTTON_CLASS}
               >
                 {regenerate.isPending ? <Loader2 className="size-3 animate-spin" /> : <RefreshCw className="size-3" />}
-                {t("common.regenerate")}
+                {previewUrl
+                  ? t("common.regenerate")
+                  : t("episode.workbench.render.generateNew")}
                 <CreditCostInline display={renderRegenCost.data?.data.display} />
               </Button>
               {renderPlatePreview ? (


### PR DESCRIPTION
## 问题

镜头详情页「渲染图」操作按钮此前无论是否已生成渲染图,始终显示「重新生成」。当该镜头尚未生成渲染图时(空态已显示「无渲染图」),按钮仍显示「重新生成」,与草图 / 角色图片按钮的文案规则不一致。

## 修复

按钮文案根据 `previewUrl`(与「无渲染图」空态同一判断信号)条件渲染,统一规则:

- 未生成过渲染图 → 「生成新图」
- 已生成过渲染图 → 「重新生成」

切换镜头时,`previewUrl` 随当前 beat 数据变化,按钮状态自动刷新。

新增 i18n key `episode.workbench.render.generateNew`(zh: 生成新图 / en: Generate new)。

## 验证

- [x] `pnpm tsc -b` 通过
- [x] `pnpm build` 通过
- 无渲染图 → 按钮显示「生成新图」
- 有渲染图 → 按钮显示「重新生成」
- 切换镜头 → 按钮状态正确刷新

🤖 Generated with [Claude Code](https://claude.com/claude-code)