### PR TITLE
fix happyhorse omni reference mode

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,10 +13,10 @@
 # 默认 3000；端口冲突时改成别的（例如 30000）。
 # ST_NEWAPI_PORT=3000
 
-# 模型网关地址(OpenAI 兼容,末尾保留 /v1)。默认 = DramaClaw 官方网关 RelayClaw。
-# DC key 可在网页「设置 → 模型配置 → 官方渠道」粘贴(推荐),或直接在下面 NEWAPI_API_KEY 填。
-# BYO 自带网关时把本行改成你的网关地址。
-NEWAPI_BASE_URL=https://relayclaw.cdnfg.com/v1
+# 自定义/BYO 模型网关地址(OpenAI 兼容,末尾保留 /v1)。
+# 官方渠道无需配置网关地址,在网页「设置 → 模型配置 → 官方渠道」填写 DC key 即可。
+# 只有使用自定义 NewAPI / BYO 网关时才填写本项,例如 https://your-gateway/v1。
+NEWAPI_BASE_URL=
 
 # DC key / 网关 token,不要提交真实密钥。留空 = 启动后在网页「模型配置 → 官方渠道」粘贴。
 # 到 https://relayclaw.cdnfg.com 注册 / 购买 DC key。
@@ -25,7 +25,7 @@ NEWAPI_API_KEY=
 # 通用文本模型 API key。foss e2e 与兼容 OpenAI 的模型适配器会读取该变量。
 MODEL_API_KEY=your_model_api_key
 
-# 模型网关模式：official 使用上面的 NEWAPI_BASE_URL/NEWAPI_API_KEY；custom 使用前端初始化后写入本地 SQLite 的用户自配 NewAPI。
+# 模型网关模式：official 使用官方渠道 + NEWAPI_API_KEY；custom 使用前端初始化、本地 SQLite 或 NEWAPI_BASE_URL/NEWAPI_API_KEY 中的用户自配 NewAPI。
 # MODEL_GATEWAY_MODE=official
 
 # CE 用户自部署 NewAPI 配置向导。开启后，前端可初始化 NewAPI、创建/复用调用令牌并写入渠道。

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -12,9 +12,10 @@ useDefault = true
 # 全局放行（覆盖所有规则，含默认 generic-api-key）：确认的误报。
 # "3gs_combined" 是 freezone「3GS 导演合成图」输入项的 UI 标识符（key: "3gs_combined"），
 # 非密钥；generic-api-key 因低熵 key:"..." 模式误判。详见 verification-ledger 2026-06-29。
+# "clarify-ws-key" 是 chat route prewarm 测试夹具的 bridge_key 桩值，非密钥。
 [allowlist]
 description = "全局放行：确认的 generic-api-key 误报（前端 UI 输入项标识符，非密钥）"
-stopwords = ["3gs_combined"]
+stopwords = ["3gs_combined", "clarify-ws-key"]
 
 [[rules]]
 id = "env-credential-real-value"

