### PR TITLE
fix(video): AI 优化主体提示词异步返回后写入触发的 Beat (#39)

### DIFF
--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -2012,6 +2012,7 @@
         },
         "seedance2GeneratePrompt": "AI optimize",
         "seedance2PromptGenerated": "Seedance2 prompt optimized",
+        "seedance2PromptGeneratedOtherBeat": "Subject prompt optimized and saved back to beat #{{n}}",
         "seedance2PromptGenerateFailed": "Seedance2 prompt generation failed",
         "videoPrompt": "Video prompt",
         "keyframePrompt": "Single-beat video prompt",

--- a/frontend/public/locales/zh/translation.json
+++ b/frontend/public/locales/zh/translation.json
@@ -2012,6 +2012,7 @@
         },
         "seedance2GeneratePrompt": "AI 优化",
         "seedance2PromptGenerated": "Seedance2 提示词 已优化",
+        "seedance2PromptGeneratedOtherBeat": "主体提示词已优化，已写回镜头 #{{n}}",
         "seedance2PromptGenerateFailed": "Seedance2 提示词 生成失败",
         "videoPrompt": "视频提示词",
         "keyframePrompt": "单个 Beat 视频提示词",

--- a/frontend/src/__tests__/components/episode/beat-workbench/video-pane.test.tsx
+++ b/frontend/src/__tests__/components/episode/beat-workbench/video-pane.test.tsx
@@ -127,6 +127,7 @@ beforeAll(async () => {
                 },
                 seedance2GeneratePrompt: "AI 优化",
                 seedance2PromptGenerated: "Seedance2 Prompt 已优化",
+                seedance2PromptGeneratedOtherBeat: "主体提示词已优化，已写回镜头 #{{n}}",
                 seedance2PromptGenerateFailed: "Seedance2 Prompt 生成失败",
                 videoPrompt: "视频提示词",
                 keyframePrompt: "单个 Beat 视频提示词",
@@ -1887,6 +1888,87 @@ describe("VideoPane Seedance2 inspector", () => {
     expect(screen.getByLabelText("Seedance2.0主体提示词")).toHaveValue(
       "optimized seedance2 prompt",
     );
+  });
+
+  it("does not write an AI-optimized prompt onto the beat switched to mid-flight", async () => {
+    const user = userEvent.setup();
+    // Hold the optimize request open so we can switch beats before it resolves.
+    let resolveOptimize: (value: unknown) => void = () => {};
+    const deferred = new Promise((resolve) => {
+      resolveOptimize = resolve;
+    });
+    generateSeedance2PromptMock.mockReturnValueOnce(deferred);
+
+    const beatA = makeBeat({ beat_number: 1 });
+    const beatB = makeBeat({
+      beat_number: 2,
+      seedance2_config_json: JSON.stringify({
+        mode: "multimodal_reference",
+        duration: 5,
+        resolution: "720p",
+        ratio: "9:16",
+        final_prompt: "beat two prompt",
+      }),
+    });
+    const view = renderPane(beatA);
+
+    // Trigger AI optimize on Beat A (request now pending).
+    await user.click(screen.getByRole("button", { name: "AI 优化" }));
+    expect(generateSeedance2PromptMock).toHaveBeenCalledWith(
+      expect.objectContaining({ beatNum: 1 }),
+    );
+
+    // User switches to Beat B while the optimize request is still in flight.
+    view.rerender(
+      <I18nextProvider i18n={i18n}>
+        <VideoPane
+          beat={beatB}
+          project="demo"
+          episode={1}
+          state="ready"
+          defaultBackend="huimeng_seedance-2.0-fast"
+        />
+      </I18nextProvider>,
+    );
+    expect(screen.getByLabelText("Seedance2.0主体提示词")).toHaveValue(
+      "beat two prompt",
+    );
+
+    // The optimize result for Beat A returns *after* the switch.
+    resolveOptimize({
+      ok: true,
+      data: {
+        final_prompt: "optimized seedance2 prompt",
+        seedance2_config_json: JSON.stringify({
+          mode: "multimodal_reference",
+          duration: 5,
+          resolution: "720p",
+          ratio: "9:16",
+          prompt_source: "generated",
+          final_prompt: "optimized seedance2 prompt",
+        }),
+        beat: makeBeat({ beat_number: 1 }),
+      },
+    });
+
+    // Result is attributed back to Beat A, not the now-mounted Beat B.
+    await waitFor(() =>
+      expect(toast.success).toHaveBeenCalledWith("主体提示词已优化，已写回镜头 #1"),
+    );
+    expect(screen.getByLabelText("Seedance2.0主体提示词")).toHaveValue(
+      "beat two prompt",
+    );
+    const leakedToBeatB = updateBeatMock.mock.calls.some((call) => {
+      try {
+        return (
+          JSON.parse(call[0].data.seedance2_config_json).final_prompt ===
+          "optimized seedance2 prompt"
+        );
+      } catch {
+        return false;
+      }
+    });
+    expect(leakedToBeatB).toBe(false);
   });
 
   it("opens reference mention candidates from the custom prompt field", async () => {

--- a/frontend/src/components/episode/beat-workbench/video-pane.tsx
+++ b/frontend/src/components/episode/beat-workbench/video-pane.tsx
@@ -562,6 +562,12 @@ export function VideoPane({
   const seedance2DraftRef = useRef(seedance2Config);
   const normalizedLegacySeedance2ConfigRef = useRef("");
   const lastSavedSeedance2ConfigKeyRef = useRef("");
+  // Always mirrors the currently-mounted beat so async handlers (e.g. AI prompt
+  // optimize) can tell whether the user switched beats while a request was in
+  // flight. `beat` captured in a handler closure is frozen at trigger time, so a
+  // ref is the only way to read the *live* beat after an await. See issue #39.
+  const currentBeatNumberRef = useRef(beat.beat_number);
+  currentBeatNumberRef.current = beat.beat_number;
   useEffect(() => {
     setSeedance2Draft(seedance2Config);
     seedance2DraftRef.current = seedance2Config;
@@ -887,15 +893,32 @@ export function VideoPane({
     showSeedance2Config,
   ]);
   const handleGenerateSeedance2Prompt = async () => {
+    // Bind the result to the beat that triggered the optimize. The request is
+    // async; if the user switches beats before it returns, applying the result
+    // to the now-mounted beat's draft would autosave it onto the WRONG beat
+    // (issue #39). The backend persists the optimized prompt to this beat and
+    // onSuccess patches it into the beats cache, so a switched-away result is
+    // safe to drop locally — it will show when the user returns to this beat.
+    const triggeredBeatNumber = beat.beat_number;
     try {
       const res = await generateSeedance2Prompt.mutateAsync({
-        beatNum: beat.beat_number,
+        beatNum: triggeredBeatNumber,
         manualPromptReference: seedance2Draft.final_prompt,
         promptGuidance: seedance2Draft.prompt_guidance,
       });
       if (!res.ok) {
         toast.error(
           res.error || t("episode.workbench.video.seedance2PromptGenerateFailed"),
+        );
+        return;
+      }
+      if (currentBeatNumberRef.current !== triggeredBeatNumber) {
+        // User moved to another beat while optimizing. Do NOT touch the current
+        // draft — the triggering beat is already updated server-side + in cache.
+        toast.success(
+          t("episode.workbench.video.seedance2PromptGeneratedOtherBeat", {
+            n: triggeredBeatNumber,
+          }),
         );
         return;
       }


### PR DESCRIPTION
Closes #39

## 问题
「AI 优化主体提示词」是异步请求，而 `VideoPane` 在切换 Beat 时是**复用**而非重挂载。旧代码在请求返回时把结果写进**当前挂载的 Beat 草稿**，而不是**发起请求的那个 Beat**。当后端较慢（线上真实 LLM 推理需要数秒）时，用户在等待期间切到别的镜头，优化结果就落到了「当前切换到的其他 Beat」上 —— 即 issue #39。

## 为什么只有线上复现
这是一个**被延迟放大的竞态**：本地优化接口往返近乎瞬时，用户来不及在"请求进行中"窗口内切镜头，所以复现不了；线上真实推理有数秒窗口，切走即触发。根因是**结果未绑定到触发请求的 beat**，只在响应够慢时暴露。

## 修复
- 在触发时把 `beat.beat_number` 快照为 `triggeredBeatNumber`。
- 用 `currentBeatNumberRef`（始终镜像当前挂载 Beat）在返回后比对：若用户已切走，**不修改当前草稿**——后端已把优化结果持久化到触发的 Beat，`onSuccess` 也已回填进 beats 缓存，切回时自然可见；同时给出「已写回镜头 #N」提示。

## 测试
- 新增回归测试：用手动控制的 deferred promise 把"响应很慢"的线上时序确定性搬到本地（render Beat A → 点优化挂起 → 切到 Beat B → 才 resolve），断言结果不落到 B、`updateBeat` 不携带优化后的提示词、并回归给 A。已验证去掉守卫即失败、加上即通过。
- `tsc -b`、`pnpm build`、video-pane 全量 61 测试均通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)