### PR TITLE
fix(auth): 后端滚动更新期的瞬时 5xx 不再踢用户下线

### DIFF
--- a/frontend/src/__tests__/stores/auth-store.test.ts
+++ b/frontend/src/__tests__/stores/auth-store.test.ts
@@ -204,6 +204,18 @@ describe("auth-store", () => {
     expect(useAuthStore.getState().username).toBeNull();
   });
 
+  it("keeps state when /auth/me returns a transient 5xx (backend mid-rollout)", async () => {
+    // A 502 during a backend rolling restart must NOT log the user out, even on
+    // the strict route-guard default: the cookie is still valid and the next
+    // poll recovers on 200.
+    useAuthStore.setState({ username: "admin", role: "admin" });
+    global.fetch = vi.fn().mockResolvedValueOnce({ ok: false, status: 502 });
+    const result = await useAuthStore.getState().validateSession();
+    expect(result).toBe(false);
+    expect(useAuthStore.getState().username).toBe("admin");
+    expect(useAuthStore.getState().role).toBe("admin");
+  });
+
   it("validateSession clears state on network failure", async () => {
     useAuthStore.setState({ username: "admin", role: "admin" });
     global.fetch = vi.fn().mockRejectedValueOnce(new Error("offline"));

--- a/frontend/src/stores/auth-store.ts
+++ b/frontend/src/stores/auth-store.ts
@@ -136,7 +136,18 @@ export const useAuthStore = create<AuthState>()(
                 signal: regionAbortController().signal,
               });
               if (!res.ok) {
-                return { user: null, authFailure: true, networkFailure: false };
+                // A 401/403 is the ONLY response that means the session cookie
+                // is missing or stale — the sole case that should tear auth
+                // down. Any other non-2xx (500/502/503 while the backend pod is
+                // mid-rollout, gateway errors) carries no auth signal: leave the
+                // session intact so a routine backend restart doesn't log every
+                // user out. We surface it as neither authFailure nor
+                // networkFailure so no caller — not even the strict route-guard
+                // default — clears local auth; the next poll recovers on 200.
+                if (res.status === 401 || res.status === 403) {
+                  return { user: null, authFailure: true, networkFailure: false };
+                }
+                return { user: null, authFailure: false, networkFailure: false };
               }
               const body = (await res.json()) as OkResponse<CurrentUser>;
               cachedCurrentUser = body.data;


### PR DESCRIPTION
## 背景 / 根因

测试账号 `test_xiaolintong` 于 7.7 19:37 无操作自动退出。排查 ACK 日志确认:后端 `novelvideo-celery-ack-api` Pod 在 19:35:56–19:36:44 CST 做了一次滚动更新(SIGTERM 优雅重启,Pod hash 变更 = 部署而非崩溃),期间约 30s 空窗,`/auth/me` 在 19:36:07 返回 **502**。

前端 `getCurrentUser` 之前把**任何非 2xx**(含 502)都当成 `authFailure`,直接清掉本地登录态 → 弹回 `/login`。这会在**每次后端部署**波及所有在线用户,而不仅是该账号;此时 Cookie 其实仍有效(19:37:29 再次 200)。

## 改动

`frontend/src/stores/auth-store.ts` —— 仅 `401/403` 才视作会话失效并清态;其余非 2xx(500/502/503、网关错误)不携带鉴权信号,既不算 `authFailure` 也不算 `networkFailure`:

- 30s 轮询(`useCurrentUser`,已带 `clearOnNetworkFailure:false`)这一 tick 返回 null 但不清态;
- 严格的路由守卫默认路径(`ensureAuthenticatedForAppRoute` / `validateSession`)因为不再清 `username`,靠 `if (auth.username) return true` 短路,不会弹 `/login`;
- 下一次轮询在后端恢复(200)时自动回填。

## 测试

- 新增用例:`/auth/me` 返回 502 时保持 `username/role` 不变。
- 既有 `401 → 清态`、`network failure → 清态` 行为不变。
- `npx vitest run` auth-store 18 passed;`tsc -b` 与 `pnpm build` 均通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)