### PR TITLE
chore: release v1.0.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "supertale-ce"
-version = "1.0.7"
+version = "1.0.8"
 description = "SuperTale Community Edition API and video pipeline"
 readme = "README.md"
 requires-python = ">=3.11,<3.13"

--- a/src/novelvideo/release-notes.md
+++ b/src/novelvideo/release-notes.md
@@ -1,20 +1,20 @@
 ---
-version: 1.0.7
+version: 1.0.8
 attention: low
 ---
-# v1.0.7
+# v1.0.8
 
 ## User-facing Highlights (zh)
 
-- **剧本导入更准确**: 章节标题边界识别更严格,减少正文里的“第一集/Chapter 1”被误切成新章节的情况。
-- **虾画视频节点更稳定**: 修复首尾帧和画布上下文串用导致的视频节点报错,跨画布编辑更可靠。
-- **登录与公开页面更可靠**: 登录页视频、商务微信二维码和浏览器 CSP 兼容性完成收口,减少黑屏、花屏和控制台告警。
+- **导入风险更清晰**: 剧本格式风险会常驻展示在导入页面,不再依赖容易错过的瞬时提示。
+- **项目工作流更顺畅**: 项目入口和导航经过收敛,更容易在剧本、角色、剧集和制作流程间切换。
+- **制作数据更可靠**: 修复身份外貌数据被污染时的校验与恢复,场景和道具规划按钮会持续反映异步任务状态。
 
 ## User-facing Highlights (en)
 
-- **More accurate script imports**: Chapter title boundary detection is stricter, reducing accidental splits when text mentions “Episode 1” or “Chapter 1” inside body copy.
-- **More stable Xiahua video nodes**: Video nodes now avoid first/last-frame and canvas-context leakage that could break cross-canvas editing.
-- **More reliable login and public pages**: Login video assets, business WeCom QR assets, and browser CSP compatibility were tightened to reduce black screens, visual glitches, and console warnings.
+- **Clearer import risks**: Script-format risks now remain visible on the import page instead of relying on easy-to-miss transient notices.
+- **Smoother project workflow**: Project entry points and navigation are streamlined, making it easier to move between script, character, episode, and production flows.
+- **More reliable production data**: Identity appearance data now validates and recovers from polluted values, while scene and prop planning buttons stay in sync with asynchronous task state.
 
 ## Fixes
 

--- a/tests/test_release_feed.py
+++ b/tests/test_release_feed.py
@@ -114,7 +114,7 @@ def test_built_wheel_contains_parseable_release_notes_artifact(tmp_path: Path) -
 def test_project_version_is_single_source_of_truth() -> None:
     pyproject = tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))
 
-    assert pyproject["project"]["version"] == "1.0.7"
+    assert pyproject["project"]["version"] == "1.0.8"
     assert importlib.metadata.version("supertale-ce") == pyproject["project"]["version"]
     assert "__version__" not in Path("src/novelvideo/__init__.py").read_text(encoding="utf-8")
 

--- a/uv.lock
+++ b/uv.lock
@@ -3419,7 +3419,7 @@ wheels = [
 
 [[package]]
 name = "supertale-ce"
-version = "1.0.7"
+version = "1.0.8"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## PR 类型 / Type of PR
- [ ] 🐞 Bug 修复 / Bug fix
- [ ] ✨ 新功能 / Feature
- [ ] 📝 文档 / Documentation
- [ ] 🧹 重构 / 清理 / Refactor or cleanup
- [x] ⚙️ 构建 / CI / Build or CI
- [ ] ⚠️ 破坏性变更 / Breaking change

## 改动说明 / What this PR does and why
将 CE 发行版本更新至 1.0.8，并同步打包元数据、锁文件、应用内双语发布说明和版本一致性断言。

## 关联 issue / Linked issues
N/A

## 给 reviewer 的说明 / Notes for the reviewer
发布说明覆盖 v1.0.7 之后已合入 main 的用户可见改动；未包含功能代码变更。

## 面向用户的变更 / User-facing change
```release-note
v1.0.8 improves script import feedback, project navigation, identity data recovery, and planning-task status visibility.
```

## 自检 / Checklist
- [x] 已自测，`uv run pytest` 通过 / Self-tested, `uv run pytest` passes
  - 已运行：`UV_CACHE_DIR=/claymorelab/.uv-cache uv run pytest tests/test_release_feed.py`（12 passed）
- [x] 必要的文档已更新 / Docs updated where needed
- [x] 提交信息清晰（建议 Conventional Commits）/ Clear commits (Conventional Commits suggested)
- [x] 每个 commit 都已 `git commit -s` 附 DCO 签署 / Every commit signed off with `git commit -s` (DCO)
- [x] 我已阅读并同意[贡献者协议](../CONTRIBUTING.md#贡献者协议) / I've read and agree to the [contributor terms](../CONTRIBUTING.md#贡献者协议)