### PR TITLE
fix(login): 修复 Edge 登录页标题左侧花屏

### DIFF
--- a/frontend/src/components/react-bits/split-text.tsx
+++ b/frontend/src/components/react-bits/split-text.tsx
@@ -142,6 +142,10 @@ export default function SplitText({
               },
               onComplete: () => {
                 animationCompletedRef.current = true;
+                // 动画结束后清除 will-change，让父元素与每个字从 GPU 合成层降回
+                // 普通渲染路径。否则在 Edge 上，background-clip:text 的元素长期处于
+                // 合成层会漏掉文字遮罩、画出图层后备纹理的垃圾（标题左侧花屏）。
+                gsap.set([el, ...(targets ?? [])], { willChange: "auto" });
                 onCompleteRef.current?.();
               },
               willChange: "transform, opacity",
@@ -191,7 +195,9 @@ export default function SplitText({
     visibility: initiallyHidden ? "hidden" : undefined,
     whiteSpace: "normal",
     wordWrap: "break-word",
-    willChange: "transform, opacity",
+    // 不在父元素上常驻 will-change：父元素本身不参与动画，常驻合成层反而会让
+    // background-clip:text 在 Edge 上花屏。字级的 will-change 由 tween 负责，
+    // 并在 onComplete 中清除。
   };
   const classes = `split-parent ${className}`;
   return createElement(tag, { ref, style, className: classes }, text);


### PR DESCRIPTION
## 问题

Edge 打开登录页时，「开启你的创作宇宙」标题**左侧出现一块花屏**（灰白色垃圾像素）；Chrome 正常。

## 根因

标题是 `SplitText` 渲染的渐变文字：用 `-webkit-background-clip: text` + `color: transparent` 把渐变裁进字形。GSAP 逐字入场动画又给 **h1 父元素和每个 `.split-char`** 常驻了 `will-change: transform, opacity`：

- 父元素来自 `split-text.tsx` 的 inline style（永久）
- 字级来自 tween 的 `willChange`，`onComplete` 从未清除

两者叠加使标题元素**永久驻留 GPU 合成层**。Edge 在合成 `background-clip:text` 图层时会漏掉文字遮罩、直接画出图层后备纹理的垃圾内存 → 花屏。Chrome 合成路径不同，故不复现。

> 注：与视频编码（HEVC）、CDN/CSP 均无关——登录后 header 里的 HEVC 徽标在 Edge 里正常播放，已排除编码因素。

## 修复

`src/components/react-bits/split-text.tsx`：

1. 动画 `onComplete` 中 `gsap.set([el, ...targets], { willChange: "auto" })`，把父元素与所有字从合成层降回普通渲染路径。
2. 移除父元素 inline style 里常驻的 `will-change`（父元素本身不参与动画，无需提升）。

字级 `will-change` 仍由 tween 负责，动画结束即清除。

## 验证

- 本地 dev：动画结束后 h1 及全部 8 个字的 computed `will-change` 均为 `auto`，合成层已卸载。
- Chrome 标题渲染无退化。
- Edge 硬刷新后标题左侧花屏消失（人工确认）。
- `tsc -b` + `pnpm build` 均通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)