### PR TITLE
fix(frontend): CSP img-src 放行 nfg-web OSS 域名

### DIFF
--- a/frontend/docker/nginx.conf.template
+++ b/frontend/docker/nginx.conf.template
@@ -52,7 +52,7 @@ server {
         # /assets/* 不受影响，仍走下面 1 年 immutable 缓存。
         add_header Cache-Control "no-cache" always;
 
-        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'sha256-LvxLzCeWBZ/DC3ejUm4WcZpQNZXYDUz4p/53gA+dzKk='; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https://novelvideo-assets-chengdu.oss-cn-chengdu.aliyuncs.com https://nfg-web-assets.cdnfg.com; media-src 'self' blob: https://novelvideo-assets-chengdu.oss-cn-chengdu.aliyuncs.com https://nfg-web-assets.cdnfg.com; font-src 'self' data:; connect-src 'self' https://novelvideo-assets-chengdu.oss-cn-chengdu.aliyuncs.com https://nfg-web-assets.cdnfg.com https://api.github.com; worker-src 'self' blob:; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'${csp_upgrade}" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'sha256-LvxLzCeWBZ/DC3ejUm4WcZpQNZXYDUz4p/53gA+dzKk='; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https://novelvideo-assets-chengdu.oss-cn-chengdu.aliyuncs.com https://nfg-web-assets.cdnfg.com https://nfg-web.oss-cn-chengdu.aliyuncs.com; media-src 'self' blob: https://novelvideo-assets-chengdu.oss-cn-chengdu.aliyuncs.com https://nfg-web-assets.cdnfg.com; font-src 'self' data:; connect-src 'self' https://novelvideo-assets-chengdu.oss-cn-chengdu.aliyuncs.com https://nfg-web-assets.cdnfg.com https://api.github.com; worker-src 'self' blob:; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'${csp_upgrade}" always;
         add_header Strict-Transport-Security $hsts_value always;
         add_header X-Frame-Options "DENY" always;
         add_header X-Content-Type-Options "nosniff" always;


### PR DESCRIPTION
## 问题

登录页商务微信二维码在 #32 中改用 OSS 在线图片（`https://nfg-web.oss-cn-chengdu.aliyuncs.com/dramaclaw/contact/wechat.png`，见 `frontend/src/components/login/login-stage.tsx:127`），但 nginx CSP 的 `img-src` 白名单未同步更新，浏览器报 CSP violation 并拦截图片加载：

> Loading the image 'https://nfg-web.oss-cn-chengdu.aliyuncs.com/dramaclaw/contact/wechat.png' violates the following Content Security Policy directive: "img-src 'self' data: blob: …"

## 修复

在 `frontend/docker/nginx.conf.template` 的 `img-src` 指令中加入 `https://nfg-web.oss-cn-chengdu.aliyuncs.com`。仅 `img-src`，其余指令不动（目前只有这一处图片引用该 bucket）。

需重新构建前端镜像并部署后生效；`index.html` 已是 `Cache-Control: no-cache`，新 CSP 头会在用户下次导航时生效，无需硬刷新。