### PR TITLE
fix: harden episode prop planning

### DIFF
--- a/license-inventory.csv
+++ b/license-inventory.csv
@@ -1555,6 +1555,7 @@ tests/test_api_sketch_ai_detection.py,Elastic-2.0,2026 SuperTale contributors,RE
 tests/test_api_sketch_pose_editor.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_api_sketch_regenerate.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_api_styles.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
+tests/test_asset_compiler_prop_planning.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_asset_compiler_scene_enrichment.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_asset_resolver.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_auth_contract_snapshot.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation

--- a/src/novelvideo/agents/asset_compiler.py
+++ b/src/novelvideo/agents/asset_compiler.py
@@ -5,8 +5,9 @@ from __future__ import annotations
 import re
 from typing import Any, Callable, Optional
 
-from pydantic import BaseModel, Field, ValidationInfo, model_validator
+from pydantic import BaseModel, Field, ValidationError, ValidationInfo, model_validator
 from pydantic_ai import Agent
+from pydantic_ai.exceptions import UnexpectedModelBehavior
 
 from novelvideo.config import (
     get_newapi_text_pydantic_model,
@@ -37,8 +38,16 @@ class DerivedSceneRequirement(BaseModel):
     atmosphere: str = Field(default="", description="派生场景特有的氛围/天气/空气感；没有就留空")
 
 
+PROP_OUTPUT_SCHEMA_HINT = (
+    "道具规划结构化输出校验失败: requirements 必须是对象数组，每项必须包含 "
+    "prop_name 和 visual_prompt；不能是字符串数组；prop_name 必须逐字来自当前场景块文本或候选道具"
+)
+
+
 class PropRequirement(BaseModel):
-    prop_name: str = Field(description="道具名称，如 '七星剑'、'玉佩'")
+    prop_name: str = Field(
+        description="道具名称，必须逐字复制自当前场景块文本或候选道具，如 '七星剑'、'玉佩'；不要改写或同义词替换"
+    )
     prop_type: str = Field(
         default="",
         description="道具类型: weapon / accessory / artifact / document / furniture",
@@ -46,7 +55,7 @@ class PropRequirement(BaseModel):
     owner: str = Field(default="", description="所属角色名（如有）")
     visual_prompt: str = Field(
         default="",
-        description="用于生成参考图的视觉提示词，写清形状、材质、颜色、可识别细节，80字内",
+        description="用于生成参考图的视觉提示词，必须写清形状、材质、颜色、可识别细节，80字内",
     )
     description: str = Field(default="", description="一句话叙述描述（用途/剧情关系，50字内）")
 
@@ -61,7 +70,7 @@ class BlockDerivedSceneOutput(BaseModel):
 class BlockPropRequirements(BaseModel):
     requirements: list[PropRequirement] = Field(
         default_factory=list,
-        description="当前场景块中有情节意义的道具",
+        description="当前场景块中有情节意义的道具对象数组；每项必须是对象，不能是字符串列表",
     )
 
     @model_validator(mode="after")
@@ -217,8 +226,23 @@ BLOCK_PROP_PROMPT = """# 你是场景块关键道具分析师
 - 道具名必须来自当前场景块文本或给定的候选道具列表
 
 ## 输出规则
+- requirements 必须是对象数组，每个元素必须包含 prop_name / visual_prompt；不能是字符串数组
+- 禁止输出 `{{"requirements":["强光手电"]}}`
+- 正确输出示例：
+  `{{
+    "requirements": [
+      {{
+        "prop_name": "强光手电",
+        "prop_type": "object",
+        "owner": "陆辰",
+        "visual_prompt": "黑色金属强光手电，冷白光束，筒身有磨损划痕",
+        "description": "陆辰在地下室照明并寻找暗格"
+      }}
+    ]
+  }}`
 - 每个道具必须给出 visual_prompt；不要只写用途，要写可画出来的外观
 - description 写剧情用途；如果没有明确用途，可以留空
+- prop_name 必须从当前场景块文本或候选道具中逐字复制；不要改写、泛化、补同义词。原文是“强光手电”，不要写“手电筒”
 """
 
 
@@ -963,11 +987,19 @@ class AssetCompiler:
                 continue
 
             preselected = self._preselect_existing_props(block_text, existing_props)
-            requirements = await self._analyze_block_props(
-                block,
-                preselected,
-                sorted(set(episode_selected_props.values())),
-            )
+            prior_reuse = self._prior_selected_props_in_block(block, episode_selected_props)
+            if prior_reuse and self._is_short_prior_prop_reuse_block(block, preselected):
+                requirements = prior_reuse
+            else:
+                try:
+                    requirements = await self._analyze_block_props(
+                        block,
+                        preselected,
+                        sorted(set(episode_selected_props.values())),
+                    )
+                except ValueError as exc:
+                    log(f"  道具[{block_index + 1}]: {exc}")
+                    raise
             requirements = self._filter_background_props(requirements, block_text)
             for req in requirements:
                 existing = await self._find_matching_prop(req.prop_name)
@@ -986,6 +1018,37 @@ class AssetCompiler:
                 log(f"  道具[{block_index + 1}]: {prop_id} [{source}]")
 
         return prop_menu
+
+    @classmethod
+    def _prior_selected_props_in_block(
+        cls,
+        block: SceneBlock,
+        episode_selected_props: dict[str, str],
+    ) -> list[PropRequirement]:
+        block_text = "\n".join(
+            item for item in [block.header_line, *block.lines] if str(item or "").strip()
+        )
+        result: list[PropRequirement] = []
+        seen: set[str] = set()
+        prior_ids = sorted(
+            {value for value in episode_selected_props.values() if str(value or "").strip()}
+        )
+        for prop_id in prior_ids:
+            if prop_id in seen:
+                continue
+            if cls._contains_text(block_text, prop_id) or cls._contains_text(prop_id, block_text):
+                seen.add(prop_id)
+                result.append(PropRequirement(prop_name=prop_id))
+        return result
+
+    @staticmethod
+    def _is_short_prior_prop_reuse_block(
+        block: SceneBlock,
+        preselected: list[NovelProp],
+    ) -> bool:
+        content_lines = [line for line in block.lines if str(line or "").strip()]
+        has_env_desc = any(str(line or "").strip().startswith("△") for line in content_lines)
+        return len(content_lines) <= 3 and not has_env_desc and not preselected
 
     def _preselect_existing_props(
         self,
@@ -1071,7 +1134,10 @@ class AssetCompiler:
             },
             name="场景块道具分析师",
         )
-        result = await agent.run(task)
+        try:
+            result = await agent.run(task)
+        except (UnexpectedModelBehavior, ValidationError) as exc:
+            raise ValueError(f"{PROP_OUTPUT_SCHEMA_HINT}；原始错误: {exc}") from exc
         return result.output.requirements
 
     @classmethod

--- a/tests/test_asset_compiler_prop_planning.py
+++ b/tests/test_asset_compiler_prop_planning.py
@@ -1,0 +1,227 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from pydantic import ValidationError
+
+from novelvideo.utils.screenplay_quality import build_import_format_check
+from novelvideo.utils.screenplay_scene_parser import parse_scene_blocks
+
+
+STANDARD_DRAMA_PROP_SCRIPT = """第1集 开始
+1-1、地下室 深夜 内
+人物：陆辰、沈月白
+△昏暗地下室里尘埃翻涌。
+陆辰：这里有东西。
+沈月白：别碰。
+陆辰：我只是看看。
+沈月白：小心。
+陆辰：这本羊皮笔记本不对劲。
+沈月白：把强光手电给我。
+陆辰：你看封面。
+沈月白：命运之书。
+"""
+
+
+class _FakeSQLiteStore:
+    async def load_working_content(self, episode_number: int) -> str:
+        return ""
+
+    async def list_props(self) -> list:
+        return []
+
+    async def get_prop(self, name: str):
+        return None
+
+
+class _FakeCogneeStore:
+    def __init__(self, raw_content: str = ""):
+        self.raw_content = raw_content
+        self.sqlite_store = _FakeSQLiteStore()
+        self.updated: list[tuple[int, dict]] = []
+
+    async def load_episode_content(self, episode_number: int) -> str:
+        return self.raw_content
+
+    async def update_episode(self, episode_number: int, **updates) -> None:
+        self.updated.append((episode_number, updates))
+
+
+def test_standard_drama_prop_sample_matches_current_import_format_rules():
+    result = build_import_format_check(STANDARD_DRAMA_PROP_SCRIPT, has_chapters=True)
+    blocks = parse_scene_blocks(STANDARD_DRAMA_PROP_SCRIPT)
+
+    assert result["level"] == "ok"
+    assert result["issues"] == []
+    assert len(blocks) == 1
+    assert blocks[0].header_line == "1-1、地下室 深夜 内"
+    assert blocks[0].location == "地下室"
+    assert blocks[0].time_of_day == "深夜"
+    assert blocks[0].interior_exterior == "内"
+
+
+def test_prop_requirements_reject_model_string_list_output():
+    from novelvideo.agents.asset_compiler import BlockPropRequirements
+
+    with pytest.raises(ValidationError) as exc_info:
+        BlockPropRequirements.model_validate(
+            {"requirements": ["手电筒", "羊皮笔记本"]},
+            context={
+                "block_text": STANDARD_DRAMA_PROP_SCRIPT,
+                "allowed_existing_names": set(),
+            },
+        )
+
+    error_locations = {tuple(error["loc"]) for error in exc_info.value.errors()}
+    assert ("requirements", 0) in error_locations
+    assert ("requirements", 1) in error_locations
+
+
+def test_block_prop_prompt_explicitly_forbids_string_list_and_synonym_names():
+    from novelvideo.agents.asset_compiler import BLOCK_PROP_PROMPT
+
+    assert "requirements 必须是对象数组" in BLOCK_PROP_PROMPT
+    assert "不能是字符串" in BLOCK_PROP_PROMPT
+    assert "原文是“强光手电”，不要写“手电筒”" in BLOCK_PROP_PROMPT
+
+
+@pytest.mark.asyncio
+async def test_standard_drama_prop_planner_reports_string_list_validation_error(
+    monkeypatch,
+):
+    import novelvideo.agents.asset_compiler as asset_compiler
+
+    captured: dict[str, object] = {}
+
+    def fake_newapi_model(model_env: str, default_model: str) -> str:
+        return "prop-model"
+
+    def fake_settings(thinking_env: str, default_thinking_level: str) -> dict[str, str]:
+        return {"openai_reasoning_effort": default_thinking_level}
+
+    class FakeAgent:
+        def __init__(self, model, **kwargs):
+            captured["agent_kwargs"] = kwargs
+
+        async def run(self, task: str):
+            captured["task"] = task
+            kwargs = captured["agent_kwargs"]
+            output_type = kwargs["output_type"]
+            return SimpleNamespace(
+                output=output_type.model_validate(
+                    {"requirements": ["手电筒", "羊皮笔记本"]},
+                    context=kwargs["validation_context"],
+                )
+            )
+
+    monkeypatch.setattr(asset_compiler, "get_newapi_text_pydantic_model", fake_newapi_model)
+    monkeypatch.setattr(
+        asset_compiler,
+        "get_newapi_text_pydantic_model_settings",
+        fake_settings,
+    )
+    monkeypatch.setattr(asset_compiler, "Agent", FakeAgent)
+
+    store = _FakeCogneeStore(raw_content=STANDARD_DRAMA_PROP_SCRIPT)
+    compiler = asset_compiler.AssetCompiler(store)
+    logs: list[str] = []
+
+    with pytest.raises(ValueError, match="requirements 必须是对象数组"):
+        await compiler.compile_episode_props(
+            SimpleNamespace(number=1, beat_source_text=STANDARD_DRAMA_PROP_SCRIPT),
+            on_log=logs.append,
+        )
+
+    assert logs[0] == "[AssetCompiler] 共识别 1 个场景块"
+    assert any("requirements 必须是对象数组" in log for log in logs)
+    assert store.updated == []
+    assert "1-1、地下室 深夜 内" in captured["task"]
+    assert "强光手电" in captured["task"]
+
+
+def test_prop_name_must_be_exact_source_substring_or_existing_candidate():
+    from novelvideo.agents.asset_compiler import BlockPropRequirements
+
+    block_text = "沈月白：把强光手电给我。"
+
+    with pytest.raises(ValidationError, match="未在当前场景块文本中出现"):
+        BlockPropRequirements.model_validate(
+            {
+                "requirements": [
+                    {
+                        "prop_name": "手电筒",
+                        "visual_prompt": "黑色金属手电筒，冷白光束",
+                    }
+                ]
+            },
+            context={"block_text": block_text, "allowed_existing_names": set()},
+        )
+
+    accepted = BlockPropRequirements.model_validate(
+        {
+            "requirements": [
+                {
+                    "prop_name": "强光手电",
+                    "visual_prompt": "黑色金属强光手电，冷白光束",
+                }
+            ]
+        },
+        context={"block_text": block_text, "allowed_existing_names": set()},
+    )
+
+    assert [req.prop_name for req in accepted.requirements] == ["强光手电"]
+
+
+@pytest.mark.asyncio
+async def test_short_block_reuses_prior_episode_prop_without_ai_reanalysis(monkeypatch):
+    import novelvideo.agents.asset_compiler as asset_compiler
+
+    blocks = [
+        SimpleNamespace(
+            header_line="场次（4）地点：旧书店一楼，晨，内；出场人物：陆辰",
+            lines=[
+                "第二天清晨。陆辰迫不及待地翻开笔记本，新的预言果然出现了。",
+                "特写：【6月15日 17:10 青鹿河老码头 李家幼子 溺水】。",
+                "陆辰呼吸急促，他死死攥着笔记本，眼神在挣扎后变得坚定。",
+            ],
+        ),
+        SimpleNamespace(
+            header_line="场次（7）地点：梦境火场，夜，外；出场人物：陆辰、祖父",
+            lines=[
+                "祖父的身影伫立在烈火中心，随着火势的蔓延，他的轮廓逐渐扭曲、消散。",
+                "陆辰：（梦呓）爷爷……不……",
+                "陆辰在梦中惊醒，浑身大汗淋漓，面前的羊皮笔记本在黑暗中散发着令人胆寒的沉寂。",
+            ],
+        ),
+    ]
+    calls: list[str] = []
+
+    async def fake_analyze(self, block, preselected, prior_selected_prop_ids):
+        calls.append(block.header_line)
+        if "梦境火场" in block.header_line:
+            raise ValueError("should not call AI for short prior-prop-only block")
+        return [
+            asset_compiler.PropRequirement(
+                prop_name="笔记本",
+                prop_type="object",
+                owner="陆辰",
+                visual_prompt="一本有些陈旧的硬皮笔记本，纸页泛黄",
+                description="陆辰查看预言的笔记本",
+            )
+        ]
+
+    monkeypatch.setattr(asset_compiler.AssetCompiler, "_analyze_block_props", fake_analyze)
+
+    store = _FakeCogneeStore()
+    compiler = asset_compiler.AssetCompiler(store)
+    logs: list[str] = []
+
+    prop_menu = await compiler._compile_props(blocks, SimpleNamespace(number=1), logs.append)
+
+    assert [item.prop_id for item in prop_menu] == ["笔记本"]
+    assert calls == ["场次（4）地点：旧书店一楼，晨，内；出场人物：陆辰"]
+    assert logs == [
+        "  道具[1]: 笔记本 [本集局部]",
+        "  道具[2]: 笔记本 [本集复用]",
+    ]


### PR DESCRIPTION
## Summary
- Tighten episode prop planner structured-output instructions so `requirements` must be an object array with `prop_name` and `visual_prompt`.
- Convert prop planner schema/model-output failures into clear task errors instead of opaque retry exhaustion.
- Deterministically reuse already selected episode props in short follow-up scene blocks, avoiding an unnecessary model call for prior-prop-only blocks.
- Add regression coverage for standard drama import format, invalid string-list model output, exact prop-name validation, and short-block prior prop reuse.

Closes #76.

## Test Plan
- `uv run pytest tests/test_format_check.py tests/test_asset_compiler_prop_planning.py tests/test_newapi_text_gateway.py::test_asset_compiler_prop_planner_uses_prop_newapi_env tests/test_asset_compiler_scene_enrichment.py`
- `uv run ruff check src/novelvideo/agents/asset_compiler.py tests/test_asset_compiler_prop_planning.py`

## Runtime Verification
- Docker `test04` latest `episode_prop_planner` runs are `completed`.
- EP1 `prop_menu_json` is populated with planned props after rerun.
- Later short blocks now show `[本集复用]` instead of failing the whole episode.