### PR TITLE
fix(frontend): 右上角积分显示改用 Tooltip 且不再简写 (#46)

### DIFF
--- a/frontend/src/__tests__/components/layout/credit-balance-badge.test.tsx
+++ b/frontend/src/__tests__/components/layout/credit-balance-badge.test.tsx
@@ -45,6 +45,15 @@ vi.mock("@/lib/queries/auth", () => ({
   }),
 }));
 
+// The badge now uses the shadcn/base-ui Tooltip; mock it so the content always
+// renders (base-ui only mounts the portal on hover). Mirrors the header test.
+vi.mock("@/components/ui/tooltip", () => ({
+  TooltipProvider: ({ children }: React.PropsWithChildren) => <>{children}</>,
+  Tooltip: ({ children }: React.PropsWithChildren) => <>{children}</>,
+  TooltipTrigger: ({ children }: React.PropsWithChildren) => <>{children}</>,
+  TooltipContent: ({ children }: React.PropsWithChildren) => <>{children}</>,
+}));
+
 vi.mock("react-i18next", () => ({
   useTranslation: () => ({
     t: (key: string) =>
@@ -78,8 +87,8 @@ describe("CreditBalanceBadge", () => {
   it("renders the current credit balance", async () => {
     renderBadge();
 
-    expect(screen.getByText("1K")).toBeInTheDocument();
-    expect(screen.getByLabelText("当前积分余额")).toHaveAttribute("title", "当前积分余额: 1,234");
+    expect(screen.getByText("1,234")).toBeInTheDocument();
+    expect(screen.getByText("当前积分余额: 1,234")).toBeInTheDocument();
   });
 
   it("renders nothing when logged out", () => {

--- a/frontend/src/components/layout/credit-balance-badge.tsx
+++ b/frontend/src/components/layout/credit-balance-badge.tsx
@@ -3,18 +3,16 @@
 import { useTranslation } from "react-i18next";
 
 import { CREDIT_VALUE_CLASS, CreditSparkIcon } from "@/components/credits/credit-visual";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { useCurrentUser } from "@/lib/queries/auth";
 import { isCeRuntime } from "@/lib/runtime-config";
 import { cn } from "@/lib/utils";
 import { useAuthStore } from "@/stores/auth-store";
-
-function formatCredits(value: number, language: string): string {
-  return new Intl.NumberFormat(language, {
-    compactDisplay: "short",
-    maximumFractionDigits: value >= 10_000 ? 1 : 0,
-    notation: "compact",
-  }).format(value);
-}
 
 function formatFullCredits(value: number, language: string): string {
   return new Intl.NumberFormat(language, { maximumFractionDigits: 0 }).format(value);
@@ -32,22 +30,38 @@ export function CreditBalanceBadge() {
 
   if (ce || !username || isError) return null;
 
+  const tooltipLabel =
+    balance === undefined
+      ? t("credits.balance")
+      : `${t("credits.balance")}: ${formatFullCredits(balance, language)}`;
+
   return (
-    <div
-      className="group/credits ml-1 flex h-9 min-w-0 items-center gap-1 px-0.5 text-sm font-medium text-muted-foreground"
-      title={
-        balance === undefined
-          ? t("credits.balance")
-          : `${t("credits.balance")}: ${formatFullCredits(balance, language)}`
-      }
-      aria-label={t("credits.balance")}
-    >
-      <span className="flex shrink-0 items-center">
-        <CreditSparkIcon className="size-[17px]" withHoverMotion />
-      </span>
-      <span className={cn("max-w-20 truncate text-[12px] leading-none", CREDIT_VALUE_CLASS)}>
-        {isLoading || balance === undefined ? "--" : formatCredits(balance, language)}
-      </span>
-    </div>
+    <TooltipProvider delay={80}>
+      <Tooltip>
+        <TooltipTrigger
+          render={
+            <div
+              className="group/credits ml-1 flex h-9 min-w-0 cursor-default items-center gap-1 px-0.5 text-sm font-medium text-muted-foreground"
+              aria-label={t("credits.balance")}
+            />
+          }
+        >
+          <span className="flex shrink-0 items-center">
+            <CreditSparkIcon className="size-[17px]" withHoverMotion />
+          </span>
+          <span className={cn("shrink-0 whitespace-nowrap text-[12px] leading-none tabular-nums", CREDIT_VALUE_CLASS)}>
+            {isLoading || balance === undefined ? "--" : formatFullCredits(balance, language)}
+          </span>
+        </TooltipTrigger>
+        <TooltipContent
+          side="bottom"
+          sideOffset={10}
+          showArrow={false}
+          className="border border-white/10 bg-background/95 text-foreground shadow-none"
+        >
+          {tooltipLabel}
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
   );
 }


### PR DESCRIPTION
## 背景 / 问题

Closes #46

右上角积分:hover 不容易触发(靠原生 `title`),且数字被简写成 `1K` 之类不直观。

## 修复

- 用 shadcn / base-ui `Tooltip` 取代原生 `title` 属性 —— hover 更易触发,样式与 header 统一。
- 徽标直接显示**完整数字**(`formatFullCredits`,如 `1,234`),移除 compact 简写。
- `tabular-nums` 等宽,数字变化不跳动。

## 测试

- `credit-balance-badge.test.tsx`:改为断言完整数字(`1,234`)与 tooltip 文案;mock `@/components/ui/tooltip` 使内容常驻渲染(base-ui 仅 hover 时挂 portal),与 header 测试一致。
- `tsc -b` ✅ / 该组件测试 3/3 ✅ / `pnpm build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)