### PR TITLE
ci: ruff 转真门禁（基线豁免模式）——只管新增代码，存量逐步治理

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: ci
 
 # INFRA-01：CI 地基。安装 uv（启用依赖缓存，按 uv.lock 取键）、校验锁文件一致性、
 # 按锁文件安装依赖。依赖含 torch/cuda（约 1GB）：首跑写满缓存，之后 run 命中缓存。
-# 在同一 job 内复用已装好的依赖，跑 ruff lint（非阻断）+ 端口闭合守栏 + pytest。
+# 在同一 job 内复用已装好的依赖，跑 ruff lint（必过门，存量走基线豁免）+ 端口闭合守栏 + pytest。
 
 on:
   push:
@@ -29,11 +29,11 @@ jobs:
       # novelvideo.ports.local.* 满足、无外部适配器。需装好依赖故挂在 deps job。
       - name: Check port closure
         run: uv run python scripts/check_ce_port_closure.py
-      # Lint：项目尚未引入 ruff 配置，先以非阻断（报告 GitHub 注解）方式接入。
-      # 待存量问题清零后，去掉 continue-on-error 即转为合入必过门。
-      - name: Lint (ruff, non-blocking)
-        continue-on-error: true
-        run: uvx ruff check --output-format=github .
+      # Lint：合入必过门，只管新增代码——存量以 per-file-ignores 基线豁免（见
+      # pyproject [tool.ruff.lint.per-file-ignores]），逐文件治理、修完删条目。
+      # 规则集冻结在 pyproject，ruff 版本锁定于 dev 依赖组，CI 与本地同版。
+      - name: Lint (ruff)
+        run: uv run ruff check --output-format=github .
       # 单元测试：pytest 默认 addopts 已排除 ee/e2e；-n auto 走 xdist 并行。
       - name: Run tests
         run: uv run pytest -n auto

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,7 +83,83 @@ dev = [
     "pytest-xdist>=3.5.0",
     "fakeredis>=2.20.0",
     "respx>=0.22.0",
+    "ruff==0.15.20",
 ]
