### PR TITLE
fix(login): 登录页视频改走 CDN 域名，修复全浏览器黑屏

### DIFF
--- a/frontend/src/components/login/cinematic/media.ts
+++ b/frontend/src/components/login/cinematic/media.ts
@@ -1,6 +1,6 @@
-const OSS_BASE = "https://nfg-web.oss-cn-chengdu.aliyuncs.com/dramaclaw";
+const CDN_BASE = "https://nfg-web-assets.cdnfg.com/dramaclaw";
 
-const oss = (path: string) => encodeURI(`${OSS_BASE}/${path}`);
+const cdn = (path: string) => encodeURI(`${CDN_BASE}/${path}`);
 
 export const cinematicVideoLibrary = [
   {
@@ -9,7 +9,7 @@ export const cinematicVideoLibrary = [
     type: "TRAILER",
     stat: "12 SHOTS",
     logline: "机械与古法在同一条时间线里重新咬合。",
-    video: oss("luban/luban-ep01.mp4"),
+    video: cdn("luban/luban-ep01.mp4"),
   },
   {
     id: "guilingsi",
@@ -17,7 +17,7 @@ export const cinematicVideoLibrary = [
     type: "SCENE",
     stat: "08 SHOTS",
     logline: "全城反光物同时作祟，收灵人被迫追查镜中源头。",
-    video: oss("guilingsi/guilingsi-ep01.mp4"),
+    video: cdn("guilingsi/guilingsi-ep01.mp4"),
   },
   {
     id: "shixiong-butianle",
@@ -25,7 +25,7 @@ export const cinematicVideoLibrary = [
     type: "CHARACTER",
     stat: "09 SHOTS",
     logline: "重生后的第一件事，是拒绝继续当命运的配角。",
-    video: oss("shixiong-butianle/shixiong-butianle-ep01.mp4"),
+    video: cdn("shixiong-butianle/shixiong-butianle-ep01.mp4"),
   },
   {
     id: "tianmingbukeqi",
@@ -33,7 +33,7 @@ export const cinematicVideoLibrary = [
     type: "WORLD",
     stat: "14 SHOTS",
     logline: "大婚当日，归乡之法与王朝秘密同时浮出水面。",
-    video: oss("tianmingbukeqi/tianmingbukeqi-ep02.mp4"),
+    video: cdn("tianmingbukeqi/tianmingbukeqi-ep02.mp4"),
   },
   {
     id: "wulongxiantu",
@@ -41,7 +41,7 @@ export const cinematicVideoLibrary = [
     type: "TRAILER",
     stat: "11 SHOTS",
     logline: "飞升系统终于激活，却把修仙路带向另一个荒唐方向。",
-    video: oss("wulongxiantu/wulongxiantu-ep01.mp4"),
+    video: cdn("wulongxiantu/wulongxiantu-ep01.mp4"),
   },
   {
     id: "feiyi-zhouwu",
@@ -49,7 +49,7 @@ export const cinematicVideoLibrary = [
     type: "WORLD",
     stat: "07 SHOTS",
     logline: "传统身段、节奏和镜头被重新编排成可观看的片段。",
-    video: oss("feiyi-zhouwu/feiyi-zhouwu.mp4"),
+    video: cdn("feiyi-zhouwu/feiyi-zhouwu.mp4"),
   },
   {
     id: "3d-anime-montage-demo",
@@ -57,7 +57,7 @@ export const cinematicVideoLibrary = [
     type: "SCENE",
     stat: "10 SHOTS",
     logline: "多个动画片段被剪进同一组高密度镜头节奏。",
-    video: oss("3d-anime-montage-demo/3d-anime-montage-demo.mp4"),
+    video: cdn("3d-anime-montage-demo/3d-anime-montage-demo.mp4"),
   },
   {
     id: "dongtai-dadou",
@@ -65,7 +65,7 @@ export const cinematicVideoLibrary = [
     type: "ACTION",
     stat: "06 SHOTS",
     logline: "动作、速度线和镜头压迫感在短片里连续推进。",
-    video: oss("dongtai-dadou/dongtai-dadou.mp4"),
+    video: cdn("dongtai-dadou/dongtai-dadou.mp4"),
   },
 ] as const;
 

--- a/frontend/src/features/liexiaoren/liexiaoren-assets.ts
+++ b/frontend/src/features/liexiaoren/liexiaoren-assets.ts
@@ -4,7 +4,7 @@
 const BASE_PATH = "/liexiaoren";
 const CDN_LOGIN_PATH = "https://nfg-web-assets.cdnfg.com/dramaclaw/login";
 const LUBAN_EPISODE_VIDEO_URL =
-  "https://nfg-web.oss-cn-chengdu.aliyuncs.com/dramaclaw/luban/luban-ep01.mp4";
+  "https://nfg-web-assets.cdnfg.com/dramaclaw/luban/luban-ep01.mp4";
 
 export const liexiaorenAssets = {
   entry: {


### PR DESCRIPTION
## 现象
登录页多屏视频在 **Chrome 和 Edge 都不显示**(黑屏),例如「从灵感到项目」屏的视频、猎魈人预览视频。

## 根因(两个叠加)
cinematic 各屏视频(`media.ts`)与猎魈人预览视频(`liexiaoren-assets.ts`)从**阿里云 OSS 原始域名** `nfg-web.oss-cn-chengdu.aliyuncs.com` 取:

1. **强制下载**:该域名对 mp4 返回 `Content-Disposition: attachment` + `x-oss-force-download: true`,`<video>` 无法内联播放。
   ```
   $ curl -sI .../dongtai-dadou.mp4
   Content-Disposition: attachment
   x-oss-force-download: true
   ```
2. **CSP 拦截**:线上 `docker/nginx.conf.template` 的 CSP `media-src` 白名单**不含**该 OSS 原始域名(只放行了 `nfg-web-assets.cdnfg.com`),视频请求直接被浏览器拦掉。

## 改动
两处 OSS 原始域名 → CDN 域名 `nfg-web-assets.cdnfg.com`(无强制下载、已在 CSP `media-src` 白名单内),路径不变:
- `components/login/cinematic/media.ts`(所有 cinematic 视频;`oss()` helper 更名 `cdn()`)
- `features/liexiaoren/liexiaoren-assets.ts`(猎魈人 `luban-ep01.mp4` 预览)

已确认这些视频均为 **H.264(avc1)**,换域名后可正常内联播放。

## 验证
- `tsc -b` ✅ / `pnpm build` ✅
- 本地 dev(指向本地 EE)硬刷新后视频正常加载
- CDN 域名响应头:无 `Content-Disposition`,`Content-Type: video/mp4`,`X-Cache: HIT`

## ⚠️ 另有独立问题(不在本 PR 范围,需转码素材)
Edge 上 hero 徽标花屏(以及猎魈档案弹窗标题)是**另一个原因**:这两个素材是 **HEVC(hvc1)** 编码,Edge/Chrome 在 macOS 无 HEVC 解码器。需把以下素材转成 H.264 重新上传(换域名解决不了):
- `login/entry-badge.mp4`(HEVC)
- `login/title.mp4`(HEVC)

🤖 Generated with [Claude Code](https://claude.com/claude-code)