### PR TITLE
fix(episode): 场景/道具规划按钮转圈跟随异步任务,不再入队即停 (#103)

### DIFF
--- a/frontend/src/__tests__/routes/episodes-workbench-integration.test.ts
+++ b/frontend/src/__tests__/routes/episodes-workbench-integration.test.ts
@@ -23,8 +23,8 @@ describe("episodes workbench integration", () => {
     expect(routeSource).toContain("usePlanEpisodeScenes");
     expect(routeSource).toContain("usePlanEpisodeProps");
     expect(routeSource).toContain('taskType: "identity_planner"');
-    expect(routeSource).toContain("onPlanScenes");
-    expect(routeSource).toContain("onPlanProps");
+    expect(routeSource).toContain("onClick={handlePlanScenes}");
+    expect(routeSource).toContain("onClick={handlePlanProps}");
     expect(routeSource).toContain("episode.list.planIdentities");
     expect(routeSource).toContain("episode.list.planScenes");
     expect(routeSource).toContain("episode.list.planProps");
@@ -64,13 +64,17 @@ describe("episodes workbench integration", () => {
     );
   });
 
-  it("scopes list-card planning spinners to the clicked episode", () => {
+  // 每张卡片自己持有规划 mutation + 任务控制器，转圈天然只作用于被点的那一集；
+  // 场景/道具在 EE 下是异步任务，转圈必须跟着任务流走到任务结束。
+  it("keeps list-card planning spinners running until the async task finishes", () => {
     expect(routeSource).toContain("planIdentities.isPending || identityTask.started");
     expect(routeSource).toContain('taskType: "identity_planner"');
-    expect(routeSource).toContain("planScenes.variables === ep.number");
-    expect(routeSource).toContain("planProps.variables === ep.number");
-    expect(routeSource).toContain("sceneDisabled={planScenes.isPending}");
-    expect(routeSource).toContain("propDisabled={planProps.isPending}");
+    expect(routeSource).toContain("planScenes.isPending || sceneTask.started");
+    expect(routeSource).toContain("planProps.isPending || propTask.started");
+    expect(routeSource).toContain("TASK_TYPES.EPISODE_SCENE_PLANNER");
+    expect(routeSource).toContain("TASK_TYPES.EPISODE_PROP_PLANNER");
+    expect(routeSource).toContain("sceneTask.start({ scope: res.scope })");
+    expect(routeSource).toContain("propTask.start({ scope: res.scope })");
   });
 
   it("shows only one episode planning action for the list state", () => {

--- a/frontend/src/lib/task-types.ts
+++ b/frontend/src/lib/task-types.ts
@@ -26,6 +26,8 @@ export const TASK_TYPES = {
   // task_type so the task stream and cancel endpoint target the same task.
   DIRECTOR_NOTES: "director_notes",
   IDENTITY_PLANNER: "identity_planner",
+  EPISODE_SCENE_PLANNER: "episode_scene_planner",
+  EPISODE_PROP_PLANNER: "episode_prop_planner",
   // Sketch
   SKETCH_GENERATION: "sketch_generation",
   BATCH_SKETCH: "batch_sketch",

--- a/frontend/src/routes/_app/projects.$project/episodes.$episode/script.lazy.tsx
+++ b/frontend/src/routes/_app/projects.$project/episodes.$episode/script.lazy.tsx
@@ -239,6 +239,43 @@ function ScriptTabContent() {
     },
   });
 
+  // 场景/道具规划在 EE 下是异步任务：POST 只负责入队，请求返回时任务才刚开始。
+  // 按钮的转圈必须跟着任务流走（含刷新页面后的重连），否则会在入队瞬间就停下，
+  // 和任务中心的「生成中」对不上。
+  const sceneTask = useTaskController({
+    key: { taskType: TASK_TYPES.EPISODE_SCENE_PLANNER, project, episode: epNum },
+    invalidateKeys: [
+      queryKeys.episodes(project),
+      queryKeys.episodeDetail(project, epNum),
+      queryKeys.scenes(project),
+      queryKeys.pipelineStatus(project),
+    ],
+    showCompleteToast: false,
+    onComplete: (result) => {
+      const data = (result ?? {}) as { total_count?: number };
+      toast.success(
+        t("episode.script.scenePlanComplete", { count: data.total_count ?? 0 }),
+      );
+    },
+  });
+
+  const propTask = useTaskController({
+    key: { taskType: TASK_TYPES.EPISODE_PROP_PLANNER, project, episode: epNum },
+    invalidateKeys: [
+      queryKeys.episodes(project),
+      queryKeys.episodeDetail(project, epNum),
+      queryKeys.props(project),
+      queryKeys.pipelineStatus(project),
+    ],
+    showCompleteToast: false,
+    onComplete: (result) => {
+      const data = (result ?? {}) as { total_count?: number };
+      toast.success(
+        t("episode.script.propPlanComplete", { count: data.total_count ?? 0 }),
+      );
+    },
+  });
+
   const saveField = async (
     data: Parameters<typeof updateEpisode.mutateAsync>[0]["data"],
   ) => {
@@ -368,13 +405,14 @@ function ScriptTabContent() {
         toast.error(backendErrorToastMessage(res.error, t));
         return;
       }
-      toast.success(
-        isPlanEpisodeAssetsResult(res)
-          ? t("episode.script.scenePlanComplete", {
-              count: res.data.total_count,
-            })
-          : res.message,
-      );
+      // CE 走同步规划，直接返回结果；EE 只是入队，交给任务控制器跟进行中状态。
+      if (isPlanEpisodeAssetsResult(res)) {
+        toast.success(
+          t("episode.script.scenePlanComplete", { count: res.data.total_count }),
+        );
+        return;
+      }
+      sceneTask.start({ scope: res.scope });
     } catch (err) {
       toast.error(backendErrorToastMessage(err, t));
     }
@@ -387,13 +425,13 @@ function ScriptTabContent() {
         toast.error(backendErrorToastMessage(res.error, t));
         return;
       }
-      toast.success(
-        isPlanEpisodeAssetsResult(res)
-          ? t("episode.script.propPlanComplete", {
-              count: res.data.total_count,
-            })
-          : res.message,
-      );
+      if (isPlanEpisodeAssetsResult(res)) {
+        toast.success(
+          t("episode.script.propPlanComplete", { count: res.data.total_count }),
+        );
+        return;
+      }
+      propTask.start({ scope: res.scope });
     } catch (err) {
       toast.error(backendErrorToastMessage(err, t));
     }
@@ -655,8 +693,8 @@ function ScriptTabContent() {
                 sceneMenu={sceneMenu}
                 propMenu={propMenu}
                 identityPending={identityPlanning}
-                scenePending={planScenes.isPending}
-                propPending={planProps.isPending}
+                scenePending={planScenes.isPending || sceneTask.started}
+                propPending={planProps.isPending || propTask.started}
                 sceneCostDisplay={planScenesCostDisplay}
                 propCostDisplay={planPropsCostDisplay}
                 onPlanIdentities={() => setPickerOpen(true)}

--- a/frontend/src/routes/_app/projects.$project/episodes.tsx
+++ b/frontend/src/routes/_app/projects.$project/episodes.tsx
@@ -42,6 +42,8 @@ import {
 } from "@/lib/queries/episodes";
 import { deriveEpisodeStats, type EpisodeStats } from "@/lib/episode-stats";
 import { useStageTask } from "@/hooks/use-stage-task";
+import { useTaskController } from "@/hooks/use-task-controller";
+import { TASK_TYPES } from "@/lib/task-types";
 import { queryKeys } from "@/lib/query-keys";
 import {
   backendErrorToastMessage,
@@ -536,28 +538,16 @@ function EpisodeListItem({
   project,
   episode,
   onSelect,
-  onPlanScenes,
-  onPlanProps,
   identityCostDisplay,
   sceneCostDisplay,
   propCostDisplay,
-  scenePending,
-  propPending,
-  sceneDisabled,
-  propDisabled,
 }: {
   project: string;
   episode: Episode;
   onSelect: () => void;
-  onPlanScenes: (episodeNum: number) => void;
-  onPlanProps: (episodeNum: number) => void;
   identityCostDisplay?: string | null;
   sceneCostDisplay?: string | null;
   propCostDisplay?: string | null;
-  scenePending: boolean;
-  propPending: boolean;
-  sceneDisabled: boolean;
-  propDisabled: boolean;
 }) {
   const { t } = useTranslation();
   // 镜头数量 = 该集 beats 数。复用既有的 beats 查询（无需后端新增字段）；react-query
@@ -593,6 +583,51 @@ function EpisodeListItem({
       } else {
         toast.warning(t("episode.script.planIdentitiesNone"));
       }
+    },
+  });
+  const planScenes = usePlanEpisodeScenes(project);
+  const planProps = usePlanEpisodeProps(project);
+  // 场景/道具规划走异步任务：POST 只是入队，请求返回时任务才刚开始。用任务控制器
+  // 接管进行中状态（含刷新页面后的重连），否则按钮转圈会在入队瞬间就停，和底部
+  // 任务中心的「生成中」对不上。
+  const sceneTask = useTaskController({
+    key: {
+      taskType: TASK_TYPES.EPISODE_SCENE_PLANNER,
+      project,
+      episode: episode.number,
+    },
+    invalidateKeys: [
+      queryKeys.episodes(project),
+      queryKeys.episodeDetail(project, episode.number),
+      queryKeys.scenes(project),
+      queryKeys.pipelineStatus(project),
+    ],
+    showCompleteToast: false,
+    onComplete: (result) => {
+      const data = (result ?? {}) as { total_count?: number };
+      toast.success(
+        t("episode.script.scenePlanComplete", { count: data.total_count ?? 0 }),
+      );
+    },
+  });
+  const propTask = useTaskController({
+    key: {
+      taskType: TASK_TYPES.EPISODE_PROP_PLANNER,
+      project,
+      episode: episode.number,
+    },
+    invalidateKeys: [
+      queryKeys.episodes(project),
+      queryKeys.episodeDetail(project, episode.number),
+      queryKeys.props(project),
+      queryKeys.pipelineStatus(project),
+    ],
+    showCompleteToast: false,
+    onComplete: (result) => {
+      const data = (result ?? {}) as { total_count?: number };
+      toast.success(
+        t("episode.script.propPlanComplete", { count: data.total_count ?? 0 }),
+      );
     },
   });
   const title =
@@ -631,6 +666,49 @@ function EpisodeListItem({
   };
 
   const identityPending = planIdentities.isPending || identityTask.started;
+
+  // CE(无控制面)下后端同步跑完并直接返回结果，没有任务可订阅；EE 走队列，
+  // 返回的是 TaskResponse，此时才接上 SSE 流。
+  const handlePlanScenes = async () => {
+    try {
+      const res = await planScenes.mutateAsync(episode.number);
+      if (res.ok === false) {
+        toast.error(backendErrorToastMessage(res.error, t));
+        return;
+      }
+      if (isPlanEpisodeAssetsResult(res)) {
+        toast.success(
+          t("episode.script.scenePlanComplete", { count: res.data.total_count }),
+        );
+        return;
+      }
+      sceneTask.start({ scope: res.scope });
+    } catch (err) {
+      toast.error(backendErrorToastMessage(err, t));
+    }
+  };
+
+  const handlePlanProps = async () => {
+    try {
+      const res = await planProps.mutateAsync(episode.number);
+      if (res.ok === false) {
+        toast.error(backendErrorToastMessage(res.error, t));
+        return;
+      }
+      if (isPlanEpisodeAssetsResult(res)) {
+        toast.success(
+          t("episode.script.propPlanComplete", { count: res.data.total_count }),
+        );
+        return;
+      }
+      propTask.start({ scope: res.scope });
+    } catch (err) {
+      toast.error(backendErrorToastMessage(err, t));
+    }
+  };
+
+  const scenePending = planScenes.isPending || sceneTask.started;
+  const propPending = planProps.isPending || propTask.started;
 
   return (
     <div
@@ -691,9 +769,9 @@ function EpisodeListItem({
               : t("episode.list.planScenes")
           }
           pending={scenePending}
-          disabled={sceneDisabled}
+          disabled={scenePending}
           costDisplay={sceneCostDisplay}
-          onClick={() => onPlanScenes(episode.number)}
+          onClick={handlePlanScenes}
         />
         <EpisodePlanShortcut
           icon={<Package className="size-3.5 shrink-0 text-amber-400" />}
@@ -704,9 +782,9 @@ function EpisodeListItem({
               : t("episode.list.planProps")
           }
           pending={propPending}
-          disabled={propDisabled}
+          disabled={propPending}
           costDisplay={propCostDisplay}
-          onClick={() => onPlanProps(episode.number)}
+          onClick={handlePlanProps}
         />
       </div>
 
@@ -824,8 +902,6 @@ function EpisodesPage() {
     (planPropsCost.error instanceof BillingRuleNotConfiguredError
       ? t("common.billingRuleNotConfiguredShort")
       : null);
-  const planScenes = usePlanEpisodeScenes(project);
-  const planProps = usePlanEpisodeProps(project);
   const planTask = useStageTask({
     taskType: "build_episodes",
     project,
@@ -868,44 +944,6 @@ function EpisodesPage() {
       toast.success(t("episode.list.refreshed"));
     } catch {
       toast.error(t("common.error"));
-    }
-  };
-
-  const handlePlanScenes = async (episodeNum: number) => {
-    try {
-      const res = await planScenes.mutateAsync(episodeNum);
-      if (res.ok === false) {
-        toast.error(backendErrorToastMessage(res.error, t));
-        return;
-      }
-      toast.success(
-        isPlanEpisodeAssetsResult(res)
-          ? t("episode.script.scenePlanComplete", {
-              count: res.data.total_count,
-            })
-          : res.message,
-      );
-    } catch (err) {
-      toast.error(backendErrorToastMessage(err, t));
-    }
-  };
-
-  const handlePlanProps = async (episodeNum: number) => {
-    try {
-      const res = await planProps.mutateAsync(episodeNum);
-      if (res.ok === false) {
-        toast.error(backendErrorToastMessage(res.error, t));
-        return;
-      }
-      toast.success(
-        isPlanEpisodeAssetsResult(res)
-          ? t("episode.script.propPlanComplete", {
-              count: res.data.total_count,
-            })
-          : res.message,
-      );
-    } catch (err) {
-      toast.error(backendErrorToastMessage(err, t));
     }
   };
 
@@ -1018,29 +1056,24 @@ function EpisodesPage() {
                   </Button>
                 </div>
               ) : (
-                <div className="grid grid-cols-[repeat(auto-fill,minmax(260px,1fr))] gap-3">
-                  {displayEpisodes.map((ep) => (
-                    <EpisodeListItem
-                      project={project}
-                      key={ep.number}
-                      episode={ep}
-                      onSelect={() => handleSelectEpisode(ep.number)}
-                      onPlanScenes={handlePlanScenes}
-                      onPlanProps={handlePlanProps}
-                      identityCostDisplay={planIdentitiesCostDisplay}
-                      sceneCostDisplay={planScenesCostDisplay}
-                      propCostDisplay={planPropsCostDisplay}
-                      scenePending={
-                        planScenes.isPending && planScenes.variables === ep.number
-                      }
-                      propPending={
-                        planProps.isPending && planProps.variables === ep.number
-                      }
-                      sceneDisabled={planScenes.isPending}
-                      propDisabled={planProps.isPending}
-                    />
-                  ))}
-                </div>
+                // 卡片内的场景/道具规划用 useTaskController 订阅任务，需要一个
+                // 注册表宿主。列表不绑定单集，用 episode=0 作为宿主 scope；每张卡
+                // 片的 key 里带自己的集数，彼此互不干扰。
+                <TaskControllerProvider project={project} episode={0}>
+                  <div className="grid grid-cols-[repeat(auto-fill,minmax(260px,1fr))] gap-3">
+                    {displayEpisodes.map((ep) => (
+                      <EpisodeListItem
+                        project={project}
+                        key={ep.number}
+                        episode={ep}
+                        onSelect={() => handleSelectEpisode(ep.number)}
+                        identityCostDisplay={planIdentitiesCostDisplay}
+                        sceneCostDisplay={planScenesCostDisplay}
+                        propCostDisplay={planPropsCostDisplay}
+                      />
+                    ))}
+                  </div>
+                </TaskControllerProvider>
               )}
             </div>
           </div>

--- a/src/novelvideo/api/routes/episodes.py
+++ b/src/novelvideo/api/routes/episodes.py
@@ -182,6 +182,7 @@ async def _enqueue_episode_asset_planner(
     return {
         "ok": True,
         "task_type": task_type,
+        "scope": task_scope,
         "task_id": queued.task_state.task_id,
         "task_key": project_task_state_key(
             task_type,

--- a/tests/test_api_episode_detail.py
+++ b/tests/test_api_episode_detail.py
@@ -466,6 +466,7 @@ async def test_plan_episode_scenes_enqueues_celery_task(monkeypatch):
     assert response == {
         "ok": True,
         "task_type": "episode_scene_planner",
+        "scope": "scene_run_test",
         "task_id": "task-123",
         "task_key": "task:episode_scene_planner:project:proj_123:4:scene_run_test",
         "backend": "celery",
@@ -543,6 +544,7 @@ async def test_plan_episode_props_enqueues_celery_task(monkeypatch):
     assert response == {
         "ok": True,
         "task_type": "episode_prop_planner",
+        "scope": "prop_run_test",
         "task_id": "task-123",
         "task_key": "task:episode_prop_planner:project:proj_123:4:prop_run_test",
         "backend": "celery",


### PR DESCRIPTION
Closes #103

## 问题

EE 下 `POST /projects/{p}/episodes/{n}/scenes/plan`、`.../props/plan` 只是把 `episode_scene_planner` / `episode_prop_planner` 入队就返回,而按钮的 loading 只绑在 react-query mutation 的 `isPending` 上——请求一返回转圈就停,但底部任务中心还在「生成中」跑进度。同卡片的「规划人物」和其它生成按钮都是从任务流派生状态的,只有这两个漏了。

## 改动

- `src/novelvideo/api/routes/episodes.py`:入队响应补上 `scope`,前端第一次就能开对 SSE 流(与 `generation.py` 的 grid_regenerate 一致)。CE 同步规划分支(`resolved.ctx is None`)行为不变,仍立即返回结果。
- `frontend/.../episodes.tsx`:规划 mutation 从父组件下沉到 `EpisodeListItem`,每张卡片自己用 `useTaskController` 订阅任务,`pending = mutation.isPending || task.started`;列表不绑单集,外层套 `TaskControllerProvider episode={0}` 作为注册表宿主(参照 characters 页)。附带修好:转圈只作用于被点的那一集,刷新页面后可重连到进行中的任务。
- `frontend/.../episodes.$episode/script.lazy.tsx`:剧本详情页同一个 bug,同样接上 `sceneTask` / `propTask`。
- `task-types.ts` 补 `EPISODE_SCENE_PLANNER` / `EPISODE_PROP_PLANNER` 常量;两处 source-text 断言测试同步更新。

## 验证

- `tsc -b` + `pnpm build` 通过
- 前端 vitest 1722 passed
- 后端 `tests/test_api_episode_detail.py`、`tests/test_project_task_routes.py`、`tests/contract/test_m05_route_contracts.py` 全过

🤖 Generated with [Claude Code](https://claude.com/claude-code)