+
+[tool.ruff]
+target-version = "py311"
+
+[tool.ruff.lint]
+# 显式冻结规则集为 ruff 默认（pycodestyle 错误 + pyflakes），
+# 避免 ruff 升级引入新规则时门禁漂移。扩规则需单独 PR。
+select = ["E4", "E7", "E9", "F"]
+
+[tool.ruff.lint.per-file-ignores]
+# wsgi 必须先执行 load_project_dotenv() 再导入 app，属有意的导入顺序依赖（永久豁免）
+"src/novelvideo/api/wsgi.py" = ["E402"]
+# ―――― 以下为存量豁免基线（2026-07-07 快照：196 处 / 61 文件）――――
+# 门禁只管新增代码：新文件、以及下列文件中新增的其他规则违例会被拦截。
+# 治理旧账时：修完某文件的某规则后删除对应条目，防止回潮。
+"src/novelvideo/agents/episode_fixer.py" = ["E402"]
+"src/novelvideo/agents/episode_planner.py" = ["F401"]
+"src/novelvideo/agents/episode_reviewer.py" = ["E402", "F401", "F541"]
+"src/novelvideo/agents/global_video_optimizer.py" = ["F541"]
+"src/novelvideo/agents/keyframe_prompt_builder.py" = ["F541"]
+"src/novelvideo/agents/video_prompt_builder.py" = ["F541"]
+"src/novelvideo/api/routes/characters.py" = ["E402"]
+"src/novelvideo/api/routes/files.py" = ["E402"]
+"src/novelvideo/api/routes/freezone.py" = ["F401"]
+"src/novelvideo/api/routes/scripts.py" = ["E402"]
+"src/novelvideo/api/routes/styles.py" = ["E402"]
+"src/novelvideo/chat/hermes_sdk.py" = ["F401", "F841"]
+"src/novelvideo/claymore/style_extractor.py" = ["F401", "F541"]
+"src/novelvideo/cognee/pipeline.py" = ["F401", "F541", "F811"]
+"src/novelvideo/cognee/store.py" = ["E402", "F541", "F811"]
+"src/novelvideo/cognee/tools.py" = ["F401"]
+"src/novelvideo/config.py" = ["F401"]
+"src/novelvideo/director_world/scene_overlap_analyzer.py" = ["F401"]
+"src/novelvideo/director_world/sync_global_props.py" = ["F401"]
+"src/novelvideo/freezone/presets.py" = ["F841"]
+"src/novelvideo/generators/episode_optimizer.py" = ["F401"]
+"src/novelvideo/generators/grid_splitter.py" = ["F401"]
+"src/novelvideo/generators/image_generator.py" = ["F401", "F541"]
+"src/novelvideo/generators/nanobanana_character.py" = ["F401", "F541"]
+"src/novelvideo/generators/nanobanana_grid.py" = ["E722", "F401", "F541", "F811", "F841"]
+"src/novelvideo/generators/nanobanana_prop.py" = ["F401", "F541"]
+"src/novelvideo/generators/pool_indexer.py" = ["F401", "F541"]
+"src/novelvideo/generators/prompt_builder.py" = ["F522", "F541", "F841"]
+"src/novelvideo/generators/scene_reference_images.py" = ["F401"]
+"src/novelvideo/generators/sketch_color_detector.py" = ["F401", "F841"]
+"src/novelvideo/generators/tts_generator.py" = ["F401", "F541"]
+"src/novelvideo/generators/video_composer.py" = ["F401", "F841"]
+"src/novelvideo/generators/video_generator.py" = ["F401", "F841"]
+"src/novelvideo/models.py" = ["F401"]
+"src/novelvideo/task_backend/cancel.py" = ["F401"]
+"src/novelvideo/utils/identity_resolver.py" = ["F401"]
+"src/novelvideo/utils/logging.py" = ["F541", "F841"]
+"src/novelvideo/verification/cli/run_gate.py" = ["F841"]
+"src/novelvideo/verification/consistency_verifier.py" = ["E402"]
+"src/novelvideo/verification/replay_capture.py" = ["F401"]
+"src/novelvideo/verification/routes.py" = ["E402"]
+"src/novelvideo/verification/sketch_selector.py" = ["F401"]
+"src/novelvideo/verification/sketch_visual_gate.py" = ["F401"]
+"src/novelvideo/verification/training_db.py" = ["F401"]
+"src/novelvideo/verification/version_hash.py" = ["F401"]
+"tests/contract/test_l014_inline_task_backend_concurrency.py" = ["F401"]
+"tests/test_api_assets.py" = ["F401"]
+"tests/test_api_freezone_canvas_from_preset.py" = ["F401"]
+"tests/test_api_render_settings.py" = ["F841"]
+"tests/test_director_staging_shape_presets.py" = ["F401"]
+"tests/test_env_config_ratchet.py" = ["F401"]
+"tests/test_freezone_asset_library_backend.py" = ["F841"]
+"tests/test_freezone_text_backend.py" = ["F401"]
+"tests/test_indextts2_fal_smoke.py" = ["F401"]
+"tests/test_openresty_upload_limit.py" = ["F401"]
+"tests/test_seedance2_voice_audio_records.py" = ["F401"]
+"tests/test_sqlite_store.py" = ["F811"]
+"tests/test_storyboard_prompt_visual_authority.py" = ["F541"]
+"tests/test_wysiwyg_consistency.py" = ["F401", "F841"]
+"tests/test_wysiwyg_neo4j.py" = ["F401"]
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"

--- a/sbom.spdx.json
+++ b/sbom.spdx.json
@@ -7,7 +7,7 @@
     ]
   },
   "dataLicense": "CC0-1.0",
