### PR TITLE
fix(script): 参考节点生成分镜脚本失败 & 占位图裂图 (#65 #66)

### DIFF
--- a/frontend/src/features/canvas/application/imageData.ts
+++ b/frontend/src/features/canvas/application/imageData.ts
@@ -166,6 +166,27 @@ export function resolveImageDisplayUrl(imageUrl: string): string {
   return imageUrl;
 }
 
+// 判断字符串是否是可作为 <img src> 渲染的真实图片来源（协议 URL 或本地图片路径）。
+// 脚本表格的「角色图/参考」是后端占位字符串字段，模型常填入 `无` 之类的非 URL 文本，
+// 直接塞进 <img> 会 404 变成裂图；渲染前用它过滤。
+export function isRenderableImageSrc(value: string): boolean {
+  if (!value) {
+    return false;
+  }
+  const lower = value.toLowerCase();
+  if (
+    lower.startsWith('data:') ||
+    lower.startsWith('http://') ||
+    lower.startsWith('https://') ||
+    lower.startsWith('blob:') ||
+    lower.startsWith('asset:') ||
+    lower.startsWith('file://')
+  ) {
+    return true;
+  }
+  return isLikelyLocalImagePath(value);
+}
+
 // Cross-origin CDN media (absolute http(s)/asset: URL) must be fetched with CORS
 // so the decoded pixels can be drawn to a <canvas> and exported (toBlob /
 // toDataURL) without tainting it. Same-origin / relative `/static/*` paths (the

--- a/frontend/src/features/canvas/nodes/ScriptNode.tsx
+++ b/frontend/src/features/canvas/nodes/ScriptNode.tsx
@@ -37,7 +37,7 @@ import {
   type ScriptGenAction,
   type ScriptNodeData,
 } from '@/features/canvas/domain/canvasNodes';
-import { resolveImageDisplayUrl } from '@/features/canvas/application/imageData';
+import { isRenderableImageSrc, resolveImageDisplayUrl } from '@/features/canvas/application/imageData';
 import { resolveNodeDisplayName } from '@/features/canvas/domain/nodeDisplay';
 import {
   NodeHeader,
@@ -314,16 +314,19 @@ function useScriptStorySubmit(
         name: ref.displayName?.trim() || undefined,
       }));
 
-    const hasMaterial =
-      upstreamText.length > 0 || Boolean(videoRef) || characterRefs.length > 0;
-    // 文本框内容：有素材时当 steering prompt；否则作为 source_text 主输入。
-    const sourceText =
-      upstreamText.length > 0 ? upstreamText : hasMaterial ? undefined : trimmedPrompt;
-    const steeringPrompt = hasMaterial ? trimmedPrompt || undefined : undefined;
+    // 后端 story-script 接口目前只消费文本(source_text/source_url):视频 / 角色图片
+    // 参考仅作为画布上的视觉参考，模型并不直接读取它们。因此真正驱动生成的是用户手动
+    // 输入的提示词(参考 libtv:素材做参考、提示词驱动生成)。优先用上游文本节点内容，
+    // 否则把输入框里用户写的提示词作为 source_text 主输入 —— 而不是塞进 steering 后
+    // 让后端因缺 source_text 报 400(#65 视频参考、#66 图片参考失败的根因)。
+    const sourceText = upstreamText.length > 0 ? upstreamText : trimmedPrompt;
+    // 有上游文本节点时输入框内容退居 steering prompt；否则它已是主输入，不再重复下发。
+    const steeringPrompt =
+      upstreamText.length > 0 ? trimmedPrompt || undefined : undefined;
 
-    if (!hasMaterial && (!sourceText || sourceText.length === 0)) {
+    if (!sourceText || sourceText.length === 0) {
       updateNodeData(nodeId, {
-        generationError: '请输入剧情或连接文本 / 视频 / 角色图片节点',
+        generationError: '请输入提示词描述剧情（视频 / 角色图片仅作参考）',
       });
       return;
     }
@@ -890,7 +893,10 @@ function ScriptResultCell({ row, col, onCommit }: ScriptResultCellProps) {
   if (col.render === 'image') {
     // 图片列暂不支持 inline 编辑 —— 替换图需要走文件选择器 / URL 输入，
     // 是另一条交互，等用户后续提。
-    const url = typeof raw === 'string' && raw.length > 0 ? raw : null;
+    // 角色图/参考是后端占位字符串字段：模型经常写入 `无` 之类的非 URL 文本，
+    // 只有真正的图片来源才渲染 <img>，否则一律回退到空占位（避免 404 裂图）。
+    const url =
+      typeof raw === 'string' && isRenderableImageSrc(raw) ? raw : null;
     if (!url) {
       return (
         <div className="flex h-14 w-14 items-center justify-center rounded border border-dashed border-[rgba(255,255,255,0.14)] text-text-muted/50">

--- a/src/novelvideo/freezone/text_node.py
+++ b/src/novelvideo/freezone/text_node.py
@@ -200,6 +200,11 @@ def create_freezone_story_script_agent(model: str | None = None) -> Agent:
         llm_model,
         system_prompt=FREEZONE_STORY_SCRIPT_SYSTEM_PROMPT,
         output_type=FreezoneStoryScriptGenerateData,
+        # 结构化脚本表字段多、且 shot_no/duration 是严格 int，模型偶尔会把时长写成
+        # "2-5"/"3秒" 之类而过不了校验。默认 output_retries=1 只给一次纠正机会不够，
+        # 抛 "Exceeded maximum output retries (1)"。对齐本仓其它复杂结构化 agent
+        # (episode_planner / content_rewriter)提到 3，让模型按回喂的校验错误自我修正。
+        output_retries=3,
         name="Freezone Story Script Generator",
     )
 


### PR DESCRIPTION
## 背景

- #65 视频参考节点 → 脚本生成器：生成分镜脚本失败
- #66 图片参考节点 → 脚本生成器：生成脚本失败

两者同一根因：后端 story-script 接口只消费 `source_text`/`source_url`，视频 URL / 角色图属画布视觉参考（libtv 式，模型不直接读取），缺 `source_text` 时报 400 `source_text or source_url is required`。

## 改动

1. **`ScriptNode.tsx`** — 无上游文本节点时，用户手动输入的提示词作为 `source_text` 驱动生成（视频/角色图仅作参考）；空提示词给出明确校验提示，不再打后端 400。
2. **`text_node.py`** — story-script agent `output_retries` 1 → 3，对齐 `episode_planner`/`content_rewriter`（结构化脚本表字段多、`shot_no`/`duration` 是严格 int），修生成成功后的 `Exceeded maximum output retries (1)`。
3. **`imageData.ts` + `ScriptNode.tsx`** — 脚本表格「角色图1/角色图2/参考」是后端占位字符串字段，系统提示词允许模型写 `无`/空串，前端此前把任何非空串当 `<img src>` 渲染 → `无` 变 404 裂图。新增 `isRenderableImageSrc()` 只放行真实图片来源（协议 URL / 本地路径），非 URL 文本回退虚线空占位。

## 验证

- `pnpm tsc -b` + `pnpm build` 通过
- 后端脚本生成用例通过
- 视频参考、图片参考两条链路本地验证：脚本正常生成、表格不再裂图

Closes #65
Closes #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)