### PR TITLE
chore: release v1.0.5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "supertale-ce"
-version = "1.0.4"
+version = "1.0.5"
 description = "SuperTale Community Edition API and video pipeline"
 readme = "README.md"
 requires-python = ">=3.11,<3.13"

--- a/src/novelvideo/release-notes.md
+++ b/src/novelvideo/release-notes.md
@@ -1,18 +1,20 @@
 ---
-version: 1.0.4
+version: 1.0.5
 attention: low
 ---
-# v1.0.4
+# v1.0.5
 
 ## User-facing Highlights (zh)
 
-- **登录状态更稳**: 后端滚动更新或短暂 5xx 波动时,前端不再误判为登录失效并把用户踢出。
-- **历史素材复用更完整**: 从画布历史中「使用」视频素材创建新视频节点时,会自动带回原始提示词,方便继续迭代。
+- **历史资产批量操作**: 画布历史弹窗现在支持批量下载和批量使用,处理多张图或多段视频时更省步骤。
+- **镜头详情更易扫读**: 镜头详情默认展开文案区,并强化四个核心区块标题,检查分镜内容更直接。
+- **生成与导入更稳**: 修复参考节点生成分镜脚本失败、占位图裂图和导入日志卡在 Step 3/3 的问题。
 
 ## User-facing Highlights (en)
 
-- **More stable sign-in state**: Temporary backend 5xx responses during rolling updates no longer make the frontend treat the session as expired and sign the user out.
-- **Better history reuse**: Creating a new video node from a canvas history asset now restores the original prompt so you can keep iterating from it.
+- **Batch history asset actions**: The canvas history dialog now supports batch download and batch use, reducing clicks when working with multiple images or videos.
+- **More scannable shot details**: Shot details now open the copy section by default and use clearer titles for the four core sections.
+- **More reliable generation and import**: Fixed reference-node storyboard generation, broken placeholder images, and import logs that could appear stuck at Step 3/3.
 
 ## Fixes
 

--- a/tests/test_release_feed.py
+++ b/tests/test_release_feed.py
@@ -114,7 +114,7 @@ def test_built_wheel_contains_parseable_release_notes_artifact(tmp_path: Path) -
 def test_project_version_is_single_source_of_truth() -> None:
     pyproject = tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))
 
-    assert pyproject["project"]["version"] == "1.0.4"
+    assert pyproject["project"]["version"] == "1.0.5"
     assert importlib.metadata.version("supertale-ce") == pyproject["project"]["version"]
     assert "__version__" not in Path("src/novelvideo/__init__.py").read_text(encoding="utf-8")
 

--- a/uv.lock
+++ b/uv.lock
@@ -3407,7 +3407,7 @@ wheels = [
 
 [[package]]
 name = "supertale-ce"
-version = "1.0.4"
+version = "1.0.5"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary

- Bump CE package version to `1.0.5`.
- Update packaged release notes for the v1.0.5 release feed.
- Sync the release feed SSOT test expectation and `uv.lock` project metadata.

## Release notes

```release-note
v1.0.5 adds batch canvas history asset actions, improves shot detail readability, and fixes several generation/import reliability issues.
```

## Verification

- `UV_CACHE_DIR=/claymorelab/.uv-cache uv pip install -e .`
- `UV_CACHE_DIR=/claymorelab/.uv-cache uv run pytest tests/test_release_feed.py`

Skipped by request:

- Local build
