### PR TITLE
feat(canvas): 历史「使用」建视频节点时回填原始提示词

### DIFF
--- a/frontend/src/features/canvas/Canvas.tsx
+++ b/frontend/src/features/canvas/Canvas.tsx
@@ -3094,6 +3094,8 @@ export function Canvas({
       const payload: CanvasAssetDragPayload = {
         kind: asset.kind,
         label: asset.label ?? '',
+        // 历史记录里存的原始提示词，回填到新建视频节点的提示词框（见 spawnAssetNode）。
+        prompt: asset.prompt ?? undefined,
         url: asset.url,
         // 世界模型节点用 coverUrl 当封面（previewImageUrl）；其余类型无封面。
         coverUrl: asset.kind === 'model' ? asset.previewUrl : null,

--- a/frontend/src/features/canvas/domain/assetDrag.ts
+++ b/frontend/src/features/canvas/domain/assetDrag.ts
@@ -21,6 +21,11 @@ export type CanvasAssetDragKind = "image" | "video" | "audio" | "model";
 export interface CanvasAssetDragPayload {
   kind: CanvasAssetDragKind;
   label: string;
+  /**
+   * 生成型节点(目前仅视频)的提示词。历史「使用」流程从对应记录带过来,用于回填
+   * 新节点的提示词框;侧栏拖拽 / live-canvas 复制不带此字段(label 是显示名非提示词)。
+   */
+  prompt?: string;
   url: string;
   aspectRatio?: string;
   /** 3GS 借用同 scene 的封面图;其余类型为空。 */
@@ -113,6 +118,9 @@ export function spawnAssetNode(
           previewImageUrl: null,
           aspectRatio: payload.aspectRatio,
           sourceFileName: payload.label,
+          // 历史「使用」带来了该记录的原始提示词时,回填到视频节点的提示词框;
+          // 无提示词(拖拽/live-canvas)则不写,保持占位符。
+          ...(payload.prompt ? { prompt: payload.prompt } : {}),
           __freezone_source: sourceMeta,
           ...candidateData,
           ...directorControlBundle,

--- a/frontend/src/features/canvas/domain/canvasAssets.ts
+++ b/frontend/src/features/canvas/domain/canvasAssets.ts
@@ -17,6 +17,13 @@ export interface CanvasAsset {
   nodeId: string;
   /** Display name from the node, falls back to a kind label upstream. */
   label: string | null;
+  /**
+   * Generation prompt recorded on this asset. Only populated in the
+   * generation-history source (where each record carries the exact prompt that
+   * produced it); left undefined for live-canvas assets whose `label` is a node
+   * display name, not a prompt. Used to seed a new node's prompt box on 使用.
+   */
+  prompt?: string | null;
   /** Best-effort creation time in ms epoch; null when the node carries none. */
   timestamp: number | null;
 }

--- a/frontend/src/features/canvas/ui/CanvasHistoryAssetsModal.tsx
+++ b/frontend/src/features/canvas/ui/CanvasHistoryAssetsModal.tsx
@@ -131,7 +131,8 @@ export function recordsToAssetBuckets(
     // always matches the video. Legacy records that never stored a prompt show
     // nothing (no node-prompt fallback — it misattributed the node's current
     // prompt to old versions). 世界记录例外:无提示词时回退到上游源图节点的名字。
-    const label = historyRecordPrompt(record) ?? nodeMeta?.name ?? null;
+    const prompt = historyRecordPrompt(record);
+    const label = prompt ?? nodeMeta?.name ?? null;
     buckets[kind].push({
       id: record.id,
       kind,
@@ -141,6 +142,9 @@ export function recordsToAssetBuckets(
       ),
       nodeId: record.node_id,
       label,
+      // 用「使用」建节点时把这条记录原始提示词灌进新节点的提示词框；label 对世界
+      // 记录可能回退成节点名,所以这里单独存 prompt（仅后端存过提示词时才有值）。
+      prompt: prompt ?? null,
       timestamp: Number.isNaN(ts) ? null : ts,
     });
   }


### PR DESCRIPTION
## 背景
从「历史记录」弹窗对一条视频记录点「使用」建出的视频节点,提示词框始终是占位符「根据文字描述生成视频。」,没有带上那条历史对应的提示词。

## 根因
`spawnAssetNode` 的 video 分支只把 `payload.label` 写进 `displayName`/`sourceFileName`,**从没写 `prompt` 字段**,而视频节点 (`VideoNode.tsx`) 的提示词框读的是 `data.prompt`。

## 改动
- `CanvasAsset` 新增可选 `prompt` 字段,仅在 generation-history 映射里填入 `historyRecordPrompt(record)`;live-canvas 源不填(其 `label` 是节点显示名而非提示词)。
- `CanvasAssetDragPayload` 加 `prompt`,`handleUseHistoryAsset` 透传。
- `spawnAssetNode` 的 **video** 分支把 `payload.prompt` 写进 `data.prompt`。

## 影响面
- 仅对**视频节点**生效:image「使用」建的是 upload 节点、audio 无提示词框,均与需求一致。
- 侧栏拖拽 / live-canvas 复制**不带** `prompt`,提示词框保持占位符,不回归。

## 已知限制
提示词里的 `@图片N` 引用素材**无法还原**:历史记录 `result` 只存了 `output_url` 与 `prompt` 文本,从未保存有序参考图列表。若要支持需另立项(后端先补存 references,且只对以后的记录生效)。

## 验证
- `tsc -b` ✓
- `pnpm build` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)