### PR TITLE
chore(release): v1.0.3

### DIFF
--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -6,7 +6,7 @@
 
 按顺序执行：
 
-1. **Bump 版本**：改 `pyproject.toml` 的 `version = "X.Y.Z"`（版本唯一真源，SSOT），并同步 `tests/test_release_feed.py::test_project_version_is_single_source_of_truth` 中钉死的版本字面量。
+1. **Bump 版本**：改 `pyproject.toml` 的 `version = "X.Y.Z"`（版本唯一真源，SSOT），并同步 `tests/test_release_feed.py::test_project_version_is_single_source_of_truth` 中钉死的版本字面量；第 3 步重装后 `uv.lock` 会随之更新，记得一并提交。
 2. **重写包内 release notes**：整体替换 `src/novelvideo/release-notes.md` 为新版本内容（用下方模板）。front-matter 的 `version:` 必须与 `pyproject.toml` 一致，否则解析门断言失败（F8）。
 3. **本地验证**：
    ```bash

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -6,7 +6,7 @@
 
 按顺序执行：
 
-1. **Bump 版本**：改 `pyproject.toml` 的 `version = "X.Y.Z"`（版本唯一真源，SSOT）。
+1. **Bump 版本**：改 `pyproject.toml` 的 `version = "X.Y.Z"`（版本唯一真源，SSOT），并同步 `tests/test_release_feed.py::test_project_version_is_single_source_of_truth` 中钉死的版本字面量。
 2. **重写包内 release notes**：整体替换 `src/novelvideo/release-notes.md` 为新版本内容（用下方模板）。front-matter 的 `version:` 必须与 `pyproject.toml` 一致，否则解析门断言失败（F8）。
 3. **本地验证**：
    ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "supertale-ce"
-version = "1.0.2"
+version = "1.0.3"
 description = "SuperTale Community Edition API and video pipeline"
 readme = "README.md"
 requires-python = ">=3.11,<3.13"

--- a/src/novelvideo/release-notes.md
+++ b/src/novelvideo/release-notes.md
@@ -1,15 +1,23 @@
 ---
-version: 1.0.2
+version: 1.0.3
 attention: low
 ---
-# v1.0.2
+# v1.0.3
 
 ## User-facing Highlights (zh)
 
-- **版本更新通知接入 Release Feed**: 进入平台后按当前版本展示更新内容,并在上游有新版时于通知中心提示升级。
-- **通知中心改为发版内容源**: 原有硬编码功能通知改为由包内 release notes 驱动,离线部署也能查看当前版本亮点。
+- **画布与视频生成体验修复**: 图片节点 21:9 不再被误吸附成 16:9,删除节点后其生成产物随历史记录同步清理,新建视频节点默认 Seedance 2.0 并继承上次所选模型。
+- **界面稳定性修复合集**: 修复从虾画切换菜单被拽回、浏览器翻译插件引发的页面崩溃、按钮加载状态刷新后丢失等问题;右上角积分改为完整数值展示。
+- **速写格子入口上线**: 界面新增速写格子入口,可直接进入速写模式。
+- **积分计费覆盖更多能力**: 助手聊天与剧集素材生成现按积分计费。
 
 ## User-facing Highlights (en)
 
-- **Release Feed powers version updates**: The app now shows highlights for the running version and can surface an upstream upgrade in the notification center.
-- **Notification Center uses release content**: Hardcoded feature notices are replaced with packaged release notes so offline self-hosted deployments still show current-version highlights.
+- **Canvas & video generation fixes**: Image nodes keep their 21:9 ratio, deleting a node now clears its generated assets from history, and new video nodes default to Seedance 2.0 while inheriting your last-used model.
+- **UI stability fixes**: Fixed navigation being pulled back when leaving the drawing page, crashes triggered by browser translation extensions, and button loading states lost after refresh; the credit balance now shows its full value.
+- **Sketch grid entry**: A new entry point opens the sketch grid directly from the UI.
+- **Credits cover more features**: Assistant chat and episode asset generation are now billed with credits.
+
+## Fixes
+
+- 其余修复与内部改动见 GitHub Release 页的 Bug Fixes 与 What's Changed。

--- a/tests/test_release_feed.py
+++ b/tests/test_release_feed.py
@@ -114,7 +114,7 @@ def test_built_wheel_contains_parseable_release_notes_artifact(tmp_path: Path) -
 def test_project_version_is_single_source_of_truth() -> None:
     pyproject = tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))
 
-    assert pyproject["project"]["version"] == "1.0.2"
+    assert pyproject["project"]["version"] == "1.0.3"
     assert importlib.metadata.version("supertale-ce") == pyproject["project"]["version"]
     assert "__version__" not in Path("src/novelvideo/__init__.py").read_text(encoding="utf-8")
 

--- a/uv.lock
+++ b/uv.lock
@@ -3407,7 +3407,7 @@ wheels = [
 
 [[package]]
 name = "supertale-ce"
-version = "1.0.2"
+version = "1.0.3"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## PR 类型 / Type of PR
- [ ] 🐞 Bug 修复 / Bug fix
- [ ] ✨ 新功能 / Feature
- [ ] 📝 文档 / Documentation
- [x] 🧹 重构 / 清理 / Refactor or cleanup
- [ ] ⚙️ 构建 / CI / Build or CI
- [ ] ⚠️ 破坏性变更 / Breaking change

## 改动说明 / What this PR does and why

v1.0.3 发版准备（按 `docs/releasing.md` runbook）：

- `pyproject.toml` version 1.0.2 → 1.0.3，同步 `tests/test_release_feed.py` 的 SSOT 版本字面量
- 重写 `src/novelvideo/release-notes.md` 为 v1.0.3 双语 Highlights（`attention: low`），覆盖 v1.0.2 以来的画布/视频修复、界面稳定性修复、速写格子入口与积分计费变更
- `docs/releasing.md` checklist 补上「测试版本字面量同步 bump」一步（本次实操发现 runbook 遗漏）

合并后打 tag `v1.0.3` 并发 GitHub Release（body 已备好，含同样双语 Highlights + Bug Fixes 分类 + 自动生成 What's Changed）。

## 关联 issue / Linked issues
N/A

## 给 reviewer 的说明 / Notes for the reviewer

- 重点看 Highlights 措辞是否准确概括 #20/#26/#41/#45/#47/#52/#53/#55/#30/#36
- `tests/test_release_feed.py` 12 passed；包内 notes 与 release body 均已真实过 parser（zh/en 各 4 条）

## 面向用户的变更 / User-facing change
```release-note
发布 v1.0.3：画布与视频生成体验修复、界面稳定性修复合集、速写格子入口上线、积分计费覆盖助手聊天与剧集素材。
```

## 自检 / Checklist
- [x] 已自测，`uv run pytest` 通过 / Self-tested, `uv run pytest` passes
- [x] 必要的文档已更新 / Docs updated where needed
- [x] 提交信息清晰（建议 Conventional Commits）/ Clear commits (Conventional Commits suggested)
- [x] 每个 commit 都已 `git commit -s` 附 DCO 签署 / Every commit signed off with `git commit -s` (DCO)
- [x] 我已阅读并同意[贡献者协议](../CONTRIBUTING.md#贡献者协议) / I've read and agree to the [contributor terms](../CONTRIBUTING.md#贡献者协议)

🤖 Generated with [Claude Code](https://claude.com/claude-code)