### PR TITLE
chore(login): 商务微信二维码改用 OSS 在线图片

### DIFF
--- a/frontend/src/components/login/login-stage.tsx
+++ b/frontend/src/components/login/login-stage.tsx
@@ -124,7 +124,7 @@ export function LoginStageContent({
               >
                 <div className={styles.businessWechatPanel}>
                   <img
-                    src="/contact/business-wechat-qr.png"
+                    src="https://nfg-web.oss-cn-chengdu.aliyuncs.com/dramaclaw/contact/wechat.png"
                     alt={t("auth.businessWechat.qrAlt")}
                     draggable={false}
                   />


### PR DESCRIPTION
## 改动
将登录页商务微信二维码 `src` 从本地静态图 `/contact/business-wechat-qr.png` 换成 OSS 在线链接：

`https://nfg-web.oss-cn-chengdu.aliyuncs.com/dramaclaw/contact/wechat.png`

## 影响
- `frontend/src/components/login/login-stage.tsx` 一行改动
- 本地静态图 `frontend/public/contact/business-wechat-qr.png` 暂不再被引用（保留）

🤖 Generated with [Claude Code](https://claude.com/claude-code)