### PR TITLE
fix(canvas): 批量删除连带清空空组一并删除

### DIFF
--- a/frontend/src/__tests__/features/canvas/group-selection-delete.test.ts
+++ b/frontend/src/__tests__/features/canvas/group-selection-delete.test.ts
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: Elastic-2.0
+// Copyright (c) 2026 ClaymoreLab
+import { describe, expect, it } from "vitest";
+
+import { collectBatchDeletableIds } from "@/features/canvas/domain/groupSelectionDelete";
+import { CANVAS_NODE_TYPES, type CanvasNode } from "@/features/canvas/domain/canvasNodes";
+
+function node(
+  id: string,
+  type: string,
+  extra: Partial<CanvasNode> & { data?: Record<string, unknown> } = {},
+): CanvasNode {
+  const { data, ...rest } = extra;
+  return {
+    id,
+    type,
+    position: { x: 0, y: 0 },
+    data: (data ?? {}) as CanvasNode["data"],
+    ...rest,
+  } as CanvasNode;
+}
+
+describe("collectBatchDeletableIds", () => {
+  it("re-includes an enclosing group when all its children are selected (the empty-group bug)", () => {
+    // The marquee drops the group from `selected`, keeping only its children.
+    const nodes = [
+      node("g1", CANVAS_NODE_TYPES.group),
+      node("a", CANVAS_NODE_TYPES.audio, { parentId: "g1" }),
+      node("b", CANVAS_NODE_TYPES.textAnnotation, { parentId: "g1" }),
+    ];
+    const deletable = collectBatchDeletableIds(nodes, ["a", "b"]);
+    expect(new Set(deletable)).toEqual(new Set(["g1", "a", "b"]));
+  });
+
+  it("handles two fully-selected groups (exact user repro)", () => {
+    const nodes = [
+      node("g1", CANVAS_NODE_TYPES.group),
+      node("a", CANVAS_NODE_TYPES.audio, { parentId: "g1" }),
+      node("g2", CANVAS_NODE_TYPES.group),
+      node("c", CANVAS_NODE_TYPES.audio, { parentId: "g2" }),
+      node("d", CANVAS_NODE_TYPES.textAnnotation, { parentId: "g2" }),
+    ];
+    const deletable = collectBatchDeletableIds(nodes, ["a", "c", "d"]);
+    expect(new Set(deletable)).toEqual(new Set(["g1", "g2", "a", "c", "d"]));
+  });
+
+  it("does NOT delete a group when only some of its children are selected", () => {
+    const nodes = [
+      node("g1", CANVAS_NODE_TYPES.group),
+      node("a", CANVAS_NODE_TYPES.audio, { parentId: "g1" }),
+      node("b", CANVAS_NODE_TYPES.textAnnotation, { parentId: "g1" }),
+    ];
+    const deletable = collectBatchDeletableIds(nodes, ["a"]);
+    expect(new Set(deletable)).toEqual(new Set(["a"]));
+  });
+
+  it("keeps a group when it contains a preset-locked child that cannot be emptied", () => {
+    const nodes = [
+      node("g1", CANVAS_NODE_TYPES.group),
+      node("a", CANVAS_NODE_TYPES.audio, { parentId: "g1" }),
+      node("locked", CANVAS_NODE_TYPES.imageGen, {
+        parentId: "g1",
+        data: { preset_managed: true },
+      }),
+    ];
+    const deletable = collectBatchDeletableIds(nodes, ["a", "locked"]);
+    // group excluded (can't be emptied), locked child excluded, only "a" deletable.
+    expect(new Set(deletable)).toEqual(new Set(["a"]));
+  });
+
+  it("excludes a preset-managed group itself", () => {
+    const nodes = [
+      node("g1", CANVAS_NODE_TYPES.group, { data: { preset_managed: true } }),
+      node("a", CANVAS_NODE_TYPES.audio, { parentId: "g1" }),
+    ];
+    const deletable = collectBatchDeletableIds(nodes, ["g1", "a"]);
+    expect(new Set(deletable)).toEqual(new Set(["a"]));
+  });
+
+  it("passes plain multi-selection through unchanged", () => {
+    const nodes = [
+      node("a", CANVAS_NODE_TYPES.audio),
+      node("b", CANVAS_NODE_TYPES.imageGen),
+    ];
+    const deletable = collectBatchDeletableIds(nodes, ["a", "b"]);
+    expect(new Set(deletable)).toEqual(new Set(["a", "b"]));
+  });
+});

