### PR TITLE
fix(cli): 删除依赖已删除 filter_characters_simple 的死命令与死分支（F821）

### DIFF
--- a/license-inventory.csv
+++ b/license-inventory.csv
@@ -1567,6 +1567,7 @@ tests/test_character_voice_storage.py,Elastic-2.0,2026 SuperTale contributors,RE
 tests/test_chat_replay_strip.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_chat_route_prewarm.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_chat_service_user_agent_scope.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
+tests/test_cli_cognee_commands.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_cli_store_lifecycle.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_cognee_episode_update_merge.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_cognee_ingest_failure_contract.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation

--- a/src/novelvideo/cli.py
+++ b/src/novelvideo/cli.py
@@ -197,10 +197,8 @@ def cognee_ingest(
 @app.command()
 def cognee_profile(
     project: str = typer.Option(..., "--project", "-p", help="项目名称"),
-    auto_filter: bool = typer.Option(True, "--auto-filter/--no-filter", help="自动过滤泛指角色"),
-    dry_run: bool = typer.Option(False, "--dry-run", help="只显示分类结果，不实际过滤"),
 ):
-    """查看和过滤图谱中的角色（从图谱查询，无需指定小说）。"""
+    """查看图谱中的角色（从图谱查询，无需指定小说）。"""
     _ensure_nest_asyncio()
     console.print(f"[bold blue]Cognee 角色管理[/bold blue]: {project}")
 
@@ -208,11 +206,10 @@ def cognee_profile(
         store = CogneeStore(project)
         await store.initialize()
         # 从图谱查询角色
-        characters = await store.list_characters()
-        return store, characters
+        return await store.list_characters()
 
     try:
-        store, characters = asyncio.run(do_profile())
+        characters = asyncio.run(do_profile())
     except Exception as e:
         console.print(f"[red]❌ 加载角色失败: {e}[/red]")
         raise typer.Exit(1)
@@ -222,112 +219,7 @@ def cognee_profile(
         raise typer.Exit(1)
 
     console.print(f"[cyan]图谱中有 {len(characters)} 个角色[/cyan]")
-
-    if auto_filter:
-        console.print("\n[bold yellow]智能角色分类中...[/bold yellow]")
-
-        async def do_filter():
-            # 使用简化版分类（不需要图谱工具）
-            return await filter_characters_simple(characters)
-
-        try:
-            classification = asyncio.run(do_filter())
-        except Exception as e:
-            console.print(f"[red]❌ 角色分类失败: {e}[/red]")
-            raise typer.Exit(1)
-
-        # 显示分类结果
-        console.print(
-            f"\n[bold green]主要角色 ({len(classification.main_characters)})[/bold green]"
-        )
-        for c in classification.main_characters:
-            console.print(f"  ✓ {c.name}: {c.reason}")
-
-        console.print(
-            f"\n[bold cyan]次要角色 ({len(classification.secondary_characters)})[/bold cyan]"
-        )
-        for c in classification.secondary_characters:
-            console.print(f"  ○ {c.name}: {c.reason}")
-
-        console.print(f"\n[bold red]排除 ({len(classification.exclude)})[/bold red]")
-        for c in classification.exclude:
-            console.print(f"  ✗ {c.name}: {c.reason}")
-
-        if dry_run:
-            console.print("\n[yellow]--dry-run 模式，不执行实际过滤[/yellow]")
-        else:
-            # 只保留 main + secondary
-            keep_names = {c.name for c in classification.main_characters}
-            keep_names.update(c.name for c in classification.secondary_characters)
-
-            filtered_chars = [c for c in characters if c.name in keep_names]
-
-            console.print(f"\n[green]✅ 保留 {len(filtered_chars)} 个角色[/green]")
-    else:
-        console.print(f"[green]✅ 提取 {len(characters)} 个角色（未过滤）[/green]")
-
-
-@app.command()
-def cognee_filter(
-    project: str = typer.Option(..., "--project", "-p", help="项目名称"),
-    dry_run: bool = typer.Option(False, "--dry-run", help="只显示分类结果，不实际过滤"),
-):
-    """对已提取的角色进行智能过滤。"""
-    _ensure_nest_asyncio()
-    console.print(f"[bold blue]Cognee 角色过滤[/bold blue]: {project}")
-
-    async def load_characters():
-        store = CogneeStore(project)
-        await store.initialize()
-        await store.load_graph_state()
-        characters = list(store._characters.values())
-        return store, characters
-
-    try:
-        store, characters = asyncio.run(load_characters())
-    except Exception as e:
-        console.print(f"[red]❌ 加载角色失败: {e}[/red]")
-        raise typer.Exit(1)
-
-    if not characters:
-        console.print("[yellow]⚠️ 未找到已提取的角色，请先运行 cognee-profile[/yellow]")
-        raise typer.Exit(1)
-
-    console.print(f"[cyan]已加载 {len(characters)} 个角色[/cyan]")
-    console.print("\n[bold yellow]智能角色分类中...[/bold yellow]")
-
-    async def do_filter():
-        return await filter_characters_simple(characters)
-
-    try:
-        classification = asyncio.run(do_filter())
-    except Exception as e:
-        console.print(f"[red]❌ 角色分类失败: {e}[/red]")
-        raise typer.Exit(1)
-
-    # 显示分类结果
-    console.print(f"\n[bold green]主要角色 ({len(classification.main_characters)})[/bold green]")
-    for c in classification.main_characters:
-        console.print(f"  ✓ {c.name}: {c.reason}")
-
-    console.print(f"\n[bold cyan]次要角色 ({len(classification.secondary_characters)})[/bold cyan]")
-    for c in classification.secondary_characters:
-        console.print(f"  ○ {c.name}: {c.reason}")
-
-    console.print(f"\n[bold red]排除 ({len(classification.exclude)})[/bold red]")
-    for c in classification.exclude:
-        console.print(f"  ✗ {c.name}: {c.reason}")
-
-    if dry_run:
-        console.print("\n[yellow]--dry-run 模式，不执行实际过滤[/yellow]")
-    else:
-        # 只保留 main + secondary
-        keep_names = {c.name for c in classification.main_characters}
-        keep_names.update(c.name for c in classification.secondary_characters)
-
-        filtered_chars = [c for c in characters if c.name in keep_names]
-
-        console.print(f"\n[green]✅ 保留 {len(filtered_chars)} 个角色[/green]")
+    console.print(f"[green]✅ 提取 {len(characters)} 个角色（未过滤）[/green]")
 
 
 @app.command()

--- a/tests/test_cli_cognee_commands.py
+++ b/tests/test_cli_cognee_commands.py
@@ -1,0 +1,27 @@
+"""锚住:cli.py 中依赖已删除的 filter_characters_simple 的死命令/死分支不再暴露。
+
+背景:EE 侧 d5faed2a 删除 character_filter 模块（filter_characters /
+filter_characters_simple）后，cli.py 仍残留两处调用——cognee-filter 命令整体、
+cognee-profile 的 --auto-filter 分支——一旦触达即 NameError（ruff F821）。
+下列测试锚住"死接口不再暴露给用户"的契约：改前红（仍存在），删除后绿。
+"""
+from typer.testing import CliRunner
+
+from novelvideo.cli import app
+
+runner = CliRunner()
+
+
+def test_cognee_filter_command_removed():
+    """cognee-filter 每条路径都调用未定义函数，整条命令不应再注册。"""
+    result = runner.invoke(app, ["cognee-filter", "--help"])
+    assert result.exit_code != 0
+    assert "No such command" in result.output
+
+
+def test_cognee_profile_drops_dead_auto_filter_options():
+    """cognee-profile 的 --auto-filter/--dry-run 依赖死分支，应移除；命令本身保留可用。"""
+    result = runner.invoke(app, ["cognee-profile", "--help"])
+    assert result.exit_code == 0
+    assert "--auto-filter" not in result.output
+    assert "--dry-run" not in result.output


### PR DESCRIPTION
## PR 类型 / Type of PR
- [x] 🐞 Bug 修复 / Bug fix
- [ ] ✨ 新功能 / Feature
- [ ] 📝 文档 / Documentation
- [ ] 🧹 重构 / 清理 / Refactor or cleanup
- [ ] ⚙️ 构建 / CI / Build or CI
- [ ] ⚠️ 破坏性变更 / Breaking change

## 改动说明 / What this PR does and why
EE 侧 `d5faed2a` 删除 `character_filter` 模块（`filter_characters` / `filter_characters_simple`）后，`src/novelvideo/cli.py` 残留两处对 `filter_characters_simple` 的调用，一旦触达即 `NameError`（ruff F821）——随 CE snapshot 带入后从未可用：

- **`cognee-filter` 命令**：每条路径都调用该函数，整条死 → 整命令删除
- **`cognee-profile` 的 `--auto-filter` 死分支**及 `--auto-filter/--dry-run` 选项 → 删除，保留可用的「从图谱列角色」路径；顺带清理未用的 `store` 解包

`cli.py`：+4 / −112。

## 关联 issue / Linked issues
N/A

## 给 reviewer 的说明 / Notes for the reviewer
- **按 TDD**：先加 `tests/test_cli_cognee_commands.py` 锚住「死接口不再暴露给用户」，在原代码上验证**先红**（命令/选项仍在），删除后**转绿**。
- **证据**：`filter_characters_simple` 在 CE / EE / 原始 SuperTale 三仓均无定义，其分类对象（`.main_characters` 等）也无任何生产者 —— 是真实 latent bug，非本次误删。
- **全量 `uv run pytest`**：1541 passed。4 处失败为 `tests/test_newapi_image_gateway.py` 预存**顺序耦合 flake**——纯净 `origin/main` 亦复现（且红的是另一个测试，隔离单跑全过），与本改动无关，另行治理。
- 这是 ruff 门禁计划里「先单独修真 bug」的一步；**门本身（per-file-ignores 挂账其余存量）另开 PR**，故本 PR 不含任何门禁改动。

## 面向用户的变更 / User-facing change
```release-note
移除无法使用的 cognee-filter 子命令，并从 cognee-profile 去除 --auto-filter/--dry-run 选项（此前触发即报错）。
```

## 自检 / Checklist
- [x] 已自测，`uv run pytest` 通过（除上述预存 flake）
- [x] 必要的文档已更新（N/A：无用户文档涉及）
- [x] 提交信息清晰（Conventional Commits）
- [x] 每个 commit 都已 `git commit -s` 附 DCO 签署
- [ ] 我已阅读并同意贡献者协议（请仓库维护者确认勾选）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
