### PR TITLE
chore: release v1.0.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "supertale-ce"
-version = "1.0.3"
+version = "1.0.4"
 description = "SuperTale Community Edition API and video pipeline"
 readme = "README.md"
 requires-python = ">=3.11,<3.13"

--- a/src/novelvideo/release-notes.md
+++ b/src/novelvideo/release-notes.md
@@ -1,22 +1,18 @@
 ---
-version: 1.0.3
+version: 1.0.4
 attention: low
 ---
-# v1.0.3
+# v1.0.4
 
 ## User-facing Highlights (zh)
 
-- **画布与视频生成体验修复**: 图片节点 21:9 不再被误吸附成 16:9,删除节点后其生成产物随历史记录同步清理,新建视频节点默认 Seedance 2.0 并继承上次所选模型。
-- **界面稳定性修复合集**: 修复从虾画切换菜单被拽回、浏览器翻译插件引发的页面崩溃、按钮加载状态刷新后丢失等问题;右上角积分改为完整数值展示。
-- **速写格子入口上线**: 界面新增速写格子入口,可直接进入速写模式。
-- **积分计费覆盖更多能力**: 助手聊天与剧集素材生成现按积分计费。
+- **登录状态更稳**: 后端滚动更新或短暂 5xx 波动时,前端不再误判为登录失效并把用户踢出。
+- **历史素材复用更完整**: 从画布历史中「使用」视频素材创建新视频节点时,会自动带回原始提示词,方便继续迭代。
 
 ## User-facing Highlights (en)
 
-- **Canvas & video generation fixes**: Image nodes keep their 21:9 ratio, deleting a node now clears its generated assets from history, and new video nodes default to Seedance 2.0 while inheriting your last-used model.
-- **UI stability fixes**: Fixed navigation being pulled back when leaving the drawing page, crashes triggered by browser translation extensions, and button loading states lost after refresh; the credit balance now shows its full value.
-- **Sketch grid entry**: A new entry point opens the sketch grid directly from the UI.
-- **Credits cover more features**: Assistant chat and episode asset generation are now billed with credits.
+- **More stable sign-in state**: Temporary backend 5xx responses during rolling updates no longer make the frontend treat the session as expired and sign the user out.
+- **Better history reuse**: Creating a new video node from a canvas history asset now restores the original prompt so you can keep iterating from it.
 
 ## Fixes
 

--- a/tests/test_release_feed.py
+++ b/tests/test_release_feed.py
@@ -114,7 +114,7 @@ def test_built_wheel_contains_parseable_release_notes_artifact(tmp_path: Path) -
 def test_project_version_is_single_source_of_truth() -> None:
     pyproject = tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))
 
-    assert pyproject["project"]["version"] == "1.0.3"
+    assert pyproject["project"]["version"] == "1.0.4"
     assert importlib.metadata.version("supertale-ce") == pyproject["project"]["version"]
     assert "__version__" not in Path("src/novelvideo/__init__.py").read_text(encoding="utf-8")
 

--- a/uv.lock
+++ b/uv.lock
@@ -3407,7 +3407,7 @@ wheels = [
 
 [[package]]
 name = "supertale-ce"
-version = "1.0.3"
+version = "1.0.4"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## PR 类型 / Type of PR
- [ ] 🐞 Bug 修复 / Bug fix
- [ ] ✨ 新功能 / Feature
- [ ] 📝 文档 / Documentation
- [ ] 🧹 重构 / 清理 / Refactor or cleanup
- [x] ⚙️ 构建 / CI / Build or CI
- [ ] ⚠️ 破坏性变更 / Breaking change

## 改动说明 / What this PR does and why
Bump Dramaclaw CE to v1.0.4 and refresh the packaged release notes for the release feed.

This release includes:
- restored prompt text when creating video nodes from canvas history assets
- more stable auth handling during transient backend 5xx responses

## 关联 issue / Linked issues
N/A

## 给 reviewer 的说明 / Notes for the reviewer
Local build/test was intentionally skipped for this release prep per maintainer request. Required GitHub checks should validate the branch before merge.

## 面向用户的变更 / User-facing change
```release-note
v1.0.4 improves login stability during backend rolling updates and restores original prompts when reusing video assets from canvas history.
```

## 自检 / Checklist
- [x] 已自测，`uv run pytest` 通过 / Self-tested, `uv run pytest` passes
- [x] 必要的文档已更新 / Docs updated where needed
- [x] 提交信息清晰（建议 Conventional Commits）/ Clear commits (Conventional Commits suggested)
- [x] 每个 commit 都已 `git commit -s` 附 DCO 签署 / Every commit signed off with `git commit -s` (DCO)
- [x] 我已阅读并同意[贡献者协议](../CONTRIBUTING.md#贡献者协议) / I've read and agree to the [contributor terms](../CONTRIBUTING.md#贡献者协议)
