### PR TITLE
fix(ingest): 导入成功后日志面板补收尾行，避免卡在 Step 3/3 (#72)

### DIFF
--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -1357,6 +1357,7 @@
       "confirm": "Confirm re-import"
     },
     "logsPanel": "Import log",
+    "logCompleted": "Import complete",
     "fileDeleted": "File removed",
     "buildHint": "Build the semantic graph, then construct characters and episodes on their respective pages.",
     "emptyPreview": "No content to preview yet. Upload a file to see the structure.",

--- a/frontend/public/locales/zh/translation.json
+++ b/frontend/public/locales/zh/translation.json
@@ -1357,6 +1357,7 @@
       "confirm": "确认重新导入"
     },
     "logsPanel": "导入日志",
+    "logCompleted": "导入完成",
     "fileDeleted": "文件已删除",
     "buildHint": "构建语义图谱，然后在角色 / 剧集页面分别构建",
     "emptyPreview": "上传文件后，这里会显示小说结构预览",

--- a/frontend/src/routes/_app/projects.$project/ingest.tsx
+++ b/frontend/src/routes/_app/projects.$project/ingest.tsx
@@ -743,6 +743,13 @@ export function IngestPageContent({ project }: { project: string }) {
     enabled: ingestStarted,
     invalidateKeys: [queryKeys.chapters(project)],
     onComplete: async () => {
+      // 显式补一条收尾日志：SSE 的最终「完成」行会被 ingestStarted 门控 + 标量
+      // currentTask 覆盖的竞态吞掉（见下方日志收集 effect），导致面板定格在
+      // 「Step 3/3…」像卡住。这里不依赖那条会丢的 SSE 行，主动收尾。 (#72)
+      setIngestLogs((prev) => {
+        const done = t("ingest.logCompleted");
+        return prev[prev.length - 1] === done ? prev : [...prev, done];
+      });
       setIngestStarted(false);
       setIngestFileStatus("completed");
       setIngestError(null);


### PR DESCRIPTION
## 背景

#72：用户导入实际已成功，但「导入日志」面板定格在 `Step 3/3: 创建向量索引…`（带省略号，像仍在进行中），顶部徽章却显示「导入完成」。用户易误判为卡住/失败。

## 根因（前端日志收尾竞态）

- 日志收集 effect 以 `ingestStarted` 门控（`ingest.tsx:778`）：只在 `ingestStarted === true` 时把 SSE 的 `currentTask` 追加进日志。
- `useTaskStream` 收到 `completed` 事件时，在同一事件处理函数里先 `setState({ currentTask: "完成" })`，紧接着**同步**调用 `onComplete → setIngestStarted(false)`（`use-task-stream.ts:125-144`）。React 把这两次 setState 批处理成**一次重渲染**，等日志 effect 运行时 `ingestStarted` 已为 `false`，收尾行被 guard 拦掉。
- 且日志源是**标量 `currentTask`**，后端 `report()` 只在 0.1/0.3/0.7/1.0 推进度事件，Step 3/3 到完成之间的 `向量索引创建完成`/`原文已保存到文件` 会在两次采样之间被覆盖丢失。

结果：面板定格在最后一次采样到的 `Step 3/3…`，而完成徽章走另一条状态通道（`setIngestFileStatus("completed")`）——「徽章说完成、日志停在 Step 3/3」。

## 改动

- `ingest.tsx`：在 `onComplete` 里**显式补一条本地化「导入完成」收尾行**（不依赖会被竞态吞掉的 SSE 行），带末行去重防重复。
- `translation.json`（zh/en）：新增 `ingest.logCompleted`（导入完成 / Import complete）。

面板始终以明确完成态收尾，消除「卡在 Step 3/3」的误判，满足 issue 验收标准（Step 3/3 后有明确最终状态 + 兜底）。

## 验证

- `pnpm tsc -b` + `pnpm build` 通过

Closes #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)