### PR TITLE
fix(canvas): 修复线上视频节点截首尾帧画布污染报错

### DIFF
--- a/frontend/src/features/canvas/application/imageData.ts
+++ b/frontend/src/features/canvas/application/imageData.ts
@@ -187,19 +187,19 @@ export function isRenderableImageSrc(value: string): boolean {
   return isLikelyLocalImagePath(value);
 }
 
-// Cross-origin CDN media (absolute http(s)/asset: URL) must be fetched with CORS
-// so the decoded pixels can be drawn to a <canvas> and exported (toBlob /
-// toDataURL) without tainting it. Same-origin / relative `/static/*` paths (the
-// dev vite proxy) deliberately skip it: that origin doesn't echo
-// Access-Control-Allow-Origin, and a same-origin draw is never tainted anyway.
+// Media drawn to a <canvas> that gets exported (toBlob / toDataURL) must be
+// fetched with CORS, otherwise the canvas taints and export throws. This
+// includes relative `/projects/.../media/*` paths: in production the backend
+// 302-redirects them to a presigned OSS URL (see _serve_or_redirect_to_oss),
+// so a no-cors load ends up cross-origin and taints anyway — that only
+// surfaced online, never against the dev vite proxy which streams the bytes
+// same-origin. CORS mode is harmless for true same-origin responses (no
+// Access-Control-Allow-Origin required) and the OSS bucket allows the site
+// origin. Only data:/blob: skip it — they can never taint a canvas.
 // Shared by the <img> loader and the offscreen <video> frame-capture paths.
 export function mediaNeedsCrossOrigin(url: string): boolean {
   const lower = url.toLowerCase();
-  return (
-    lower.startsWith('http://') ||
-    lower.startsWith('https://') ||
-    lower.startsWith('asset:')
-  );
+  return !lower.startsWith('data:') && !lower.startsWith('blob:');
 }
 
 // Cache-busting convention:


### PR DESCRIPTION
## 问题

线上画布视频节点「截首帧/尾帧」卡住,Console 报:

```
Uncaught SecurityError: Failed to execute 'toBlob' on 'HTMLCanvasElement': Tainted canvases may not be exported.
```

本地环境正常。

## 根因

1. 线上开启 `STATIC_VIA_OSS`,后端 `_serve_or_redirect_to_oss` 对 `/projects/.../media/*` 会 **302 到跨域的 OSS 预签名 URL**;本地走同源 `FileResponse`,所以本地无此问题。
2. 截帧离屏 `<video>` 的 `mediaNeedsCrossOrigin` 只对绝对 `http(s)://` URL 设 `crossOrigin="anonymous"`,相对路径不设。
3. 线上:相对路径 → 跟随 302 → 以 no-cors 模式加载跨域 OSS 视频 → `drawImage` 污染画布 → `toBlob` 抛 `SecurityError`。

## 修复

`mediaNeedsCrossOrigin` 改为:除 `data:` / `blob:`(永不污染画布)外一律返回 true。同源响应不需要 ACAO,CORS 模式无副作用;302 到 OSS 后浏览器带 `Origin` 走 CORS 拿到 ACAO,画布不再污染。一处 helper 覆盖全部 5 个画布导出路径(VideoNode 截帧、VideoClipPanel、filmstrip、CoverEditor、loadImageElement)。

## 验证

- 实测线上 bucket `novelvideo-assets-chengdu`:对站点 origin `https://dramaclaw.cdnfg.com` 的 preflight(OPTIONS)与实际 GET 均返回 `Access-Control-Allow-Origin`,且带 `Vary: Origin`(浏览器缓存不会串用 no-cors 响应)
- `tsc -b`、`pnpm build`、canvas 相关 vitest 全部通过

## 注意

`dramaclaw.ai` 不在 bucket CORS 白名单(实测 403)。目前它 301 到 cdnfg.com 无影响;若未来该域名直接跑应用,需在 OSS bucket CORS 规则里补充该 origin。

🤖 Generated with [Claude Code](https://claude.com/claude-code)