### PR TITLE
ci: 加固 sync-to-gitee（超时 + SSH keepalive + 重试）

### DIFF
--- a/.github/workflows/sync-to-gitee.yml
+++ b/.github/workflows/sync-to-gitee.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   sync:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     steps:
       - name: Checkout full history
@@ -23,9 +24,23 @@ jobs:
           echo "${{ secrets.GITEE_SSH_PRIVATE_KEY }}" > ~/.ssh/id_ed25519
           chmod 600 ~/.ssh/id_ed25519
           ssh-keyscan gitee.com >> ~/.ssh/known_hosts
+          # 跨境链路易出现 TCP 僵死连接：keepalive 让 ssh 在 ~2 分钟内
+          # 主动断开死连接并报错，交给下面的重试兜底，而不是无限挂起
+          cat >> ~/.ssh/config <<'SSHEOF'
+          Host gitee.com
+            ServerAliveInterval 30
+            ServerAliveCountMax 4
+          SSHEOF
 
       - name: Push to Gitee
         run: |
           git remote add gitee git@gitee.com:dramaclaw/dramaclaw.git
-          git push gitee --all --force
-          git push gitee --tags --force
+          for attempt in 1 2 3; do
+            if git push gitee --all --force && git push gitee --tags --force; then
+              exit 0
+            fi
+            echo "push attempt ${attempt} failed, retrying in 30s..."
+            sleep 30
+          done
+          echo "all push attempts failed"
+          exit 1


### PR DESCRIPTION
## 背景

#81 合并后首次全量镜像推送（打包约 131MB）在 `Push to Gitee` 步骤挂了 36 分钟无进展——跨境链路 TCP 连接僵死，git 会无限等待，且默认 job 超时是 6 小时。

## 修改（三层兜底）

1. **`timeout-minutes: 30`**：job 级超时，最坏情况不再白挂 6 小时
2. **SSH keepalive**（`ServerAliveInterval 30` × `ServerAliveCountMax 4`）：死连接约 2 分钟内被主动断开并报错，而不是无限挂起
3. **自动重试**：push 失败重试至多 3 次（间隔 30s），跨境断线场景通常重试即可恢复，无需人工介入

## 验证

- YAML 语法本地校验通过
- 首次全量同步已另行手动 workflow_dispatch 触发验证中；本 PR 合并后的 push 会再次触发增量同步