### PR TITLE
chore(seo): 补充站点 meta description / og / twitter 标签

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,7 +4,28 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/png" href="/brand/dclogo.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>DramaClaw</title>
+    <title>DramaClaw 虾导 — 通用 AIGC 视频引擎 / General-purpose AIGC Video Engine</title>
+    <meta
+      name="description"
+      content="A general-purpose AIGC video engine: script to finished film in one pipeline — dramas, ads, product videos, otome games, and more. | 通用 AIGC 视频引擎 —— 从剧本到成片一条流水线，漫剧、广告、电商、乙游皆可"
+    />
+    <link rel="canonical" href="https://dramaclaw.cdnfg.com/" />
+    <meta property="og:type" content="website" />
+    <meta property="og:site_name" content="DramaClaw" />
+    <meta property="og:title" content="DramaClaw 虾导 — 通用 AIGC 视频引擎 / General-purpose AIGC Video Engine" />
+    <meta
+      property="og:description"
+      content="A general-purpose AIGC video engine: script to finished film in one pipeline — dramas, ads, product videos, otome games, and more. | 通用 AIGC 视频引擎 —— 从剧本到成片一条流水线，漫剧、广告、电商、乙游皆可"
+    />
+    <meta property="og:url" content="https://dramaclaw.cdnfg.com/" />
+    <meta property="og:image" content="https://dramaclaw.cdnfg.com/brand/dclogo.png" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="DramaClaw 虾导 — 通用 AIGC 视频引擎 / General-purpose AIGC Video Engine" />
+    <meta
+      name="twitter:description"
+      content="A general-purpose AIGC video engine: script to finished film in one pipeline — dramas, ads, product videos, otome games, and more. | 通用 AIGC 视频引擎 —— 从剧本到成片一条流水线，漫剧、广告、电商、乙游皆可"
+    />
+    <meta name="twitter:image" content="https://dramaclaw.cdnfg.com/brand/dclogo.png" />
     <script>
       (function () {
         try {


### PR DESCRIPTION
## 背景
在浏览器搜索 `dramaclaw` 时,线上 `https://dramaclaw.cdnfg.com` 的搜索结果描述显示为登录页某条示例短剧的剧情文案(「归灵司 全城反光物同时作祟…」)。

**根因**:`frontend/index.html` 此前只有 `<title>`,**没有 `<meta name="description">`**,搜索引擎(Bing)只能从页面可见正文里抓取一段当描述。

## 改动
给 `index.html` 补充正式的中英双语 `meta description`,并配套 `og:*` / `twitter:*` / `canonical` 标签,使搜索快照可控:

> A general-purpose AIGC video engine: script to finished film in one pipeline — dramas, ads, product videos, otome games, and more. | 通用 AIGC 视频引擎 —— 从剧本到成片一条流水线,漫剧、广告、电商、乙游皆可

`<title>` 也从旧的「AI 短剧」定位调整为与文案一致的「通用 AIGC 视频引擎」。

## 验证
- `tsc -b` ✅ / `pnpm build` ✅
- 打包产物 `dist/index.html` 已含 meta/og/twitter description(3 处)

## 生效说明(需人工)
1. 合并后**重新部署** `dist` 到 `dramaclaw.cdnfg.com` 才会出现在真实页面。
2. 部署后到 **Bing Webmaster Tools / Google Search Console** 提交 URL 催一次 re-crawl,快照更新有延迟。
3. SPA 限制:所有子路由共用这份静态 meta;若未来需按页面区分描述,需 SSR/预渲染。

🤖 Generated with [Claude Code](https://claude.com/claude-code)