### PR TITLE
chore: release v1.0.7

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "supertale-ce"
-version = "1.0.6"
+version = "1.0.7"
 description = "SuperTale Community Edition API and video pipeline"
 readme = "README.md"
 requires-python = ">=3.11,<3.13"

--- a/src/novelvideo/release-notes.md
+++ b/src/novelvideo/release-notes.md
@@ -1,20 +1,20 @@
 ---
-version: 1.0.6
+version: 1.0.7
 attention: low
 ---
-# v1.0.6
+# v1.0.7
 
 ## User-facing Highlights (zh)
 
-- **原生桌面运行更完整**: Windows 和 macOS 原生运行路径补齐,自部署不再只依赖 Docker 场景。
-- **画布创作更顺手**: 连线拖拽反馈、多选按连线排列和历史资产模型/模式记忆让图像与视频节点编排更稳定。
-- **登录页和站点呈现升级**: 猎魈人主题入口、主行动按钮和搜索分享信息完成收口,公开站点展示更统一。
+- **剧本导入更准确**: 章节标题边界识别更严格,减少正文里的“第一集/Chapter 1”被误切成新章节的情况。
+- **虾画视频节点更稳定**: 修复首尾帧和画布上下文串用导致的视频节点报错,跨画布编辑更可靠。
+- **登录与公开页面更可靠**: 登录页视频、商务微信二维码和浏览器 CSP 兼容性完成收口,减少黑屏、花屏和控制台告警。
 
 ## User-facing Highlights (en)
 
-- **More complete native desktop support**: Windows and macOS native runtime paths are now covered, so self-hosting is no longer limited to Docker-first workflows.
-- **Smoother canvas creation**: Connection feedback, connection-aware multi-selection layout, and history asset model/mode memory make image and video node workflows more predictable.
-- **Refined login and site presentation**: The Liexiaoren themed entry, primary action buttons, and search/social metadata now present a more consistent public experience.
+- **More accurate script imports**: Chapter title boundary detection is stricter, reducing accidental splits when text mentions “Episode 1” or “Chapter 1” inside body copy.
+- **More stable Xiahua video nodes**: Video nodes now avoid first/last-frame and canvas-context leakage that could break cross-canvas editing.
+- **More reliable login and public pages**: Login video assets, business WeCom QR assets, and browser CSP compatibility were tightened to reduce black screens, visual glitches, and console warnings.
 
 ## Fixes
 

--- a/tests/test_release_feed.py
+++ b/tests/test_release_feed.py
@@ -114,7 +114,7 @@ def test_built_wheel_contains_parseable_release_notes_artifact(tmp_path: Path) -
 def test_project_version_is_single_source_of_truth() -> None:
     pyproject = tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))
 
-    assert pyproject["project"]["version"] == "1.0.6"
+    assert pyproject["project"]["version"] == "1.0.7"
     assert importlib.metadata.version("supertale-ce") == pyproject["project"]["version"]
     assert "__version__" not in Path("src/novelvideo/__init__.py").read_text(encoding="utf-8")
 

--- a/uv.lock
+++ b/uv.lock
@@ -3419,7 +3419,7 @@ wheels = [
 
 [[package]]
 name = "supertale-ce"
-version = "1.0.6"
+version = "1.0.7"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## PR 类型 / Type of PR
- [ ] 🐞 Bug 修复 / Bug fix
- [ ] ✨ 新功能 / Feature
- [x] 📝 文档 / Documentation
- [ ] 🧹 重构 / 清理 / Refactor or cleanup
- [x] ⚙️ 构建 / CI / Build or CI
- [ ] ⚠️ 破坏性变更 / Breaking change

## 改动说明 / What this PR does and why
准备 Dramaclaw v1.0.7 release：
- 将 `pyproject.toml` / `uv.lock` 版本从 1.0.6 bump 到 1.0.7。
- 更新包内 `src/novelvideo/release-notes.md`，覆盖 v1.0.6 之后合入的用户可见改动。
- 同步 `tests/test_release_feed.py` 中的版本 SSOT 断言。

## 关联 issue / Linked issues
N/A

## 给 reviewer 的说明 / Notes for the reviewer
本 PR 只准备 release commit，不打 tag、不创建 GitHub Release、不合入 main。合入后再按 `docs/releasing.md` 继续 tag 与 GitHub Release 发布步骤。

## 面向用户的变更 / User-facing change
```release-note
发布 v1.0.7：改进剧本导入章节识别、虾画视频节点稳定性，以及登录/公开页面资源加载可靠性。
```

## 自检 / Checklist
- [x] 已自测，`uv run pytest` 通过 / Self-tested, `uv run pytest` passes
- [x] 必要的文档已更新 / Docs updated where needed
- [x] 提交信息清晰（建议 Conventional Commits）/ Clear commits (Conventional Commits suggested)
- [x] 每个 commit 都已 `git commit -s` 附 DCO 签署 / Every commit signed off with `git commit -s` (DCO)
- [x] 我已阅读并同意[贡献者协议](../CONTRIBUTING.md#贡献者协议) / I've read and agree to the [contributor terms](../CONTRIBUTING.md#贡献者协议)

## 验证 / Verification
- `UV_CACHE_DIR=/claymorelab/.uv-cache uv pip install -e .`
- `UV_CACHE_DIR=/claymorelab/.uv-cache uv run pytest tests/test_release_feed.py` → 12 passed

未运行全量 `uv run pytest`。