-  "documentNamespace": "https://supertale.local/spdx/supertale-ce/b23313348b9ad4e7",
+  "documentNamespace": "https://supertale.local/spdx/supertale-ce/6c2ba5bf67b4bd6c",
   "name": "supertale-ce-p0b-sbom",
   "packages": [
     {
@@ -1941,6 +1941,16 @@
       "versionInfo": "2026.5.1"
     },
     {
+      "SPDXID": "SPDXRef-Package-ruff",
+      "copyrightText": "NOASSERTION",
+      "downloadLocation": "NOASSERTION",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "name": "ruff",
+      "versionInfo": "0.15.20"
+    },
+    {
       "SPDXID": "SPDXRef-Package-safetensors",
       "copyrightText": "NOASSERTION",
       "downloadLocation": "NOASSERTION",
@@ -3329,6 +3339,11 @@
     },
     {
       "relatedSpdxElement": "SPDXRef-Package-rpds-py",
+      "relationshipType": "DEPENDS_ON",
+      "spdxElementId": "SPDXRef-Package-supertale-ce"
+    },
+    {
+      "relatedSpdxElement": "SPDXRef-Package-ruff",
       "relationshipType": "DEPENDS_ON",
       "spdxElementId": "SPDXRef-Package-supertale-ce"
     },

--- a/uv.lock
+++ b/uv.lock
@@ -3198,6 +3198,31 @@ wheels = [
 ]
 
 [[package]]
+name = "ruff"
+version = "0.15.20"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/dc/35b341fc554ba02f217fc10da57d1a75168cfbcf75b0ef2202176d4c4f2d/ruff-0.15.20.tar.gz", hash = "sha256:1416eb04349192646b54de98f146c4f59afe37d0decfc02c3cbbf396f3a28566", size = 4755489, upload-time = "2026-06-25T17:20:37.578Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/d9/2d5014f0253ba541d2061d9fa7193f48e941c8b21bb88a7ff9bbe0bd0596/ruff-0.15.20-py3-none-linux_armv6l.whl", hash = "sha256:00e188c53e499c3c1637f73c91dcf2fb56d576cab76ce1be50a27c4e80e37078", size = 10839665, upload-time = "2026-06-25T17:19:44.702Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/d3/ac1798ba64f670698867fcfc591d50e7e421bef137db564858f619a30fcf/ruff-0.15.20-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:9ebd1fd9b9c95fc0bd7b2761aebec1f030013d2e193a2901b224af68fe47251b", size = 11208649, upload-time = "2026-06-25T17:19:48.787Z" },
+    { url = "https://files.pythonhosted.org/packages/47/47/d3ac899991202095dfcf3d5176be4272642be3cf981a2f1a30f72a2afb95/ruff-0.15.20-py3-none-macosx_11_0_arm64.whl", hash = "sha256:c5b16cdd67ca108185cd36dce98c576350c03b1660a751de725fb049193a0632", size = 10622638, upload-time = "2026-06-25T17:19:51.354Z" },
+    { url = "https://files.pythonhosted.org/packages/33/13/4e043fe30aa94d4ff5213a9881fc296d12960f5971b234a5263fdc225312/ruff-0.15.20-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3413bb3c3d2ca6a8208f1f4809cd2dca3c6de6d0b491c0e70847672bde6e6efd", size = 10984227, upload-time = "2026-06-25T17:19:54.044Z" },
+    { url = "https://files.pythonhosted.org/packages/76/e6/92e7bf40388bc5800073b96564f56264f7e48bfd1a498f5ced6ae6d5a769/ruff-0.15.20-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:bd7ec42b3bb3da066488db093308a69c4ac5ee6d2af333a86ba6e2eb2e7dd44b", size = 10622882, upload-time = "2026-06-25T17:19:57.037Z" },
+    { url = "https://files.pythonhosted.org/packages/13/7a/43460be3f24495a3aa46d4b16873e2c4941b3b5f0b00cf88c03b7b94b339/ruff-0.15.20-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e1a36ad0eb77fba9aabfb69ede54de6f376d04ac18ebea022847046d340a8267", size = 11474808, upload-time = "2026-06-25T17:20:00.357Z" },
+    { url = "https://files.pythonhosted.org/packages/27/a0/f37077884873221c6b33b4ab49eb18f9f88e54a16a25a5bca59bef46dd66/ruff-0.15.20-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b6df3b1e4610432f0386dba04d853b5f08cbbc903410c6fcc02f620f05aff53c", size = 12293094, upload-time = "2026-06-25T17:20:03.446Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/74/165545b60256a9704c21ac0ec4a0d07933b320812f9584836c9f4aca4292/ruff-0.15.20-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e89f198a1ea6ef0d727c1cf16088bc91a6cb0ab947dedc966715691647186eae", size = 11526176, upload-time = "2026-06-25T17:20:06.301Z" },
+    { url = "https://files.pythonhosted.org/packages/86/b1/a976a136d40ade83ce743578399865f57001003a409acadc0ecbb3051082/ruff-0.15.20-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:309809086c2acb67624950a3c8133e80f32d0d3e27106c0cd60ff26657c9f24b", size = 11520767, upload-time = "2026-06-25T17:20:09.191Z" },
+    { url = "https://files.pythonhosted.org/packages/19/0f/f032696cb01c9b54c0263fa393474d7758f1cdc021a01b04e3cbc2500999/ruff-0.15.20-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:2d2374caa2f2c2f9e2b7da0a50802cfb8b79f55a9b5e49379f564544fbf56487", size = 11500132, upload-time = "2026-06-25T17:20:13.602Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/f4/51b1a14bc69e8c224b15dab9cce8e99b425e0455d462caa2b3c9be2b6a8e/ruff-0.15.20-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:a1ed17b65293e0c2f22fc387bc13198a5de94bf4429589b0ff6946b0feaf21a3", size = 10943828, upload-time = "2026-06-25T17:20:16.635Z" },
+    { url = "https://files.pythonhosted.org/packages/71/4b/fe267640783cd02bf6c5cc290b1df1051be2ec294c678b5c15fe19e52343/ruff-0.15.20-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:f701305e66b38ea6c91882490eb73459796808e4c6362a1b765255e0cdcd4053", size = 10645418, upload-time = "2026-06-25T17:20:19.4Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/c0/a65aa4ec2f5e87a1df32dc3ec1fede434fe3dfd5cbcf3b503cafc676ab54/ruff-0.15.20-py3-none-musllinux_1_2_i686.whl", hash = "sha256:5b9c0c367ad8e5d0d5b5b8537864c469a0a0e55417aadfbeca41fa61333be9f4", size = 11211770, upload-time = "2026-06-25T17:20:22.033Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/a4/0caa331d954ae2723d729d351c989cb4ca8b6077d5c6c2cb6de75e98c041/ruff-0.15.20-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:01cc00dd58f0df339d0e902219dd53990ea99996a0344e5d9cc8d45d5307e460", size = 11618698, upload-time = "2026-06-25T17:20:25.259Z" },
+    { url = "https://files.pythonhosted.org/packages/10/9b/5f14927848d2fd4aa891fd88d883788c5a7baba561c7874732364045708c/ruff-0.15.20-py3-none-win32.whl", hash = "sha256:ed65ef510e43a137207e0f01cfcf998aeddb1aeeda5c9d35023e910284d7cf21", size = 10857322, upload-time = "2026-06-25T17:20:28.612Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/f0/fe47c501f9dea92a26d788ff98bb5d92ed4cb4c88792c5c88af6b697dc8e/ruff-0.15.20-py3-none-win_amd64.whl", hash = "sha256:a525c81c70fb0380344dd1d8745d8cc1c890b7fc94a58d5a07bd8eb9557b8415", size = 11993274, upload-time = "2026-06-25T17:20:31.871Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/2b/9555445e1201d92b3195f45cdb153a0b68f24e0a4273f6e3d5ab46e212bb/ruff-0.15.20-py3-none-win_arm64.whl", hash = "sha256:2f5b2a6d614e8700388806a14996c40fab2c47b819ef57d790a34878858ed9ca", size = 11343498, upload-time = "2026-06-25T17:20:35.03Z" },
+]
+
+[[package]]
 name = "safetensors"
 version = "0.8.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3444,6 +3469,7 @@ dev = [
     { name = "pytest-asyncio" },
     { name = "pytest-xdist" },
     { name = "respx" },