--- a/frontend/src/features/canvas/domain/groupSelectionDelete.ts
+++ b/frontend/src/features/canvas/domain/groupSelectionDelete.ts
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: Elastic-2.0
+// Copyright (c) 2026 ClaymoreLab
+import { CANVAS_NODE_TYPES, type CanvasNode } from "./canvasNodes";
+import { isPresetManagedNode } from "./mainlineNodeFlags";
+
+/**
+ * 批量删除时,「所选节点」实际可删的 id 集合。
+ *
+ * 为什么不能直接用 selected 节点:画布的框选(见 Canvas 的自定义 marquee)会把
+ * 「包住其它命中节点的组」从选择里剔除——这样拖动多选时父子不会双重位移。代价是
+ * 用户框选整个组时,组本身的 `selected` 始终为假,只有组内子节点被选中。若批量删除
+ * 只删 selected,就会把子节点删光、留下空组框(#62 后续 bug)。
+ *
+ * 这里补回那些「即将被清空」的组:某个组的每个子节点都在选择内 ⇒ 删除会清空它 ⇒
+ * 把这个空壳组也一并删掉。preset/主线锁定的组(及含锁定子节点、无法真正清空的组)
+ * 保持排除。store 的 deleteNodes 会自动级联删除后代,故只需把组 id 补进来即可。
+ */
+export function collectBatchDeletableIds(
+  nodes: CanvasNode[],
+  selectedIds: Iterable<string>,
+): string[] {
+  const selectedSet = new Set(selectedIds);
+
+  const deletable = new Set<string>();
+  for (const node of nodes) {
+    if (selectedSet.has(node.id) && !isPresetManagedNode(node)) {
+      deletable.add(node.id);
+    }
+  }
+
+  // 一次遍历统计每个父节点的子节点总数 / 已选数 / 是否含锁定子节点。
+  const childTally = new Map<
+    string,
+    { total: number; selected: number; hasLocked: boolean }
+  >();
+  for (const node of nodes) {
+    if (!node.parentId) {
+      continue;
+    }
+    const tally =
+      childTally.get(node.parentId) ?? { total: 0, selected: 0, hasLocked: false };
+    tally.total += 1;
+    if (selectedSet.has(node.id)) {
+      tally.selected += 1;
+    }
+    if (isPresetManagedNode(node)) {
+      tally.hasLocked = true;
+    }
+    childTally.set(node.parentId, tally);
+  }
+
+  // 补回会被清空的普通组:全部子节点都被选中、无锁定子节点、组本身未锁定。
+  for (const node of nodes) {
+    if (node.type !== CANVAS_NODE_TYPES.group) {
+      continue;
+    }
+    if (deletable.has(node.id) || isPresetManagedNode(node)) {
+      continue;
+    }
+    const tally = childTally.get(node.id);
+    if (tally && tally.total > 0 && tally.total === tally.selected && !tally.hasLocked) {
+      deletable.add(node.id);
+    }
+  }
+
+  return Array.from(deletable);
+}

--- a/frontend/src/features/canvas/ui/MultiSelectionToolbar.tsx
+++ b/frontend/src/features/canvas/ui/MultiSelectionToolbar.tsx
@@ -25,7 +25,7 @@ import {
   DEFAULT_NODE_WIDTH,
   type CanvasNode,
 } from '@/features/canvas/domain/canvasNodes';
-import { isPresetManagedNode } from '@/features/canvas/domain/mainlineNodeFlags';
+import { collectBatchDeletableIds } from '@/features/canvas/domain/groupSelectionDelete';
 
 // 合并分镜组只接受图片类节点。
 const STORYBOARD_IMAGE_NODE_TYPES = new Set<string>([
@@ -110,13 +110,13 @@ export const MultiSelectionToolbar = memo(() => {
 
   // Preset/mainline-managed nodes are not user-deletable — the store filters
   // them out internally too, but we compute the deletable subset here so the
-  // button can disable itself when the whole selection is locked.
+  // button can disable itself when the whole selection is locked. The marquee
+  // drops a fully-enclosed group from `selected` (so dragging children doesn't
+  // double-move them), so we also re-include any group whose every child is
+  // selected — otherwise a batch delete empties the group but leaves its frame.
   const deletableIds = useMemo(
-    () =>
-      selectedNodes
-        .filter((node) => !isPresetManagedNode(node))
-        .map((node) => node.id),
-    [selectedNodes]
+    () => collectBatchDeletableIds(nodes, selectedIds),
+    [nodes, selectedIds]
   );
 
   // Resolve a node's absolute (canvas-space) position by walking its parent


### PR DESCRIPTION
## 问题

有两个组,框选这两个组后点「批量删除」,只有组内节点被删,空组框残留。

## 根因

画布框选走 `Canvas.tsx` 的自定义 marquee。它命中所有相交节点后,把「作为其它命中节点祖先的组」从选择里剔除(`selectedIds = hitIds − ancestorsOfHits`),以避免拖动多选时父子双重位移。副作用:框选整个组时组本身的 `selected` 始终为假,只有子节点入选。`MultiSelectionToolbar.deletableIds` 只取 selected,批量删除便只删子节点,空组框残留。

## 修复

不动 marquee(对拖动是正确行为),仅在批量删除处补回「即将被清空」的组:某组每个子节点都被选中、且无锁定子节点、组本身未锁定时,把组一并纳入删除;store 的 `deleteNodes` 会级联删除其后代。逻辑抽成纯函数 `collectBatchDeletableIds` 并加单测。

## 验证

- 新增单测 `group-selection-delete.test.ts` 6/6 通过(含两组全选的用户复现场景)
- `tsc -b` + `pnpm build` 全绿
- 本地手动验证:框选两组 → 批量删除,组连同节点一起消失

🤖 Generated with [Claude Code](https://claude.com/claude-code)