### PR TITLE
fix(frontend): 修复按钮 loading 刷新后丢失 + 生成卡片进度覆盖层 (#37)

### DIFF
--- a/frontend/src/components/assets/props-panel.tsx
+++ b/frontend/src/components/assets/props-panel.tsx
@@ -50,6 +50,7 @@ import {
 } from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
 import { useTaskController } from "@/hooks/use-task-controller";
+import { propReferenceAssetScope } from "@/lib/task-scope";
 import { backendErrorToastMessage } from "@/lib/api-errors";
 import {
   useBatchGeneratePropReferences,
@@ -256,7 +257,9 @@ function PropAssetCardController({
       taskType: "prop_reference_asset",
       project,
       episode: 0,
-      scope: `prop:${prop.name}:reference`,
+      // Must match the BE-hashed scope (see task-scope.ts), else the button
+      // loses its loading state after a refresh.
+      scope: propReferenceAssetScope(prop.name),
     },
     invalidateKeys: [queryKeys.props(project)],
   });

--- a/frontend/src/components/assets/scenes-panel.tsx
+++ b/frontend/src/components/assets/scenes-panel.tsx
@@ -65,6 +65,10 @@ import {
 } from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
 import { useTaskController } from "@/hooks/use-task-controller";
+import {
+  sceneReferenceAssetScope,
+  stageAssetScope,
+} from "@/lib/task-scope";
 import { openPresetProjectionInMyCanvas } from "@/features/freezone/openPresetProjection";
 import { sceneTypeLabel, sceneTypeOptions } from "@/lib/scene-type";
 import { timeOfDayLabel, timeOfDayOptions } from "@/lib/time-of-day";
@@ -611,12 +615,20 @@ function SceneAssetCardController({
   const generateStagePly = useGenerateScene3gsPlyAsync(project, scene.name);
   const saveDirectorWorld = useSaveSceneDirectorWorld(project, scene.name);
   const clearDirectorWorld = useClearSceneDirectorWorld(project, scene.name);
+  // Reconcile keys must reproduce the BE-hashed task scope exactly (see
+  // task-scope.ts) — a human-readable placeholder never matches the row stored
+  // on `/tasks`, so loading state is silently dropped after a refresh.
+  // Pano runs are keyed by source: when a master exists the BE step is
+  // `pano_from_master`, otherwise `pano_from_text` (mirrors the card's
+  // `panoSource = hasMaster ? "master" : "text"`).
+  const hasMaster = Boolean(resolveMediaUrl(scene.master_url));
+  const panoStep = hasMaster ? "pano_from_master" : "pano_from_text";
   const masterTask = useTaskController({
     key: {
       taskType: "scene_reference_asset",
       project,
       episode: 0,
-      scope: `scene:${scene.name}:master`,
+      scope: sceneReferenceAssetScope(scene.name, "master"),
     },
     invalidateKeys: [queryKeys.scenes(project)],
   });
@@ -625,7 +637,7 @@ function SceneAssetCardController({
       taskType: "stage_asset",
       project,
       episode: 0,
-      scope: `scene:${scene.name}:pano`,
+      scope: stageAssetScope(scene.name, panoStep),
     },
     invalidateKeys: [queryKeys.scenes(project)],
   });
@@ -634,7 +646,7 @@ function SceneAssetCardController({
       taskType: "scene_reference_asset",
       project,
       episode: 0,
-      scope: `scene:${scene.name}:reverse`,
+      scope: sceneReferenceAssetScope(scene.name, "reverse_master"),
     },
     invalidateKeys: [queryKeys.scenes(project)],
   });
@@ -643,7 +655,7 @@ function SceneAssetCardController({
       taskType: "stage_asset",
       project,
       episode: 0,
-      scope: `scene:${scene.name}:single_face_sharp`,
+      scope: stageAssetScope(scene.name, "single_face_sharp"),
     },
     invalidateKeys: [queryKeys.scenes(project)],
     onComplete: () => setStagePlySource(null),
@@ -654,7 +666,7 @@ function SceneAssetCardController({
       taskType: "stage_asset",
       project,
       episode: 0,
-      scope: `scene:${scene.name}:pano_sharp`,
+      scope: stageAssetScope(scene.name, "pano_sharp"),
     },
     invalidateKeys: [queryKeys.scenes(project)],
     onComplete: () => setStagePlySource(null),

--- a/frontend/src/components/episode/beat-workbench/render-section.tsx
+++ b/frontend/src/components/episode/beat-workbench/render-section.tsx
@@ -18,6 +18,7 @@ import {
   Lock,
   Loader2,
   RefreshCw,
+  Square,
   SunMedium,
   Upload,
   X,
@@ -203,6 +204,14 @@ export function RenderSection({
     : null;
   const detailRender = assignedRender ?? candidates[0] ?? null;
   const previewUrl = beat.frame_url ?? detailRender?.cell_url ?? null;
+  // Live loading state for the preview card while a render regen runs. Progress
+  // comes from the active task's SSE stream (0–1) and survives refresh because
+  // the controller reconciles against the persisted task row.
+  const renderActive = regenTask.started;
+  const renderPercent = Math.max(
+    0,
+    Math.min(100, Math.round((regenTask.stream?.progress ?? 0) * 100)),
+  );
   const backgroundData =
     backgroundAnchors.data?.ok === true ? backgroundAnchors.data.data : null;
   const currentBackgroundSource =
@@ -387,30 +396,55 @@ export function RenderSection({
     <div className="flex flex-col gap-3">
       <section className="rounded-[10px] border border-white/[0.055] bg-white/[0.016] p-3">
         <div className={RENDER_GRID_CLASS}>
-          {/* Left: preview image */}
-          {previewUrl ? (
-            <button
-              type="button"
-              onClick={() => {
-                const safe = resolveMediaUrl(previewUrl);
-                if (safe) onPreview?.(safe);
-              }}
-              className={RENDER_PREVIEW_CLASS}
-              style={{ aspectRatio: ratioToCss(aspectSpec.renderAspect) }}
-            >
-              <img
-                src={resolveMediaUrl(previewUrl) ?? ""}
-                alt={`Beat ${beat.beat_number} render`}
-                className={RENDER_PREVIEW_IMAGE_CLASS}
-                loading="lazy"
-                decoding="async"
-              />
-            </button>
-          ) : (
-            <div className={RENDER_EMPTY_CLASS} style={{ aspectRatio: ratioToCss(aspectSpec.renderAspect) }}>
-              {t("episode.beat.noRender")}
-            </div>
-          )}
+          {/* Left: preview image (with a live progress overlay while generating) */}
+          <div className="relative justify-self-start">
+            {previewUrl ? (
+              <button
+                type="button"
+                onClick={() => {
+                  const safe = resolveMediaUrl(previewUrl);
+                  if (safe) onPreview?.(safe);
+                }}
+                className={RENDER_PREVIEW_CLASS}
+                style={{ aspectRatio: ratioToCss(aspectSpec.renderAspect) }}
+              >
+                <img
+                  src={resolveMediaUrl(previewUrl) ?? ""}
+                  alt={`Beat ${beat.beat_number} render`}
+                  className={RENDER_PREVIEW_IMAGE_CLASS}
+                  loading="lazy"
+                  decoding="async"
+                />
+              </button>
+            ) : (
+              <div className={RENDER_EMPTY_CLASS} style={{ aspectRatio: ratioToCss(aspectSpec.renderAspect) }}>
+                {t("episode.beat.noRender")}
+              </div>
+            )}
+            {renderActive && (
+              <div
+                className="pointer-events-none absolute inset-0 z-10 flex flex-col items-center justify-center gap-2 rounded-[10px] bg-black/55 backdrop-blur-[1px]"
+                role="progressbar"
+                aria-valuemin={0}
+                aria-valuemax={100}
+                aria-valuenow={renderPercent}
+              >
+                <Loader2 aria-hidden className="size-5 animate-spin text-white/90" />
+                <div className="flex items-baseline leading-none text-white">
+                  <span className="text-2xl font-semibold tabular-nums tracking-tight">
+                    {renderPercent}
+                  </span>
+                  <span className="ml-0.5 text-xs font-medium text-white/70">%</span>
+                </div>
+                <div className="h-1 w-24 overflow-hidden rounded-full bg-white/20">
+                  <div
+                    className="h-full rounded-full bg-white/85 transition-[width] duration-300 ease-out"
+                    style={{ width: `${renderPercent}%` }}
+                  />
+                </div>
+              </div>
+            )}
+          </div>
 
           {/* Right: candidates + actions */}
           <div className="flex min-h-0 flex-col gap-2.5">
@@ -466,19 +500,36 @@ export function RenderSection({
           {/* Actions — full width row below both columns */}
           <div className="col-span-2 flex flex-wrap items-center gap-x-3 gap-y-2 pt-1">
             <div className="flex items-center gap-1.5">
-              <Button
-                size="xs"
-                variant="outline"
-                onClick={() => setRegenConfirm(true)}
-                disabled={regenerate.isPending}
-                className={MEDIA_PRIMARY_ACTION_BUTTON_CLASS}
-              >
-                {regenerate.isPending ? <Loader2 className="size-3 animate-spin" /> : <RefreshCw className="size-3" />}
-                {previewUrl
-                  ? t("common.regenerate")
-                  : t("episode.workbench.render.generateNew")}
-                <CreditCostInline display={renderRegenCost.data?.data.display} />
-              </Button>
+              {regenTask.started ? (
+                <Button
+                  size="xs"
+                  variant="outline"
+                  onClick={() => void regenTask.stop()}
+                  disabled={regenTask.stopping}
+                  className={MEDIA_PRIMARY_ACTION_BUTTON_CLASS}
+                >
+                  {regenTask.stopping ? (
+                    <Loader2 className="size-3 animate-spin" />
+                  ) : (
+                    <Square className="size-3" />
+                  )}
+                  {t("common.stop")}
+                </Button>
+              ) : (
+                <Button
+                  size="xs"
+                  variant="outline"
+                  onClick={() => setRegenConfirm(true)}
+                  disabled={regenerate.isPending}
+                  className={MEDIA_PRIMARY_ACTION_BUTTON_CLASS}
+                >
+                  {regenerate.isPending ? <Loader2 className="size-3 animate-spin" /> : <RefreshCw className="size-3" />}
+                  {previewUrl
+                    ? t("common.regenerate")
+                    : t("episode.workbench.render.generateNew")}
+                  <CreditCostInline display={renderRegenCost.data?.data.display} />
+                </Button>
+              )}
               {renderPlatePreview ? (
                 <RenderRelightBadge
                   relight={renderPlatePreview.relight}

--- a/frontend/src/components/episode/beat-workbench/sketch-section.tsx
+++ b/frontend/src/components/episode/beat-workbench/sketch-section.tsx
@@ -3,7 +3,7 @@
 import { useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
-import { Accessibility, Box, Crop, Download, ExternalLink, ImageIcon, Loader2, Package, RefreshCw, Sparkles, Upload } from "lucide-react";
+import { Accessibility, Box, Crop, Download, ExternalLink, ImageIcon, Loader2, Package, RefreshCw, Sparkles, Square, Upload } from "lucide-react";
 
 import { useGenerationCreditCost } from "@/lib/queries/generation-credit-cost";
 import {
@@ -180,6 +180,16 @@ export function SketchSection({
 
   const resolved = resolveImage(images, assignments, beat.beat_number, "sketch", beat.sketch_url ?? null);
   const resolvedDownloadUrl = resolved.url ? resolveMediaUrl(resolved.url) : null;
+  // Live loading state for the preview card: either the director generation or
+  // a regen run drives the overlay. Progress from the active task's SSE stream
+  // (0–1) is surfaced as a percentage; it survives refresh because both
+  // controllers reconcile against the persisted task row.
+  const sketchActive = directorTask.started || regenTask.started;
+  const sketchStream = directorTask.started ? directorTask.stream : regenTask.stream;
+  const sketchPercent = Math.max(
+    0,
+    Math.min(100, Math.round((sketchStream?.progress ?? 0) * 100)),
+  );
   const candidates = images
     .filter((i) => i.type === "sketch" && i.cell_url)
     .sort((a, b) => {
@@ -486,30 +496,55 @@ export function SketchSection({
         </div>
       )}
 
-      {/* Left: preview image */}
-      {resolved.url ? (
-        <button
-          type="button"
-          onClick={() => {
-            const safe = resolveMediaUrl(resolved.url);
-            if (safe) onPreview?.(safe);
-          }}
-          className={SKETCH_PREVIEW_CLASS}
-          style={{ aspectRatio: ratioToCss(spec.sketchAspect) }}
-        >
-          <img
-            src={resolveMediaUrl(resolved.url) ?? ""}
-            alt={`Beat ${beat.beat_number} sketch`}
-            className={SKETCH_PREVIEW_IMAGE_CLASS}
-            loading="lazy"
-            decoding="async"
-          />
-        </button>
-      ) : (
-        <div className={SKETCH_EMPTY_CLASS} style={{ aspectRatio: ratioToCss(spec.sketchAspect) }}>
-          {t("episode.beat.noSketch")}
-        </div>
-      )}
+      {/* Left: preview image (with a live progress overlay while generating) */}
+      <div className="relative justify-self-start">
+        {resolved.url ? (
+          <button
+            type="button"
+            onClick={() => {
+              const safe = resolveMediaUrl(resolved.url);
+              if (safe) onPreview?.(safe);
+            }}
+            className={SKETCH_PREVIEW_CLASS}
+            style={{ aspectRatio: ratioToCss(spec.sketchAspect) }}
+          >
+            <img
+              src={resolveMediaUrl(resolved.url) ?? ""}
+              alt={`Beat ${beat.beat_number} sketch`}
+              className={SKETCH_PREVIEW_IMAGE_CLASS}
+              loading="lazy"
+              decoding="async"
+            />
+          </button>
+        ) : (
+          <div className={SKETCH_EMPTY_CLASS} style={{ aspectRatio: ratioToCss(spec.sketchAspect) }}>
+            {t("episode.beat.noSketch")}
+          </div>
+        )}
+        {sketchActive && (
+          <div
+            className="pointer-events-none absolute inset-0 z-10 flex flex-col items-center justify-center gap-2 rounded-[10px] bg-black/55 backdrop-blur-[1px]"
+            role="progressbar"
+            aria-valuemin={0}
+            aria-valuemax={100}
+            aria-valuenow={sketchPercent}
+          >
+            <Loader2 aria-hidden className="size-5 animate-spin text-white/90" />
+            <div className="flex items-baseline leading-none text-white">
+              <span className="text-2xl font-semibold tabular-nums tracking-tight">
+                {sketchPercent}
+              </span>
+              <span className="ml-0.5 text-xs font-medium text-white/70">%</span>
+            </div>
+            <div className="h-1 w-24 overflow-hidden rounded-full bg-white/20">
+              <div
+                className="h-full rounded-full bg-white/85 transition-[width] duration-300 ease-out"
+                style={{ width: `${sketchPercent}%` }}
+              />
+            </div>
+          </div>
+        )}
+      </div>
 
       {/* Right: casted characters + candidates + actions */}
       <div className="flex min-h-0 flex-col gap-2.5">
@@ -536,20 +571,37 @@ export function SketchSection({
                 {t("episode.workbench.sketch.directorControlFile")}
               </div>
             </div>
-            <Button
-              size="xs"
-              variant="outline"
-              onClick={handleConvertDirectorControl}
-              disabled={directorConvert.isPending}
-              className="gap-1"
-            >
-              {directorConvert.isPending ? (
-                <Loader2 className="size-3 animate-spin" />
-              ) : (
-                <Sparkles className="size-3" />
-              )}
-              {t("episode.workbench.sketch.convertDirectorControl")}
-            </Button>
+            {directorTask.started ? (
+              <Button
+                size="xs"
+                variant="outline"
+                onClick={() => void directorTask.stop()}
+                disabled={directorTask.stopping}
+                className="gap-1"
+              >
+                {directorTask.stopping ? (
+                  <Loader2 className="size-3 animate-spin" />
+                ) : (
+                  <Square className="size-3" />
+                )}
+                {t("common.stop")}
+              </Button>
+            ) : (
+              <Button
+                size="xs"
+                variant="outline"
+                onClick={handleConvertDirectorControl}
+                disabled={directorConvert.isPending}
+                className="gap-1"
+              >
+                {directorConvert.isPending ? (
+                  <Loader2 className="size-3 animate-spin" />
+                ) : (
+                  <Sparkles className="size-3" />
+                )}
+                {t("episode.workbench.sketch.convertDirectorControl")}
+              </Button>
+            )}
           </div>
         )}
         {candidates.length > 0 && (
@@ -602,19 +654,36 @@ export function SketchSection({
       {/* Actions — full width row below both columns */}
       <div className="col-span-2 flex flex-wrap items-center gap-x-3 gap-y-2 pt-1">
         <div className="flex items-center gap-1.5">
-          <Button
-            size="xs"
-            variant="outline"
-            onClick={() => setRegenConfirm(true)}
-            disabled={regenerate.isPending}
-            className={MEDIA_PRIMARY_ACTION_BUTTON_CLASS}
-          >
-            {regenerate.isPending ? <Loader2 className="size-3 animate-spin" /> : <RefreshCw className="size-3" />}
-            {hasSketch
-              ? t("common.regenerate")
-              : t("episode.workbench.sketch.generateNow")}
-            <CreditCostInline display={sketchRegenCost.data?.data.display} />
-          </Button>
+          {regenTask.started ? (
+            <Button
+              size="xs"
+              variant="outline"
+              onClick={() => void regenTask.stop()}
+              disabled={regenTask.stopping}
+              className={MEDIA_PRIMARY_ACTION_BUTTON_CLASS}
+            >
+              {regenTask.stopping ? (
+                <Loader2 className="size-3 animate-spin" />
+              ) : (
+                <Square className="size-3" />
+              )}
+              {t("common.stop")}
+            </Button>
+          ) : (
+            <Button
+              size="xs"
+              variant="outline"
+              onClick={() => setRegenConfirm(true)}
+              disabled={regenerate.isPending}
+              className={MEDIA_PRIMARY_ACTION_BUTTON_CLASS}
+            >
+              {regenerate.isPending ? <Loader2 className="size-3 animate-spin" /> : <RefreshCw className="size-3" />}
+              {hasSketch
+                ? t("common.regenerate")
+                : t("episode.workbench.sketch.generateNow")}
+              <CreditCostInline display={sketchRegenCost.data?.data.display} />
+            </Button>
+          )}
         </div>
         <div className="flex items-center gap-1.5">
           <Button

--- a/frontend/src/components/episode/beat-workbench/video-pane.tsx
+++ b/frontend/src/components/episode/beat-workbench/video-pane.tsx
@@ -25,6 +25,7 @@ import {
   RefreshCw,
   Scissors,
   Settings2,
+  Square,
   Trash2,
   Upload,
   WandSparkles,
@@ -281,6 +282,18 @@ export function VideoPane({
       queryKeys.videoPool(project, episode),
     ],
   });
+  // Beat 视频提示词生成在 EE 下是后台任务（同步分支仅 CE 单机命中），mutateAsync
+  // 只拿到入队 ack，isPending 一闪而过。用任务控制器让 loading 覆盖真实生成过程，
+  // 并在刷新后仍能恢复；完成后 invalidate beats 会把提示词回填到文本框。
+  const beatVideoPromptTask = useTaskController({
+    key: {
+      taskType: "beat_video_prompt",
+      project,
+      episode,
+      beatNum: beat.beat_number,
+    },
+    invalidateKeys: [queryKeys.beats(project, episode)],
+  });
   const poolSelect = useVideoPoolSelect(project, episode);
   const { data: poolRes } = useVideoPool(project, episode);
   const { data: videoBackendsRes } = useVideoBackends(project);
@@ -449,6 +462,14 @@ export function VideoPane({
     legacyPromptField,
   ]);
   const previewAspectCss = "16 / 9";
+  // Live loading state for the video preview while a single-shot regen runs.
+  // Progress comes from the active task's SSE stream (0–1) and survives refresh
+  // because the controller reconciles against the persisted task row.
+  const videoActive = regenTask.started;
+  const videoPercent = Math.max(
+    0,
+    Math.min(100, Math.round((regenTask.stream?.progress ?? 0) * 100)),
+  );
   const seedance2Status = useSeedance2BeatStatus(
     project,
     episode,
@@ -1305,6 +1326,7 @@ export function VideoPane({
         return;
       }
       if (!("data" in res)) {
+        beatVideoPromptTask.start();
         toast.success(t("episode.workbench.video.beatVideoPromptGenerateStarted"));
         return;
       }
@@ -1352,6 +1374,29 @@ export function VideoPane({
           >
             <Download className="size-3.5" />
           </a>
+        )}
+        {videoActive && (
+          <div
+            className="pointer-events-none absolute inset-0 z-20 flex flex-col items-center justify-center gap-2 rounded-[10px] bg-black/55 backdrop-blur-[1px]"
+            role="progressbar"
+            aria-valuemin={0}
+            aria-valuemax={100}
+            aria-valuenow={videoPercent}
+          >
+            <Loader2 aria-hidden className="size-5 animate-spin text-white/90" />
+            <div className="flex items-baseline leading-none text-white">
+              <span className="text-2xl font-semibold tabular-nums tracking-tight">
+                {videoPercent}
+              </span>
+              <span className="ml-0.5 text-xs font-medium text-white/70">%</span>
+            </div>
+            <div className="h-1 w-24 overflow-hidden rounded-full bg-white/20">
+              <div
+                className="h-full rounded-full bg-white/85 transition-[width] duration-300 ease-out"
+                style={{ width: `${videoPercent}%` }}
+              />
+            </div>
+          </div>
         )}
       </div>
 
@@ -1438,11 +1483,14 @@ export function VideoPane({
             <Button
               size="xs"
               variant="outline"
-              disabled={generateBeatVideoPrompt.isPending}
+              disabled={
+                generateBeatVideoPrompt.isPending || beatVideoPromptTask.started
+              }
               onClick={() => void handleGenerateBeatVideoPrompt()}
               className={MEDIA_PRIMARY_ACTION_BUTTON_CLASS}
             >
-              {generateBeatVideoPrompt.isPending ? (
+              {generateBeatVideoPrompt.isPending ||
+              beatVideoPromptTask.started ? (
                 <Loader2 className="size-3 animate-spin" />
               ) : (
                 <WandSparkles className="size-3" />
@@ -1628,23 +1676,40 @@ export function VideoPane({
             </>
           )}
           <VideoParamField label="" hiddenLabel>
-            <Button
-              size="xs"
-              variant="outline"
-              onClick={openRegenConfirm}
-              disabled={regenerate.isPending}
-              className={VIDEO_PARAM_ACTION_CLASS}
-            >
-              {regenerate.isPending ? (
-                <Loader2 className="size-3 animate-spin" />
-              ) : hasGeneratedVideo ? (
-                <RefreshCw className="size-3" />
-              ) : (
-                <Film className="size-3" />
-              )}
-              {videoActionLabel}
-              <CreditCostInline display={videoCost.data?.data.display} />
-            </Button>
+            {regenTask.started ? (
+              <Button
+                size="xs"
+                variant="outline"
+                onClick={() => void regenTask.stop()}
+                disabled={regenTask.stopping}
+                className={VIDEO_PARAM_ACTION_CLASS}
+              >
+                {regenTask.stopping ? (
+                  <Loader2 className="size-3 animate-spin" />
+                ) : (
+                  <Square className="size-3" />
+                )}
+                {t("common.stop")}
+              </Button>
+            ) : (
+              <Button
+                size="xs"
+                variant="outline"
+                onClick={openRegenConfirm}
+                disabled={regenerate.isPending}
+                className={VIDEO_PARAM_ACTION_CLASS}
+              >
+                {regenerate.isPending ? (
+                  <Loader2 className="size-3 animate-spin" />
+                ) : hasGeneratedVideo ? (
+                  <RefreshCw className="size-3" />
+                ) : (
+                  <Film className="size-3" />
+                )}
+                {videoActionLabel}
+                <CreditCostInline display={videoCost.data?.data.display} />
+              </Button>
+            )}
           </VideoParamField>
         </div>
       )}
@@ -2418,23 +2483,40 @@ export function VideoPane({
                     : t("episode.workbench.video.seedance2GeneratePrompt")}
                   <CreditCostInline display={seedance2PromptCostDisplay} />
                 </Button>
-                <Button
-                  size="xs"
-                  variant="outline"
-                  onClick={openRegenConfirm}
-                  disabled={regenerate.isPending}
-                  className={MEDIA_PRIMARY_ACTION_BUTTON_CLASS}
-                >
-                  {regenerate.isPending ? (
-                    <Loader2 className="size-3 animate-spin" />
-                  ) : hasGeneratedVideo ? (
-                    <RefreshCw className="size-3" />
-                  ) : (
-                    <Film className="size-3" />
-                  )}
-                  {videoActionLabel}
-                  <CreditCostInline display={videoCost.data?.data.display} />
-                </Button>
+                {regenTask.started ? (
+                  <Button
+                    size="xs"
+                    variant="outline"
+                    onClick={() => void regenTask.stop()}
+                    disabled={regenTask.stopping}
+                    className={MEDIA_PRIMARY_ACTION_BUTTON_CLASS}
+                  >
+                    {regenTask.stopping ? (
+                      <Loader2 className="size-3 animate-spin" />
+                    ) : (
+                      <Square className="size-3" />
+                    )}
+                    {t("common.stop")}
+                  </Button>
+                ) : (
+                  <Button
+                    size="xs"
+                    variant="outline"
+                    onClick={openRegenConfirm}
+                    disabled={regenerate.isPending}
+                    className={MEDIA_PRIMARY_ACTION_BUTTON_CLASS}
+                  >
+                    {regenerate.isPending ? (
+                      <Loader2 className="size-3 animate-spin" />
+                    ) : hasGeneratedVideo ? (
+                      <RefreshCw className="size-3" />
+                    ) : (
+                      <Film className="size-3" />
+                    )}
+                    {videoActionLabel}
+                    <CreditCostInline display={videoCost.data?.data.display} />
+                  </Button>
+                )}
               </div>
             </div>
           </div>

--- a/frontend/src/lib/task-scope.test.ts
+++ b/frontend/src/lib/task-scope.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  propReferenceAssetScope,
+  sceneReferenceAssetScope,
+  stageAssetScope,
+} from "./task-scope";
+
+// Golden values produced by the backend's own helpers
+// (novelvideo.task_scopes) so the FE hash stays byte-compatible with the
+// scope stored on task rows. If these drift, `useTaskController` reconcile
+// stops matching and loading state is lost on refresh.
+describe("task-scope hashing matches the backend", () => {
+  it("scene_reference_asset_scope", () => {
+    expect(sceneReferenceAssetScope("大学宿舍", "master")).toBe(
+      "scene_ref__f126561a8bba",
+    );
+    // `reverse_master` is the kind the BE uses for the 背面 image (not "reverse").
+    expect(sceneReferenceAssetScope("大学宿舍", "reverse_master")).toBe(
+      "scene_ref__02e6e3b31892",
+    );
+    expect(sceneReferenceAssetScope("苏鸢寝殿", "master")).toBe(
+      "scene_ref__d902739345bd",
+    );
+    expect(sceneReferenceAssetScope("苏鸢寝殿", "reverse_master")).toBe(
+      "scene_ref__c99c0228dd85",
+    );
+  });
+
+  it("stage_asset_scope", () => {
+    expect(stageAssetScope("大学宿舍", "pano_from_master")).toBe(
+      "stage_asset__0060da8d52de",
+    );
+    expect(stageAssetScope("大学宿舍", "pano_from_text")).toBe(
+      "stage_asset__03118b334715",
+    );
+    expect(stageAssetScope("大学宿舍", "single_face_sharp")).toBe(
+      "stage_asset__a1b352c6307b",
+    );
+    expect(stageAssetScope("大学宿舍", "pano_sharp")).toBe(
+      "stage_asset__f3813dfc19bc",
+    );
+    expect(stageAssetScope("苏鸢寝殿", "pano_from_master")).toBe(
+      "stage_asset__f70b565fb943",
+    );
+    expect(stageAssetScope("苏鸢寝殿", "pano_sharp")).toBe(
+      "stage_asset__d81c1edae22e",
+    );
+  });
+
+  it("prop_reference_asset_scope", () => {
+    expect(propReferenceAssetScope("道具A")).toBe("prop_ref__a6d6813f7e52");
+    expect(propReferenceAssetScope("sword")).toBe("prop_ref__d36303bf3afe");
+    expect(propReferenceAssetScope("宝剑")).toBe("prop_ref__a87302d6d2cc");
+  });
+});

--- a/frontend/src/lib/task-scope.ts
+++ b/frontend/src/lib/task-scope.ts
@@ -1,0 +1,116 @@
+/**
+ * Frontend mirror of the backend task-scope hashing in
+ * `novelvideo/task_identity.py` + `novelvideo/task_scopes.py`.
+ *
+ * The backend derives a task's `scope` as:
+ *   hashed_scope(label, json.dumps(config, sort_keys=True,
+ *                                  ensure_ascii=False, separators=(",", ":")))
+ *   -> `${label}__${sha1(payloadUtf8).hex.slice(0, 12)}`
+ *
+ * `useTaskController` reconciles a card against the live `/tasks` list by
+ * comparing `key.scope` to the row's stored `scope`. That stored scope is the
+ * hashed value above, so the FE reconcile key MUST reproduce the exact same
+ * hash — a human-readable placeholder like `scene:大学宿舍:pano` never matches,
+ * which silently drops the loading state after a refresh.
+ */
+
+/** Synchronous SHA-1 over raw bytes, returning lowercase hex. */
+function sha1Hex(bytes: Uint8Array): string {
+  const withOne = bytes.length + 1;
+  const totalLen = withOne + (((56 - (withOne % 64)) + 64) % 64) + 8;
+  const msg = new Uint8Array(totalLen);
+  msg.set(bytes);
+  msg[bytes.length] = 0x80;
+
+  const dv = new DataView(msg.buffer);
+  const bitLen = bytes.length * 8;
+  dv.setUint32(totalLen - 8, Math.floor(bitLen / 0x100000000));
+  dv.setUint32(totalLen - 4, bitLen >>> 0);
+
+  let h0 = 0x67452301;
+  let h1 = 0xefcdab89;
+  let h2 = 0x98badcfe;
+  let h3 = 0x10325476;
+  let h4 = 0xc3d2e1f0;
+  const w = new Uint32Array(80);
+
+  for (let off = 0; off < totalLen; off += 64) {
+    for (let i = 0; i < 16; i++) w[i] = dv.getUint32(off + i * 4);
+    for (let i = 16; i < 80; i++) {
+      const n = w[i - 3] ^ w[i - 8] ^ w[i - 14] ^ w[i - 16];
+      w[i] = ((n << 1) | (n >>> 31)) >>> 0;
+    }
+    let a = h0;
+    let b = h1;
+    let c = h2;
+    let d = h3;
+    let e = h4;
+    for (let i = 0; i < 80; i++) {
+      let f: number;
+      let k: number;
+      if (i < 20) {
+        f = (b & c) | (~b & d);
+        k = 0x5a827999;
+      } else if (i < 40) {
+        f = b ^ c ^ d;
+        k = 0x6ed9eba1;
+      } else if (i < 60) {
+        f = (b & c) | (b & d) | (c & d);
+        k = 0x8f1bbcdc;
+      } else {
+        f = b ^ c ^ d;
+        k = 0xca62c1d6;
+      }
+      const tmp = (((a << 5) | (a >>> 27)) + f + e + k + w[i]) >>> 0;
+      e = d;
+      d = c;
+      c = ((b << 30) | (b >>> 2)) >>> 0;
+      b = a;
+      a = tmp;
+    }
+    h0 = (h0 + a) >>> 0;
+    h1 = (h1 + b) >>> 0;
+    h2 = (h2 + c) >>> 0;
+    h3 = (h3 + d) >>> 0;
+    h4 = (h4 + e) >>> 0;
+  }
+
+  const hex = (n: number) => `0000000${(n >>> 0).toString(16)}`.slice(-8);
+  return hex(h0) + hex(h1) + hex(h2) + hex(h3) + hex(h4);
+}
+
+/**
+ * Canonical JSON matching Python's
+ * `json.dumps(config, sort_keys=True, ensure_ascii=False, separators=(",", ":"))`.
+ * Keys are sorted; `JSON.stringify` on each string yields the same escaping and
+ * keeps non-ASCII characters raw (matching `ensure_ascii=False`).
+ */
+function canonicalJson(config: Record<string, string>): string {
+  const keys = Object.keys(config).sort();
+  const parts = keys.map((k) => `${JSON.stringify(k)}:${JSON.stringify(config[k])}`);
+  return `{${parts.join(",")}}`;
+}
+
+/** Mirror of `task_config_scope(label, config)`. */
+export function taskConfigScope(label: string, config: Record<string, string>): string {
+  const payload = new TextEncoder().encode(canonicalJson(config));
+  return `${label}__${sha1Hex(payload).slice(0, 12)}`;
+}
+
+/** Mirror of `scene_reference_asset_scope` — kinds: "master", "reverse". */
+export function sceneReferenceAssetScope(sceneName: string, kind: string): string {
+  return taskConfigScope("scene_ref", { scene: sceneName, kind });
+}
+
+/**
+ * Mirror of `stage_asset_scope` — steps: "pano_from_master", "pano_from_text",
+ * "single_face_sharp", "pano_sharp".
+ */
+export function stageAssetScope(sceneName: string, step: string): string {
+  return taskConfigScope("stage_asset", { scene: sceneName, step });
+}
+
+/** Mirror of `prop_reference_asset_scope`. */
+export function propReferenceAssetScope(propName: string): string {
+  return taskConfigScope("prop_ref", { prop: propName });
+}

--- a/license-inventory.csv
+++ b/license-inventory.csv
@@ -1046,6 +1046,8 @@ frontend/src/lib/script-feedback.ts,Elastic-2.0,2026 SuperTale contributors,REUS
 frontend/src/lib/sketch-colors.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/lib/sketch-pose-editor-model.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/lib/style-preview-url.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
+frontend/src/lib/task-scope.test.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
+frontend/src/lib/task-scope.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/lib/task-types.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/lib/time-of-day.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/lib/url-params.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation


### PR DESCRIPTION
## 背景

Closes #37

存在一类按钮：点击后显示 loading，但**刷新页面后 loading 状态丢失**。

## 根因

场景 / 道具素材的任务 `scope` 在后端经 SHA-1 哈希生成（`task_config_scope(label, config)` → `${label}__${sha1(canonical_json).hex[:12]}`），而前端 `useTaskController` 的 reconcile key 之前用的是人类可读字面量（如 `scene:大学宿舍:pano`），永远匹配不上 `/tasks` 里持久化的任务行 → 刷新后无法把 loading 状态 reconcile 回来。

（角色素材用的是后端 f-string 明文 scope，前后端一致，未受影响。）

## 改动

- **新增 `src/lib/task-scope.ts`**：把后端 `hashed_scope` / `task_config_scope` 的 SHA-1 + canonical JSON（`sort_keys` + `ensure_ascii=False` + 紧凑分隔符）逻辑移植到 TS，保证前端算出的 scope 与任务行字节兼容。
- **新增 `task-scope.test.ts`**：以后端 helper 产出的 golden values 做单测，防止前后端哈希漂移（3/3 通过）。
- **`scenes-panel.tsx`**：master / pano / reverse_master / single_face_sharp / pano_sharp 共 5 个 reconcile key 改用哈希 scope。
- **`props-panel.tsx`**：道具参考图 reconcile key 改用哈希 scope。
- **`video-pane.tsx`**：beat 视频提示词按钮补 `beat_video_prompt` controller，点击即显 loading，提示词生成完自动消失。
- **草图 / 渲染图 / 视频预览卡片**：新增统一进度覆盖层（`Loader2` 旋转 + 大号百分比 + 进度条），进度取活跃任务的 SSE `stream.progress`，刷新后随 reconcile 恢复。

## 验证

- `pnpm tsc -b` ✅
- `pnpm build` ✅
- `npx vitest run src/lib/task-scope.test.ts` ✅ 3/3

🤖 Generated with [Claude Code](https://claude.com/claude-code)