+    { name = "ruff" },
 ]
 
 [package.metadata]
@@ -3504,6 +3530,7 @@ dev = [
     { name = "pytest-asyncio", specifier = ">=0.23.0" },
     { name = "pytest-xdist", specifier = ">=3.5.0" },
     { name = "respx", specifier = ">=0.22.0" },
+    { name = "ruff", specifier = "==0.15.20" },
 ]
 
 [[package]]


### PR DESCRIPTION
## PR 类型 / Type of PR
- [ ] 🐞 Bug 修复 / Bug fix
- [ ] ✨ 新功能 / Feature
- [ ] 📝 文档 / Documentation
- [ ] 🧹 重构 / 清理 / Refactor or cleanup
- [x] ⚙️ 构建 / CI / Build or CI
- [ ] ⚠️ 破坏性变更 / Breaking change

## 改动说明 / What this PR does and why
把 CI 里原本 `continue-on-error: true` 的**非阻断** `ruff check` 升级为**合入必过门**，兑现引入非阻断 lint 时的承诺（存量挂账后去掉 `continue-on-error` 转为必过门）。

采用**标准 `[tool.ruff.lint.per-file-ignores]` 挂账存量、只拦新增**——不自造 baseline 机制。

- `pyproject.toml` 新增 `[tool.ruff]`：`target-version=py311`（对齐 `requires-python`）、`select=["E4","E7","E9","F"]`（冻结 ruff 默认集，防升级引入新规则时门禁漂移）；`per-file-ignores` 挂账存量 **196 处 / 61 文件**（2026-07-07 快照）；`wsgi.py` 的 E402 为有意导入顺序依赖，单列**永久豁免**；dev 依赖钉 `ruff==0.15.20`
- `.github/workflows/ci.yml`：删 `continue-on-error`，step 更名 `Lint (ruff)`，`uvx ruff` → `uv run ruff`（CI 与本地同版）
- `uv.lock` / `sbom.spdx.json`：收录 ruff

