### PR TITLE
ci: 新增 sync-to-gitee workflow（GitHub → Gitee 镜像同步）

### DIFF
--- a/.github/workflows/sync-to-gitee.yml
+++ b/.github/workflows/sync-to-gitee.yml
@@ -1,0 +1,31 @@
+name: Sync to Gitee
+
+on:
+  push:
+    branches:
+      - main
+      - master
+  workflow_dispatch:
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout full history
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup SSH key
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.GITEE_SSH_PRIVATE_KEY }}" > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
+          ssh-keyscan gitee.com >> ~/.ssh/known_hosts
+
+      - name: Push to Gitee
+        run: |
+          git remote add gitee git@gitee.com:claymorelab/dramaclaw.git
+          git push gitee --all --force
+          git push gitee --tags --force

--- a/license-inventory.csv
+++ b/license-inventory.csv
@@ -17,6 +17,7 @@ path,license_expression,copyright,evidence
 .github/workflows/frontend.yml,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 .github/workflows/release-images.yml,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 .github/workflows/secret-scan.yml,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
+.github/workflows/sync-to-gitee.yml,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 .gitignore,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 .gitleaks.toml,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 .hermes/plugins/dramaclaw/__init__.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation


### PR DESCRIPTION
## 内容

新增 `.github/workflows/sync-to-gitee.yml`：

- **触发**：push 到 `main` / `master`，或手动 `workflow_dispatch`
- **动作**：checkout 全量历史后，将所有分支与 tags force push 到镜像仓库 `git@gitee.com:claymorelab/dramaclaw.git`
- **认证**：SSH key，读取仓库 secret `GITEE_SSH_PRIVATE_KEY`

## 合并前置条件

- [ ] 仓库 secrets 已配置 `GITEE_SSH_PRIVATE_KEY`（对应公钥需加到 Gitee `claymorelab/dramaclaw` 的部署/账号 SSH key）

## 备注

- 同步为单向覆盖（`--force`），Gitee 侧的任何直接改动会被 GitHub 侧覆盖