### PR TITLE
fix(backup): skip hot-file recheck and exclude .hermes runtime dirs in rclone sync

### DIFF
--- a/src/novelvideo/backup/files_sync.py
+++ b/src/novelvideo/backup/files_sync.py
@@ -10,6 +10,8 @@ import tempfile
 from datetime import datetime, timezone
 from pathlib import Path
 
+# Per-user .hermes dirs hold agent runtime state: keep only config/memory —
+# never sync .env (secrets), caches, logs or tmp to the backup bucket.
 RCLONE_FILTER = """\
 - *.db
 - *.db-*
@@ -18,6 +20,12 @@ RCLONE_FILTER = """\
 - *-litestream/**
 - *.snapshot
 - *.snapshot.tmp
+- .hermes/.env
+- .hermes/*_cache/**
+- .hermes/logs/**
+- .hermes/tmp/**
+- .hermes/.cache/**
+- .hermes/.local/**
 + **
 """
 
@@ -50,6 +58,12 @@ def build_sync_cmd(*, src: str, dst: str, history_dst: str, filter_file: Path) -
         "--transfers",
         "8",
         "--skip-links",
+        # Hot files (freezone canvas json / _canvas_events jsonl / idempotency json)
+        # keep being written during the sync; without this flag rclone flags them as
+        # "corrupted on transfer: md5/size differ" and the whole job exits 1. They are
+        # normal live-data churn, not corruption — skip the post-transfer recheck and
+        # let the next sync round pick up the latest content.
+        "--local-no-check-updated",
         "--log-level",
         "INFO",
     ]

--- a/tests/test_backup_files_sync.py
+++ b/tests/test_backup_files_sync.py
@@ -13,6 +13,12 @@ def test_filter_excludes_all_sqlite_and_litestream_state():
         "- *-litestream/**",
         "- *.snapshot",
         "- *.snapshot.tmp",
+        "- .hermes/.env",
+        "- .hermes/*_cache/**",
+        "- .hermes/logs/**",
+        "- .hermes/tmp/**",
+        "- .hermes/.cache/**",
+        "- .hermes/.local/**",
         "+ **",
     ):
         assert required in lines
@@ -31,6 +37,8 @@ def test_build_sync_cmd_shape(tmp_path):
     assert cmd[:3] == ["rclone", "sync", "/data/state"]
     assert "--filter-from" in cmd and str(filter_file) in cmd
     assert "--backup-dir" in cmd and "--fast-list" in cmd
+    # Hot live files (freezone canvas/idempotency json) must not fail the job.
+    assert "--local-no-check-updated" in cmd
 
 
 def test_build_rclone_env(monkeypatch):


### PR DESCRIPTION
Port of the internal tip that the OSS snapshot missed:

- `--local-no-check-updated`: freezone canvas/idempotency json keep being written during sync; without the flag rclone reports them as "corrupted on transfer" and the whole backup job exits 1.
- `.hermes` filter rules: never mirror per-user agent `.env` (secrets), caches, logs or tmp to the backup bucket.

Both behaviors are locked in by new assertions in `tests/test_backup_files_sync.py` (4 passed).