### PR TITLE
chore: release v1.0.6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "supertale-ce"
-version = "1.0.5"
+version = "1.0.6"
 description = "SuperTale Community Edition API and video pipeline"
 readme = "README.md"
 requires-python = ">=3.11,<3.13"

--- a/src/novelvideo/release-notes.md
+++ b/src/novelvideo/release-notes.md
@@ -1,20 +1,20 @@
 ---
-version: 1.0.5
+version: 1.0.6
 attention: low
 ---
-# v1.0.5
+# v1.0.6
 
 ## User-facing Highlights (zh)
 
-- **历史资产批量操作**: 画布历史弹窗现在支持批量下载和批量使用,处理多张图或多段视频时更省步骤。
-- **镜头详情更易扫读**: 镜头详情默认展开文案区,并强化四个核心区块标题,检查分镜内容更直接。
-- **生成与导入更稳**: 修复参考节点生成分镜脚本失败、占位图裂图和导入日志卡在 Step 3/3 的问题。
+- **原生桌面运行更完整**: Windows 和 macOS 原生运行路径补齐,自部署不再只依赖 Docker 场景。
+- **画布创作更顺手**: 连线拖拽反馈、多选按连线排列和历史资产模型/模式记忆让图像与视频节点编排更稳定。
+- **登录页和站点呈现升级**: 猎魈人主题入口、主行动按钮和搜索分享信息完成收口,公开站点展示更统一。
 
 ## User-facing Highlights (en)
 
-- **Batch history asset actions**: The canvas history dialog now supports batch download and batch use, reducing clicks when working with multiple images or videos.
-- **More scannable shot details**: Shot details now open the copy section by default and use clearer titles for the four core sections.
-- **More reliable generation and import**: Fixed reference-node storyboard generation, broken placeholder images, and import logs that could appear stuck at Step 3/3.
+- **More complete native desktop support**: Windows and macOS native runtime paths are now covered, so self-hosting is no longer limited to Docker-first workflows.
+- **Smoother canvas creation**: Connection feedback, connection-aware multi-selection layout, and history asset model/mode memory make image and video node workflows more predictable.
+- **Refined login and site presentation**: The Liexiaoren themed entry, primary action buttons, and search/social metadata now present a more consistent public experience.
 
 ## Fixes
 

--- a/tests/test_release_feed.py
+++ b/tests/test_release_feed.py
@@ -114,7 +114,7 @@ def test_built_wheel_contains_parseable_release_notes_artifact(tmp_path: Path) -
 def test_project_version_is_single_source_of_truth() -> None:
     pyproject = tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))
 
-    assert pyproject["project"]["version"] == "1.0.5"
+    assert pyproject["project"]["version"] == "1.0.6"
     assert importlib.metadata.version("supertale-ce") == pyproject["project"]["version"]
     assert "__version__" not in Path("src/novelvideo/__init__.py").read_text(encoding="utf-8")
 

--- a/uv.lock
+++ b/uv.lock
@@ -3419,7 +3419,7 @@ wheels = [
 
 [[package]]
 name = "supertale-ce"
-version = "1.0.5"
+version = "1.0.6"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## PR 类型 / Type of PR
- [ ] 🐞 Bug 修复 / Bug fix
- [ ] ✨ 新功能 / Feature
- [ ] 📝 文档 / Documentation
- [ ] 🧹 重构 / 清理 / Refactor or cleanup
- [ ] ⚙️ 构建 / CI / Build or CI
- [ ] ⚠️ 破坏性变更 / Breaking change

## 改动说明 / What this PR does and why
发布 v1.0.6：

- 将 `supertale-ce` 版本从 `1.0.5` 更新为 `1.0.6`。
- 更新包内 `src/novelvideo/release-notes.md`，供 Release Feed 和 What's New 弹窗展示。
- 同步 `tests/test_release_feed.py` 中的版本断言。
- 重装 editable 包后同步 `uv.lock`。

## 关联 issue / Linked issues
N/A

## 给 reviewer 的说明 / Notes for the reviewer
本 PR 只包含 release bump 文件，不包含 PR #92 的章节切分修复。

## 面向用户的变更 / User-facing change
```release-note
发布 v1.0.6，包含原生 Windows/macOS 运行支持、画布体验改进和登录页/站点呈现升级。
```

## 自检 / Checklist
- [x] 已自测，`uv run pytest` 通过 / Self-tested, `uv run pytest` passes
- [x] 必要的文档已更新 / Docs updated where needed
- [x] 提交信息清晰（建议 Conventional Commits）/ Clear commits (Conventional Commits suggested)
- [x] 每个 commit 都已 `git commit -s` 附 DCO 签署 / Every commit signed off with `git commit -s` (DCO)
- [x] 我已阅读并同意[贡献者协议](../CONTRIBUTING.md#贡献者协议) / I've read and agree to the [contributor terms](../CONTRIBUTING.md#贡献者协议)

验证命令：
`UV_CACHE_DIR=/Users/newyue/claymorelab/.uv-cache uv run pytest tests/test_release_feed.py`