## 关联 issue / Linked issues
N/A

## 给 reviewer 的说明 / Notes for the reviewer
- **只拦新增、不动存量**：本 PR 零源码/测试改动，纯 infra。存量 196 处逐文件挂账，治理方式=谁将来动了某文件就顺手清、删对应豁免行（注释已写明"修完删条目防回潮"），不需要一次性大清理。
- **真 bug 已单独处理**：存量里唯一的真缺陷（`cli.py` 的 F821，调用已删除的 `filter_characters_simple`）已在 **#40** 单独 TDD 修复合入，故本豁免清单**不含 cli.py**——门不掩盖真缺陷。
- **门有效性自证（本地）**：基线 `uv run ruff check .` = 0；新文件带未用 import → 拦（exit 1）；向"只豁免 E402"的文件注入 F401 → 拦（exit 1，证明是**逐规则窄豁免**，不是整文件放行）。建议合入后在 PR 分支故意加个坏 import 验证 CI 真变红。
- 存量规则分布：F401×75 / E402×50 / F541×40 / F841×19 / F811×8 / F522×3 / E722×1。

## 面向用户的变更 / User-facing change
```release-note
NONE
```

## 自检 / Checklist
- [x] 已自测，`uv run pytest` 通过（1545 passed / 16 skipped）
- [x] 必要的文档已更新（N/A：纯 CI infra）
- [x] 提交信息清晰（Conventional Commits）
- [x] 每个 commit 都已 `git commit -s` 附 DCO 签署
- [ ] 我已阅读并同意贡献者协议（请仓库维护者确认勾选）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
