### PR TITLE
fix(ci): 修正 Gitee 镜像仓库路径为 dramaclaw/dramaclaw

### DIFF
--- a/.github/workflows/sync-to-gitee.yml
+++ b/.github/workflows/sync-to-gitee.yml
@@ -26,6 +26,6 @@ jobs:
 
       - name: Push to Gitee
         run: |
-          git remote add gitee git@gitee.com:claymorelab/dramaclaw.git
+          git remote add gitee git@gitee.com:dramaclaw/dramaclaw.git
           git push gitee --all --force
           git push gitee --tags --force


### PR DESCRIPTION
## 背景

#80 合并后 Sync to Gitee 首跑失败：`Auth error: 404 not found!`（SSH 认证已通过，是仓库路径解析不到）。

排查发现 Gitee 组织的**显示名**是 claymorelab，但**实际命名空间路径**是 `dramaclaw`——仓库页面给出的真实地址为 `gitee.com/dramaclaw/dramaclaw.git`。

## 修改

- workflow 中 remote 由 `git@gitee.com:claymorelab/dramaclaw.git` 改为 `git@gitee.com:dramaclaw/dramaclaw.git`

## 验证方式

合并后 push 到 main 会自动触发同步；也可在 Actions 中对 Sync to Gitee 手动 `workflow_dispatch` 验证。