### PR TITLE
fix(frontend): 修复从虾画切换到其他菜单被拽回的问题 (#44)

### DIFF
--- a/frontend/src/__tests__/lib/url-params.test.ts
+++ b/frontend/src/__tests__/lib/url-params.test.ts
@@ -1,7 +1,9 @@
 // SPDX-License-Identifier: Elastic-2.0
 // Copyright (c) 2026 ClaymoreLab
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { AnyRouter } from "@tanstack/react-router";
 
+import { setAppRouter } from "@/lib/app-router";
 import { writeUrl } from "@/lib/url-params";
 
 describe("freezone url params", () => {
@@ -40,5 +42,84 @@ describe("freezone url params", () => {
     } finally {
       window.removeEventListener("popstate", listener);
     }
+  });
+});
+
+describe("freezone url params — routes through tanstack when a router is registered", () => {
+  afterEach(() => setAppRouter(null));
+
+  function mockRouter(pathname: string, search: Record<string, unknown> = {}) {
+    const navigate = vi.fn();
+    setAppRouter({
+      navigate,
+      state: { location: { pathname, search } },
+    } as unknown as AnyRouter);
+    return navigate;
+  }
+
+  it("navigates through the router instead of mutating window.history", () => {
+    window.history.pushState(null, "", "/projects/proj-a/freezone");
+    const navigate = mockRouter("/projects/proj-a/freezone");
+    let popstateCount = 0;
+    const listener = () => {
+      popstateCount += 1;
+    };
+    window.addEventListener("popstate", listener);
+
+    try {
+      writeUrl({ canvas: "canvas-9" }, { replace: true, notify: false });
+
+      expect(navigate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          to: "/projects/$project/freezone",
+          params: { project: "proj-a" },
+          search: { canvas: "canvas-9" },
+          replace: true,
+        }),
+      );
+      // The router owns the URL now: no raw history write, no synthetic popstate
+      // that could race with tanstack's throttled history queue.
+      expect(window.location.search).toBe("");
+      expect(popstateCount).toBe(0);
+    } finally {
+      window.removeEventListener("popstate", listener);
+    }
+  });
+
+  it("targets the ingest route when the project is cleared", () => {
+    window.history.pushState(null, "", "/projects/proj-a/freezone");
+    const navigate = mockRouter("/projects/proj-a/freezone", { canvas: "c1" });
+
+    writeUrl({ project: null, canvas: null });
+
+    expect(navigate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: "/projects/$project/ingest",
+        params: { project: "proj-a" },
+        search: {},
+      }),
+    );
+  });
+
+  it("still no-ops on non-freezone routes even with a router registered", () => {
+    window.history.pushState(null, "", "/projects/proj-a/episodes/3/script");
+    const navigate = mockRouter("/projects/proj-a/episodes/3/script");
+
+    writeUrl({ canvas: "canvas-2" });
+
+    expect(navigate).not.toHaveBeenCalled();
+  });
+
+  it("does not yank back to freezone when the router already left (window.location lags)", () => {
+    // Real leave transition: tanstack throttles history onto a microtask, so
+    // the router's location is already /characters while window.location still
+    // reads the old /freezone. A stray canvas-sync write here must NOT navigate
+    // back to freezone — that was the regression that trapped users on 虾画.
+    window.history.pushState(null, "", "/projects/proj-a/freezone");
+    const navigate = mockRouter("/projects/proj-a/characters");
+
+    writeUrl({ canvas: "canvas-2" }, { replace: true, notify: false });
+
+    expect(navigate).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/features/freezone/FreezoneShell.tsx
+++ b/frontend/src/features/freezone/FreezoneShell.tsx
@@ -20,7 +20,8 @@ import {
   SheetTitle,
 } from "@/components/ui/sheet";
 import { useMediaQuery } from "@/hooks/use-media-query";
-import { readUrl, rememberLastCanvas, writeUrl } from "@/lib/url-params";
+import { currentCanvasParam } from "@/lib/app-router";
+import { rememberLastCanvas, writeUrl } from "@/lib/url-params";
 import { isCeRuntime } from "@/lib/runtime-config";
 import { cn } from "@/lib/utils";
 import { SuperChatPanel } from "@/features/superchat/superchat-panel";
@@ -411,7 +412,7 @@ export function FreezoneShell({ project, canvasId }: FreezoneShellProps) {
 
   useEffect(() => {
     rememberLastCanvas(projectId, canvasId);
-    if (canvasId !== "default" && readUrl().canvas !== canvasId) {
+    if (canvasId !== "default" && currentCanvasParam() !== canvasId) {
       writeUrl({ canvas: canvasId }, { replace: true, notify: false });
     }
   }, [canvasId, projectId]);

--- a/frontend/src/features/freezone/openPresetProjection.ts
+++ b/frontend/src/features/freezone/openPresetProjection.ts
@@ -5,6 +5,7 @@ import {
   type FreezonePresetCanvasRequest,
 } from "@/api/canvas";
 import { useAuthStore } from "@/stores/auth-store";
+import { getAppRouter } from "@/lib/app-router";
 import { writeUrl } from "@/lib/url-params";
 import {
   consumeQueuedLocalFreezoneProjections,
@@ -22,8 +23,15 @@ export async function openPresetProjectionInMyCanvas(
   projectId: string,
   request: Omit<FreezonePresetCanvasRequest, "canvas_id" | "overwrite_existing" | "base_revision">,
 ): Promise<string> {
+  // Read the pathname from the router when available: tanstack throttles its
+  // navigations onto a microtask, so window.location lags a pending navigation
+  // (e.g. the user clicking away to /ingest while this request is in-flight).
+  // Reading window.location here would miss that and wrongly pull the SPA back
+  // to Freezone below.
+  const router = getAppRouter();
   const startPathname =
-    typeof window !== "undefined" ? window.location.pathname : null;
+    router?.state.location.pathname ??
+    (typeof window !== "undefined" ? window.location.pathname : null);
   const username = useAuthStore.getState().username?.trim();
   if (!username) {
     throw new Error("Missing current user");
@@ -51,18 +59,32 @@ export async function openPresetProjectionInMyCanvas(
   consumeQueuedLocalFreezoneProjections(projectId, canvasId);
 
   const freezonePath = `/projects/${encodeURIComponent(projectId)}/freezone`;
-  if (typeof window !== "undefined" && window.location.pathname !== startPathname) {
+  // Same source as startPathname: use the router's location so an in-flight
+  // navigation (queued but not yet flushed to window.location) is respected.
+  const currentPathname =
+    router?.state.location.pathname ??
+    (typeof window !== "undefined" ? window.location.pathname : null);
+  if (currentPathname !== startPathname) {
     // The user navigated elsewhere while the projection request was in-flight.
     // Do not pull the SPA back to Freezone after their explicit navigation.
     return canvasId;
   }
-  if (typeof window !== "undefined" && window.location.pathname !== freezonePath) {
-    window.history.pushState(
-      {},
-      "",
-      `${freezonePath}?canvas=${encodeURIComponent(canvasId)}`,
-    );
-    window.dispatchEvent(new PopStateEvent("popstate"));
+  if (currentPathname !== freezonePath) {
+    if (router) {
+      router.navigate({
+        to: "/projects/$project/freezone",
+        params: { project: projectId },
+        search: { canvas: canvasId },
+        resetScroll: false,
+      });
+    } else if (typeof window !== "undefined") {
+      window.history.pushState(
+        {},
+        "",
+        `${freezonePath}?canvas=${encodeURIComponent(canvasId)}`,
+      );
+      window.dispatchEvent(new PopStateEvent("popstate"));
+    }
   } else {
     writeUrl({ canvas: canvasId });
   }

--- a/frontend/src/lib/app-router.ts
+++ b/frontend/src/lib/app-router.ts
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: Elastic-2.0
+// Copyright (c) 2026 ClaymoreLab
+import type { AnyRouter } from "@tanstack/react-router";
+
+// The app's tanstack-router singleton. Registered once from main.tsx after the
+// router is created, so plain (non-hook) modules — url-params, openPresetProjection —
+// can route navigations THROUGH the router instead of mutating window.history
+// directly.
+//
+// Why this matters: tanstack throttles its own navigations onto a microtask
+// (@tanstack/history queueHistoryAction), so window.location lags a pending
+// navigation, and a raw window.history write + synthetic popstate desyncs the
+// rendered route from the URL (symptom: navigate to /ingest but still render the
+// canvas). Going through router.navigate keeps everything on one consistent
+// queue.
+//
+// Stays null under unit tests (no RouterProvider); callers fall back to the raw
+// History API in that case.
+let appRouter: AnyRouter | null = null;
+
+export function setAppRouter(router: AnyRouter | null): void {
+  appRouter = router;
+}
+
+export function getAppRouter(): AnyRouter | null {
+  return appRouter;
+}
+
+/**
+ * Current `?canvas` value, read from the router's location when available so it
+ * reflects an in-flight (queued-but-not-yet-flushed) navigation. Falls back to
+ * window.location for non-router contexts (unit tests, pre-mount).
+ */
+export function currentCanvasParam(): string | null {
+  const router = appRouter;
+  if (router) {
+    const search = router.state.location.search as { canvas?: unknown };
+    const canvas = search?.canvas;
+    return typeof canvas === "string" && canvas.length > 0 ? canvas : null;
+  }
+  return new URLSearchParams(window.location.search).get("canvas");
+}

--- a/frontend/src/lib/url-params.ts
+++ b/frontend/src/lib/url-params.ts
@@ -1,7 +1,11 @@
 // SPDX-License-Identifier: Elastic-2.0
 // Copyright (c) 2026 ClaymoreLab
 // Parse + push freezone URL params for /projects/<project_id>/freezone?canvas=<id>.
-// Mutating these uses History API so back/forward keep working.
+// Mutating these routes through tanstack-router when it is registered (see
+// getAppRouter). Falling back to the raw History API is only for non-router
+// contexts (unit tests, pre-mount).
+
+import { getAppRouter } from "@/lib/app-router";
 
 export interface FreezoneUrl {
   /** SuperTale project_id. Display names are not accepted by project-scoped APIs. */
@@ -21,6 +25,11 @@ function projectFromPathname(pathname = window.location.pathname): string | null
   return match ? decodeURIComponent(match[1]) : null;
 }
 
+function canvasFromRouterSearch(router: NonNullable<ReturnType<typeof getAppRouter>>): string | null {
+  const canvas = (router.state.location.search as { canvas?: unknown }).canvas;
+  return typeof canvas === "string" && canvas.length > 0 ? canvas : null;
+}
+
 export function readUrl(): FreezoneUrl {
   const params = new URLSearchParams(window.location.search);
   return {
@@ -30,16 +39,49 @@ export function readUrl(): FreezoneUrl {
 }
 
 export function writeUrl(next: Partial<FreezoneUrl>, options: WriteUrlOptions = {}) {
-  const pathProject = projectFromPathname();
+  const router = getAppRouter();
+  // When the router is registered it — not window.location — is the source of
+  // truth for "where are we". tanstack throttles its navigations onto a
+  // microtask, so window.location LAGS a pending navigation: while the user is
+  // leaving Freezone the router already reads /characters but window.location
+  // still reads /freezone. Guarding on the stale window.location would let a
+  // stray canvas-sync write here navigate the user BACK to Freezone, trapping
+  // them on 虾画. Read the pathname/canvas from the router so a write that
+  // fires after the route has moved off Freezone simply no-ops.
+  const currentPathname = router?.state.location.pathname;
+  const pathProject = currentPathname
+    ? projectFromPathname(currentPathname)
+    : projectFromPathname();
   if (!pathProject) return;
 
-  const current = readUrl();
+  const current: FreezoneUrl = router
+    ? { project: pathProject, canvas: canvasFromRouterSearch(router) }
+    : readUrl();
   // 显式区分"未传"和"传 null"：?? 会把 null 当作回退到 current，导致
   // writeUrl({ project: null }) 这种"清空字段"的语义失效（例如返回项目列表）。
   const merged: FreezoneUrl = {
     project: "project" in next ? next.project ?? null : current.project,
     canvas: "canvas" in next ? next.canvas ?? null : current.canvas,
   };
+  if (router) {
+    // Route THROUGH tanstack so this navigation joins the router's throttled
+    // history queue and router state stays consistent. Mutating window.history
+    // directly (the fallback below) races with that queue: window.location lags
+    // a pending navigation, so a raw write + synthetic popstate can leave the
+    // URL and the rendered route out of sync (navigate to /ingest but still
+    // render the canvas).
+    router.navigate({
+      to: merged.project
+        ? "/projects/$project/freezone"
+        : "/projects/$project/ingest",
+      params: { project: pathProject },
+      search: merged.canvas ? { canvas: merged.canvas } : {},
+      replace: options.replace ?? false,
+      resetScroll: false,
+    });
+    return;
+  }
+
   const params = new URLSearchParams();
   if (merged.canvas) params.set("canvas", merged.canvas);
   const search = params.toString();

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -10,6 +10,7 @@ import { loadClusterConfig } from "@/lib/cluster-config";
 import { loadRuntimeConfig } from "@/lib/runtime-config";
 import { initDevBackendWatch } from "@/lib/dev-backend-watch";
 import { setApiQueryClient } from "@/lib/api";
+import { setAppRouter } from "@/lib/app-router";
 import { getOrCreateReactRoot } from "@/lib/react-root";
 import {
   installChunkLoadRecovery,
@@ -51,6 +52,12 @@ const router = createRouter({
   // do instant nav; match them. If we ever want a transition on a specific
   // <Link>, opt in per-link with viewTransition={true}.
 });
+
+// Register the singleton so plain (non-hook) modules — url-params,
+// openPresetProjection — route navigations through the router instead of
+// mutating window.history directly (which races with tanstack's throttled
+// history queue). See @/lib/app-router.
+setAppRouter(router);
 
 declare module "@tanstack/react-router" {
   interface Register {

--- a/frontend/src/routes/_app/projects.$project/freezone.lazy.tsx
+++ b/frontend/src/routes/_app/projects.$project/freezone.lazy.tsx
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Elastic-2.0
 // Copyright (c) 2026 ClaymoreLab
-import { createLazyFileRoute } from "@tanstack/react-router";
+import { createLazyFileRoute, useRouterState } from "@tanstack/react-router";
 import { ReactFlowProvider } from "@xyflow/react";
 import { useEffect, useMemo, useState } from "react";
 
@@ -13,21 +13,26 @@ import {
 import { FreezoneShell } from "@/features/freezone/FreezoneShell";
 import { canvasIdForFreezoneEntry } from "@/features/freezone/projections";
 import { useAllProjectSummaries } from "@/lib/queries/projects";
-import { readLastCanvas, readUrl, writeUrl } from "@/lib/url-params";
+import { readLastCanvas, writeUrl } from "@/lib/url-params";
 import { useAuthStore } from "@/stores/auth-store";
 
 function FreezoneProjectRoute() {
   const { project } = Route.useParams();
-  const [, setTick] = useState(0);
   const username = useAuthStore((state) => state.username);
   const { data: projects, isLoading } = useAllProjectSummaries();
   const [globalError, setGlobalError] = useState<GlobalErrorDialogDetail | null>(null);
 
-  useEffect(() => {
-    const handler = () => setTick((n) => n + 1);
-    window.addEventListener("popstate", handler);
-    return () => window.removeEventListener("popstate", handler);
-  }, []);
+  // Read `?canvas` from the router's location so it stays consistent with an
+  // in-flight navigation (tanstack throttles history onto a microtask, so
+  // window.location — and any raw readUrl() — lags a queued canvas switch).
+  // This subscription also re-renders the route when the canvas param changes,
+  // replacing the old raw popstate listener.
+  const canvasParam = useRouterState({
+    select: (s) => {
+      const canvas = (s.location.search as { canvas?: unknown }).canvas;
+      return typeof canvas === "string" && canvas.length > 0 ? canvas : null;
+    },
+  });
 
   useEffect(() => subscribeOpenGlobalErrorDialog(setGlobalError), []);
 
@@ -79,7 +84,7 @@ function FreezoneProjectRoute() {
   }
 
   const canvasId = canvasIdForFreezoneEntry({
-    explicitCanvasId: readUrl().canvas ?? readLastCanvas(matchedProject.id),
+    explicitCanvasId: canvasParam ?? readLastCanvas(matchedProject.id),
     username,
   });
 

--- a/license-inventory.csv
+++ b/license-inventory.csv
@@ -970,6 +970,7 @@ frontend/src/index.css,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggreg
 frontend/src/lib/api-errors.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/lib/api-path.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/lib/api.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
+frontend/src/lib/app-router.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/lib/app-update-available.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/lib/app-version.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/lib/aspect-ratio.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation


### PR DESCRIPTION
## 背景 / 问题

Closes #44

从虾画(freezone)切换到其他菜单时,有时会失败仍显示画布;上一版把 URL 变更改走 tanstack 路由后,进一步出现「完全无法从虾画切出去」的回归。

## 根因

tanstack 把导航节流到微任务,`window.location` 会**滞后**于路由。离开 freezone 时路由已到目标页(如 `/characters`),但 `window.location` 仍停在 `/freezone`。`writeUrl` / `openPresetProjection` 的「当前在哪个路由」守卫读的是滞后的 `window.location.pathname`,于是把 canvas-sync 写入 `router.navigate` **回 freezone**,将用户困在虾画。

## 修复

- URL 变更一律走路由:新增 `src/lib/app-router.ts`(`setAppRouter`/`getAppRouter`/`currentCanvasParam` 单例),`main.tsx` 注册。
- **关键**:`writeUrl` / `openPresetProjection` 的路由判定改读 `router.state.location`(pathname + search),不再读滞后的 `window.location`。路由离开 freezone 后的写入自动 no-op,不再拽回。
- `freezone.lazy` 用 `useRouterState` 读 `?canvas`,移除 raw popstate 监听。
- `license-inventory.csv` 补入 `app-router.ts`(DEP-11 准入)。

## 测试

- 新增回归测试(`__tests__/lib/url-params.test.ts`):router 已离开 freezone、`window.location` 滞后时 `writeUrl` **不再** navigate 回 freezone。
- `tsc -b` ✅ / 全量 vitest **1693 passed** ✅ / `pnpm build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)