--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -3657,7 +3657,7 @@
     "modelConfig": {
       "title": "Model Config",
       "description": "Choose a model gateway channel: the platform official gateway, or your own local NewAPI.",
-      "baseUrlHint": "The server can also pin this value via the NEWAPI_BASE_URL environment variable.",
+      "baseUrlHint": "Custom NewAPI can use NEWAPI_BASE_URL as its default address.",
       "effectiveBadge": "Active: {{channel}}",
       "loading": "Loading…",
       "requestFailed": "Request failed, please retry.",
@@ -3679,12 +3679,12 @@
         "adminUsername": "Admin Username"
       },
       "official": {
-        "description": "Enter the platform official gateway URL and API Key, then save. You may enter the root domain or the full /v1 URL.",
+        "description": "Enter the platform official channel API Key, then save.",
         "save": "Save & Enable",
         "enable": "Switch to Official",
         "saved": "Saved and switched to the official channel.",
         "enabled": "Switched to the official channel.",
-        "missingFields": "Please fill in the gateway URL and API Key.",
+        "missingFields": "Please fill in the API Key.",
         "registerLink": "Register at RelayClaw"
       },
       "custom": {

--- a/frontend/public/locales/zh/translation.json
+++ b/frontend/public/locales/zh/translation.json
@@ -3657,7 +3657,7 @@
     "modelConfig": {
       "title": "模型配置",
       "description": "选择模型网关渠道：使用平台官方网关，或自配本地 NewAPI。",
-      "baseUrlHint": "服务端也可以通过环境变量 NEWAPI_BASE_URL 固定该值。",
+      "baseUrlHint": "自定义 NewAPI 可通过环境变量 NEWAPI_BASE_URL 提供默认地址。",
       "effectiveBadge": "当前生效：{{channel}}",
       "loading": "加载中…",
       "requestFailed": "请求失败，请重试。",
@@ -3679,12 +3679,12 @@
         "adminUsername": "管理员用户名"
       },
       "official": {
-        "description": "填入平台官方网关地址与 API Key 并保存，保存后自动切换为官方渠道；地址可填根域名或完整 /v1 地址。",
+        "description": "填入平台官方渠道 API Key 并保存，保存后自动切换为官方渠道。",
         "save": "保存并启用",
         "enable": "切换到官方",
         "saved": "已保存并切换为官方渠道。",
         "enabled": "已切换为官方渠道。",
-        "missingFields": "请填写网关地址与 API Key。",
+        "missingFields": "请填写 API Key。",
         "registerLink": "请前往 RelayClaw 进行注册"
       },
       "custom": {

--- a/frontend/src/components/settings/settings-dialog.tsx
+++ b/frontend/src/components/settings/settings-dialog.tsx
@@ -111,8 +111,6 @@ export function SettingsDialog({ open, onOpenChange }: SettingsDialogProps) {
 
 const GATEWAY_MODES: GatewayMode[] = ["official", "custom"];
 
-// 官方网关地址默认值（服务端未返回时的回退）。
-const DEFAULT_OFFICIAL_GATEWAY_URL = "https://relayclaw.cdnfg.com/v1";
 const DEFAULT_CUSTOM_NEWAPI_URL = "http://127.0.0.1:3000";
 
 async function getRequestErrorMessage(error: unknown, fallback: string): Promise<string> {
@@ -338,29 +336,14 @@ function OfficialGatewayPanel({
   const enableOfficial = useEnableOfficial();
   const saveOfficial = useSaveOfficialConfig();
 
-  const [baseUrl, setBaseUrl] = useState(DEFAULT_OFFICIAL_GATEWAY_URL);
   const [apiKey, setApiKey] = useState("");
   const [revealKey, setRevealKey] = useState(false);
 
-  // 初值跟随服务端：优先已保存的官方 baseUrl，回退 .env 默认，再回退内置默认。
-  const seededBaseUrl =
-    official?.baseUrl || official?.environment.baseUrl || DEFAULT_OFFICIAL_GATEWAY_URL;
-  useEffect(() => {
-    setBaseUrl((current) => (current === seededBaseUrl ? current : seededBaseUrl));
-  }, [seededBaseUrl]);
-
   const handleSave = async () => {
-    const trimmedBaseUrl = baseUrl.trim();
     const trimmedApiKey = apiKey.trim();
-    const savedOfficialBaseUrl = official?.baseUrl?.trim() || official?.environment.baseUrl?.trim() || "";
-    const targetBaseUrl = trimmedBaseUrl || savedOfficialBaseUrl;
-    if (!targetBaseUrl) {
-      toast.error(t("settings.modelConfig.official.missingFields"));
-      return;
-    }
     try {
       if (!trimmedApiKey) {
-        if (!official?.configured || targetBaseUrl !== savedOfficialBaseUrl) {
+        if (!official?.configured) {
           toast.error(t("settings.modelConfig.official.missingFields"));
           return;
         }
@@ -373,14 +356,12 @@ function OfficialGatewayPanel({
         return;
       }
       const response = await saveOfficial.mutateAsync({
-        newApiBaseUrl: targetBaseUrl,
         newApiApiKey: trimmedApiKey,
       });
       if (!response.ok) {
         toast.error(getResponseErrorMessage(response, t("settings.modelConfig.requestFailed")));
         return;
       }
-      setBaseUrl(targetBaseUrl);
       setApiKey("");
       toast.success(t("settings.modelConfig.official.saved"));
     } catch (error) {
@@ -403,12 +384,6 @@ function OfficialGatewayPanel({
       </p>
 
       <div className="space-y-2.5">
-        <FieldRow
-          label={t("settings.modelConfig.fields.gatewayBaseUrl")}
-          value={baseUrl}
-          onChange={setBaseUrl}
-          placeholder={DEFAULT_OFFICIAL_GATEWAY_URL}
-        />
         <div className="grid grid-cols-[120px_1fr] items-center gap-3">
           <Label className="justify-start text-[11px] font-normal tracking-wide text-muted-foreground uppercase">
             {t("settings.modelConfig.fields.apiKey")}

--- a/frontend/src/features/canvas/nodes/VideoNode.tsx
+++ b/frontend/src/features/canvas/nodes/VideoNode.tsx
@@ -385,6 +385,13 @@ function isGrokVideoChannelModel(modelId: string | null | undefined): boolean {
   return normalized.includes("grokvideochannel");
 }
 
+function isHappyHorseVideoModel(modelId: string | null | undefined): boolean {
+  const normalized = String(modelId ?? "")
+    .replace(/[\s._-]/g, "")
+    .toLowerCase();
+  return normalized.includes("happyhorse10");
+}
+
 function videoModelReferenceDisabledReason(
   modelId: string | null | undefined,
   counts: { images: number; videos: number; audios: number },
@@ -724,6 +731,8 @@ export const VideoNode = memo(
       );
     }, [availableVideoModels, data.model]);
     const modelId = selectedVideoModel?.id ?? DEFAULT_VIDEO_MODEL_ID;
+    const selectedVideoModelId = selectedVideoModel?.apiModel ?? selectedVideoModel?.id ?? modelId;
+    const isHappyHorseModel = isHappyHorseVideoModel(selectedVideoModelId);
     // aspectRatio 只认合法的比例预设（含 "auto"）；历史上曾被写成像素串(如
     // "1248:704")的旧节点在这里吸附到最接近的合法视频比例，保证 chip 显示干净。
     const aspectRatio: FreezoneVideoAspectRatio = (
@@ -1558,8 +1567,13 @@ export const VideoNode = memo(
     useEffect(() => {
       if (data.genMode != null) return;
       if (referenceImages.length === 0) return;
-      updateNodeData(id, { genMode: "allReference" });
-    }, [data.genMode, id, referenceImages.length, updateNodeData]);
+      updateNodeData(id, { genMode: isHappyHorseModel ? "imageToVideo" : "allReference" });
+    }, [data.genMode, id, isHappyHorseModel, referenceImages.length, updateNodeData]);
+
+    useEffect(() => {
+      if (!isHappyHorseModel || genMode !== "allReference") return;
+      updateNodeData(id, { genMode: upstreamCounts.images > 0 ? "imageToVideo" : "textToVideo" });
+    }, [genMode, id, isHappyHorseModel, upstreamCounts.images, updateNodeData]);
 
     // Audio refs only carry meaning under the omni-gen (allReference) path —
     // textToVideo / firstLastFrame / imageToVideo discard them. So when an
@@ -1574,10 +1588,10 @@ export const VideoNode = memo(
     useEffect(() => {
       const prev = prevHasAudioRef.current;
       prevHasAudioRef.current = hasAudioUpstream;
-      if (!prev && hasAudioUpstream && data.genMode !== "allReference") {
+      if (!prev && hasAudioUpstream && data.genMode !== "allReference" && !isHappyHorseModel) {
         updateNodeData(id, { genMode: "allReference" });
       }
-    }, [data.genMode, hasAudioUpstream, id, updateNodeData]);
+    }, [data.genMode, hasAudioUpstream, id, isHappyHorseModel, updateNodeData]);
 
     // 上游接入视频素材时，只有「全能参考」能消费视频；其它模式（文生 / 图生 /
     // 首尾帧 / 图片参考）都会把视频丢弃。所以只要上游存在视频就强制切到
@@ -1585,9 +1599,10 @@ export const VideoNode = memo(
     // 与音频的「0→≥1 transition」不同，这里每次都纠正，确保视频在场期间无法切走。
     useEffect(() => {
       if (upstreamCounts.videos === 0) return;
+      if (isHappyHorseModel) return;
       if (genMode === "allReference") return;
       updateNodeData(id, { genMode: "allReference" });
-    }, [upstreamCounts.videos, genMode, id, updateNodeData]);
+    }, [upstreamCounts.videos, genMode, id, isHappyHorseModel, updateNodeData]);
 
     // 文生视频不接受任何素材引用。即便用户先手动选了 textToVideo 再接入
     // 图片/音频（此时上面两个自动切换 effect 都因 genMode 已显式而 bail），
@@ -1596,9 +1611,10 @@ export const VideoNode = memo(
     useEffect(() => {
       if (genMode !== "textToVideo") return;
       if (upstreamCounts.images === 0 && upstreamCounts.audios === 0) return;
-      updateNodeData(id, { genMode: "allReference" });
+      updateNodeData(id, { genMode: isHappyHorseModel ? "imageToVideo" : "allReference" });
     }, [
       genMode,
+      isHappyHorseModel,
       upstreamCounts.images,
       upstreamCounts.audios,
       id,
@@ -1612,8 +1628,8 @@ export const VideoNode = memo(
     useEffect(() => {
       if (genMode !== "firstLastFrame") return;
       if (upstreamCounts.images <= 2) return;
-      updateNodeData(id, { genMode: "allReference" });
-    }, [genMode, upstreamCounts.images, id, updateNodeData]);
+      updateNodeData(id, { genMode: isHappyHorseModel ? "imageToVideo" : "allReference" });
+    }, [genMode, isHappyHorseModel, upstreamCounts.images, id, updateNodeData]);
 
     useEffect(
       () => () => {
@@ -1948,6 +1964,17 @@ export const VideoNode = memo(
               nodeId: targetId,
             });
         } else if (genMode === "allReference") {
+          if (isHappyHorseModel) {
+            void showErrorDialog(
+              "HappyHorse 不支持全能参考模式，请切换为文生视频或图生视频。",
+              t("common.error"),
+            );
+            updateNodeData(id, {
+              isGenerating: false,
+              generationStartedAt: null,
+            });
+            return;
+          }
           // Omni-gen: classify each upstream node by its media type.
           // backend caps: image≤9, video≤3, audio≤3, total≤12.
           const upstream = collectUpstream();
@@ -2894,6 +2921,7 @@ export const VideoNode = memo(
                 <div className="ml-3 flex shrink-0 items-center gap-3">
                   <GenModeSelect
                     value={genMode}
+                    modelId={selectedVideoModel?.apiModel ?? selectedVideoModel?.id ?? modelId}
                     upstreamCounts={upstreamCounts}
                     onChange={(nextMode) => updateNodeData(id, { genMode: nextMode })}
                   />
@@ -3148,14 +3176,19 @@ VideoNode.displayName = "VideoNode";
 
 interface GenModeSelectProps {
   value: VideoGenMode;
+  modelId: string | null | undefined;
   upstreamCounts: { videos: number; images: number; audios: number };
   onChange: (next: VideoGenMode) => void;
 }
 
 function videoModeDisabledReason(
   mode: VideoGenMode,
+  modelId: string | null | undefined,
   upstreamCounts: { videos: number; images: number; audios: number },
 ): string | null {
+  if (mode === "allReference" && isHappyHorseVideoModel(modelId)) {
+    return "HappyHorse 不支持全能参考模式";
+  }
   if (upstreamCounts.videos > 0 && mode !== "allReference") {
     return "上游含视频素材时只能用「全能参考」";
   }
@@ -3174,7 +3207,7 @@ function videoModeDisabledReason(
   return null;
 }
 
-function GenModeSelect({ value, upstreamCounts, onChange }: GenModeSelectProps) {
+function GenModeSelect({ value, modelId, upstreamCounts, onChange }: GenModeSelectProps) {
   const { t } = useTranslation();
   const triggerRef = useRef<HTMLButtonElement>(null);
   const popoverRef = useRef<HTMLDivElement>(null);
@@ -3246,7 +3279,7 @@ function GenModeSelect({ value, upstreamCounts, onChange }: GenModeSelectProps) 
         >
           {MODE_TABS.map((tab) => {
             const isActive = tab.key === value;
-            const disabledReason = videoModeDisabledReason(tab.key, upstreamCounts);
+            const disabledReason = videoModeDisabledReason(tab.key, modelId, upstreamCounts);
             const isDisabled = disabledReason != null && !isActive;
             return (
               <button

--- a/frontend/src/lib/queries/model-gateway.ts
+++ b/frontend/src/lib/queries/model-gateway.ts
@@ -109,7 +109,6 @@ export interface ModelGatewayConfig {
 }
 
 export interface SaveOfficialConfigInput {
-  newApiBaseUrl: string;
   newApiApiKey: string;
 }
 

--- a/src/novelvideo/api/routes/freezone.py
+++ b/src/novelvideo/api/routes/freezone.py
@@ -6987,9 +6987,11 @@ async def freezone_video_omni_gen(
     except ValueError as exc:
         raise HTTPException(400, str(exc)) from exc
     is_happyhorse = is_freezone_happyhorse_backend(backend)
-    if not is_freezone_seedance2_backend(backend) and not is_happyhorse:
+    if is_happyhorse:
+        raise HTTPException(400, "HappyHorse video does not support omni reference mode")
+    if not is_freezone_seedance2_backend(backend):
         raise HTTPException(
-            400, "omni video currently only supports Seedance 2.0 or HappyHorse models"
+            400, "omni video currently only supports Seedance 2.0 models"
         )
 
     raw_reference_items = [item.model_dump() for item in body.references]
@@ -6997,17 +6999,6 @@ async def freezone_video_omni_gen(
         validate_omni_reference_limits(raw_reference_items)
     except ValueError as exc:
         raise HTTPException(400, str(exc)) from exc
-    if is_happyhorse:
-        image_count = sum(1 for item in raw_reference_items if item.get("type") == "image")
-        video_count = sum(1 for item in raw_reference_items if item.get("type") == "video")
-        audio_count = sum(1 for item in raw_reference_items if item.get("type") == "audio")
-        if audio_count:
-            raise HTTPException(400, "HappyHorse video does not support audio references")
-        if video_count > 1:
-            raise HTTPException(400, "HappyHorse video edit supports at most one video reference")
-        if video_count and image_count > 5:
-            raise HTTPException(400, "HappyHorse video edit supports at most 5 reference images")
-
     reference_items: list[dict[str, str]] = []
     for item in raw_reference_items:
         path_list = _resolve_url_list(project_dir, [str(item.get("url") or "")])

--- a/src/novelvideo/api/routes/model_gateway.py
+++ b/src/novelvideo/api/routes/model_gateway.py
@@ -15,7 +15,7 @@ from novelvideo.model_gateway_settings import (
     normalize_relay_base_url,
     normalize_api_key,
     save_media_relay_config,
-    save_official_newapi_gateway,
+    save_official_newapi_key,
     save_custom_newapi_gateway,
     save_newapi_database_config,
     save_newapi_embedding_model_config,
@@ -60,7 +60,6 @@ OFFICIAL_ONLY_MEDIA_MODEL_NAMES = {
 
 
 class OfficialGatewayBody(BaseModel):
-    new_api_base_url: str = Field(alias="newApiBaseUrl")
     new_api_api_key: str = Field(alias="newApiApiKey")
 
 
@@ -327,7 +326,7 @@ async def get_model_gateway_config() -> dict[str, Any]:
         "ok": True,
         "data": {
             **build_model_gateway_status(
-                official_base_url=app_config.NEWAPI_BASE_URL,
+                official_base_url=app_config.OFFICIAL_NEWAPI_BASE_URL,
                 official_api_key=app_config.NEWAPI_API_KEY,
             ),
             "provisioner": build_provisioner_status(),
@@ -343,7 +342,7 @@ async def enable_official_gateway() -> dict[str, Any]:
     except PermissionError as exc:
         raise _permission_error(exc) from exc
     status = build_model_gateway_status(
-        official_base_url=app_config.NEWAPI_BASE_URL,
+        official_base_url=app_config.OFFICIAL_NEWAPI_BASE_URL,
         official_api_key=app_config.NEWAPI_API_KEY,
     )
     if not status["official"]["configured"]:
@@ -356,7 +355,7 @@ async def enable_official_gateway() -> dict[str, Any]:
     return {
         "ok": True,
         "data": build_model_gateway_status(
-            official_base_url=app_config.NEWAPI_BASE_URL,
+            official_base_url=app_config.OFFICIAL_NEWAPI_BASE_URL,
             official_api_key=app_config.NEWAPI_API_KEY,
         ),
         "runtime": runtime,
@@ -369,18 +368,15 @@ async def save_official_gateway_config(body: OfficialGatewayBody) -> dict[str, A
         require_provisioner_enabled()
     except PermissionError as exc:
         raise _permission_error(exc) from exc
-    base_url = normalize_relay_base_url(body.new_api_base_url)
     api_key = normalize_api_key(body.new_api_api_key)
-    if not base_url:
-        raise HTTPException(status_code=400, detail="newApiBaseUrl is required")
     if not api_key:
         raise HTTPException(status_code=400, detail="newApiApiKey is required")
-    save_official_newapi_gateway(base_url=base_url, api_key=api_key, activate=True)
+    save_official_newapi_key(api_key=api_key, activate=True)
     runtime = refresh_model_gateway_runtime()
     return {
         "ok": True,
         "data": build_model_gateway_status(
-            official_base_url=app_config.NEWAPI_BASE_URL,
+            official_base_url=app_config.OFFICIAL_NEWAPI_BASE_URL,
             official_api_key=app_config.NEWAPI_API_KEY,
         ),
         "runtime": runtime,
@@ -502,7 +498,7 @@ async def init_custom_newapi(body: NewApiInitBody = NewApiInitBody()) -> dict[st
             },
             "database": build_provisioner_status()["database"],
             "effective": build_model_gateway_status(
-                official_base_url=app_config.NEWAPI_BASE_URL,
+                official_base_url=app_config.OFFICIAL_NEWAPI_BASE_URL,
                 official_api_key=app_config.NEWAPI_API_KEY,
             )["effective"],
             "runtime": runtime,

--- a/src/novelvideo/chat/hermes_workspace.py
+++ b/src/novelvideo/chat/hermes_workspace.py
@@ -133,15 +133,25 @@ def _root_value(*names: str) -> str:
 def _effective_newapi_gateway() -> tuple[str, str]:
     """Return effective NewAPI ``(api_key, base_url)`` for Hermes.
 
-    Root .env values are passed as the official fallback, but settings.db wins
-    when the UI selected a custom NewAPI channel.
+    The official gateway URL is fixed in code. Root .env values are only used
+    as key/custom-gateway fallback, and settings.db wins when the UI selected a
+    custom NewAPI channel.
     """
     from novelvideo.model_gateway_settings import get_effective_newapi_config
+    from novelvideo.model_gateway_settings import MODE_CUSTOM
+    from novelvideo.model_gateway_settings import normalize_relay_base_url
+    from novelvideo.official_defaults import OFFICIAL_NEWAPI_BASE_URL
 
+    root_base_url = _root_value("NEWAPI_BASE_URL")
+    root_api_key = _root_value("NEWAPI_API_KEY")
     gateway = get_effective_newapi_config(
-        official_base_url=_root_value("NEWAPI_BASE_URL"),
-        official_api_key=_root_value("NEWAPI_API_KEY"),
+        official_base_url=OFFICIAL_NEWAPI_BASE_URL,
+        official_api_key=root_api_key,
     )
+    if gateway.mode == MODE_CUSTOM and gateway.base_url:
+        return gateway.api_key, gateway.base_url
+    if root_base_url:
+        return root_api_key, normalize_relay_base_url(root_base_url)
     return gateway.api_key, gateway.base_url
 
 

--- a/src/novelvideo/config.py
+++ b/src/novelvideo/config.py
@@ -511,7 +511,7 @@ INDEXTTS2_FAL_ENDPOINT = os.environ.get(
 )
 INDEXTTS2_TIMEOUT_SECONDS = float(os.environ.get("INDEXTTS2_TIMEOUT_SECONDS", "1800"))
 
-NEWAPI_BASE_URL = os.environ.get("NEWAPI_BASE_URL", OFFICIAL_NEWAPI_BASE_URL)
+NEWAPI_BASE_URL = os.environ.get("NEWAPI_BASE_URL", "")
 NEWAPI_API_KEY = os.environ.get("NEWAPI_API_KEY", "")
 
 
@@ -520,7 +520,7 @@ def get_effective_newapi_gateway_config():
     from novelvideo.model_gateway_settings import get_effective_newapi_config
 
     return get_effective_newapi_config(
-        official_base_url=NEWAPI_BASE_URL,
+        official_base_url=OFFICIAL_NEWAPI_BASE_URL,
         official_api_key=NEWAPI_API_KEY,
     )
 

--- a/src/novelvideo/generators/scene_reference_images.py
+++ b/src/novelvideo/generators/scene_reference_images.py
@@ -664,10 +664,12 @@ async def generate_scene_reference_image(
             image_config=_scene_image_config(selected_model),
         )
     elif provider == "newapi":
-        from novelvideo.config import get_effective_newapi_gateway_config
+        from novelvideo.config import get_newapi_runtime_credentials
 
-        gateway = get_effective_newapi_gateway_config()
-        api_key = gateway.api_key or ""
+        api_key, base_url = get_newapi_runtime_credentials(
+            api_key_override=NEWAPI_API_KEY,
+            base_url_override=NEWAPI_BASE_URL,
+        )
         selected_model = _scene_image_model(kind, provider, model)
         image_bytes, _text, error = await _call_newapi_image_api(
             api_key=api_key,
@@ -675,7 +677,7 @@ async def generate_scene_reference_image(
             prompt=prompt,
             reference_images=references or None,
             image_config=_scene_image_config(selected_model),
-            base_url=gateway.base_url,
+            base_url=base_url,
         )
     elif provider in {"huimeng", "huimengi"}:
         api_key = HUIMENGI_API_KEY or ""

--- a/src/novelvideo/model_gateway_runtime.py
+++ b/src/novelvideo/model_gateway_runtime.py
@@ -79,7 +79,7 @@ def refresh_model_gateway_runtime() -> dict[str, Any]:
     from novelvideo import config as app_config
 
     gateway = get_effective_newapi_config(
-        official_base_url=app_config.NEWAPI_BASE_URL,
+        official_base_url=app_config.OFFICIAL_NEWAPI_BASE_URL,
         official_api_key=app_config.NEWAPI_API_KEY,
     )
     api_key = str(gateway.api_key or "").strip()

--- a/src/novelvideo/model_gateway_settings.py
+++ b/src/novelvideo/model_gateway_settings.py
@@ -1,9 +1,9 @@
 """CE runtime model gateway settings.
 
-The CE build can run with an official/default NewAPI gateway from env vars, or
-with a user-provisioned local NewAPI instance saved in a local SQLite settings
-database. The selected mode is explicit so stale custom settings do not silently
-override the official gateway.
+The CE build can run with the built-in official NewAPI gateway, or with a
+user-provisioned/custom NewAPI instance saved in local settings or provided via
+environment variables. The selected mode is explicit so stale custom settings do
+not silently override the official gateway.
 """
 
 from __future__ import annotations
@@ -22,6 +22,7 @@ from novelvideo.official_defaults import (
     DEFAULT_COGNEE_EMBEDDING_MODEL,
     DEFAULT_COGNEE_EMBEDDING_PROVIDER,
     DEFAULT_EMBEDDING_BATCH_SIZE,
+    OFFICIAL_NEWAPI_BASE_URL,
 )
 from novelvideo.sqlite_pragmas import configure_sqlite_connection
 
@@ -188,14 +189,12 @@ def set_model_gateway_mode(mode: str) -> None:
     _write_many({"model_gateway_mode": normalize_gateway_mode(mode)})
 
 
-def save_official_newapi_gateway(
+def save_official_newapi_key(
     *,
-    base_url: str,
     api_key: str,
     activate: bool = True,
 ) -> None:
     values = {
-        "official_newapi_base_url": normalize_relay_base_url(base_url),
         "official_newapi_api_key": str(api_key or "").strip(),
     }
     if activate:
@@ -511,6 +510,8 @@ def get_model_gateway_settings() -> dict[str, str]:
     env_mode = os.environ.get("MODEL_GATEWAY_MODE")
     if "model_gateway_mode" not in data and env_mode:
         data["model_gateway_mode"] = normalize_gateway_mode(env_mode)
+    if "model_gateway_mode" not in data and os.environ.get("NEWAPI_BASE_URL", "").strip():
+        data["model_gateway_mode"] = MODE_CUSTOM
     data.setdefault("model_gateway_mode", MODE_OFFICIAL)
     return data
 
@@ -528,21 +529,18 @@ def get_effective_newapi_config(
             source="custom",
             base_url=normalize_relay_base_url(
                 settings.get("custom_newapi_base_url", "")
+                or os.environ.get("NEWAPI_BASE_URL", "")
             ),
-            api_key=normalize_api_key(settings.get("custom_newapi_api_key", "")),
+            api_key=normalize_api_key(
+                settings.get("custom_newapi_api_key", "")
+                or os.environ.get("NEWAPI_API_KEY", "")
+            ),
         )
-    db_official_base_url = normalize_relay_base_url(
-        settings.get("official_newapi_base_url", "")
-    )
     db_official_api_key = normalize_api_key(settings.get("official_newapi_api_key", ""))
     return EffectiveNewApiConfig(
         mode=MODE_OFFICIAL,
         source="official",
-        base_url=normalize_relay_base_url(
-            db_official_base_url
-            or official_base_url
-            or os.environ.get("NEWAPI_BASE_URL", "")
-        ),
+        base_url=normalize_relay_base_url(OFFICIAL_NEWAPI_BASE_URL),
         api_key=normalize_api_key(
             db_official_api_key
             or (
@@ -735,19 +733,13 @@ def build_model_gateway_status(
     official_api_key: str | None = None,
 ) -> dict[str, Any]:
     settings = get_model_gateway_settings()
-    env_official_base_url = normalize_relay_base_url(
-        official_base_url or os.environ.get("NEWAPI_BASE_URL", "")
-    )
+    official_base_url_value = normalize_relay_base_url(OFFICIAL_NEWAPI_BASE_URL)
     env_official_api_key = normalize_api_key(
         official_api_key
         if official_api_key is not None
         else os.environ.get("NEWAPI_API_KEY", "")
     )
-    db_official_base_url = normalize_relay_base_url(
-        settings.get("official_newapi_base_url", "")
-    )
     db_official_api_key = normalize_api_key(settings.get("official_newapi_api_key", ""))
-    official_base_url_value = db_official_base_url or env_official_base_url
     official_api_key_value = db_official_api_key or env_official_api_key
     custom_base_url = normalize_relay_base_url(
         settings.get("custom_newapi_base_url", "")
@@ -769,15 +761,11 @@ def build_model_gateway_status(
             "baseUrl": official_base_url_value,
             "apiKeyPreview": mask_secret(official_api_key_value),
             "configured": bool(official_base_url_value and official_api_key_value),
-            "source": (
-                "database"
-                if db_official_base_url or db_official_api_key
-                else "environment"
-            ),
+            "source": "database" if db_official_api_key else "environment",
             "environment": {
-                "baseUrl": env_official_base_url,
+                "baseUrl": official_base_url_value,
                 "apiKeyPreview": mask_secret(env_official_api_key),
-                "configured": bool(env_official_base_url and env_official_api_key),
+                "configured": bool(official_base_url_value and env_official_api_key),
             },
         },
         "custom": {

--- a/tests/test_freezone_image_backend.py
+++ b/tests/test_freezone_image_backend.py
@@ -287,6 +287,27 @@ async def test_freezone_reverse_prompt_limit_exception_bubbles_to_global_handler
 
 
 @pytest.mark.asyncio
+async def test_freezone_video_omni_gen_rejects_happyhorse_model(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _patch_freezone_project(monkeypatch, tmp_path)
+
+    with pytest.raises(HTTPException) as exc:
+        await freezone_routes.freezone_video_omni_gen(
+            project="58",
+            body=freezone_routes.FreezoneVideoOmniGenRequest(
+                prompt="雨夜街头，人物缓慢回头。",
+                model="newapi_happyhorse-1.0",
+            ),
+            user={"username": "admin"},
+        )
+
+    assert exc.value.status_code == 400
+    assert "HappyHorse video does not support omni reference mode" in str(exc.value.detail)
+
+
+@pytest.mark.asyncio
 async def test_freezone_video_start_runtime_error_is_logged(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/tests/test_model_gateway_settings.py
+++ b/tests/test_model_gateway_settings.py
@@ -11,6 +11,7 @@ from httpx import Response
 
 from novelvideo import config
 from novelvideo.api.routes import model_gateway
+from novelvideo.official_defaults import OFFICIAL_NEWAPI_BASE_URL
 from novelvideo.model_gateway_settings import (
     MODE_CUSTOM,
     MODE_OFFICIAL,
@@ -19,7 +20,7 @@ from novelvideo.model_gateway_settings import (
     get_effective_cognee_embedding_config,
     get_effective_newapi_config,
     normalize_relay_base_url,
-    save_official_newapi_gateway,
+    save_official_newapi_key,
     save_custom_newapi_gateway,
     save_newapi_embedding_model_config,
     save_media_relay_config,
@@ -145,7 +146,7 @@ def test_model_gateway_can_switch_back_to_official(monkeypatch, tmp_path):
         official_api_key="sk-official-secret",
     )
     assert effective.mode == MODE_OFFICIAL
-    assert effective.base_url == "https://official.example/v1"
+    assert effective.base_url == OFFICIAL_NEWAPI_BASE_URL
     assert effective.api_key == "sk-official-secret"
 
     status = build_model_gateway_status(
@@ -161,8 +162,7 @@ def test_model_gateway_status_keeps_official_section_when_custom_is_active(
     tmp_path,
 ):
     _isolate_settings_db(monkeypatch, tmp_path)
-    save_official_newapi_gateway(
-        base_url="https://official.example/v1",
+    save_official_newapi_key(
         api_key="sk-official-secret",
         activate=True,
     )
@@ -180,14 +180,13 @@ def test_model_gateway_status_keeps_official_section_when_custom_is_active(
     assert status["mode"] == MODE_CUSTOM
     assert status["effective"]["source"] == "custom"
     assert status["effective"]["baseUrl"] == "http://new-api:3000/v1"
-    assert status["official"]["baseUrl"] == "https://official.example/v1"
+    assert status["official"]["baseUrl"] == OFFICIAL_NEWAPI_BASE_URL
     assert status["official"]["source"] == "database"
 
 
-def test_model_gateway_official_database_config_overrides_env(monkeypatch, tmp_path):
+def test_model_gateway_official_database_key_overrides_env(monkeypatch, tmp_path):
     _isolate_settings_db(monkeypatch, tmp_path)
-    save_official_newapi_gateway(
-        base_url="https://user-official.example/v1",
+    save_official_newapi_key(
         api_key="sk-user-official-secret",
         activate=True,
     )
@@ -197,7 +196,7 @@ def test_model_gateway_official_database_config_overrides_env(monkeypatch, tmp_p
         official_api_key="sk-env-official-secret",
     )
     assert effective.mode == MODE_OFFICIAL
-    assert effective.base_url == "https://user-official.example/v1"
+    assert effective.base_url == OFFICIAL_NEWAPI_BASE_URL
     assert effective.api_key == "sk-user-official-secret"
 
     status = build_model_gateway_status(
@@ -206,6 +205,19 @@ def test_model_gateway_official_database_config_overrides_env(monkeypatch, tmp_p
     )
     assert status["official"]["source"] == "database"
     assert status["official"]["environment"]["configured"] is True
+
+
+def test_model_gateway_official_url_ignores_newapi_base_url_env(monkeypatch, tmp_path):
+    _isolate_settings_db(monkeypatch, tmp_path)
+    monkeypatch.setenv("MODEL_GATEWAY_MODE", MODE_OFFICIAL)
+    monkeypatch.setenv("NEWAPI_BASE_URL", "https://malicious.example/v1")
+    monkeypatch.setenv("NEWAPI_API_KEY", "sk-env-secret")
+
+    effective = get_effective_newapi_config()
+
+    assert effective.mode == MODE_OFFICIAL
+    assert effective.base_url == OFFICIAL_NEWAPI_BASE_URL
+    assert effective.api_key == "sk-env-secret"
 
 
 def test_newapi_base_url_normalizers_keep_admin_and_relay_urls_separate():
@@ -997,7 +1009,6 @@ def test_save_official_gateway_route_persists_user_registered_key(
     response = client.post(
         "/model-gateway/official/config",
         json={
-            "newApiBaseUrl": "https://official-user.example/v1",
             "newApiApiKey": "sk-user-registered-secret",
         },
     )
@@ -1005,7 +1016,7 @@ def test_save_official_gateway_route_persists_user_registered_key(
     assert response.status_code == 200
     data = response.json()["data"]
     assert data["mode"] == MODE_OFFICIAL
-    assert data["official"]["baseUrl"] == "https://official-user.example/v1"
+    assert data["official"]["baseUrl"] == OFFICIAL_NEWAPI_BASE_URL
     assert data["official"]["source"] == "database"
     assert data["official"]["apiKeyPreview"] == "sk-u...cret"
     assert "sk-user-registered-secret" not in response.text
@@ -1014,13 +1025,19 @@ def test_save_official_gateway_route_persists_user_registered_key(
         official_base_url="https://env.example/v1",
         official_api_key="sk-env-secret",
     )
-    assert effective.base_url == "https://official-user.example/v1"
+    assert effective.base_url == OFFICIAL_NEWAPI_BASE_URL
     assert effective.api_key == "sk-user-registered-secret"
 
 
-def test_save_official_gateway_route_accepts_root_gateway_url(monkeypatch, tmp_path):
+def test_save_official_gateway_route_ignores_submitted_gateway_url(
+    monkeypatch, tmp_path
+):
     _isolate_settings_db(monkeypatch, tmp_path)
     monkeypatch.setenv("NEWAPI_PROVISIONER_ENABLED", "true")
+    monkeypatch.setattr(
+        model_gateway.app_config, "NEWAPI_BASE_URL", "https://env.example/v1"
+    )
+    monkeypatch.setattr(model_gateway.app_config, "NEWAPI_API_KEY", "sk-env-secret")
 
     app = FastAPI()
     app.include_router(model_gateway.router)
@@ -1035,12 +1052,13 @@ def test_save_official_gateway_route_accepts_root_gateway_url(monkeypatch, tmp_p
     )
 
     assert response.status_code == 200
-    assert (
-        response.json()["data"]["official"]["baseUrl"]
-        == "https://official-user.example/v1"
+    assert response.json()["data"]["official"]["baseUrl"] == OFFICIAL_NEWAPI_BASE_URL
+    effective = get_effective_newapi_config(
+        official_base_url="https://env.example/v1",
+        official_api_key="sk-env-secret",
     )
-    effective = get_effective_newapi_config()
-    assert effective.base_url == "https://official-user.example/v1"
+    assert effective.base_url == OFFICIAL_NEWAPI_BASE_URL
+    assert effective.api_key == "sk-user-registered-secret"
 
 
 def test_custom_newapi_init_route_accepts_empty_body(monkeypatch, tmp_path):

--- a/tests/test_newapi_image_gateway.py
+++ b/tests/test_newapi_image_gateway.py
@@ -13,6 +13,7 @@ def _isolate_settings_db(monkeypatch, tmp_path):
     import novelvideo.config as config
 
     state_dir = str(tmp_path / "state")
+    monkeypatch.delenv("MODEL_GATEWAY_MODE", raising=False)
     monkeypatch.setenv("NOVELVIDEO_STATE_DIR", state_dir)
     monkeypatch.setattr(config, "STATE_DIR", state_dir)
 


### PR DESCRIPTION
## Summary
- disable omni reference mode for HappyHorse video generation in Freezone
- add backend validation to reject unsupported HappyHorse omni requests
- add regression coverage for the unsupported mode

## Tests
- uv run pytest -n auto
- corepack pnpm --dir frontend build
- corepack pnpm --dir frontend test
- uv run ruff check --output-format=github .