### PR TITLE
Enforce episode asset feature billing

### DIFF
--- a/frontend/src/__tests__/lib/queries/episodes.test.tsx
+++ b/frontend/src/__tests__/lib/queries/episodes.test.tsx
@@ -130,6 +130,39 @@ describe("episode planning", () => {
       BillingRuleNotConfiguredError,
     );
   });
+
+  it.each([
+    ["scene", "episode_scene_planner", usePlanEpisodeScenes],
+    ["prop", "episode_prop_planner", usePlanEpisodeProps],
+  ] as const)(
+    "surfaces missing %s planning billing rules as a typed error",
+    async (kind, billingKey, useHook) => {
+      server.use(
+        http.post(
+          `http://localhost:3000/api/v1/projects/demo/episodes/1/${kind === "scene" ? "scenes" : "props"}/plan`,
+          () =>
+            HttpResponse.json(
+              {
+                ok: false,
+                error: "计费规则未配置，请联系管理员设置积分规则",
+                data: {
+                  error_code: "BILLING_RULE_NOT_CONFIGURED",
+                  billing_kind: "feature",
+                  billing_key: billingKey,
+                },
+              },
+              { status: 409 },
+            ),
+        ),
+      );
+
+      const { result } = renderHook(() => useHook("demo"), { wrapper });
+
+      await expect(result.current.mutateAsync(1)).rejects.toBeInstanceOf(
+        BillingRuleNotConfiguredError,
+      );
+    },
+  );
 });
 
 describe("pipeline status contract", () => {

--- a/frontend/src/__tests__/routes/episodes-workbench-integration.test.ts
+++ b/frontend/src/__tests__/routes/episodes-workbench-integration.test.ts
@@ -39,6 +39,31 @@ describe("episodes workbench integration", () => {
     expect(routeSource).toContain("<CreditCostInline display={costDisplay} />");
   });
 
+  it("shows feature credit cost on list-card scene and prop planning actions", () => {
+    expect(routeSource).toContain(
+      'useGenerationCreditCost("feature", "episode_scene_planner")',
+    );
+    expect(routeSource).toContain(
+      'useGenerationCreditCost("feature", "episode_prop_planner")',
+    );
+    expect(routeSource).toContain(
+      "planScenesCost.error instanceof BillingRuleNotConfiguredError",
+    );
+    expect(routeSource).toContain(
+      "planPropsCost.error instanceof BillingRuleNotConfiguredError",
+    );
+    expect(routeSource).toContain("sceneCostDisplay={planScenesCostDisplay}");
+    expect(routeSource).toContain("propCostDisplay={planPropsCostDisplay}");
+    expect(routeSource).toContain("costDisplay={sceneCostDisplay}");
+    expect(routeSource).toContain("costDisplay={propCostDisplay}");
+    expect(routeSource).toMatch(
+      /const handlePlanScenes[\s\S]*toast\.error\(backendErrorToastMessage\(res\.error, t\)\)[\s\S]*catch \(err\)[\s\S]*toast\.error\(backendErrorToastMessage\(err, t\)\)/,
+    );
+    expect(routeSource).toMatch(
+      /const handlePlanProps[\s\S]*toast\.error\(backendErrorToastMessage\(res\.error, t\)\)[\s\S]*catch \(err\)[\s\S]*toast\.error\(backendErrorToastMessage\(err, t\)\)/,
+    );
+  });
+
   it("scopes list-card planning spinners to the clicked episode", () => {
     expect(routeSource).toContain("planIdentities.isPending || identityTask.started");
     expect(routeSource).toContain('taskType: "identity_planner"');

--- a/frontend/src/__tests__/routes/ingest-credit-cost-contract.test.ts
+++ b/frontend/src/__tests__/routes/ingest-credit-cost-contract.test.ts
@@ -11,7 +11,10 @@ const routeSource = readFileSync(
 
 describe("ingest feature credit contract", () => {
   it("shows the strict feature billing configuration fallback", () => {
-    expect(routeSource).toContain('useGenerationCreditCost("feature", "ingest_fast")');
+    expect(routeSource).toContain(
+      'useGenerationCreditCost("feature", "ingest_fast", {',
+    );
+    expect(routeSource).toContain("quantity: billingBillableChars");
     expect(routeSource).toContain(
       "ingestFeatureCost.error instanceof BillingRuleNotConfiguredError",
     );

--- a/frontend/src/__tests__/routes/script-source-editor-integration.test.ts
+++ b/frontend/src/__tests__/routes/script-source-editor-integration.test.ts
@@ -52,6 +52,39 @@ describe("script route source editor integration", () => {
     expect(route).toContain("project={project}");
   });
 
+  it("shows feature credit cost on detail scene and prop planning", () => {
+    const route = readFileSync(
+      "src/routes/_app/projects.$project/episodes.$episode/script.lazy.tsx",
+      "utf8",
+    );
+    const planning = readFileSync(
+      "src/components/episode/episode-asset-planning.tsx",
+      "utf8",
+    );
+
+    expect(route).toContain(
+      'useGenerationCreditCost("feature", "episode_scene_planner")',
+    );
+    expect(route).toContain(
+      'useGenerationCreditCost("feature", "episode_prop_planner")',
+    );
+    expect(route).toContain(
+      "planScenesCost.error instanceof BillingRuleNotConfiguredError",
+    );
+    expect(route).toContain(
+      "planPropsCost.error instanceof BillingRuleNotConfiguredError",
+    );
+    expect(route).toContain("sceneCostDisplay={planScenesCostDisplay}");
+    expect(route).toContain("propCostDisplay={planPropsCostDisplay}");
+    expect(route).toMatch(
+      /const handlePlanScenes[\s\S]*toast\.error\(backendErrorToastMessage\(res\.error, t\)\)[\s\S]*catch \(err\)[\s\S]*toast\.error\(backendErrorToastMessage\(err, t\)\)/,
+    );
+    expect(route).toMatch(
+      /const handlePlanProps[\s\S]*toast\.error\(backendErrorToastMessage\(res\.error, t\)\)[\s\S]*catch \(err\)[\s\S]*toast\.error\(backendErrorToastMessage\(err, t\)\)/,
+    );
+    expect(planning).toContain("<CreditCostInline display={costDisplay} />");
+  });
+
   it("shows feature credit cost on detail identity planning", () => {
     const route = readFileSync(
       "src/routes/_app/projects.$project/episodes.$episode/script.lazy.tsx",

--- a/frontend/src/components/episode/episode-asset-planning.tsx
+++ b/frontend/src/components/episode/episode-asset-planning.tsx
@@ -12,6 +12,7 @@ import {
 import { useEffect, useMemo, useState, type ReactNode } from "react";
 import { toast } from "sonner";
 
+import { CreditCostInline } from "@/components/credit-cost-inline";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
@@ -81,6 +82,8 @@ interface EpisodeAssetPlanningProps {
   identityDefaultMap?: Record<string, string> | null;
   sceneMenu?: EpisodeSceneMenuItem[] | null;
   propMenu?: EpisodePropMenuItem[] | null;
+  sceneCostDisplay?: string | null;
+  propCostDisplay?: string | null;
   identityPending?: boolean;
   scenePending?: boolean;
   propPending?: boolean;
@@ -139,6 +142,8 @@ export function EpisodeAssetPlanning({
   identityDefaultMap,
   sceneMenu,
   propMenu,
+  sceneCostDisplay,
+  propCostDisplay,
   identityPending = false,
   scenePending = false,
   propPending = false,
@@ -220,6 +225,7 @@ export function EpisodeAssetPlanning({
           emptyLabel={labels.noScenes}
           items={scenes}
           actionLabel={scenes.length > 0 ? labels.replanScenes : labels.planScenes}
+          costDisplay={sceneCostDisplay}
           pending={scenePending}
           onPlan={onPlanScenes}
         />
@@ -233,6 +239,7 @@ export function EpisodeAssetPlanning({
           emptyLabel={labels.noProps}
           items={props.map((item) => item.prop_id.trim())}
           actionLabel={props.length > 0 ? labels.replanProps : labels.planProps}
+          costDisplay={propCostDisplay}
           pending={propPending}
           onPlan={onPlanProps}
           renderItem={(propId) => {
@@ -271,6 +278,7 @@ function AssetPlanningRow({
   emptyLabel,
   items,
   actionLabel,
+  costDisplay,
   pending,
   onPlan,
   renderItem,
@@ -281,6 +289,7 @@ function AssetPlanningRow({
   emptyLabel: string;
   items: string[];
   actionLabel: string;
+  costDisplay?: string | null;
   pending: boolean;
   onPlan: () => void;
   renderItem?: (item: string) => ReactNode;
@@ -308,6 +317,7 @@ function AssetPlanningRow({
         >
           {pending && <Loader2 className="animate-spin" />}
           {actionLabel}
+          <CreditCostInline display={costDisplay} />
         </Button>
       </div>
       <div className="flex min-h-0 flex-1 flex-wrap content-start items-center gap-1.5 overflow-y-auto">

--- a/frontend/src/lib/queries/episodes.ts
+++ b/frontend/src/lib/queries/episodes.ts
@@ -223,6 +223,9 @@ function usePlanEpisodeAssets(project: string, kind: "scene" | "prop") {
       jsonWithBackendError<PlanEpisodeAssetsResponse>(
         api.post(
           p`api/v1/projects/${project}/episodes/${episodeNum}/${kind === "scene" ? "scenes" : "props"}/plan`,
+          {
+            throwHttpErrors: false,
+          },
         ),
       ),
     onSuccess: (res, episodeNum) => {

--- a/frontend/src/routes/_app/projects.$project/episodes.$episode/script.lazy.tsx
+++ b/frontend/src/routes/_app/projects.$project/episodes.$episode/script.lazy.tsx
@@ -100,7 +100,19 @@ function ScriptTabContent() {
       ? t("common.billingRuleNotConfiguredShort")
       : null);
   const planScenes = usePlanEpisodeScenes(project);
+  const planScenesCost = useGenerationCreditCost("feature", "episode_scene_planner");
+  const planScenesCostDisplay =
+    planScenesCost.data?.data.display ??
+    (planScenesCost.error instanceof BillingRuleNotConfiguredError
+      ? t("common.billingRuleNotConfiguredShort")
+      : null);
   const planProps = usePlanEpisodeProps(project);
+  const planPropsCost = useGenerationCreditCost("feature", "episode_prop_planner");
+  const planPropsCostDisplay =
+    planPropsCost.data?.data.display ??
+    (planPropsCost.error instanceof BillingRuleNotConfiguredError
+      ? t("common.billingRuleNotConfiguredShort")
+      : null);
   const generateScript = useGenerateScript(project, epNum);
   const generateScriptCost = useGenerationCreditCost("feature", "script_writer");
   const generateScriptCostDisplay =
@@ -353,7 +365,7 @@ function ScriptTabContent() {
     try {
       const res = await planScenes.mutateAsync(epNum);
       if (res.ok === false) {
-        toast.error(res.error || t("common.error"));
+        toast.error(backendErrorToastMessage(res.error, t));
         return;
       }
       toast.success(
@@ -372,7 +384,7 @@ function ScriptTabContent() {
     try {
       const res = await planProps.mutateAsync(epNum);
       if (res.ok === false) {
-        toast.error(res.error || t("common.error"));
+        toast.error(backendErrorToastMessage(res.error, t));
         return;
       }
       toast.success(
@@ -641,6 +653,8 @@ function ScriptTabContent() {
                 identityPending={identityPlanning}
                 scenePending={planScenes.isPending}
                 propPending={planProps.isPending}
+                sceneCostDisplay={planScenesCostDisplay}
+                propCostDisplay={planPropsCostDisplay}
                 onPlanIdentities={() => setPickerOpen(true)}
                 onIdentityChange={handleIdentityChange}
                 onPlanScenes={handlePlanScenes}

--- a/frontend/src/routes/_app/projects.$project/episodes.tsx
+++ b/frontend/src/routes/_app/projects.$project/episodes.tsx
@@ -532,6 +532,8 @@ function EpisodeListItem({
   onPlanScenes,
   onPlanProps,
   identityCostDisplay,
+  sceneCostDisplay,
+  propCostDisplay,
   scenePending,
   propPending,
   sceneDisabled,
@@ -543,6 +545,8 @@ function EpisodeListItem({
   onPlanScenes: (episodeNum: number) => void;
   onPlanProps: (episodeNum: number) => void;
   identityCostDisplay?: string | null;
+  sceneCostDisplay?: string | null;
+  propCostDisplay?: string | null;
   scenePending: boolean;
   propPending: boolean;
   sceneDisabled: boolean;
@@ -681,6 +685,7 @@ function EpisodeListItem({
           }
           pending={scenePending}
           disabled={sceneDisabled}
+          costDisplay={sceneCostDisplay}
           onClick={() => onPlanScenes(episode.number)}
         />
         <EpisodePlanShortcut
@@ -693,6 +698,7 @@ function EpisodeListItem({
           }
           pending={propPending}
           disabled={propDisabled}
+          costDisplay={propCostDisplay}
           onClick={() => onPlanProps(episode.number)}
         />
       </div>
@@ -799,6 +805,18 @@ function EpisodesPage() {
     (planIdentitiesCost.error instanceof BillingRuleNotConfiguredError
       ? t("common.billingRuleNotConfiguredShort")
       : null);
+  const planScenesCost = useGenerationCreditCost("feature", "episode_scene_planner");
+  const planScenesCostDisplay =
+    planScenesCost.data?.data.display ??
+    (planScenesCost.error instanceof BillingRuleNotConfiguredError
+      ? t("common.billingRuleNotConfiguredShort")
+      : null);
+  const planPropsCost = useGenerationCreditCost("feature", "episode_prop_planner");
+  const planPropsCostDisplay =
+    planPropsCost.data?.data.display ??
+    (planPropsCost.error instanceof BillingRuleNotConfiguredError
+      ? t("common.billingRuleNotConfiguredShort")
+      : null);
   const planScenes = usePlanEpisodeScenes(project);
   const planProps = usePlanEpisodeProps(project);
   const planTask = useStageTask({
@@ -850,7 +868,7 @@ function EpisodesPage() {
     try {
       const res = await planScenes.mutateAsync(episodeNum);
       if (res.ok === false) {
-        toast.error(res.error || t("common.error"));
+        toast.error(backendErrorToastMessage(res.error, t));
         return;
       }
       toast.success(
@@ -860,8 +878,8 @@ function EpisodesPage() {
             })
           : res.message,
       );
-    } catch {
-      toast.error(t("common.error"));
+    } catch (err) {
+      toast.error(backendErrorToastMessage(err, t));
     }
   };
 
@@ -869,7 +887,7 @@ function EpisodesPage() {
     try {
       const res = await planProps.mutateAsync(episodeNum);
       if (res.ok === false) {
-        toast.error(res.error || t("common.error"));
+        toast.error(backendErrorToastMessage(res.error, t));
         return;
       }
       toast.success(
@@ -879,8 +897,8 @@ function EpisodesPage() {
             })
           : res.message,
       );
-    } catch {
-      toast.error(t("common.error"));
+    } catch (err) {
+      toast.error(backendErrorToastMessage(err, t));
     }
   };
 
@@ -1003,6 +1021,8 @@ function EpisodesPage() {
                       onPlanScenes={handlePlanScenes}
                       onPlanProps={handlePlanProps}
                       identityCostDisplay={planIdentitiesCostDisplay}
+                      sceneCostDisplay={planScenesCostDisplay}
+                      propCostDisplay={planPropsCostDisplay}
                       scenePending={
                         planScenes.isPending && planScenes.variables === ep.number
                       }

--- a/src/novelvideo/ports/local/usage.py
+++ b/src/novelvideo/ports/local/usage.py
@@ -125,6 +125,7 @@ class NoOpUsageMeter:
         username: Optional[str],
         project_name: Optional[str],
         resource_kind: str = "",
+        billing_metadata: Optional[dict[str, Any]] = None,
     ) -> None:
         return None
 

--- a/src/novelvideo/ports/usage.py
+++ b/src/novelvideo/ports/usage.py
@@ -92,6 +92,7 @@ class UsageMeter(Protocol):
         username: Optional[str],
         project_name: Optional[str],
         resource_kind: str = "",
+        billing_metadata: Optional[dict[str, Any]] = None,
     ) -> None: ...
 
     async def get_user_credit_balance(self, user_id: str) -> int | None: ...

--- a/src/novelvideo/task_backend/runners/episode_assets.py
+++ b/src/novelvideo/task_backend/runners/episode_assets.py
@@ -52,6 +52,7 @@ async def _run_episode_asset_planner(
     task_type = str(envelope.get("task_type") or "")
     scope = envelope.get("scope")
     payload = envelope.get("payload") or {}
+    billing_metadata = envelope.get("billing_metadata") or {}
     asset_kind = str(payload.get("asset_kind") or _TASK_ASSET_KIND.get(task_type, ""))
     expected_kind = _TASK_ASSET_KIND.get(task_type)
     if asset_kind not in {"scene", "prop"} or (expected_kind and asset_kind != expected_kind):
@@ -66,6 +67,7 @@ async def _run_episode_asset_planner(
         username=ctx.owner_username,
         project_name=ctx.project_name,
         resource_kind="script",
+        billing_metadata=billing_metadata if isinstance(billing_metadata, dict) else None,
     )
 
     label = "场景" if asset_kind == "scene" else "道具"


### PR DESCRIPTION
## Summary
- show feature credit costs for episode scene and prop planning actions
- surface missing billing rules as typed business errors instead of generic request failures
- pass feature billing metadata into episode asset runners so internal model calls remain covered by feature billing

## Tests
- corepack pnpm build
- corepack pnpm test
- ./node_modules/.bin/vitest run src/__tests__/lib/queries/episodes.test.tsx src/__tests__/routes/script-source-editor-integration.test.ts src/__tests__/routes/episodes-workbench-integration.test.ts
- uv run pytest tests/ports/test_usage_noop.py tests/test_task_backend_celery_metadata.py -q
- uv run pytest tests/test_api_model_credit_cost.py -q