### PR TITLE
docs(self-hosting): 备份指南补恢复/迁移到新机步骤（DOCS-14）

### DIFF
--- a/docs/en/guides/self-hosting.md
+++ b/docs/en/guides/self-hosting.md
@@ -62,7 +62,7 @@ docker compose logs -f api       # logs
 docker compose down              # stop (keeps the data volume)
 ```
 
-## 5. Where the data lives / Backups
+## 5. Where the data lives / Backup, restore & migrate
 
 - Project data lives in the named volume `ce-data` (`/data` inside the container); output is in `NOVELVIDEO_OUTPUT_DIR` (default `output`).
 - Back up the data volume:
@@ -73,6 +73,15 @@ docker run --rm -v dramaclaw-ce_ce-data:/data -v "$PWD":/backup alpine \
 ```
 
 (The volume name is prefixed with the compose project name; run `docker volume ls` to confirm the actual name.)
+
+- Restore, or move to a new machine — copy `ce-data-backup.tar.gz` to the target host, then unpack it back into the data volume (the `-v` mount creates the volume if it does not exist yet):
+
+```bash
+docker run --rm -v dramaclaw-ce_ce-data:/data -v "$PWD":/backup alpine \
+  tar xzf /backup/ce-data-backup.tar.gz -C /data
+```
+
+Then bring the stack up as usual (`docker compose -f docker-compose.selfhosted.yml up -d`). Copy the `output` directory (`NOVELVIDEO_OUTPUT_DIR`) and your `.env` across too if you want generated media and settings to carry over.
 
 ## 6. Upgrades
 

--- a/docs/zh/guides/self-hosting.md
+++ b/docs/zh/guides/self-hosting.md
@@ -62,7 +62,7 @@ docker compose logs -f api       # 日志
 docker compose down              # 停止（保留数据卷）
 ```
 
-## 5. 数据在哪 / 备份
+## 5. 数据在哪 / 备份、恢复与迁移
 
 - 项目数据在命名卷 `ce-data`（容器内 `/data`），输出在 `NOVELVIDEO_OUTPUT_DIR`（默认 `output`）。
 - 备份数据卷：
@@ -73,6 +73,15 @@ docker run --rm -v dramaclaw-ce_ce-data:/data -v "$PWD":/backup alpine \
 ```
 
 （卷名前缀随 compose 项目名，`docker volume ls` 确认实际名。）
+
+- 恢复 / 搬到新机 —— 把 `ce-data-backup.tar.gz` 拷到目标机，反向解回数据卷（`-v` 挂载会在卷不存在时自动创建）：
+
+```bash
+docker run --rm -v dramaclaw-ce_ce-data:/data -v "$PWD":/backup alpine \
+  tar xzf /backup/ce-data-backup.tar.gz -C /data
+```
+
+然后照常起服务（`docker compose -f docker-compose.selfhosted.yml up -d`）。若要一并带上已生成的媒体与配置，把 `output` 目录（`NOVELVIDEO_OUTPUT_DIR`）和 `.env` 也拷过去。
 
 ## 6. 升级
 


### PR DESCRIPTION
## Background
`docs/{en,zh}/guides/self-hosting.md` §5 already covers where the data lives and how to back up the data volume, but the restore / move-to-a-new-machine step was missing. This PR fills that gap.

## Changes
- §5 heading → "Backup, restore & migrate / 备份、恢复与迁移"
- Add a restore/migrate snippet: the inverse of the existing backup command (`tar xzf` back into the data volume; the `-v` mount creates the volume if absent) + bring the stack up + note to copy the `output` dir and `.env` across
- en / zh in sync

Docs-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)