### PR TITLE
chore(compliance): 补登 groupSelectionDelete 到 license 清单(修复 main 的 deps 关卡)

### DIFF
--- a/license-inventory.csv
+++ b/license-inventory.csv
@@ -324,6 +324,7 @@ frontend/src/__tests__/features/canvas/cross-project-assets.test.ts,Elastic-2.0,
 frontend/src/__tests__/features/canvas/director-control-bundle-badge.test.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/__tests__/features/canvas/director-world-sources.test.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/__tests__/features/canvas/generation-task-arbitration.test.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
+frontend/src/__tests__/features/canvas/group-selection-delete.test.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/__tests__/features/canvas/history-assets-buckets.test.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/__tests__/features/canvas/image-gen-director-world-entry.test.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/__tests__/features/canvas/image-gen-node-context-palette.test.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
@@ -711,6 +712,7 @@ frontend/src/features/canvas/domain/canvasNodes.ts,Elastic-2.0,2026 SuperTale co
 frontend/src/features/canvas/domain/directorWorldSceneSaveRegistry.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/features/canvas/domain/directorWorldSources.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/features/canvas/domain/groupColors.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
+frontend/src/features/canvas/domain/groupSelectionDelete.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/features/canvas/domain/inheritMainlineFields.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/features/canvas/domain/lastVideoModel.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/features/canvas/domain/mainlineNodeFlags.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation


### PR DESCRIPTION
## 背景

#69 合并进 main 时,只带上了修复提交,遗漏了随附的 `license-inventory.csv` 更新。结果 main 上新增的两个前端文件未被 DEP-11 许可证准入门(`test_license_inventory_covers_current_git_index`)登记,**后续所有 PR 的 `deps` 关卡都会因此变红**。

## 改动

用 `scripts/compliance/generate_p0b_artifacts.py` 重新生成清单,补入缺失的两条:

- `frontend/src/features/canvas/domain/groupSelectionDelete.ts`
- `frontend/src/__tests__/features/canvas/group-selection-delete.test.ts`

均为项目自有源码,沿用 `Elastic-2.0 / REUSE.toml aggregate annotation`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)