### PR TITLE
fix(canvas): 历史资产图片显示提示词 & 「使用」还原为成品图片节点 (#62)

### DIFF
--- a/frontend/src/__tests__/features/canvas/history-assets-buckets.test.ts
+++ b/frontend/src/__tests__/features/canvas/history-assets-buckets.test.ts
@@ -96,6 +96,18 @@ describe("recordsToAssetBuckets — world history", () => {
     expect(buckets.model).toHaveLength(0);
   });
 
+  it("carries the record's prompt onto image assets (drives the image prompt caption)", () => {
+    const buckets = recordsToAssetBuckets([
+      record({
+        id: "img-2",
+        media_type: "image",
+        result: { image_url: "/static/p/y.png", prompt: "一只在雨中的猫" },
+      }),
+    ]);
+    expect(buckets.image[0]?.prompt).toBe("一只在雨中的猫");
+    expect(buckets.image[0]?.label).toBe("一只在雨中的猫");
+  });
+
   it("falls back to the host node's cover/name when the record carries neither", () => {
     const buckets = recordsToAssetBuckets(
       [

--- a/frontend/src/features/canvas/Canvas.tsx
+++ b/frontend/src/features/canvas/Canvas.tsx
@@ -3099,6 +3099,9 @@ export function Canvas({
         url: asset.url,
         // 世界模型节点用 coverUrl 当封面（previewImageUrl）；其余类型无封面。
         coverUrl: asset.kind === 'model' ? asset.previewUrl : null,
+        // 历史「使用」还原的是生成产物：图片应还原成成品「图片节点」(imageGen)——
+        // 带回提示词、展开操作区、按图自适应比例，而非只读的上传参考图节点（见 spawnAssetNode）。
+        restoreAsGeneratedImage: true,
         source: {},
       };
       const newNodeId = spawnAssetNode(

--- a/frontend/src/features/canvas/domain/assetDrag.ts
+++ b/frontend/src/features/canvas/domain/assetDrag.ts
@@ -22,10 +22,16 @@ export interface CanvasAssetDragPayload {
   kind: CanvasAssetDragKind;
   label: string;
   /**
-   * 生成型节点(目前仅视频)的提示词。历史「使用」流程从对应记录带过来,用于回填
+   * 生成型节点(视频 / 图片)的提示词。历史「使用」流程从对应记录带过来,用于回填
    * 新节点的提示词框;侧栏拖拽 / live-canvas 复制不带此字段(label 是显示名非提示词)。
    */
   prompt?: string;
+  /**
+   * 仅历史「使用」置真:表示这是一张「生成产物」而非上传参考图。图片据此还原成
+   * 成品「图片节点」(imageGen)——带回提示词、按图自适应比例、显示分辨率角标;
+   * 不置(普通拖拽 / 素材库参考图)则仍建 upload 节点(替换素材)。
+   */
+  restoreAsGeneratedImage?: boolean;
   url: string;
   aspectRatio?: string;
   /** 3GS 借用同 scene 的封面图;其余类型为空。 */
@@ -145,6 +151,29 @@ export function spawnAssetNode(
       );
     case "image":
     default:
+      // 历史「使用」还原生成产物 → 建成品「图片节点」(imageGen):带回提示词与操作区,
+      // onLoad 按图片自然尺寸自适应比例并显示分辨率角标(见 ImageGenNode)。写入
+      // committed_* 使其与生成完成后落地的节点字段一致(成品图直接展示、可继续再生成)。
+      // 普通拖拽 / 素材库参考图(无此标记)仍建 upload 节点(替换素材)。
+      if (payload.restoreAsGeneratedImage) {
+        return store.addNode(
+          CANVAS_NODE_TYPES.imageGen,
+          position,
+          {
+            displayName: payload.label,
+            imageUrl: payload.url,
+            previewImageUrl: payload.url,
+            committed_at: new Date().toISOString(),
+            committed_slot_url: payload.url,
+            ...(payload.prompt ? { prompt: payload.prompt } : {}),
+            __freezone_source: sourceMeta,
+            ...candidateData,
+            ...directorControlBundle,
+            ...mainlineData,
+            ...slotData,
+          } as Record<string, unknown> as Partial<CanvasNodeData>,
+        );
+      }
       return store.addNode(
         CANVAS_NODE_TYPES.upload,
         position,

--- a/frontend/src/features/canvas/ui/CanvasHistoryAssetsModal.tsx
+++ b/frontend/src/features/canvas/ui/CanvasHistoryAssetsModal.tsx
@@ -784,18 +784,21 @@ function AssetCard({
       )}
       </div>
 
-      {/* 提示词：非音频卡片在缩略图下方以卡片形式常显该版本提示词（最多三行，title
-          看全文）。视频历史里即「视频 + 提示词」一张卡片。 */}
-      {/* 提示词只在视频卡片显示（图片历史不需要）；双击看全文。 */}
-      {asset.kind === 'video' && !selectionMode && asset.label && (
-        <div
-          title={asset.label}
-          onDoubleClick={onOpenPrompt}
-          className="line-clamp-[6] flex-none cursor-pointer select-none px-2.5 py-2 text-[12px] leading-snug text-white/75 transition-colors hover:text-white/90"
-        >
-          {asset.label}
-        </div>
-      )}
+      {/* 提示词：图片 / 视频卡片在缩略图下方以卡片形式常显该版本提示词（多行截断，
+          title 悬停看全文，双击开完整弹窗）。历史资产里即「产物 + 提示词」一张卡片。
+          用 asset.prompt 作为显示条件（仅生成历史记录才有值）：分镜取图（live-canvas）
+          的 label 是文件名而非提示词、prompt 为空，故那里不会误显文件名。 */}
+      {(asset.kind === 'image' || asset.kind === 'video') &&
+        !selectionMode &&
+        asset.prompt && (
+          <div
+            title={asset.prompt}
+            onDoubleClick={onOpenPrompt}
+            className="line-clamp-[6] flex-none cursor-pointer select-none px-2.5 py-2 text-[12px] leading-snug text-white/75 transition-colors hover:text-white/90"
+          >
+            {asset.prompt}
+          </div>
+        )}
 
       {/* 世界模型：缩略图下方常显名字（提示词缺失时回退到「导演世界」默认名），
           让没有封面的世界卡片至少能认出是什么。双击看全文（有提示词时）。 */}


### PR DESCRIPTION
## 背景
Closes #62。历史资产两处与图片相关的体验缺陷:
1. 历史资产弹窗里图片卡片不显示提示词(视频卡片有)。
2. 图片「使用」还原后是一个上传参考图节点:没有提示词框与操作区,且比例不对(缺省回落 1:1 → 画面被信箱化裁切),与原生成节点观感不一致。

## 改动
- **图片卡片显示提示词**(commit `d4d17f7`):`recordsToAssetBuckets` 已随 #59 把记录提示词带到 image 资产上;弹窗渲染分支放行 `image`(与 `video` 一致),仅在 `asset.prompt` 存在时展示,避免 live-canvas 分镜选择器把文件名当提示词。
- **「使用」还原为成品图片节点**(commit `6dcc6f5`):`CanvasAssetDragPayload` 新增判别位 `restoreAsGeneratedImage`;`spawnAssetNode` 的 image 分支据此改建 `imageGenNode`,回填 `imageUrl/previewImageUrl/prompt` 并写 `committed_*`,使节点直接展示成品图、展开操作区、可继续再生成,`onLoad` 按图片自然尺寸自适应比例并显示分辨率角标。普通拖拽 / 素材库参考图不带此标记,仍建 `uploadNode`(替换素材),行为不变。

## 验证
- `tsc -b`、`pnpm build` 通过
- 单测 29 pass(`history-assets-buckets`、`auth-store` 等),新增 image prompt bucket 断言
- 本地实机验证:历史「使用」图片后节点观感与原生成节点一致(提示词 + 操作区 + 正确比例 + 分辨率角标)

🤖 Generated with [Claude Code](https://claude.com/claude-code)