### PR TITLE
Gate assistant chat by credits

### DIFF
--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -1340,6 +1340,8 @@
     "restoredFilename": "Imported novel",
     "statFilename": "Filename",
     "statTotalChars": "Total chars",
+    "statBillableChars": "Billable chars",
+    "creditPerChars": "{{credits}} per {{chars}} chars",
     "statChaptersDetected": "Chapters detected",
     "statEpisodesEstimated": "Estimated episodes",
     "episodesUnit": "eps",

--- a/frontend/public/locales/zh/translation.json
+++ b/frontend/public/locales/zh/translation.json
@@ -1340,6 +1340,8 @@
     "restoredFilename": "已导入小说",
     "statFilename": "文件名",
     "statTotalChars": "总字数",
+    "statBillableChars": "计费字数",
+    "creditPerChars": "每 {{chars}} 字 {{credits}}",
     "statChaptersDetected": "检测章节",
     "statEpisodesEstimated": "预计生成",
     "episodesUnit": "集",

--- a/frontend/src/lib/queries/generation-credit-cost.ts
+++ b/frontend/src/lib/queries/generation-credit-cost.ts
@@ -12,6 +12,10 @@ import type { OkResponse } from "@/types/api";
 export type GenerationCreditCost = {
   cost: number;
   display: string;
+  unit?: "call" | "item" | "second" | "token" | "character" | string;
+  unit_cost?: number;
+  quantity?: number;
+  params?: Record<string, unknown>;
 };
 
 export type GenerationCreditCostOptions = {

--- a/frontend/src/lib/queries/ingest.ts
+++ b/frontend/src/lib/queries/ingest.ts
@@ -27,6 +27,7 @@ export interface UploadResult {
   filename: string;
   size: number;
   total_chars?: number;
+  billable_chars?: number;
   count?: number;
   chapters?: Chapter[];
   format_check?: FormatCheck;
@@ -35,6 +36,7 @@ export interface UploadResult {
 interface ChaptersResult {
   chapters: Chapter[];
   total_chars: number;
+  billable_chars?: number;
   count?: number;
 }
 
@@ -65,6 +67,7 @@ export function useUploadNovel(project: string) {
             data: {
               chapters: preview.chapters,
               total_chars: preview.total_chars,
+              billable_chars: preview.billable_chars,
               count: preview.count,
             },
           },

--- a/frontend/src/routes/_app/projects.$project/ingest.tsx
+++ b/frontend/src/routes/_app/projects.$project/ingest.tsx
@@ -28,6 +28,7 @@ import {
   useStartIngest,
   useUploadNovel,
   type FormatCheck,
+  type UploadResult,
 } from "@/lib/queries/ingest";
 import { FormatCheckDetailsDialog } from "@/components/ingest/FormatCheckDetailsDialog";
 import { useStyles } from "@/lib/queries/styles";
@@ -231,6 +232,10 @@ function formatSize(bytes: number): string {
   if (bytes < 1024) return `${bytes} B`;
   if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
   return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+function countBillableNovelChars(text: string): number {
+  return text ? text.replace(/[\s\u3000]+/g, "").length : 0;
 }
 
 function hiddenImportedPreviewKey(project: string): string {
@@ -664,10 +669,7 @@ export function IngestPageContent({ project }: { project: string }) {
   const queryClient = useQueryClient();
 
   // Upload state
-  const [uploadedFile, setUploadedFile] = useState<{
-    filename: string;
-    size: number;
-  } | null>(null);
+  const [uploadedFile, setUploadedFile] = useState<UploadResult | null>(null);
   const [uploadedFileSource, setUploadedFileSource] =
     useState<UploadedFileSource | null>(null);
   const [inputMode, setInputMode] = useState<InputMode>("upload");
@@ -705,9 +707,26 @@ export function IngestPageContent({ project }: { project: string }) {
   // Re-import warning if characters already exist
   const { data: charactersRes } = useCharacters(project);
   const hasCharacters = (charactersRes?.data?.length ?? 0) > 0;
-  const ingestFeatureCost = useGenerationCreditCost("feature", "ingest_fast");
+  const pastedBillableChars = useMemo(
+    () => countBillableNovelChars(pastedText.trim()),
+    [pastedText],
+  );
+  const billingBillableChars =
+    inputMode === "paste" && pastedBillableChars > 0
+      ? pastedBillableChars
+      : typeof uploadedFile?.billable_chars === "number"
+        ? uploadedFile.billable_chars
+        : typeof chaptersData?.billable_chars === "number"
+          ? chaptersData.billable_chars
+          : null;
+  const ingestFeatureCost = useGenerationCreditCost("feature", "ingest_fast", {
+    quantity: billingBillableChars && billingBillableChars > 0
+      ? billingBillableChars
+      : undefined,
+  });
+  const ingestFeatureCostData = ingestFeatureCost.data?.data;
   const ingestFeatureCostDisplay =
-    ingestFeatureCost.data?.data.display ??
+    ingestFeatureCostData?.display ??
     (ingestFeatureCost.error instanceof BillingRuleNotConfiguredError
       ? t("common.billingRuleNotConfiguredShort")
       : null);
@@ -997,6 +1016,12 @@ export function IngestPageContent({ project }: { project: string }) {
             sum + (ch.word_count ?? ch.char_count ?? ch.content?.length ?? 0),
           0,
         );
+  const billableChars =
+    typeof uploadedFile?.billable_chars === "number"
+      ? uploadedFile.billable_chars
+      : typeof chaptersData?.billable_chars === "number"
+        ? chaptersData.billable_chars
+        : totalChars;
   const totalCharsUnknown = totalChars === 0 && !chaptersData?.total_chars;
   const isStarting = updateProject.isPending || startIngestMutation.isPending;
 
@@ -1374,7 +1399,7 @@ export function IngestPageContent({ project }: { project: string }) {
                   </h2>
 
                   {/* Stat cards */}
-                  <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+                  <div className="grid grid-cols-2 gap-3 sm:grid-cols-5">
                     <StatCard
                       label={t("ingest.statFilename")}
                       value={
@@ -1393,6 +1418,14 @@ export function IngestPageContent({ project }: { project: string }) {
                         totalCharsUnknown
                           ? <span className="text-muted-foreground/60">—</span>
                           : totalChars.toLocaleString()
+                      }
+                    />
+                    <StatCard
+                      label={t("ingest.statBillableChars")}
+                      value={
+                        totalCharsUnknown
+                          ? <span className="text-muted-foreground/60">—</span>
+                          : billableChars.toLocaleString()
                       }
                     />
                     <StatCard

--- a/src/novelvideo/api/chapter_preview.py
+++ b/src/novelvideo/api/chapter_preview.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 from novelvideo.cognee.chapter_detector import ChapterDetector
 from novelvideo.utils.document_parsers import (
+    count_billable_novel_chars as _count_billable_novel_chars,
     decode_novel_bytes as _decode_novel_bytes,
 )
 from novelvideo.utils.document_parsers import (
@@ -19,6 +20,10 @@ def decode_novel_bytes(raw: bytes) -> str:
 
 def load_novel_text(path: str | Path) -> str:
     return _load_novel_text(path)
+
+
+def count_billable_novel_chars(text: str) -> int:
+    return _count_billable_novel_chars(text)
 
 
 def build_chapter_preview(novel_text: str) -> dict:
@@ -43,6 +48,7 @@ def build_chapter_preview(novel_text: str) -> dict:
 
     return {
         "total_chars": len(novel_text),
+        "billable_chars": count_billable_novel_chars(novel_text),
         "count": len(chapters),
         "chapters": payload,
     }

--- a/src/novelvideo/api/routes/chat.py
+++ b/src/novelvideo/api/routes/chat.py
@@ -24,9 +24,20 @@ from novelvideo.api.auth import (
 from novelvideo.api.deps import list_user_projects
 from novelvideo.chat import service as chat_service
 from novelvideo.chat.store import ChatScope, chat_store
+from novelvideo.ports import get_usage_meter
 from novelvideo.project_context import ProjectContext, resolve_project_context
+from novelvideo.shared.billing_errors import (
+    BILLING_RULE_NOT_CONFIGURED_MESSAGE,
+    INSUFFICIENT_CREDITS_MESSAGE,
+    billing_rule_not_configured_payload,
+    find_billing_rule_not_configured_error,
+    find_insufficient_credits_error,
+    insufficient_credits_payload,
+)
 
 router = APIRouter()
+
+AI_ASSISTANT_CHAT_FEATURE_KEY = "ai_assistant_chat"
 
 
 @router.post("/chat/cancel")
@@ -261,6 +272,32 @@ async def _project_context_for_scope(
         user=user,
         project_id=str(scope.id),
         required_role="viewer",
+    )
+
+
+async def _requester_user_id_for_chat(user: dict[str, Any], scope: ChatScope) -> str:
+    if scope.kind == "project":
+        project_ctx = await _project_context_for_scope(user, scope)
+        if project_ctx is not None and project_ctx.requester_user_id:
+            return project_ctx.requester_user_id
+    user_id = str(user.get("id") or user.get("user_id") or "").strip()
+    if user_id:
+        return user_id
+    return str(user.get("username") or "").strip()
+
+
+async def _require_ai_assistant_access(
+    *,
+    user: dict[str, Any],
+    scope: ChatScope,
+) -> None:
+    user_id = await _requester_user_id_for_chat(user, scope)
+    await get_usage_meter().require_feature_credit_balance(
+        user_id=user_id,
+        feature_key=AI_ASSISTANT_CHAT_FEATURE_KEY,
+        project_id=str(scope.id or "") if scope.kind == "project" else "",
+        resource_kind="chat",
+        metadata={"scope": scope.to_dict()},
     )
 
 
@@ -735,6 +772,7 @@ async def chat_ws(websocket: WebSocket) -> None:
                 continue
 
             try:
+                await _require_ai_assistant_access(user=user, scope=scope)
                 if scope.kind == "project":
                     await _stream_project_turn(
                         websocket=websocket,
@@ -773,6 +811,30 @@ async def chat_ws(websocket: WebSocket) -> None:
                             "turn_id": turn_id,
                             "scope": scope.to_dict(),
                             "message": message,
+                        },
+                    )
+                    continue
+                billing_rule_error = find_billing_rule_not_configured_error(exc)
+                if billing_rule_error is not None:
+                    await _send_json_best_effort(
+                        websocket,
+                        {
+                            "type": "error",
+                            "turn_id": turn_id,
+                            "message": BILLING_RULE_NOT_CONFIGURED_MESSAGE,
+                            "data": billing_rule_not_configured_payload(billing_rule_error),
+                        },
+                    )
+                    continue
+                insufficient_error = find_insufficient_credits_error(exc)
+                if insufficient_error is not None:
+                    await _send_json_best_effort(
+                        websocket,
+                        {
+                            "type": "error",
+                            "turn_id": turn_id,
+                            "message": INSUFFICIENT_CREDITS_MESSAGE,
+                            "data": insufficient_credits_payload(insufficient_error),
                         },
                     )
                     continue

--- a/src/novelvideo/api/routes/ingest.py
+++ b/src/novelvideo/api/routes/ingest.py
@@ -6,7 +6,11 @@ from pathlib import Path
 from fastapi import APIRouter, Depends, File, UploadFile
 
 from novelvideo.api.auth import get_api_user, require_scope
-from novelvideo.api.chapter_preview import build_chapter_preview, load_novel_text
+from novelvideo.api.chapter_preview import (
+    build_chapter_preview,
+    count_billable_novel_chars,
+    load_novel_text,
+)
 from novelvideo.api.deps import resolve_project_scope
 from novelvideo.api.schemas import IngestStart
 from novelvideo.project_config import (
@@ -123,6 +127,24 @@ async def start_ingest(
     if not novel_path.exists():
         return {"ok": False, "error": f"File '{body.filename}' not found in uploads/"}
 
+    try:
+        billable_chars = count_billable_novel_chars(load_novel_text(novel_path))
+    except DocumentParseError as exc:
+        return {
+            "ok": False,
+            "error": f"解析章节失败: {exc}",
+            "error_type": "parse",
+            "format": exc.source_format,
+            "detail": str(exc),
+        }
+    except Exception:
+        logger.warning(
+            "[%s] failed to parse uploaded novel for billing",
+            project,
+            exc_info=True,
+        )
+        return {"ok": False, "error": "解析章节失败"}
+
     config = {"rebuild": body.rebuild}
     if body.spine_template is not None:
         if not body.rebuild:
@@ -141,7 +163,14 @@ async def start_ingest(
             task_type="ingest_fast",
             queue_kind="default",
             episode=0,
-            payload={"novel_path": str(novel_path), "config": config},
+            payload={
+                "novel_path": str(novel_path),
+                "config": config,
+                "billing": {
+                    "billable_chars": billable_chars,
+                    "billing_quantity": billable_chars,
+                },
+            },
         )
         return {
             "ok": True,

--- a/src/novelvideo/api/routes/model_credits.py
+++ b/src/novelvideo/api/routes/model_credits.py
@@ -381,7 +381,7 @@ async def get_generation_credit_cost(
     surface: GenerationCreditSurface = Query("supertale"),
     value: str = Query("", max_length=256),
     params: str = Query("", max_length=2048),
-    quantity: int = Query(1, ge=0, le=1_000_000),
+    quantity: int = Query(1, ge=0, le=50_000_000),
     mode_key: str = Query("", max_length=128),
     image_role: str = Query("", max_length=64),
     user: dict = Depends(get_api_user),
@@ -406,10 +406,17 @@ async def get_generation_credit_cost(
         ),
         quantity=_clean_quantity(quantity),
     )
-    return {
-        "ok": True,
-        "data": {
-            "cost": quote.total_cost,
-            "display": _display_credit_cost(quote.total_cost),
-        },
+    data = {
+        "cost": quote.total_cost,
+        "display": _display_credit_cost(quote.total_cost),
     }
+    if getattr(quote, "unit", "call") == "character":
+        data.update(
+            {
+                "unit": "character",
+                "unit_cost": getattr(quote, "unit_cost", 0),
+                "quantity": getattr(quote, "quantity", quantity),
+                "params": getattr(quote, "params", None) or {},
+            }
+        )
+    return {"ok": True, "data": data}

--- a/src/novelvideo/ports/credit_quote.py
+++ b/src/novelvideo/ports/credit_quote.py
@@ -10,6 +10,10 @@ from typing import Protocol
 class CreditQuote:
     total_cost: int
     display: str
+    unit: str = "call"
+    unit_cost: int = 0
+    quantity: int = 1
+    params: dict | None = None
 
 
 class CreditQuotePort(Protocol):

--- a/src/novelvideo/ports/local/credit_quote.py
+++ b/src/novelvideo/ports/local/credit_quote.py
@@ -14,4 +14,4 @@ class LocalCreditQuote:
         params: dict,
         quantity: int,
     ) -> CreditQuote:
-        return CreditQuote(total_cost=0, display="0")
+        return CreditQuote(total_cost=0, display="0", unit="call", unit_cost=0, quantity=1, params={})

--- a/src/novelvideo/ports/local/usage.py
+++ b/src/novelvideo/ports/local/usage.py
@@ -55,6 +55,23 @@ class NoOpUsageMeter:
             "reason": "feature_reserved",
         }
 
+    async def require_feature_credit_balance(
+        self,
+        *,
+        user_id: str,
+        feature_key: str,
+        project_id: str = "",
+        resource_kind: str = "",
+        metadata: Optional[dict[str, Any]] = None,
+    ) -> dict[str, Any]:
+        return {
+            "user_id": user_id,
+            "feature_key": feature_key,
+            "required_balance": 0,
+            "balance": None,
+            "allowed": True,
+        }
+
     async def confirm_feature_credit_reservation(
         self,
         reservation_id: str,

--- a/src/novelvideo/ports/usage.py
+++ b/src/novelvideo/ports/usage.py
@@ -39,6 +39,16 @@ class UsageMeter(Protocol):
         require_positive_cost: bool = False,
     ) -> dict[str, Any]: ...
 
+    async def require_feature_credit_balance(
+        self,
+        *,
+        user_id: str,
+        feature_key: str,
+        project_id: str = "",
+        resource_kind: str = "",
+        metadata: Optional[dict[str, Any]] = None,
+    ) -> dict[str, Any]: ...
+
     async def confirm_feature_credit_reservation(
         self,
         reservation_id: str,

--- a/src/novelvideo/shared/billing_errors.py
+++ b/src/novelvideo/shared/billing_errors.py
@@ -8,7 +8,7 @@ INSUFFICIENT_CREDITS_CODE = "INSUFFICIENT_CREDITS"
 INSUFFICIENT_CREDITS_MESSAGE = "积分不足，请联系管理员充值"
 BILLING_RULE_NOT_CONFIGURED_CODE = "BILLING_RULE_NOT_CONFIGURED"
 BILLING_RULE_NOT_CONFIGURED_MESSAGE = "计费规则未配置，请联系管理员设置积分规则"
-GENERATION_BILLING_UNITS = {"call", "item", "second", "token"}
+GENERATION_BILLING_UNITS = {"call", "item", "second", "token", "character"}
 
 
 class InsufficientCreditsError(RuntimeError):

--- a/src/novelvideo/utils/document_parsers.py
+++ b/src/novelvideo/utils/document_parsers.py
@@ -4,10 +4,12 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
+import re
 
 TEXT_NOVEL_EXTENSIONS = {".txt", ".md"}
 SUPPORTED_NOVEL_EXTENSIONS = TEXT_NOVEL_EXTENSIONS | {".docx"}
 SUPPORTED_NOVEL_EXTENSION_ORDER = (".txt", ".md", ".docx")
+_BILLABLE_WHITESPACE_RE = re.compile(r"[\s\u3000]+")
 
 
 @dataclass
@@ -29,6 +31,18 @@ def supported_novel_extensions_label() -> str:
 
 def is_supported_novel_path(path: str | Path) -> bool:
     return Path(path).suffix.lower() in SUPPORTED_NOVEL_EXTENSIONS
+
+
+def count_billable_novel_chars(text: str) -> int:
+    """Count parsed novel text characters used for import billing.
+
+    The import pipeline works on decoded/extracted plain text, so billing uses
+    that same text and ignores layout whitespace. Punctuation remains billable
+    because it is still model-visible input.
+    """
+    if not text:
+        return 0
+    return len(_BILLABLE_WHITESPACE_RE.sub("", text))
 
 
 def decode_novel_bytes(raw: bytes) -> str:

--- a/tests/test_api_ingest_chapter_preview.py
+++ b/tests/test_api_ingest_chapter_preview.py
@@ -129,6 +129,7 @@ async def test_upload_novel_returns_nicegui_chapter_preview(tmp_path, monkeypatc
     assert data["filename"] == "novel.txt"
     assert data["size"] == len(raw)
     assert data["total_chars"] == len(NOVEL_TEXT)
+    assert data["billable_chars"] == len("".join(NOVEL_TEXT.split()))
     assert data["count"] == 2
     assert data["chapters"][0]["number"] == 1
     assert data["chapters"][0]["title"] == "第一章 启程"

--- a/tests/test_chat_route_prewarm.py
+++ b/tests/test_chat_route_prewarm.py
@@ -32,3 +32,26 @@ def test_ws_connect_does_not_prewarm_default_home_scope() -> None:
 
 def test_ws_connect_can_prewarm_non_home_scope() -> None:
     assert chat_route._should_prewarm_on_ws_connect(ChatScope(kind="project", id="project_a")) is True
+
+
+@pytest.mark.anyio
+async def test_ai_assistant_access_check_uses_chat_feature_key(monkeypatch) -> None:
+    seen = {}
+
+    class FakeUsageMeter:
+        async def require_feature_credit_balance(self, **kwargs):
+            seen.update(kwargs)
+            return {"allowed": True}
+
+    monkeypatch.setattr(chat_route, "get_usage_meter", lambda: FakeUsageMeter())
+
+    await chat_route._require_ai_assistant_access(
+        user={"id": "usr_1", "username": "alice"},
+        scope=ChatScope(kind="home"),
+    )
+
+    assert seen["user_id"] == "usr_1"
+    assert seen["feature_key"] == "ai_assistant_chat"
+    assert seen["project_id"] == ""
+    assert seen["resource_kind"] == "chat"
+    assert seen["metadata"]["scope"] == {"kind": "home", "id": None}


### PR DESCRIPTION
## Summary
- check assistant chat credit access before entering Hermes
- add usage-meter port support for feature access checks
- keep CE local usage meter as a no-op
- add route test for the assistant access key

## Tests
- PYTHONPATH=/Users/hg/data/dramaclaw/src PYTEST_ADDOPTS='-p no:cacheprovider' NOVELVIDEO_STATE_DIR=/private/tmp/dramaclaw-test-state NOVELVIDEO_OUTPUT_DIR=/private/tmp/dramaclaw-test-output /Users/hg/data/dramaclaw/.venv/bin/python -m pytest tests/test_chat_route_prewarm.py