### PR TITLE
fix(freezone): 画布节点删除后历史记录仍保留其生成产物

### DIFF
--- a/frontend/src/__tests__/features/canvas/use-canvas-generation-history.test.ts
+++ b/frontend/src/__tests__/features/canvas/use-canvas-generation-history.test.ts
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: Elastic-2.0
+// Copyright (c) 2026 ClaymoreLab
+import { renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const fetchCanvasGenerationHistory = vi.hoisted(() => vi.fn());
+const readUrl = vi.hoisted(() => vi.fn());
+
+vi.mock("@/api/ops", () => ({ fetchCanvasGenerationHistory }));
+vi.mock("@/lib/url-params", () => ({ readUrl }));
+
+import { useCanvasGenerationHistory } from "@/features/canvas/hooks/useCanvasGenerationHistory";
+
+describe("useCanvasGenerationHistory", () => {
+  beforeEach(() => {
+    fetchCanvasGenerationHistory.mockReset();
+    readUrl.mockReset();
+    readUrl.mockReturnValue({ project: "p1", canvas: "c1" });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("fetches the whole canvas history once (no per-node fan-out)", async () => {
+    const records = [
+      { id: "a", node_id: "kept", status: "completed", recorded_at: "2026-06-16T00:00:00Z" },
+      // A record whose node no longer exists on the canvas still comes back —
+      // that is the deleted-node-survives-in-history guarantee.
+      { id: "b", node_id: "deleted", status: "completed", recorded_at: "2026-06-15T00:00:00Z" },
+    ];
+    fetchCanvasGenerationHistory.mockResolvedValue(records);
+
+    const { result } = renderHook(() => useCanvasGenerationHistory({ enabled: true }));
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(fetchCanvasGenerationHistory).toHaveBeenCalledTimes(1);
+    expect(fetchCanvasGenerationHistory).toHaveBeenCalledWith("p1", "c1");
+    expect(result.current.records).toEqual(records);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("does not fetch when disabled", async () => {
+    fetchCanvasGenerationHistory.mockResolvedValue([]);
+    renderHook(() => useCanvasGenerationHistory({ enabled: false }));
+    await Promise.resolve();
+    expect(fetchCanvasGenerationHistory).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the default canvas id when the url has none", async () => {
+    readUrl.mockReturnValue({ project: "p1", canvas: null });
+    fetchCanvasGenerationHistory.mockResolvedValue([]);
+
+    const { result } = renderHook(() => useCanvasGenerationHistory({ enabled: true }));
+
+    await waitFor(() => expect(fetchCanvasGenerationHistory).toHaveBeenCalled());
+    expect(fetchCanvasGenerationHistory).toHaveBeenCalledWith("p1", "default");
+    expect(result.current.error).toBeNull();
+  });
+
+  it("surfaces a fetch error", async () => {
+    fetchCanvasGenerationHistory.mockRejectedValue(new Error("boom"));
+
+    const { result } = renderHook(() => useCanvasGenerationHistory({ enabled: true }));
+
+    await waitFor(() => expect(result.current.error).not.toBeNull());
+    expect(result.current.error?.message).toBe("boom");
+    expect(result.current.records).toEqual([]);
+  });
+});

--- a/frontend/src/__tests__/features/canvas/use-canvas-generation-history.test.ts
+++ b/frontend/src/__tests__/features/canvas/use-canvas-generation-history.test.ts
@@ -3,10 +3,16 @@
 import { renderHook, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import { ApiError } from "@/api/client";
+
 const fetchCanvasGenerationHistory = vi.hoisted(() => vi.fn());
+const fetchNodeGenerationHistory = vi.hoisted(() => vi.fn());
 const readUrl = vi.hoisted(() => vi.fn());
 
-vi.mock("@/api/ops", () => ({ fetchCanvasGenerationHistory }));
+vi.mock("@/api/ops", () => ({
+  fetchCanvasGenerationHistory,
+  fetchNodeGenerationHistory,
+}));
 vi.mock("@/lib/url-params", () => ({ readUrl }));
 
 import { useCanvasGenerationHistory } from "@/features/canvas/hooks/useCanvasGenerationHistory";
@@ -14,6 +20,7 @@ import { useCanvasGenerationHistory } from "@/features/canvas/hooks/useCanvasGen
 describe("useCanvasGenerationHistory", () => {
   beforeEach(() => {
     fetchCanvasGenerationHistory.mockReset();
+    fetchNodeGenerationHistory.mockReset();
     readUrl.mockReset();
     readUrl.mockReturnValue({ project: "p1", canvas: "c1" });
   });
@@ -31,18 +38,40 @@ describe("useCanvasGenerationHistory", () => {
     ];
     fetchCanvasGenerationHistory.mockResolvedValue(records);
 
-    const { result } = renderHook(() => useCanvasGenerationHistory({ enabled: true }));
+    const { result } = renderHook(() =>
+      useCanvasGenerationHistory(["kept"], { enabled: true }),
+    );
 
     await waitFor(() => expect(result.current.isLoading).toBe(false));
     expect(fetchCanvasGenerationHistory).toHaveBeenCalledTimes(1);
     expect(fetchCanvasGenerationHistory).toHaveBeenCalledWith("p1", "c1");
+    expect(fetchNodeGenerationHistory).not.toHaveBeenCalled();
     expect(result.current.records).toEqual(records);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("falls back to per-node fan-out when the aggregate route is missing (404)", async () => {
+    fetchCanvasGenerationHistory.mockRejectedValue(new ApiError("Not Found", 404));
+    fetchNodeGenerationHistory.mockImplementation(async (_p, _c, nodeId: string) =>
+      nodeId === "n1"
+        ? [{ id: "r1", node_id: "n1", status: "completed", recorded_at: "2026-06-16T00:00:00Z" }]
+        : [{ id: "r2", node_id: "n2", status: "completed", recorded_at: "2026-06-17T00:00:00Z" }],
+    );
+
+    const { result } = renderHook(() =>
+      useCanvasGenerationHistory(["n1", "n2"], { enabled: true }),
+    );
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(fetchNodeGenerationHistory).toHaveBeenCalledTimes(2);
+    // Merged + sorted newest-first across the fanned-out nodes.
+    expect(result.current.records.map((r) => r.id)).toEqual(["r2", "r1"]);
     expect(result.current.error).toBeNull();
   });
 
   it("does not fetch when disabled", async () => {
     fetchCanvasGenerationHistory.mockResolvedValue([]);
-    renderHook(() => useCanvasGenerationHistory({ enabled: false }));
+    renderHook(() => useCanvasGenerationHistory(["n1"], { enabled: false }));
     await Promise.resolve();
     expect(fetchCanvasGenerationHistory).not.toHaveBeenCalled();
   });
@@ -51,19 +80,24 @@ describe("useCanvasGenerationHistory", () => {
     readUrl.mockReturnValue({ project: "p1", canvas: null });
     fetchCanvasGenerationHistory.mockResolvedValue([]);
 
-    const { result } = renderHook(() => useCanvasGenerationHistory({ enabled: true }));
+    const { result } = renderHook(() =>
+      useCanvasGenerationHistory([], { enabled: true }),
+    );
 
     await waitFor(() => expect(fetchCanvasGenerationHistory).toHaveBeenCalled());
     expect(fetchCanvasGenerationHistory).toHaveBeenCalledWith("p1", "default");
     expect(result.current.error).toBeNull();
   });
 
-  it("surfaces a fetch error", async () => {
-    fetchCanvasGenerationHistory.mockRejectedValue(new Error("boom"));
+  it("surfaces a non-404 error without falling back", async () => {
+    fetchCanvasGenerationHistory.mockRejectedValue(new ApiError("boom", 500));
 
-    const { result } = renderHook(() => useCanvasGenerationHistory({ enabled: true }));
+    const { result } = renderHook(() =>
+      useCanvasGenerationHistory(["n1"], { enabled: true }),
+    );
 
     await waitFor(() => expect(result.current.error).not.toBeNull());
+    expect(fetchNodeGenerationHistory).not.toHaveBeenCalled();
     expect(result.current.error?.message).toBe("boom");
     expect(result.current.records).toEqual([]);
   });

--- a/frontend/src/api/ops.ts
+++ b/frontend/src/api/ops.ts
@@ -67,6 +67,26 @@ export async function fetchNodeGenerationHistory(
   return data?.records ?? [];
 }
 
+/**
+ * Read the whole canvas's generation history in one request (most recent
+ * first). Unlike {@link fetchNodeGenerationHistory} this is not scoped to a
+ * single node, and the backend aggregates across every node that ever recorded
+ * history on this canvas — including nodes since deleted from the canvas — so
+ * their past attempts stay visible in the history browser.
+ */
+export async function fetchCanvasGenerationHistory(
+  project: string,
+  canvasId: string,
+  limit = 500,
+): Promise<FreezoneGenerationHistoryRecord[]> {
+  const data = await apiCall<{ records?: FreezoneGenerationHistoryRecord[] }>(
+    `projects/${encodeURIComponent(project)}/freezone/canvases/${encodeURIComponent(
+      canvasId,
+    )}/generation-history?limit=${limit}`,
+  );
+  return data?.records ?? [];
+}
+
 // /freezone/gen ----------------------------------------------------------- //
 
 export type FreezoneProvider =

--- a/frontend/src/features/canvas/hooks/useCanvasGenerationHistory.ts
+++ b/frontend/src/features/canvas/hooks/useCanvasGenerationHistory.ts
@@ -3,7 +3,7 @@
 import { useCallback, useEffect, useState } from "react";
 
 import {
-  fetchNodeGenerationHistory,
+  fetchCanvasGenerationHistory,
   type FreezoneGenerationHistoryRecord,
 } from "@/api/ops";
 import { readUrl } from "@/lib/url-params";
@@ -15,49 +15,16 @@ export interface UseCanvasGenerationHistoryResult {
   refresh: () => Promise<void>;
 }
 
-/** Fan-out concurrency cap for the per-node aggregation. */
-const FANOUT_CONCURRENCY = 6;
-
 /**
- * Aggregate per-node generation history client-side: one request per node id
- * (capped concurrency), merges, dedupes by record id, sorts newest-first.
- */
-async function aggregatePerNode(
-  project: string,
-  canvasId: string,
-  nodeIds: string[],
-): Promise<FreezoneGenerationHistoryRecord[]> {
-  const out: FreezoneGenerationHistoryRecord[] = [];
-  for (let i = 0; i < nodeIds.length; i += FANOUT_CONCURRENCY) {
-    const slice = nodeIds.slice(i, i + FANOUT_CONCURRENCY);
-    const batches = await Promise.all(
-      slice.map((nodeId) =>
-        fetchNodeGenerationHistory(project, canvasId, nodeId).catch(() => []),
-      ),
-    );
-    for (const batch of batches) out.push(...batch);
-  }
-  const seen = new Set<string>();
-  return out
-    .filter((record) => {
-      if (seen.has(record.id)) return false;
-      seen.add(record.id);
-      return true;
-    })
-    .sort(
-      (a, b) =>
-        new Date(b.recorded_at).getTime() - new Date(a.recorded_at).getTime(),
-    );
-}
-
-/**
- * Read the whole canvas's generation history for the history-assets modal by
- * fanning out the per-node generation-history endpoint over `nodeIds` and
- * merging. History lives outside the canvas JSON, so this is a plain on-demand
- * fetch gated by `enabled` (the modal only mounts when opened).
+ * Read the whole canvas's generation history for the history-assets modal.
+ *
+ * The backend aggregates across every node that ever recorded history on this
+ * canvas — including nodes since deleted from the canvas — so deleting a node
+ * no longer drops its past generations from the history browser. History lives
+ * outside the canvas JSON, so this is a plain on-demand fetch gated by
+ * `enabled` (the modal only mounts when opened).
  */
 export function useCanvasGenerationHistory(
-  nodeIds: string[],
   options?: { enabled?: boolean },
 ): UseCanvasGenerationHistoryResult {
   const enabled = options?.enabled ?? true;
@@ -65,18 +32,13 @@ export function useCanvasGenerationHistory(
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<Error | null>(null);
 
-  // Snapshot the ids as a stable string so the callback identity only changes
-  // when the actual id set changes (not on every nodes-array reference churn).
-  const nodeIdsKey = nodeIds.join(",");
-
   const refresh = useCallback(async () => {
     const project = readUrl().project;
     if (!project) return;
     const canvasId = readUrl().canvas ?? "default";
     setIsLoading(true);
     try {
-      const ids = nodeIdsKey ? nodeIdsKey.split(",") : [];
-      const recs = await aggregatePerNode(project, canvasId, ids);
+      const recs = await fetchCanvasGenerationHistory(project, canvasId);
       setRecords(recs);
       setError(null);
     } catch (err) {
@@ -84,7 +46,7 @@ export function useCanvasGenerationHistory(
     } finally {
       setIsLoading(false);
     }
-  }, [nodeIdsKey]);
+  }, []);
 
   useEffect(() => {
     if (!enabled) return;

--- a/frontend/src/features/canvas/hooks/useCanvasGenerationHistory.ts
+++ b/frontend/src/features/canvas/hooks/useCanvasGenerationHistory.ts
@@ -4,8 +4,10 @@ import { useCallback, useEffect, useState } from "react";
 
 import {
   fetchCanvasGenerationHistory,
+  fetchNodeGenerationHistory,
   type FreezoneGenerationHistoryRecord,
 } from "@/api/ops";
+import { ApiError } from "@/api/client";
 import { readUrl } from "@/lib/url-params";
 
 export interface UseCanvasGenerationHistoryResult {
@@ -15,16 +17,67 @@ export interface UseCanvasGenerationHistoryResult {
   refresh: () => Promise<void>;
 }
 
+/** Fan-out concurrency cap for the per-node fallback. */
+const FANOUT_CONCURRENCY = 6;
+
+function sortNewestFirst(
+  records: FreezoneGenerationHistoryRecord[],
+): FreezoneGenerationHistoryRecord[] {
+  return [...records].sort(
+    (a, b) =>
+      new Date(b.recorded_at).getTime() - new Date(a.recorded_at).getTime(),
+  );
+}
+
+/**
+ * Legacy per-node aggregation: one request per live node id (capped
+ * concurrency), merged + deduped + sorted newest-first. Used only as a fallback
+ * when the backend lacks the canvas-level aggregate endpoint (older deploy).
+ */
+async function aggregatePerNode(
+  project: string,
+  canvasId: string,
+  nodeIds: string[],
+): Promise<FreezoneGenerationHistoryRecord[]> {
+  const out: FreezoneGenerationHistoryRecord[] = [];
+  for (let i = 0; i < nodeIds.length; i += FANOUT_CONCURRENCY) {
+    const slice = nodeIds.slice(i, i + FANOUT_CONCURRENCY);
+    const batches = await Promise.all(
+      slice.map((nodeId) =>
+        fetchNodeGenerationHistory(project, canvasId, nodeId).catch(() => []),
+      ),
+    );
+    for (const batch of batches) out.push(...batch);
+  }
+  const seen = new Set<string>();
+  return sortNewestFirst(
+    out.filter((record) => {
+      if (seen.has(record.id)) return false;
+      seen.add(record.id);
+      return true;
+    }),
+  );
+}
+
 /**
  * Read the whole canvas's generation history for the history-assets modal.
  *
- * The backend aggregates across every node that ever recorded history on this
- * canvas — including nodes since deleted from the canvas — so deleting a node
- * no longer drops its past generations from the history browser. History lives
- * outside the canvas JSON, so this is a plain on-demand fetch gated by
- * `enabled` (the modal only mounts when opened).
+ * Prefers the canvas-level aggregate endpoint, which merges every node that
+ * ever recorded history on this canvas — including nodes since deleted from the
+ * canvas — so deleting a node no longer drops its past generations from the
+ * browser.
+ *
+ * `fallbackNodeIds` are the live canvas node ids used ONLY when the backend does
+ * not yet expose the aggregate route (404 during a frontend-ahead-of-backend
+ * deploy). In that window we fall back to the old per-node fan-out so existing
+ * users' history still shows (minus deleted nodes — the pre-existing behavior).
+ * Once the backend ships the route, deleted-node history is recovered too.
+ *
+ * History lives outside the canvas JSON, so this is a plain on-demand fetch
+ * gated by `enabled` (the modal only mounts when opened).
  */
 export function useCanvasGenerationHistory(
+  fallbackNodeIds: string[],
   options?: { enabled?: boolean },
 ): UseCanvasGenerationHistoryResult {
   const enabled = options?.enabled ?? true;
@@ -32,13 +85,29 @@ export function useCanvasGenerationHistory(
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<Error | null>(null);
 
+  // Snapshot the ids as a stable string so the callback identity only changes
+  // when the actual id set changes (not on every nodes-array reference churn).
+  const nodeIdsKey = fallbackNodeIds.join(",");
+
   const refresh = useCallback(async () => {
     const project = readUrl().project;
     if (!project) return;
     const canvasId = readUrl().canvas ?? "default";
     setIsLoading(true);
     try {
-      const recs = await fetchCanvasGenerationHistory(project, canvasId);
+      let recs: FreezoneGenerationHistoryRecord[];
+      try {
+        recs = await fetchCanvasGenerationHistory(project, canvasId);
+      } catch (err) {
+        // Backend without the aggregate route (older deploy) → 404. Fall back to
+        // the per-node fan-out so history still shows during version skew.
+        if (err instanceof ApiError && err.status === 404) {
+          const ids = nodeIdsKey ? nodeIdsKey.split(",") : [];
+          recs = await aggregatePerNode(project, canvasId, ids);
+        } else {
+          throw err;
+        }
+      }
       setRecords(recs);
       setError(null);
     } catch (err) {
@@ -46,7 +115,7 @@ export function useCanvasGenerationHistory(
     } finally {
       setIsLoading(false);
     }
-  }, []);
+  }, [nodeIdsKey]);
 
   useEffect(() => {
     if (!enabled) return;

--- a/frontend/src/features/canvas/ui/CanvasHistoryAssetsModal.tsx
+++ b/frontend/src/features/canvas/ui/CanvasHistoryAssetsModal.tsx
@@ -23,6 +23,7 @@ import {
   type CanvasAssetBuckets,
   type CanvasAssetKind,
 } from '@/features/canvas/domain/canvasAssets';
+import { CANVAS_NODE_TYPES } from '@/features/canvas/domain/canvasNodes';
 import { useCanvasGenerationHistory } from '@/features/canvas/hooks/useCanvasGenerationHistory';
 import {
   historyRecordOutputUrl,
@@ -42,6 +43,24 @@ import { ThreeDDirectorDialog } from '@/features/viewer-kit/three-d/ThreeDDirect
 
 import { ImageViewerModal } from './ImageViewerModal';
 import { VideoViewerModal } from './VideoViewerModal';
+
+// Node types that record backend generation history. Used only to scope the
+// per-node fallback fan-out (see useCanvasGenerationHistory); the canvas-level
+// aggregate endpoint ignores this list. Pure reference / annotation / layout
+// nodes never have history, so we skip them.
+const GENERATIVE_HISTORY_NODE_TYPES = new Set<string>([
+  CANVAS_NODE_TYPES.imageGen,
+  CANVAS_NODE_TYPES.imageEdit,
+  CANVAS_NODE_TYPES.exportImage,
+  CANVAS_NODE_TYPES.storyboardSplit,
+  CANVAS_NODE_TYPES.storyboardGen,
+  CANVAS_NODE_TYPES.video,
+  CANVAS_NODE_TYPES.videoStory,
+  CANVAS_NODE_TYPES.videoCompose,
+  CANVAS_NODE_TYPES.audio,
+  CANVAS_NODE_TYPES.script,
+  CANVAS_NODE_TYPES.threeDWorld,
+]);
 
 // Cap how many recent records each tab shows. Records arrive newest-first
 // (backend sorts by recorded_at desc), so slicing keeps the latest.
@@ -175,11 +194,17 @@ export function CanvasHistoryAssetsModal({
   const nodes = useCanvasStore((state) => state.nodes);
   const useHistory = assetSource === 'generation-history';
 
-  // History is aggregated backend-side across every node that ever recorded on
-  // this canvas — including nodes since deleted — so we no longer scope the
-  // fetch to live node ids. `nodes` is still used below to enrich records with
-  // live-node metadata (covers/names) and for the non-history asset tab.
-  const { records, isLoading } = useCanvasGenerationHistory({
+  // Live-node ids feed the per-node fallback fan-out for backends that don't yet
+  // expose the canvas-level aggregate endpoint. When the aggregate route is
+  // present it ignores these and returns history for deleted nodes too.
+  const fallbackNodeIds = useMemo(
+    () =>
+      nodes
+        .filter((node) => GENERATIVE_HISTORY_NODE_TYPES.has(node.type))
+        .map((node) => node.id),
+    [nodes],
+  );
+  const { records, isLoading } = useCanvasGenerationHistory(fallbackNodeIds, {
     enabled: useHistory,
   });
 

--- a/frontend/src/features/canvas/ui/CanvasHistoryAssetsModal.tsx
+++ b/frontend/src/features/canvas/ui/CanvasHistoryAssetsModal.tsx
@@ -23,7 +23,6 @@ import {
   type CanvasAssetBuckets,
   type CanvasAssetKind,
 } from '@/features/canvas/domain/canvasAssets';
-import { CANVAS_NODE_TYPES } from '@/features/canvas/domain/canvasNodes';
 import { useCanvasGenerationHistory } from '@/features/canvas/hooks/useCanvasGenerationHistory';
 import {
   historyRecordOutputUrl,
@@ -44,25 +43,8 @@ import { ThreeDDirectorDialog } from '@/features/viewer-kit/three-d/ThreeDDirect
 import { ImageViewerModal } from './ImageViewerModal';
 import { VideoViewerModal } from './VideoViewerModal';
 
-// Node types that record backend generation history — used only to scope the
-// per-node fan-out fallback (the aggregate endpoint ignores this list). Pure
-// reference / annotation / layout nodes never have history, so we skip them.
-const GENERATIVE_HISTORY_NODE_TYPES = new Set<string>([
-  CANVAS_NODE_TYPES.imageGen,
-  CANVAS_NODE_TYPES.imageEdit,
-  CANVAS_NODE_TYPES.exportImage,
-  CANVAS_NODE_TYPES.storyboardSplit,
-  CANVAS_NODE_TYPES.storyboardGen,
-  CANVAS_NODE_TYPES.video,
-  CANVAS_NODE_TYPES.videoStory,
-  CANVAS_NODE_TYPES.videoCompose,
-  CANVAS_NODE_TYPES.audio,
-  CANVAS_NODE_TYPES.script,
-  CANVAS_NODE_TYPES.threeDWorld,
-]);
-
 // Cap how many recent records each tab shows. Records arrive newest-first
-// (aggregatePerNode sorts by recorded_at desc), so slicing keeps the latest.
+// (backend sorts by recorded_at desc), so slicing keeps the latest.
 const HISTORY_DISPLAY_CAP = 20;
 
 /**
@@ -193,15 +175,11 @@ export function CanvasHistoryAssetsModal({
   const nodes = useCanvasStore((state) => state.nodes);
   const useHistory = assetSource === 'generation-history';
 
-  // Scope the per-node fallback fan-out to nodes that can actually have history.
-  const historyNodeIds = useMemo(
-    () =>
-      nodes
-        .filter((node) => GENERATIVE_HISTORY_NODE_TYPES.has(node.type))
-        .map((node) => node.id),
-    [nodes],
-  );
-  const { records, isLoading } = useCanvasGenerationHistory(historyNodeIds, {
+  // History is aggregated backend-side across every node that ever recorded on
+  // this canvas — including nodes since deleted — so we no longer scope the
+  // fetch to live node ids. `nodes` is still used below to enrich records with
+  // live-node metadata (covers/names) and for the non-history asset tab.
+  const { records, isLoading } = useCanvasGenerationHistory({
     enabled: useHistory,
   });
 

--- a/license-inventory.csv
+++ b/license-inventory.csv
@@ -349,6 +349,7 @@ frontend/src/__tests__/features/canvas/snap-aspect-ratio.test.ts,Elastic-2.0,202
 frontend/src/__tests__/features/canvas/system-managed-node-data.test.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/__tests__/features/canvas/three-d-world-node-source-scope.test.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/__tests__/features/canvas/timelineModel.test.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
+frontend/src/__tests__/features/canvas/use-canvas-generation-history.test.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/__tests__/features/canvas/use-reference-mention-sync.test.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/__tests__/features/canvas/viewport-bookmarks-domain.test.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/__tests__/features/companion/petdex-pets.test.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
@@ -1593,6 +1594,7 @@ tests/test_format_check.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml ag
 tests/test_freezone_asset_library_backend.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_freezone_audio_backend.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_freezone_audio_separate_runner.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
+tests/test_freezone_canvas_generation_history.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_freezone_canvas_store.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_freezone_generation_history_prompt.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_freezone_image_backend.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation

--- a/src/novelvideo/api/routes/freezone.py
+++ b/src/novelvideo/api/routes/freezone.py
@@ -96,6 +96,7 @@ from novelvideo.freezone.canvas_static_urls import (
 from novelvideo.freezone.history import (
     append_generation_history,
     build_node_history_record,
+    read_canvas_generation_history,
     read_generation_history,
 )
 from novelvideo.freezone.image_node import (
@@ -9959,6 +9960,56 @@ async def get_node_generation_history(
             project_dir=project_dir,
             canvas_id=canvas_id,
             node_id=node_id,
+            limit=limit,
+        )
+    except ValueError as exc:
+        raise HTTPException(400, str(exc)) from exc
+    records = [
+        sanitize_project_local_paths_in_memory(
+            migrate_canvas_static_urls_in_memory(
+                record,
+                project_id=ctx.project_id,
+                owner_username=ctx.owner_username,
+                project_name=ctx.project_name,
+                project_dir=project_dir,
+            )
+            or record,
+            project_id=ctx.project_id,
+            project_dir=project_dir,
+        )
+        or record
+        for record in records
+    ]
+    return {"ok": True, "data": {"records": records}}
+
+
+@router.get(
+    "/projects/{project}/freezone/canvases/{canvas_id}/generation-history",
+    tags=[TAG_FREEZONE_CANVAS],
+)
+async def get_canvas_generation_history(
+    project: str,
+    canvas_id: str,
+    limit: int = Query(500, ge=1, le=2000),
+    user: dict = Depends(get_api_user),
+):
+    """Return every node's recorded generation attempts for a whole canvas.
+
+    Aggregates across all nodes (newest first), including nodes that were deleted
+    from the canvas — their history files persist, so their past attempts stay
+    recoverable in the history browser.
+    """
+    if not CANVAS_ID_RE.match(canvas_id):
+        raise HTTPException(400, "invalid canvas_id")
+    ctx, _username, _project_name, project_dir, _output_dir = await _resolve_freezone_project(
+        project,
+        user,
+        required_role="viewer",
+    )
+    try:
+        records = read_canvas_generation_history(
+            project_dir=project_dir,
+            canvas_id=canvas_id,
             limit=limit,
         )
     except ValueError as exc:

--- a/src/novelvideo/freezone/history.py
+++ b/src/novelvideo/freezone/history.py
@@ -109,14 +109,7 @@ def append_generation_history(
     return normalized
 
 
-def read_generation_history(
-    *,
-    project_dir: Path,
-    canvas_id: str,
-    node_id: str,
-    limit: int = _DEFAULT_LIMIT,
-) -> list[dict[str, Any]]:
-    path = generation_history_path(project_dir, canvas_id, node_id)
+def _read_history_file(path: Path) -> list[dict[str, Any]]:
     if not path.exists():
         return []
     records: list[dict[str, Any]] = []
@@ -129,6 +122,46 @@ def read_generation_history(
             continue
         if isinstance(value, dict):
             records.append(value)
+    return records
+
+
+def read_generation_history(
+    *,
+    project_dir: Path,
+    canvas_id: str,
+    node_id: str,
+    limit: int = _DEFAULT_LIMIT,
+) -> list[dict[str, Any]]:
+    records = _read_history_file(generation_history_path(project_dir, canvas_id, node_id))
     if limit <= 0:
         return records
     return records[-limit:]
+
+
+def read_canvas_generation_history(
+    *,
+    project_dir: Path,
+    canvas_id: str,
+    limit: int = _DEFAULT_LIMIT,
+) -> list[dict[str, Any]]:
+    """Aggregate every node's generation history for a whole canvas.
+
+    Reads all per-node JSONL files under the canvas history dir and merges them,
+    newest first. Unlike the per-node read, this is *not* scoped to nodes still
+    present on the canvas — a node deleted from the canvas keeps its history file,
+    so its past attempts stay recoverable here. Malformed lines/files are skipped.
+    """
+    canvas = (canvas_id or "").strip() or "default"
+    if not CANVAS_ID_RE.match(canvas):
+        raise ValueError(f"invalid canvas_id: {canvas_id!r}")
+    canvas_dir = generation_history_dir(project_dir) / canvas
+    if not canvas_dir.is_dir():
+        return []
+    records: list[dict[str, Any]] = []
+    for path in canvas_dir.glob("*.jsonl"):
+        records.extend(_read_history_file(path))
+    # Newest first; records without a usable timestamp sort last (empty string).
+    records.sort(key=lambda record: str(record.get("recorded_at") or ""), reverse=True)
+    if limit <= 0:
+        return records
+    return records[:limit]

--- a/tests/test_freezone_canvas_generation_history.py
+++ b/tests/test_freezone_canvas_generation_history.py
@@ -1,0 +1,83 @@
+"""Canvas-level generation-history aggregation.
+
+Deleting a node from the canvas must NOT remove its past generations from the
+history browser. History lives in per-node append-only JSONL files that the
+canvas JSON never touches, so ``read_canvas_generation_history`` reads *every*
+node file under a canvas — including nodes that no longer exist on the canvas.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from novelvideo.freezone.history import (
+    append_generation_history,
+    generation_history_path,
+    read_canvas_generation_history,
+)
+
+
+def _append(project_dir: Path, node_id: str, job_id: str, recorded_at: str) -> None:
+    append_generation_history(
+        project_dir=project_dir,
+        canvas_id="default",
+        node_id=node_id,
+        record={
+            "job_id": job_id,
+            "status": "completed",
+            "media_type": "video",
+            "recorded_at": recorded_at,
+            "result": {"output_url": f"/static/{job_id}.mp4"},
+        },
+    )
+
+
+def test_canvas_history_includes_deleted_node(tmp_path: Path) -> None:
+    project_dir = tmp_path / "proj"
+    _append(project_dir, "kept_node", "job_kept", "2026-06-16T00:00:00Z")
+    _append(project_dir, "deleted_node", "job_deleted", "2026-06-15T00:00:00Z")
+
+    # Simulate the node being removed from the canvas: only the canvas JSON would
+    # drop it — the history file stays on disk, which is the whole point.
+    assert generation_history_path(project_dir, "default", "deleted_node").exists()
+
+    records = read_canvas_generation_history(project_dir=project_dir, canvas_id="default")
+    job_ids = {r["job_id"] for r in records}
+    assert job_ids == {"job_kept", "job_deleted"}
+
+
+def test_canvas_history_sorted_newest_first(tmp_path: Path) -> None:
+    project_dir = tmp_path / "proj"
+    _append(project_dir, "node_a", "job_old", "2026-06-10T00:00:00Z")
+    _append(project_dir, "node_b", "job_mid", "2026-06-12T00:00:00Z")
+    _append(project_dir, "node_a", "job_new", "2026-06-14T00:00:00Z")
+
+    records = read_canvas_generation_history(project_dir=project_dir, canvas_id="default")
+    assert [r["job_id"] for r in records] == ["job_new", "job_mid", "job_old"]
+
+
+def test_canvas_history_respects_limit(tmp_path: Path) -> None:
+    project_dir = tmp_path / "proj"
+    _append(project_dir, "node_a", "job_old", "2026-06-10T00:00:00Z")
+    _append(project_dir, "node_b", "job_new", "2026-06-14T00:00:00Z")
+
+    records = read_canvas_generation_history(
+        project_dir=project_dir, canvas_id="default", limit=1
+    )
+    assert [r["job_id"] for r in records] == ["job_new"]
+
+
+def test_canvas_history_missing_canvas_dir_is_empty(tmp_path: Path) -> None:
+    records = read_canvas_generation_history(
+        project_dir=tmp_path / "proj", canvas_id="default"
+    )
+    assert records == []
+
+
+def test_canvas_history_rejects_bad_canvas_id(tmp_path: Path) -> None:
+    with pytest.raises(ValueError):
+        read_canvas_generation_history(
+            project_dir=tmp_path / "proj", canvas_id="../escape"
+        )


### PR DESCRIPTION
## 问题

在画布上删除一个已生成好的视频/图片节点后，历史资产弹窗里该节点的产物也被一并删掉了。

## 根因

历史资源此前由前端 `useCanvasGenerationHistory` 按「当前画布上活跃节点的 id」逐个扇出调用 per-node 历史端点。节点一旦从画布删除，它的 id 就不在活跃列表里，于是它的历史产物在弹窗中消失——但产物其实并没丢，后端的 per-node 追加式 JSONL 文件始终存在。

## 方案（Option A：前后端一个 PR）

- **后端** 新增画布级聚合端点 `GET /projects/{project}/freezone/canvases/{canvas_id}/generation-history`：遍历该画布目录下所有 per-node JSONL（**含已从画布删除的节点文件**），按 `recorded_at` 倒序合并返回。复用 node-level 端点相同的 URL 迁移 / 本地路径脱敏处理。
- **前端** `useCanvasGenerationHistory` 优先调用该聚合端点，一次拉全画布，不再依赖活跃节点 id。删除节点不再影响历史记录。

## 兼容性（部署错峰）

新前端 + 旧后端（还没有聚合路由）时，聚合请求会 404。为避免这一窗口内历史资产全空，前端在收到 `ApiError 404` 时**自动回退到旧的逐节点扇出**（复用活跃节点 id）；其余错误照常透出、不静默兜底。后端上线聚合路由后仍走聚合，被删节点历史照常保留。数据未做任何迁移/改动——聚合读的是与旧接口完全相同的 JSONL 文件，返回旧数据的超集。

## 测试

- 后端 `tests/test_freezone_canvas_generation_history.py`：已删除节点的历史仍返回、倒序、limit、缺目录、非法 canvas_id。
- 前端 `use-canvas-generation-history.test.ts`：单次聚合拉取、**404 回退逐节点**、非 404 不回退、disabled 不拉取、缺 canvas 回退 `default`。
- 本地已在真实运行环境验证通过（重启 API 加载新路由后，删除节点历史仍保留）。
- `tsc -b`、`pnpm build`、相关前后端用例均通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)