### PR TITLE
feat(episode): 镜头详情默认展开文案区 & 强化四区块标题 (#21)

### DIFF
--- a/frontend/src/__tests__/components/episode/beat-workbench/action-panel.test.tsx
+++ b/frontend/src/__tests__/components/episode/beat-workbench/action-panel.test.tsx
@@ -124,7 +124,7 @@ function makeBeat(beatNumber: number): Beat {
 }
 
 describe("ActionPanel", () => {
-  it("starts with detail sections collapsed", () => {
+  it("defaults to the 文案 section expanded with other sections collapsed (#21)", () => {
     const states: BeatStates = {
       1: {
         script: "missing",
@@ -148,7 +148,9 @@ describe("ActionPanel", () => {
       </I18nextProvider>,
     );
 
-    expect(screen.queryByText("TextPane")).not.toBeInTheDocument();
+    // 文案默认展开，用户无需点击即可看到文案内容；其它区块仍折叠。
+    expect(screen.getByText("TextPane")).toBeInTheDocument();
+    expect(screen.queryByText("SketchSection")).not.toBeInTheDocument();
   });
 
   it("keeps section open state after the panel remounts for the same episode", async () => {
@@ -176,10 +178,11 @@ describe("ActionPanel", () => {
       </I18nextProvider>,
     );
 
-    fireEvent.click(screen.getByRole("button", { name: /文案/ }));
+    // 用一个非默认展开的区块（草图）验证展开状态跨 remount 持久化。
+    fireEvent.click(screen.getByRole("button", { name: /草图/ }));
 
     await waitFor(() => {
-      expect(screen.getByText("TextPane")).toBeInTheDocument();
+      expect(screen.getByText("SketchSection")).toBeInTheDocument();
     });
 
     unmount();
@@ -190,7 +193,7 @@ describe("ActionPanel", () => {
       </I18nextProvider>,
     );
 
-    expect(screen.getByText("TextPane")).toBeInTheDocument();
+    expect(screen.getByText("SketchSection")).toBeInTheDocument();
   });
 
   it("keeps section open state when switching between beats", () => {
@@ -223,8 +226,9 @@ describe("ActionPanel", () => {
       </I18nextProvider>,
     );
 
-    fireEvent.click(screen.getByRole("button", { name: /文案/ }));
-    expect(screen.getByText("TextPane")).toBeInTheDocument();
+    // 用一个非默认展开的区块（草图）验证切换 beat 时展开状态保留。
+    fireEvent.click(screen.getByRole("button", { name: /草图/ }));
+    expect(screen.getByText("SketchSection")).toBeInTheDocument();
 
     rerender(
       <I18nextProvider i18n={i18n}>
@@ -240,7 +244,7 @@ describe("ActionPanel", () => {
       </I18nextProvider>,
     );
 
-    expect(screen.getByText("TextPane")).toBeInTheDocument();
+    expect(screen.getByText("SketchSection")).toBeInTheDocument();
   });
 
   it("opens the target section from a deep link", () => {

--- a/frontend/src/components/episode/beat-workbench/single-beat-panel.tsx
+++ b/frontend/src/components/episode/beat-workbench/single-beat-panel.tsx
@@ -141,7 +141,7 @@ export function SingleBeatPanel({
             <div key={id}>
               <div
                 className={cn(
-                  "sticky top-0 z-20 flex min-h-11 items-center border-b border-white/[0.055] bg-[#111111] text-[13px] font-medium text-muted-foreground shadow-[0_1px_0_rgba(255,255,255,0.03)] transition-colors hover:bg-white/[0.035] hover:text-foreground",
+                  "sticky top-0 z-20 flex min-h-11 items-center border-b border-white/[0.055] bg-[#111111] text-sm font-semibold text-muted-foreground shadow-[0_1px_0_rgba(255,255,255,0.03)] transition-colors hover:bg-white/[0.035] hover:text-foreground",
                   isOpen && "bg-[#121212] text-foreground/90",
                 )}
               >
@@ -157,8 +157,8 @@ export function SingleBeatPanel({
                       isOpen && "text-muted-foreground/75",
                     )}
                   />
-                  <Icon className={cn("size-3.5", isOpen ? "text-muted-foreground/80" : "text-muted-foreground/70")} />
-                  <span className="text-foreground/78">{t(labelKey)}</span>
+                  <Icon className={cn("size-4", isOpen ? "text-primary/85" : "text-muted-foreground/85")} />
+                  <span className={cn("font-semibold tracking-tight", isOpen ? "text-foreground" : "text-foreground/90")}>{t(labelKey)}</span>
                 </button>
                 {id === "video" && (
                   <VideoBackendHeaderSelect

--- a/frontend/src/stores/episode-workbench-store.ts
+++ b/frontend/src/stores/episode-workbench-store.ts
@@ -26,7 +26,11 @@ export const DEFAULT_BEAT_SELECTION: PersistedBeatSelection = {
   mode: "none",
   activeBeat: null,
 };
-export const DEFAULT_ACTION_PANEL_SECTIONS: readonly BeatActionPanelSectionId[] = [];
+// 默认展开「文案」区块：台词/类型/场景/画面描述等核心信息无需额外点击即可见
+// (#21)。仅作用于未自定义过的 scope；用户手动折叠后会按 scope 持久化覆盖此默认。
+export const DEFAULT_ACTION_PANEL_SECTIONS: readonly BeatActionPanelSectionId[] = [
+  "text",
+];
 export const DEFAULT_VIEW_TOGGLES: readonly BeatViewToggleId[] = [
   "text",
   "sketch",


### PR DESCRIPTION
## 背景

#21：打开单个镜头详情后，当前不默认展开「文案」区块——用户要额外点一次才能看到台词、类型、场景、画面描述、出场身份、出场道具等核心信息；同时「文案 / 草图 / 渲染图 / 视频」四个折叠区块标题在深色界面下视觉权重偏弱，和普通字段标签层级不清。

## 改动

1. **默认展开文案**（`episode-workbench-store.ts`）：`DEFAULT_ACTION_PANEL_SECTIONS` 由 `[]` → `["text"]`。仅作用于**未自定义过的 scope**；用户手动折叠后仍按 scope 持久化覆盖此默认，不会强行每次重开。
2. **强化四区块标题**（`single-beat-panel.tsx`）：
   - 字号 `text-[13px]` → `text-sm`
   - 字重 `font-medium` → `font-semibold`
   - 提高文字对比度（展开态 `text-foreground`，折叠态 `text-foreground/90`）
   - 图标 `size-3.5` → `size-4`，展开态带主色调
   - 与普通字段标签形成清晰层级差异
3. **单测更新**（`action-panel.test.tsx`）：原断言「默认折叠」的用例改为断言「文案默认展开、其它区块折叠」；两个持久化用例改用非默认展开的「草图」区块验证展开状态跨 remount / 切换 beat 的持久化。

## 验收对照

- ✅ 新打开任意镜头详情时「文案」默认展开，用户无需点击即可看到文案内容
- ✅ 四个一级标题更大更粗、对比度更高，和字段标签层级清晰

## 验证

- `pnpm tsc -b` + `pnpm build` 通过
- beat-workbench 相关单测 + UI 契约测试全绿（251 passed）

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)