### PR TITLE
perf(freezone): 修复虾画/虾集切换卡顿 + 导入页小说格式说明

### DIFF
--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -314,26 +314,10 @@
     "waiting": "Waiting for chat service...",
     "waitingResponse": "Waiting for Xia Director",
     "waitingResponses": [
-      "Xia Director is checking the storyboard",
-      "Xia Director is tracing the plot",
-      "Xia Director is tuning the rhythm",
-      "Xia Director is aligning the setup",
-      "Xia Director is sorting the ideas",
-      "Xia Director is reviewing the task",
-      "Xia Director is shaping the shot",
-      "Xia Director is reading character motives",
-      "Xia Director is filling the context",
-      "Xia Director is finding the key clue",
-      "Xia Director is cutting the noise",
-      "Xia Director is calibrating the direction",
-      "Xia Director is breaking down the request",
-      "Xia Director is composing the reply",
-      "Xia Director is checking project state",
-      "Xia Director is handling the creative room",
-      "Xia Director is turning ideas into steps",
-      "Xia Director is blocking the scene",
-      "Xia Director is picking the essentials",
-      "Xia Director is catching the spark"
+      "Thinking…",
+      "Putting it into words…",
+      "Let me think…",
+      "Almost there…"
     ],
     "send": "Send",
     "queueMessage": "Queue message",
@@ -948,6 +932,14 @@
       "unmute": "Unmute",
       "fullscreen": "Fullscreen",
       "exitFullscreen": "Exit fullscreen"
+    },
+    "download": {
+      "label": "Desktop",
+      "primary": {
+        "mac": "macOS",
+        "windows": "Windows"
+      },
+      "aria": "Download the desktop app"
     }
   },
   "project": {
@@ -1274,6 +1266,7 @@
     "stop": "Stop",
     "reupload": "Re-upload",
     "regenerate": "Regenerate",
+    "generateNew": "Generate new",
     "regenerateSelected": "Regenerate Selected",
     "preview": "Preview",
     "cutToPool": "Cut to Pool",
@@ -1868,7 +1861,8 @@
         "identitiesNotPlanned": "Episode identities not planned. Go to Script page to configure.",
         "propsNotPlanned": "Episode props not planned. Go to Script page to configure.",
         "more": "More",
-        "saveFailed": "Save failed"
+        "saveFailed": "Save failed",
+        "noSceneVariant": "No variant"
       },
       "insertManual": {
         "titleBeforeFirst": "Insert manual shot before first beat",
@@ -1902,7 +1896,12 @@
         "identitiesPlaceholder": "Comma-separated (e.g. {{example}}); leave blank to auto-detect from visual description",
         "identitiesPlaceholderEmpty": "Comma-separated identity IDs; leave blank to auto-detect",
         "submit": "Insert",
-        "success": "Manual shot inserted"
+        "success": "Manual shot inserted",
+        "sceneVariant": "Variant",
+        "noSceneVariant": "No variant",
+        "props": "Props",
+        "propsPlaceholder": "Comma-separated (e.g. {{example}}); leave blank to auto-detect from visual description",
+        "propsPlaceholderEmpty": "Comma-separated prop IDs; leave blank to auto-detect"
       },
       "audio": {
         "narrationEmpty": "Narration is empty — this beat cannot generate audio. Fill in text first.",
@@ -2218,7 +2217,8 @@
         "backgroundUploaded": "Render background reference uploaded",
         "backgroundUploadFailed": "Failed to upload render background reference",
         "backgroundSaved": "Render background reference switched",
-        "backgroundSaveFailed": "Failed to save render background reference"
+        "backgroundSaveFailed": "Failed to save render background reference",
+        "backgroundCropSave": "Save crop"
       },
       "renderGrid": {
         "title": "Render Grid",
@@ -2371,6 +2371,12 @@
         "faceScore": "Face {{score}}",
         "clothingScore": "Clothing {{score}}",
         "jumpBeat": "Jump to beat {{n}}"
+      },
+      "actionPanel": {
+        "episodeFreezone": "Episode canvas",
+        "episodeFreezoneTooltip": "Open this episode's assets in the canvas",
+        "episodeFreezoneOpened": "Episode canvas opened",
+        "episodeFreezoneOpenFailed": "Failed to open the episode canvas"
       }
     },
     "state": {
@@ -2581,7 +2587,8 @@
     "noStylesAvailable": "No styles available. Click top-right to create.",
     "paramsExtracted": "Style params extracted",
     "idNameRequired": "Enter ID and name",
-    "styleCreated": "Style created"
+    "styleCreated": "Style created",
+    "renameTitle": "Rename Style"
   },
   "identityPicker": {
     "title": "Select Character Identities",
@@ -3320,6 +3327,12 @@
           "redo": "Redo",
           "reset": "Reset"
         }
+      },
+      "player": {
+        "play": "Play",
+        "pause": "Pause",
+        "mute": "Mute",
+        "unmute": "Unmute"
       }
     }
   },
@@ -3645,7 +3658,8 @@
         "actor": "Actor",
         "prop": "Prop",
         "staging": "Staging"
-      }
+      },
+      "actorColor": "Actor color"
     }
   },
   "split": {

--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -1368,6 +1368,12 @@
     "buildHint": "Build the semantic graph, then construct characters and episodes on their respective pages.",
     "emptyPreview": "No content to preview yet. Upload a file to see the structure.",
     "chapterTitleFallback": "Chapter {{n}}",
+    "novelFormat": {
+      "button": "Novel format",
+      "title": "Premium drama format",
+      "specLabel": "Standard format",
+      "exampleLabel": "Example excerpt"
+    },
     "projectType": "Project type",
     "projectTypeLocked": "Project type is locked after import. Re-import to switch.",
     "projectTypes": {

--- a/frontend/public/locales/zh/translation.json
+++ b/frontend/public/locales/zh/translation.json
@@ -1368,6 +1368,12 @@
     "buildHint": "构建语义图谱，然后在角色 / 剧集页面分别构建",
     "emptyPreview": "上传文件后，这里会显示小说结构预览",
     "chapterTitleFallback": "第 {{n}} 章",
+    "novelFormat": {
+      "button": "小说格式",
+      "title": "精品剧格式",
+      "specLabel": "标准格式",
+      "exampleLabel": "示例片段"
+    },
     "projectType": "项目类型",
     "projectTypeLocked": "项目类型已锁定，如需切换请重新导入",
     "projectTypes": {

--- a/frontend/public/locales/zh/translation.json
+++ b/frontend/public/locales/zh/translation.json
@@ -314,26 +314,10 @@
     "waiting": "等待聊天服务连接...",
     "waitingResponse": "等待虾导回复",
     "waitingResponses": [
-      "虾导正在看分镜",
-      "虾导正在捋剧情",
-      "虾导正在检查节奏",
-      "虾导正在对齐设定",
-      "虾导正在整理灵感",
-      "虾导正在翻看任务",
-      "虾导正在推敲镜头",
-      "虾导正在盘角色动机",
-      "虾导正在补齐上下文",
-      "虾导正在找关键线索",
-      "虾导正在压缩废话",
-      "虾导正在校准创作方向",
-      "虾导正在拆解你的需求",
-      "虾导正在组织回答",
-      "虾导正在确认项目状态",
-      "虾导正在处理创作现场",
-      "虾导正在把想法落地",
-      "虾导正在看这场戏怎么走",
-      "虾导正在挑重点",
-      "虾导正在接住这段灵感"
+      "正在思考…",
+      "组织语言中…",
+      "让我想想…",
+      "马上就好…"
     ],
     "send": "发送",
     "queueMessage": "加入发送队列",
@@ -948,6 +932,14 @@
       "unmute": "取消静音",
       "fullscreen": "全屏",
       "exitFullscreen": "退出全屏"
+    },
+    "download": {
+      "label": "桌面端",
+      "primary": {
+        "mac": "macOS",
+        "windows": "Windows"
+      },
+      "aria": "下载桌面端"
     }
   },
   "project": {
@@ -1274,6 +1266,7 @@
     "stop": "停止",
     "reupload": "重新上传",
     "regenerate": "重新生成",
+    "generateNew": "生成新图",
     "regenerateSelected": "重新生成选中",
     "preview": "试听",
     "cutToPool": "切割入池",
@@ -1868,7 +1861,8 @@
         "identitiesNotPlanned": "本集身份未规划，请先到「脚本」页配置本集身份。",
         "propsNotPlanned": "本集道具未规划，请先到「脚本」页配置本集道具。",
         "more": "更多",
-        "saveFailed": "保存失败"
+        "saveFailed": "保存失败",
+        "noSceneVariant": "无变体"
       },
       "insertManual": {
         "titleBeforeFirst": "在首个 Beat 前插入手工镜头",
@@ -1902,7 +1896,12 @@
         "identitiesPlaceholder": "逗号分隔，如 {{example}}；留空自动从画面描述提取",
         "identitiesPlaceholderEmpty": "逗号分隔身份ID；留空自动从画面描述提取",
         "submit": "插入",
-        "success": "已插入手工镜头"
+        "success": "已插入手工镜头",
+        "sceneVariant": "变体",
+        "noSceneVariant": "无变体",
+        "props": "出场道具",
+        "propsPlaceholder": "逗号分隔，如 {{example}}；留空自动从画面描述提取",
+        "propsPlaceholderEmpty": "逗号分隔道具ID；留空自动从画面描述提取"
       },
       "audio": {
         "narrationEmpty": "旁白为空，此 beat 无法生成音频。请先到「文案」填写。",
@@ -2218,7 +2217,8 @@
         "backgroundUploaded": "渲染 背景参考已上传",
         "backgroundUploadFailed": "上传 渲染 背景参考失败",
         "backgroundSaved": "渲染 背景参考已切换",
-        "backgroundSaveFailed": "保存 渲染 背景参考失败"
+        "backgroundSaveFailed": "保存 渲染 背景参考失败",
+        "backgroundCropSave": "保存截图"
       },
       "renderGrid": {
         "title": "渲染网格",
@@ -2371,6 +2371,12 @@
         "faceScore": "面部 {{score}}",
         "clothingScore": "服装 {{score}}",
         "jumpBeat": "跳 beat {{n}}"
+      },
+      "actionPanel": {
+        "episodeFreezone": "本集虾画",
+        "episodeFreezoneTooltip": "在虾画中打开本集素材",
+        "episodeFreezoneOpened": "已打开本集虾画",
+        "episodeFreezoneOpenFailed": "打开本集虾画失败"
       }
     },
     "state": {
@@ -2581,7 +2587,8 @@
     "noStylesAvailable": "没有可用的风格。点击右上角创建。",
     "paramsExtracted": "风格参数已提取",
     "idNameRequired": "请输入 ID 和名称",
-    "styleCreated": "风格已创建"
+    "styleCreated": "风格已创建",
+    "renameTitle": "重命名风格"
   },
   "identityPicker": {
     "title": "选择角色身份",
@@ -3320,6 +3327,12 @@
           "redo": "重做",
           "reset": "重置"
         }
+      },
+      "player": {
+        "play": "播放",
+        "pause": "暂停",
+        "mute": "静音",
+        "unmute": "取消静音"
       }
     }
   },
@@ -3645,7 +3658,8 @@
         "actor": "人物",
         "prop": "道具",
         "staging": "占位"
-      }
+      },
+      "actorColor": "人物颜色"
     }
   },
   "split": {

--- a/frontend/src/components/episode/beat-workbench/sketch-section.tsx
+++ b/frontend/src/components/episode/beat-workbench/sketch-section.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 import { Accessibility, Box, Crop, Download, ExternalLink, ImageIcon, Loader2, Package, RefreshCw, Sparkles, Square, Upload } from "lucide-react";
 
+import { isNoReferenceMarker } from "@/lib/beat-markers";
 import { useGenerationCreditCost } from "@/lib/queries/generation-credit-cost";
 import {
   useBeatBackgroundAnchors,
@@ -208,6 +209,7 @@ export function SketchSection({
     const sketchColors = scriptRes?.data?.sketch_colors ?? {};
     const characterNames = new Set((charsRes?.data ?? []).map((c) => c.name));
     return (beat.detected_identities ?? [])
+      .filter((identityId) => !isNoReferenceMarker(identityId))
       .map((identityId) => {
         const { hex } = parseColorValue(sketchColors[identityId] ?? "");
         if (!hex) return null;
@@ -220,15 +222,21 @@ export function SketchSection({
     const propById = new Map(
       (episodeRes?.data?.prop_menu ?? []).map((prop) => [prop.prop_id, prop]),
     );
-    return (beat.detected_props ?? []).map((propId) => {
-      const prop = propById.get(propId);
-      const { hex } = parseColorValue(prop?.marker_color ?? "");
-      return { propId, hex };
-    });
+    // __NO_PROP__ 是「本镜无道具」的哨兵，不是道具 id —— 过滤掉，否则会当成一个
+    // 名叫 __NO_PROP__ 的道具渲染成 chip。
+    return (beat.detected_props ?? [])
+      .filter((propId) => !isNoReferenceMarker(propId))
+      .map((propId) => {
+        const prop = propById.get(propId);
+        const { hex } = parseColorValue(prop?.marker_color ?? "");
+        return { propId, hex };
+      });
   }, [beat.detected_props, episodeRes]);
   const markedPropEntries = useMemo(() => {
     const detected = new Set(beat.detected_props ?? []);
-    return extractMarkedProps(beat.visual_description ?? "").filter((propId) => !detected.has(propId));
+    return extractMarkedProps(beat.visual_description ?? "").filter(
+      (propId) => !detected.has(propId) && !isNoReferenceMarker(propId),
+    );
   }, [beat.detected_props, beat.visual_description]);
   const directorControl =
     directorStatus.data?.ok === true ? directorStatus.data.data : null;

--- a/frontend/src/components/ingest/NovelFormatDialog.tsx
+++ b/frontend/src/components/ingest/NovelFormatDialog.tsx
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: Elastic-2.0
+// Copyright (c) 2026 ClaymoreLab
+import { useTranslation } from "react-i18next";
+
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { ScrollArea } from "@/components/ui/scroll-area";
+
+/**
+ * 精品剧（drama）的导入标准格式与示例。逐行写死而不是塞进 i18n 的长字符串：
+ * 这是要按原样展示的样例，任何换行/空格都有意义，不该被译者改动。
+ */
+const DRAMA_FORMAT_SPEC = [
+  "第X集",
+  "1-X 场景：【内/外 地点 日/夜】",
+  "人物：",
+  "△ 画面描述：[动作清晰，无多余修饰，直白描述]",
+  "角色A(表情/动作)：台词内容",
+  "△ 画面描述：",
+  "角色B(表情/动作)：台词内容",
+  "△ 画面描述：",
+  "角色A OS：内心独白内容",
+].join("\n");
+
+const DRAMA_FORMAT_EXAMPLE = [
+  "第 1 集",
+  "1-1 场景：苏鸾寝殿深夜内",
+  "人物：苏糖（附身苏鸾）、锦绣（贴身侍女）",
+  "△【闪回】漆黑寝殿，匕首尖正对跳动的烛火，刀身映出一张布满冷汗、瞳孔骤缩的少女脸。",
+  "△苏糖 OS：我不能死！",
+  "△【闪出】寒光匕首狠狠刺入少女心口，鲜血瞬间喷溅在锦被上。凶手缓缓抬头，露出贴身侍女锦绣冰冷的脸。",
+  "△苏糖 OS：我不能死得不明不白！",
+  "△【闪回】现代大学宿舍，书本被狠狠砸在地上，苏糖和室友激烈争吵。",
+  "△苏糖 OS：我叫苏糖，普通女大学生。昨天还在跟人吵架，今天一睁眼……",
+  "△【闪出】苏糖猛地从床榻弹坐而起，寝衣被冷汗浸透，双手死死攥住床帐，指节泛白。",
+  "苏糖（大口喘气，眼神涣散，声音发颤）：这种风格是……《乱世凤鸣录》？",
+  "△【特写】一双纤白细腻、完全陌生的手，在苏糖眼前缓缓攥成拳。",
+  "△苏糖 OS：这里是凤鸣大陆，七国乱战。我附身的人，是苏鸾！",
+  "△苏糖浑身剧烈一颤。",
+  "△苏糖 OS：这个世界的规则只有一条——弱肉强食。原著里，苏鸾是个路人甲。",
+  "△寝殿门扇“吱呀”一声，悄无声息推开一道缝。",
+  "△【特写】一只素白的手端着青瓷汤碗走入，宽大袖口滑落，手腕处一道细长的刀鞘轮廓，一闪而过。",
+  "△苏糖 OS：她会死。三天后，在这张床上，被她最信任的侍女一刀穿心。",
+  "△锦绣垂着头，无声走到床边，面色平静得没有一丝波澜。",
+  "苏糖（瞬间收敛所有情绪，声音带着刚睡醒的沙哑慵懒）：锦绣，几更了？",
+  "锦绣（头埋得极低，声音恭顺）：回公主，三更。公主噩梦惊醒，奴婢炖了安神汤。",
+  "△苏糖的眼神骤然锐利，随即立刻垂下眼帘，露出一副困倦不堪的模样。",
+].join("\n");
+
+export function NovelFormatDialog({
+  open,
+  onOpenChange,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) {
+  const { t } = useTranslation();
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-4xl rounded-lg bg-black sm:max-w-4xl">
+        <DialogHeader>
+          <DialogTitle>{t("ingest.novelFormat.title")}</DialogTitle>
+        </DialogHeader>
+
+        {/* 滚动条做细做淡：长度由内容/视口比例决定，改不动，只能让它别抢戏。 */}
+        <ScrollArea className="max-h-[58vh] [&_[data-slot=scroll-area-scrollbar]]:w-1.5 [&_[data-slot=scroll-area-thumb]]:bg-white/15">
+          <div className="space-y-5 pr-3">
+            <section className="space-y-2">
+              <h3 className="text-xs font-medium text-muted-foreground">
+                {t("ingest.novelFormat.specLabel")}
+              </h3>
+              <pre className="whitespace-pre-wrap rounded-md border border-white/10 bg-white/[0.03] px-3.5 py-3 text-[13px] leading-7 text-foreground/90">
+                {DRAMA_FORMAT_SPEC}
+              </pre>
+            </section>
+
+            <section className="space-y-2">
+              <h3 className="text-xs font-medium text-muted-foreground">
+                {t("ingest.novelFormat.exampleLabel")}
+              </h3>
+              <pre className="whitespace-pre-wrap rounded-md border border-white/10 bg-white/[0.03] px-3.5 py-3 text-[13px] leading-7 text-foreground/70">
+                {DRAMA_FORMAT_EXAMPLE}
+              </pre>
+            </section>
+          </div>
+        </ScrollArea>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/components/layout/header.tsx
+++ b/frontend/src/components/layout/header.tsx
@@ -46,6 +46,7 @@ import { LiexiaorenSkinPreview } from "@/features/liexiaoren/LiexiaorenSkinPrevi
 import {
   ProjectHeaderNavigation,
   ProjectSwitcher,
+  ProjectXiajiMenu,
 } from "@/components/layout/project-header-navigation";
 const ACCOUNT_PANEL_TRANSITION_MS = 350;
 
@@ -342,6 +343,7 @@ export function Header() {
           </div>
         </div>
       </header>
+      {project ? <ProjectXiajiMenu project={project} /> : null}
       {accountPanelOpen
         ? createPortal(
             <AccountPanel

--- a/frontend/src/components/layout/project-header-navigation.tsx
+++ b/frontend/src/components/layout/project-header-navigation.tsx
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Elastic-2.0
 // Copyright (c) 2026 ClaymoreLab
 import { useEffect, useMemo, useRef, useState } from "react";
-import { createPortal } from "react-dom";
 import { Link, useNavigate, useRouterState } from "@tanstack/react-router";
 import { ArrowLeft, Check, ChevronDown, Clapperboard, Sparkles } from "lucide-react";
 import { useTranslation } from "react-i18next";
@@ -27,7 +26,6 @@ import { getProjectCover } from "@/lib/project-cover";
 import { cn } from "@/lib/utils";
 
 const XIAJI_DEFAULT_ROUTE = PROJECT_SECTION_ROUTES.ingest;
-const XIAJI_MENU_OFFSET_Y = 10;
 
 const xiajiMenuItems = [
   { labelKey: "nav.ingest", to: PROJECT_SECTION_ROUTES.ingest },
@@ -150,14 +148,59 @@ export function ProjectSwitcher({ current }: { current: string }) {
   );
 }
 
+/**
+ * 「虾集」子页菜单，作为 header 的第二行渲染 —— 它必须在文档流里占真实高度，
+ * 而不是浮在内容之上：内容区是独立滚动容器，任何浮层都会被滚上来的内容穿过。
+ */
+export function ProjectXiajiMenu({ project }: { project: string }) {
+  const { t } = useTranslation();
+  const pathname = useRouterState({ select: (state) => state.location.pathname });
+  const rememberedEpisodeLocation = useEpisodeWorkbenchStore(
+    (state) => state.lastEpisodeLocationByProject[project],
+  );
+
+  if (projectModeFromPath(pathname) !== "xiaji") return null;
+
+  return (
+    <div className="flex justify-center px-4 pb-2">
+      <nav
+        aria-label={t("nav.xiajiMenu")}
+        className="flex items-center gap-3 whitespace-nowrap rounded-full border border-white/[0.08] bg-white/[0.04] px-3.5 py-[3px] text-sidebar-foreground"
+      >
+        {xiajiMenuItems.map((item) => {
+          const target =
+            "rememberKey" in item && rememberedEpisodeLocation
+              ? normalizeLastEpisodeLocation(project, rememberedEpisodeLocation) ?? item.to
+              : item.to;
+          // 高亮按栏目自身的路由判断：target 可能是带 ?query 的剧集深链，
+          // 拿它比 pathname 永远不相等（虾镜里就不会高亮）。
+          const sectionPath = item.to.replace("$project", encodeURIComponent(project));
+          const active = pathname === sectionPath || pathname.startsWith(`${sectionPath}/`);
+          return (
+            <Link
+              key={item.labelKey}
+              to={target}
+              params={{ project }}
+              className={cn(
+                "flex h-7 items-center px-1.5 text-xs font-semibold transition-colors duration-150 ease-[var(--ease-out-quint)]",
+                active ? "text-foreground" : "text-muted-foreground hover:text-foreground",
+              )}
+              aria-current={active ? "page" : undefined}
+            >
+              {t(item.labelKey)}
+            </Link>
+          );
+        })}
+      </nav>
+    </div>
+  );
+}
+
 export function ProjectHeaderNavigation({ project }: { project: string }) {
   const { t } = useTranslation();
   const navigate = useNavigate();
   const pathname = useRouterState({ select: (state) => state.location.pathname });
   const activeMode = projectModeFromPath(pathname);
-  const navRef = useRef<HTMLElement | null>(null);
-  const [menuPosition, setMenuPosition] = useState<{ left: number; top: number } | null>(null);
-  const [menuVisible, setMenuVisible] = useState(false);
   const rememberedEpisodeLocation = useEpisodeWorkbenchStore(
     (state) => state.lastEpisodeLocationByProject[project],
   );
@@ -187,43 +230,6 @@ export function ProjectHeaderNavigation({ project }: { project: string }) {
     setLastEpisodeLocation(project, `${pathname}${window.location.search}`);
   }, [clearLastEpisodeLocation, pathname, project, setLastEpisodeLocation]);
 
-  useEffect(() => {
-    if (activeMode !== "xiaji") {
-      setMenuVisible(false);
-      setMenuPosition(null);
-      return undefined;
-    }
-    let frame = 0;
-    const updatePosition = () => {
-      const rect = navRef.current?.getBoundingClientRect();
-      setMenuPosition(
-        rect
-          ? {
-              left: Math.round(rect.left + rect.width / 2),
-              top: Math.round(rect.bottom + XIAJI_MENU_OFFSET_Y),
-            }
-          : null,
-      );
-    };
-    const scheduleUpdate = () => {
-      cancelAnimationFrame(frame);
-      frame = requestAnimationFrame(updatePosition);
-    };
-    updatePosition();
-    setMenuVisible(false);
-    frame = requestAnimationFrame(() => {
-      updatePosition();
-      setMenuVisible(true);
-    });
-    window.addEventListener("resize", scheduleUpdate);
-    window.addEventListener("scroll", scheduleUpdate, true);
-    return () => {
-      cancelAnimationFrame(frame);
-      window.removeEventListener("resize", scheduleUpdate);
-      window.removeEventListener("scroll", scheduleUpdate, true);
-    };
-  }, [activeMode]);
-
   const changeMode = (mode: "xiahua" | "xiaji") => {
     if (mode === activeMode) return;
     if (mode === "xiahua") {
@@ -241,91 +247,48 @@ export function ProjectHeaderNavigation({ project }: { project: string }) {
     navigate({ to: target, params: { project } });
   };
 
-  const menu = menuPosition && typeof document !== "undefined"
-    ? createPortal(
-        <nav
-          aria-label={t("nav.xiajiMenu")}
-          className={cn(
-            "fixed z-[1000] flex -translate-x-1/2 items-center gap-3 whitespace-nowrap rounded-full border border-white/[0.08] bg-black/[0.30] px-3.5 py-[3px] text-sidebar-foreground backdrop-blur-[18px] transition-[opacity,transform,filter] duration-[220ms] ease-[var(--ease-out-quint)] will-change-[opacity,transform,filter]",
-            menuVisible
-              ? "translate-y-0 opacity-100 blur-0"
-              : "pointer-events-none -translate-y-1 opacity-0 blur-[2px]",
-          )}
-          style={{ left: menuPosition.left, top: menuPosition.top }}
-        >
-          {xiajiMenuItems.map((item) => {
-            const target =
-              "rememberKey" in item && rememberedEpisodeLocation
-                ? normalizeLastEpisodeLocation(project, rememberedEpisodeLocation) ?? item.to
-                : item.to;
-            const targetPath = target.replace("$project", encodeURIComponent(project));
-            const active = pathname === targetPath || pathname.startsWith(`${targetPath}/`);
-            return (
-              <Link
-                key={item.labelKey}
-                to={target}
-                params={{ project }}
-                className={cn(
-                  "flex h-7 items-center px-1.5 text-xs font-semibold transition-colors duration-150 ease-[var(--ease-out-quint)]",
-                  active ? "text-foreground" : "text-muted-foreground hover:text-foreground",
-                )}
-                aria-current={active ? "page" : undefined}
-              >
-                {t(item.labelKey)}
-              </Link>
-            );
-          })}
-        </nav>,
-        document.body,
-      )
-    : null;
-
   return (
-    <>
-      <nav
-        ref={navRef}
-        aria-label={t("nav.creationMode")}
-        className="absolute left-1/2 top-1/2 z-30 flex -translate-x-1/2 translate-y-[calc(-50%+4px)] items-center"
-      >
-        <div className="relative flex h-8 items-center rounded-full bg-white/[0.07]">
-          <span
-            aria-hidden="true"
-            className={cn(
-              "absolute left-0 top-1/2 h-7 w-[74px] -translate-y-1/2 rounded-full bg-foreground transition-transform duration-300 ease-[var(--ease-out-quint)]",
-              activeMode === "xiaji" && "translate-x-[74px]",
-            )}
-          />
-          <button
-            type="button"
-            onClick={() => changeMode("xiahua")}
-            className={cn(
-              "relative z-10 inline-flex h-8 w-[74px] items-center justify-center gap-1.5 rounded-full text-xs font-semibold transition-colors",
-              activeMode === "xiahua"
-                ? "text-background"
-                : "text-muted-foreground hover:text-foreground",
-            )}
-            aria-pressed={activeMode === "xiahua"}
-          >
-            <Sparkles className="size-3.5" />
-            {t("nav.freezone")}
-          </button>
-          <button
-            type="button"
-            onClick={() => changeMode("xiaji")}
-            className={cn(
-              "relative z-10 inline-flex h-8 w-[74px] items-center justify-center gap-1.5 rounded-full text-xs font-semibold transition-colors",
-              activeMode === "xiaji"
-                ? "text-background"
-                : "text-muted-foreground hover:text-foreground",
-            )}
-            aria-pressed={activeMode === "xiaji"}
-          >
-            <Clapperboard className="size-3.5" />
-            {t("nav.xiaji")}
-          </button>
-        </div>
-      </nav>
-      {menu}
-    </>
+    <nav
+      aria-label={t("nav.creationMode")}
+      className="absolute left-1/2 top-1/2 z-30 flex -translate-x-1/2 translate-y-[calc(-50%+4px)] items-center"
+    >
+      <div className="relative flex h-8 items-center rounded-full bg-white/[0.07]">
+        <span
+          aria-hidden="true"
+          className={cn(
+            "absolute left-0 top-1/2 h-7 w-[74px] -translate-y-1/2 rounded-full bg-foreground transition-transform duration-300 ease-[var(--ease-out-quint)]",
+            activeMode === "xiaji" && "translate-x-[74px]",
+          )}
+        />
+        <button
+          type="button"
+          onClick={() => changeMode("xiahua")}
+          className={cn(
+            "relative z-10 inline-flex h-8 w-[74px] items-center justify-center gap-1.5 rounded-full text-xs font-semibold transition-colors",
+            activeMode === "xiahua"
+              ? "text-background"
+              : "text-muted-foreground hover:text-foreground",
+          )}
+          aria-pressed={activeMode === "xiahua"}
+        >
+          <Sparkles className="size-3.5" />
+          {t("nav.freezone")}
+        </button>
+        <button
+          type="button"
+          onClick={() => changeMode("xiaji")}
+          className={cn(
+            "relative z-10 inline-flex h-8 w-[74px] items-center justify-center gap-1.5 rounded-full text-xs font-semibold transition-colors",
+            activeMode === "xiaji"
+              ? "text-background"
+              : "text-muted-foreground hover:text-foreground",
+          )}
+          aria-pressed={activeMode === "xiaji"}
+        >
+          <Clapperboard className="size-3.5" />
+          {t("nav.xiaji")}
+        </button>
+      </div>
+    </nav>
   );
 }

--- a/frontend/src/components/login/cinematic/LoginCinematicHero.tsx
+++ b/frontend/src/components/login/cinematic/LoginCinematicHero.tsx
@@ -1,11 +1,16 @@
 import { useEffect, useState } from "react";
-import { ChevronDown, MessageCircle, Mouse } from "lucide-react";
+import { ChevronDown, Download, MessageCircle, Mouse } from "lucide-react";
 import type { CSSProperties } from "react";
 import { useTranslation } from "react-i18next";
 import { Brand } from "@/components/login/login-stage";
 import Aurora from "@/components/react-bits/aurora";
 import SplitText from "@/components/react-bits/split-text";
 import { PRODUCT_MANUAL_URL } from "@/lib/product-manual";
+import {
+  DESKTOP_DOWNLOAD_URL,
+  detectDesktopPlatform,
+  type DesktopPlatform,
+} from "@/lib/desktop-download";
 import styles from "@/components/login/login.module.css";
 import layout from "./hero-layout.module.css";
 import { businessWechatQrUrl } from "./media";
@@ -57,6 +62,77 @@ function GithubMark() {
   );
 }
 
+function AppleMark() {
+  return (
+    <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+      <path d="M16.36 12.72c.02-2.32 1.9-3.43 1.98-3.49-1.08-1.58-2.76-1.8-3.36-1.82-1.43-.14-2.79.84-3.52.84-.72 0-1.84-.82-3.03-.8-1.56.02-3 .9-3.8 2.29-1.62 2.81-.41 6.97 1.16 9.25.77 1.11 1.69 2.36 2.9 2.32 1.16-.05 1.6-.75 3.01-.75 1.4 0 1.8.75 3.03.72 1.25-.02 2.04-1.13 2.8-2.25.88-1.29 1.25-2.54 1.27-2.6-.03-.01-2.43-.94-2.44-3.71zM14.1 5.98c.64-.78 1.07-1.85.95-2.93-.92.04-2.03.61-2.69 1.38-.59.69-1.11 1.79-.97 2.84 1.02.08 2.07-.52 2.71-1.29z" />
+    </svg>
+  );
+}
+
+function WindowsMark() {
+  return (
+    <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+      <path d="M3 5.7l7.2-.98v6.95H3V5.7zm0 12.6l7.2.98v-6.86H3v5.88zm8.05 1.09L21 20.75v-8.34h-9.95v6.98zM11.05 4.6v7.07H21V3.25l-9.95 1.35z" />
+    </svg>
+  );
+}
+
+/**
+ * Installer downloads, in the header next to 商务联系 / Star. The detected
+ * platform is listed first so the common case is the first thing under the
+ * cursor, but both stay one click away — no OS sniffing dead-ends.
+ */
+function DesktopDownload() {
+  const { t } = useTranslation();
+  const [platform, setPlatform] = useState<DesktopPlatform>("mac");
+
+  // Detect after mount so a cached/prerendered shell can't bake in the wrong
+  // platform's ordering.
+  useEffect(() => {
+    setPlatform(detectDesktopPlatform());
+  }, []);
+
+  const ordered: DesktopPlatform[] =
+    platform === "windows" ? ["windows", "mac"] : ["mac", "windows"];
+
+  return (
+    <div className={styles.desktopDownload}>
+      <button
+        type="button"
+        className={styles.desktopDownloadTrigger}
+        aria-label={t("auth.download.aria")}
+      >
+        <Download aria-hidden="true" />
+        {t("auth.download.label")}
+        <ChevronDown className={styles.desktopDownloadCaret} aria-hidden="true" />
+      </button>
+      <div
+        className={styles.desktopDownloadPopover}
+        role="dialog"
+        aria-label={t("auth.download.aria")}
+      >
+        <div className={styles.desktopDownloadPanel}>
+          {ordered.map((os) => {
+            const Mark = os === "mac" ? AppleMark : WindowsMark;
+            return (
+              <a
+                key={os}
+                className={styles.desktopDownloadItem}
+                href={DESKTOP_DOWNLOAD_URL[os]}
+                download
+              >
+                <Mark />
+                {t(`auth.download.primary.${os}`)}
+              </a>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}
+
 export function LoginCinematicHeader({
   className,
   style,
@@ -74,6 +150,7 @@ export function LoginCinematicHeader({
     >
       <Brand />
       <div className={styles.stageActions}>
+        <DesktopDownload />
         <div className={styles.businessWechat}>
           <button
             type="button"

--- a/frontend/src/components/login/login.module.css
+++ b/frontend/src/components/login/login.module.css
@@ -79,6 +79,122 @@
   gap: 28px;
 }
 
+/* 安装包下载：与「商务联系」同一套 hover 浮层结构，只是面板里换成两个平台条目。
+   ::after 是悬停缓冲区，鼠标从触发器移到面板的路上不会穿帮收起。 */
+.desktopDownload {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+}
+
+.desktopDownload::after {
+  content: "";
+  position: absolute;
+  top: 100%;
+  left: -12px;
+  right: -12px;
+  height: 18px;
+}
+
+.desktopDownloadTrigger {
+  appearance: none;
+  -webkit-appearance: none;
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: rgba(246, 248, 255, 0.72);
+  cursor: pointer;
+  font: inherit;
+  font-size: 13px;
+  font-weight: 440;
+  transition: color 200ms ease;
+}
+
+.desktopDownloadTrigger svg {
+  width: 15px;
+  height: 15px;
+}
+
+.desktopDownloadCaret {
+  transition: transform 200ms ease;
+}
+
+.desktopDownloadTrigger:hover,
+.desktopDownload:focus-within .desktopDownloadTrigger {
+  color: rgba(255, 255, 255, 0.94);
+}
+
+.desktopDownload:hover .desktopDownloadCaret,
+.desktopDownload:focus-within .desktopDownloadCaret {
+  transform: rotate(180deg);
+}
+
+.desktopDownloadPopover {
+  position: absolute;
+  top: calc(100% + 18px);
+  right: 50%;
+  z-index: 40;
+  width: max-content;
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  transform: translate(50%, -6px);
+  transition:
+    opacity 160ms ease,
+    transform 180ms ease,
+    visibility 160ms ease;
+}
+
+.desktopDownload:hover .desktopDownloadPopover,
+.desktopDownload:focus-within .desktopDownloadPopover {
+  opacity: 1;
+  visibility: visible;
+  pointer-events: auto;
+  transform: translate(50%, 0);
+}
+
+.desktopDownloadPanel {
+  overflow: hidden;
+  border-radius: 9px;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  background: rgba(32, 34, 38, 0.38);
+  padding: 6px;
+  backdrop-filter: blur(22px) saturate(135%);
+  -webkit-backdrop-filter: blur(22px) saturate(135%);
+}
+
+.desktopDownloadItem {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  width: 100%;
+  padding: 8px 12px;
+  border-radius: 6px;
+  color: rgba(255, 255, 255, 0.86);
+  font-size: 12.5px;
+  font-weight: 400;
+  white-space: nowrap;
+  text-decoration: none;
+  transition:
+    background 180ms ease,
+    color 180ms ease;
+}
+
+.desktopDownloadItem:hover {
+  background: rgba(255, 255, 255, 0.1);
+  color: #fff;
+}
+
+.desktopDownloadItem svg {
+  width: 14px;
+  height: 14px;
+  flex-shrink: 0;
+  opacity: 0.9;
+}
+
 .businessWechat {
   position: relative;
   display: inline-flex;

--- a/frontend/src/components/task-center/status-bar.tsx
+++ b/frontend/src/components/task-center/status-bar.tsx
@@ -12,6 +12,7 @@ import {
 import { useAppStore } from "@/stores/app-store";
 import { displayLabel } from "@/task-center/derivations";
 import { RegionBadge } from "@/components/layout/region-badge";
+import { APP_VERSION } from "@/lib/app-version";
 import { cn } from "@/lib/utils";
 import type { StreamHealth, TaskState } from "@/task-center/types";
 
@@ -109,6 +110,15 @@ export function TaskStatusBar({ onOpenPikoStation }: TaskStatusBarProps) {
       onKeyDown={onBarKeyDown}
     >
       <div className="flex min-w-0 items-center gap-1.5">
+        <span
+          className="shrink-0 bg-gradient-to-r from-cyan-200 via-violet-200 to-rose-200 bg-clip-text font-medium tabular-nums text-transparent opacity-90"
+          title={APP_VERSION}
+        >
+          {APP_VERSION}
+        </span>
+        <span className="shrink-0 text-muted-foreground/45" aria-hidden>
+          ·
+        </span>
         <span className="inline-flex shrink-0 items-center gap-1 text-muted-foreground/90">
           <ChevronUp
             className={cn(

--- a/frontend/src/components/ui/select.tsx
+++ b/frontend/src/components/ui/select.tsx
@@ -65,7 +65,9 @@ function SelectContent({
   sideOffset = 4,
   align = "center",
   alignOffset = 0,
-  alignItemWithTrigger = true,
+  // 下拉面板挂在触发器下方，而不是 base-ui 默认的「选中项对齐触发器」——
+  // 后者会让面板整个压在触发器上，看着像错位。
+  alignItemWithTrigger = false,
   ...props
 }: SelectPrimitive.Popup.Props &
   Pick<

--- a/frontend/src/features/canvas/nodes/ImageGenNode.tsx
+++ b/frontend/src/features/canvas/nodes/ImageGenNode.tsx
@@ -1427,7 +1427,7 @@ export const ImageGenNode = memo(({ id, data, selected, width, height }: ImageGe
           <div className="nodrag absolute inset-x-5 top-1/2 z-10 flex -translate-y-1/2 flex-col items-center text-center">
             <div className="inline-flex items-center gap-1.5 text-[12px] font-semibold text-red-200">
               <AlertTriangle className="h-3.5 w-3.5 shrink-0 text-red-300/90" />
-              <span>{t("canvas.imageNode.generationFailed")}</span>
+              <span>{t("node.imageNode.generationFailed")}</span>
             </div>
             <div
               className="mt-1 max-h-12 max-w-full overflow-y-auto break-words text-[11px] leading-4 text-red-100/76 [overflow-wrap:anywhere]"
@@ -1437,13 +1437,13 @@ export const ImageGenNode = memo(({ id, data, selected, width, height }: ImageGe
             </div>
             {generationErrorRequestId && (
               <div className="mt-1 flex max-w-full items-center justify-center gap-1.5 text-[10px] text-text-muted/58">
-                <span className="shrink-0">{t("canvas.imageNode.requestId")}</span>
+                <span className="shrink-0">{t("node.imageNode.requestId")}</span>
                 <code className="min-w-0 max-w-[160px] truncate font-mono" title={generationErrorRequestId}>
                   {generationErrorRequestId}
                 </code>
                 <button
                   type="button"
-                  title={requestIdCopied ? t("canvas.imageNode.requestIdCopied") : t("canvas.imageNode.copyRequestId")}
+                  title={requestIdCopied ? t("node.imageNode.requestIdCopied") : t("node.imageNode.copyRequestId")}
                   onClick={(event) => {
                     event.stopPropagation();
                     void handleCopyRequestId();

--- a/frontend/src/features/freezone/FreezoneShell.tsx
+++ b/frontend/src/features/freezone/FreezoneShell.tsx
@@ -337,6 +337,10 @@ function stringOrUndefined(value: unknown): string | undefined {
  * so this shell omits the back button, project picker, import/extract/
  * video-ref/3GS triggers, and the top-right Beat Workbench task entry.
  */
+const canvasKey = (projectId: string, canvasId: string) => `${projectId}::${canvasId}`;
+/** 上一次真正画出来的画布；跨挂载保留，用来判断重进时能否直接复用 store 里的内容。 */
+let lastRenderedCanvasKey: string | null = null;
+
 export function FreezoneShell({ project, canvasId }: FreezoneShellProps) {
   const { t } = useTranslation();
   const queryClient = useQueryClient();
@@ -365,7 +369,15 @@ export function FreezoneShell({ project, canvasId }: FreezoneShellProps) {
   // there is no UI bound to a syncing/removing value, so no state is kept.
   const syncingProjectionRef = useRef<string | null>(null);
   const removingProjectionRef = useRef<string | null>(null);
-  const [hasRenderedCanvas, setHasRenderedCanvas] = useState(false);
+  // 顶栏在「虾画 / 虾集」之间切换会整体卸载再挂载本组件，但画布数据留在全局 store 里。
+  // 如果这里从 false 起步，回到虾画就会先把画面换成「正在加载画布…」，等 hydrate 回来
+  // 才重新画出来 —— 看着就是卡。同一个画布重进时直接渲染 store 里的既有内容，
+  // hydrate 期间只叠一层轻量 overlay。
+  const [hasRenderedCanvas, setHasRenderedCanvas] = useState(
+    () =>
+      lastRenderedCanvasKey === canvasKey(projectId, canvasId) &&
+      useCanvasStore.getState().nodes.length > 0,
+  );
   const [projectionStatusRefreshToken, setProjectionStatusRefreshToken] = useState(0);
   const lastProjectionStatusRevisionRef = useRef<{
     canvasId: string;
@@ -419,9 +431,10 @@ export function FreezoneShell({ project, canvasId }: FreezoneShellProps) {
 
   useEffect(() => {
     if (sync.status === "ready" && sync.hydratedCanvasId === canvasId) {
+      lastRenderedCanvasKey = canvasKey(projectId, canvasId);
       setHasRenderedCanvas(true);
     }
-  }, [canvasId, sync.hydratedCanvasId, sync.status]);
+  }, [canvasId, projectId, sync.hydratedCanvasId, sync.status]);
 
   const projectionKeys = useMemo(
     () => projectionKeysFromMetadata(sync.metadata),
@@ -1492,9 +1505,11 @@ function CanvasLoadingScreen() {
 }
 
 function CanvasLoadingOverlay() {
+  // hydrate 还在飞时画布上的编辑既不会入队保存，也会被随后的 setCanvasData(remote)
+  // 整个盖掉。所以这层遮罩必须真的吃掉指针事件，不能只是视觉上蒙一层。
   return (
     <div
-      className="pointer-events-none absolute inset-0 z-20 bg-bg-dark/10 backdrop-blur-[1px]"
+      className="absolute inset-0 z-20 cursor-wait bg-bg-dark/10 backdrop-blur-[1px]"
       aria-hidden="true"
     />
   );

--- a/frontend/src/features/freezone/useCanvasSync.ts
+++ b/frontend/src/features/freezone/useCanvasSync.ts
@@ -61,7 +61,32 @@ const DRAFT_DEBOUNCE_MS = 300;
 /** Extra app-level retry attempts when ky surfaces a 503 canvas_lock_busy. */
 const LOCK_BUSY_MAX_RETRIES = 1;
 export const FREEZONE_HYDRATE_RELEASE_GRACE_MS = 50;
-export const FREEZONE_HYDRATE_SETTLED_REUSE_MS = 5_000;
+/**
+ * 已结算的 hydrate 结果保留多久可复用。顶栏在「虾画 / 虾集」之间来回切时会整体
+ * 卸载再挂载画布，复用能省掉一趟往返的全量拉取。仅在期间没有任何本地编辑
+ * （userEditsSinceHydrate === 0）时复用。
+ *
+ * 窗口刻意压得很短：复用的 payload 连同它的 revision 一起被当成最新的，期间别的
+ * 标签页或协作者改了同一张画布，我们既画的是旧内容，之后保存还会撞 409。10 秒够
+ * 覆盖「切过去又立刻切回来」，再长就是拿正确性换手感了。
+ */
+export const FREEZONE_HYDRATE_SETTLED_REUSE_MS = 10_000;
+
+let prunePending = false;
+
+/** 整页生命周期内只调度一次旧草稿清理，且一旦排上队就让它跑完。 */
+function schedulePruneOnce(): void {
+  if (prunePending) return;
+  prunePending = true;
+  const run = () => {
+    pruneOldCanvasDrafts();
+  };
+  if (typeof window.requestIdleCallback === "function") {
+    window.requestIdleCallback(run, { timeout: 2_000 });
+    return;
+  }
+  window.setTimeout(run, 300);
+}
 
 type HydrateFlight = {
   controller: AbortController;
@@ -229,11 +254,19 @@ function statusFromError(err: unknown): number | null {
  * viewport resize, selection, hover, focus, tool dialogs, image preview) never
  * touch it, so they no longer trigger a full PUT.
  */
-function canvasContentSignature(
-  nodes: CanvasNode[],
-  edges: CanvasEdge[],
-): string {
-  const nodeShapes = nodes.map((node) => ({
+/**
+ * 逐节点/逐边的指纹缓存。store 的更新是不可变的：一次选中、一次拖拽只会替换受影响的
+ * 那几个节点对象，其余节点对象的引用不变。按对象身份缓存分片后，签名的代价就从
+ * 「每次变更都 stringify 整张图」降到「只 stringify 真正变了的那几个节点」——画布里
+ * 有几十个图片/视频节点时，这是切页那一帧卡死的主要来源。
+ */
+const nodeSignatureCache = new WeakMap<object, string>();
+const edgeSignatureCache = new WeakMap<object, string>();
+
+function nodeSignature(node: CanvasNode): string {
+  const cached = nodeSignatureCache.get(node);
+  if (cached !== undefined) return cached;
+  const signature = JSON.stringify({
     id: node.id,
     type: node.type,
     position: node.position,
@@ -243,8 +276,15 @@ function canvasContentSignature(
     parentId: node.parentId,
     extent: node.extent,
     data: node.data,
-  }));
-  const edgeShapes = edges.map((edge) => ({
+  });
+  nodeSignatureCache.set(node, signature);
+  return signature;
+}
+
+function edgeSignature(edge: CanvasEdge): string {
+  const cached = edgeSignatureCache.get(edge);
+  if (cached !== undefined) return cached;
+  const signature = JSON.stringify({
     id: edge.id,
     source: edge.source,
     target: edge.target,
@@ -252,8 +292,18 @@ function canvasContentSignature(
     targetHandle: edge.targetHandle,
     type: edge.type,
     data: edge.data,
-  }));
-  return JSON.stringify({ nodes: nodeShapes, edges: edgeShapes });
+  });
+  edgeSignatureCache.set(edge, signature);
+  return signature;
+}
+
+function canvasContentSignature(
+  nodes: CanvasNode[],
+  edges: CanvasEdge[],
+): string {
+  return `${nodes.map(nodeSignature).join("")}${edges
+    .map(edgeSignature)
+    .join("")}`;
 }
 
 type HydrateDraftDecision =
@@ -906,7 +956,10 @@ export function useCanvasSync(
   // ---- 1. Hydrate ---- //
   useEffect(() => {
     let cancelled = false;
-    pruneOldCanvasDrafts();
+    // 清理旧草稿要遍历并解析整个 localStorage（草稿动辄几 MB），放在挂载的关键路径上
+    // 会直接卡住切页那一帧；挪到空闲期做，它跟本次 hydrate 没有先后依赖。整页只跑一次，
+    // 且不随卸载取消 —— 否则「进画布不到两秒就切走」这种最常见的路径永远清理不到。
+    schedulePruneOnce();
     const hydrateFlight = acquireHydrateFlight(project, canvasId, reloadKey);
     setSyncStatus("loading");
     setError(null);
@@ -1189,6 +1242,15 @@ export function useCanvasSync(
     const unsubscribeCanvas = useCanvasStore.subscribe((state, prev) => {
       if (state.viewportBookmarks !== prev.viewportBookmarks) {
         triggerSave();
+      }
+      // store 里还住着视口、选中、弹窗等纯视图状态，它们的变更不可能改到 nodes/edges。
+      // 数组引用没变就直接放行，连签名都不用算 —— 切页时这里是热点。
+      if (state.nodes === prev.nodes && state.edges === prev.edges) {
+        // 抑制标志总是紧挨着 applyCanvasDataEdit 设的（同步，中间插不进别的变更），
+        // 所以这里必须顺手消费掉：万一那次程序化改写产出的数组原样未变，标志留到
+        // 下一次就会把用户真正的编辑连保存带草稿一起吞了。
+        suppressNextCanvasAutosaveRef.current = false;
+        return;
       }
       const nextSignature = canvasContentSignature(state.nodes, state.edges);
       if (suppressNextCanvasAutosaveRef.current) {

--- a/frontend/src/i18n/index.ts
+++ b/frontend/src/i18n/index.ts
@@ -4,7 +4,7 @@ import i18n from "i18next";
 import { initReactI18next } from "react-i18next";
 import HttpBackend from "i18next-http-backend";
 import { useAppStore } from "@/stores/app-store";
-import { APP_VERSION } from "@/lib/app-version";
+import { BUILD_ID } from "@/lib/app-version";
 
 const SUPPORTED = ["zh", "en"] as const;
 type Supported = (typeof SUPPORTED)[number];
@@ -38,8 +38,10 @@ i18n
     backend: {
       // 翻译 JSON 是静态文件、会被浏览器/CDN 长期缓存。不带版本号时，发版后新增的
       // key 在老用户那里仍读旧缓存 → 直接显示成原始 key（如 ingest.reuploadConfirm.*）。
-      // 按构建版本加 query 破缓存：每次发版 URL 变化拉到新文件，同版本内仍走缓存。
-      loadPath: `/locales/{{lng}}/{{ns}}.json?v=${encodeURIComponent(APP_VERSION)}`,
+      // 按 BUILD_ID 加 query 破缓存：每次构建 URL 变化拉到新文件，同一构建内仍走缓存。
+      // 用 BUILD_ID 而非 APP_VERSION —— 后者在 CI 不注入时是个固定默认值，两次发版
+      // 长得一样，缓存就破不掉了。
+      loadPath: `/locales/{{lng}}/{{ns}}.json?v=${encodeURIComponent(BUILD_ID)}`,
     },
     interpolation: {
       escapeValue: false,

--- a/frontend/src/lib/app-version.ts
+++ b/frontend/src/lib/app-version.ts
@@ -1,14 +1,20 @@
 // SPDX-License-Identifier: Elastic-2.0
 // Copyright (c) 2026 ClaymoreLab
 /**
- * Build-time app version, injected by Vite's `define` (see vite.config.ts).
+ * Build-time constants, injected by Vite's `define` (see vite.config.ts).
  *
- * Source precedence:
- *   1. $VITE_APP_VERSION in the build environment (set by CI from the git tag
- *      on tag/dispatch builds, or `dev-<sha>` on main-push dev builds).
- *   2. `git describe --tags --always --dirty` (local dev fallback).
- *   3. `unknown` (last resort — repo missing git, etc.).
+ * APP_VERSION — the human-facing version shown in the status bar.
+ *   1. $VITE_APP_VERSION in the build environment (set by CI from the git tag).
+ *   2. a hardcoded default otherwise.
+ * Two different builds can carry the SAME APP_VERSION, so never use it to
+ * decide whether a deploy happened — use BUILD_ID for that.
+ *
+ * BUILD_ID — the deploy fingerprint, unique per build (`git describe`, or the
+ * build timestamp when git is unavailable). version-update-watch compares it
+ * against the deployed /version.json to detect that a new bundle shipped.
  */
 declare const __APP_VERSION__: string;
+declare const __BUILD_ID__: string;
 
 export const APP_VERSION: string = __APP_VERSION__;
+export const BUILD_ID: string = __BUILD_ID__;

--- a/frontend/src/lib/beat-markers.ts
+++ b/frontend/src/lib/beat-markers.ts
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: Elastic-2.0
+// Copyright (c) 2026 ClaymoreLab
+/**
+ * Sentinels the backend puts in `detected_identities` / `detected_props` to say
+ * "this beat deliberately has no character / no prop" — they are NOT ids, and
+ * must never reach the UI as a chip, mention or option label.
+ */
+export const NO_CHARACTER_MARKER = "__NO_CHARACTER__";
+export const NO_PROP_MARKER = "__NO_PROP__";
+
+export function isNoReferenceMarker(id: string): boolean {
+  return id === NO_CHARACTER_MARKER || id === NO_PROP_MARKER;
+}

--- a/frontend/src/lib/desktop-download.ts
+++ b/frontend/src/lib/desktop-download.ts
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: Elastic-2.0
+// Copyright (c) 2026 ClaymoreLab
+/**
+ * Desktop installer downloads offered on the login hero.
+ *
+ * TODO(wx): 换成真实的安装包地址（OSS / GitHub Releases 均可）。在此之前按钮
+ * 指向占位地址，先把版式和样式定下来。
+ */
+export type DesktopPlatform = "mac" | "windows";
+
+export const DESKTOP_DOWNLOAD_URL: Record<DesktopPlatform, string> = {
+  mac: "#download-mac-placeholder",
+  windows: "#download-windows-placeholder",
+};
+
+/**
+ * Which installer to feature as the filled primary button. Falls back to macOS
+ * on anything we can't identify (Linux, phones, bots) so the row never renders
+ * empty — the other platform stays one click away as the adjacent text link.
+ */
+export function detectDesktopPlatform(
+  userAgent: string = typeof navigator === "undefined" ? "" : navigator.userAgent,
+): DesktopPlatform {
+  return /windows|win32|win64/i.test(userAgent) ? "windows" : "mac";
+}

--- a/frontend/src/lib/version-update-watch.ts
+++ b/frontend/src/lib/version-update-watch.ts
@@ -1,15 +1,19 @@
 // SPDX-License-Identifier: Elastic-2.0
 // Copyright (c) 2026 ClaymoreLab
 import { markUpdateAvailable } from "@/lib/app-update-available";
-import { APP_VERSION } from "@/lib/app-version";
+import { BUILD_ID } from "@/lib/app-version";
 
 // Poll a tiny build-emitted manifest (/version.json) and compare the deployed
-// version against APP_VERSION — the compile-time constant baked into THIS
-// running bundle (see the emit-version-json plugin in vite.config.ts). Because
-// the baseline is the running code's own version (not a fetched-then-remembered
+// buildId against BUILD_ID — the compile-time constant baked into THIS running
+// bundle (see the emit-version-json plugin in vite.config.ts). Because the
+// baseline is the running code's own fingerprint (not a fetched-then-remembered
 // value), there is no seed race: a deploy that lands between page load and the
 // first poll is still caught. It's also independent of the backend, so CDN-only
 // frontend deploys are detected even when the API never restarts.
+//
+// This deliberately keys off buildId, NOT the display version: APP_VERSION
+// falls back to a hardcoded default when CI doesn't inject one, so comparing it
+// would make two different deploys look identical and silently never prompt.
 const POLL_INTERVAL_MS = 120_000;
 
 export function deployedVersionDiffers(
@@ -19,7 +23,7 @@ export function deployedVersionDiffers(
   return deployed !== null && deployed !== running;
 }
 
-async function fetchDeployedVersion(): Promise<string | null> {
+async function fetchDeployedBuildId(): Promise<string | null> {
   try {
     // Cache-bust + no-store so a CDN/proxy can't hand back a stale manifest.
     const response = await fetch(`/version.json?_v=${Date.now()}`, {
@@ -28,8 +32,8 @@ async function fetchDeployedVersion(): Promise<string | null> {
     });
     if (!response.ok) return null;
     const data: unknown = await response.json();
-    const version = (data as { version?: unknown } | null)?.version;
-    return typeof version === "string" && version.length > 0 ? version : null;
+    const buildId = (data as { buildId?: unknown } | null)?.buildId;
+    return typeof buildId === "string" && buildId.length > 0 ? buildId : null;
   } catch {
     return null;
   }
@@ -58,10 +62,10 @@ export function installVersionUpdateWatch(): () => void {
     // hitting the origin. onVisible re-checks promptly the moment it refocuses.
     if (inFlight || stopped || document.visibilityState !== "visible") return;
     inFlight = true;
-    const deployed = await fetchDeployedVersion();
+    const deployed = await fetchDeployedBuildId();
     inFlight = false;
     if (stopped) return;
-    if (deployedVersionDiffers(deployed, APP_VERSION)) {
+    if (deployedVersionDiffers(deployed, BUILD_ID)) {
       markUpdateAvailable();
       // The signal is sticky; no reason to keep polling once we've nudged.
       stop();

--- a/frontend/src/routes/_app/projects.$project/episodes.$episode/compose.lazy.tsx
+++ b/frontend/src/routes/_app/projects.$project/episodes.$episode/compose.lazy.tsx
@@ -403,7 +403,7 @@ function ComposeTabContent() {
                   variant="outline"
                   size="sm"
                   onClick={() => void handleExport("srt")}
-                  className="gap-1.5 rounded-lg"
+                  className="gap-1.5"
                 >
                   <FileText className="size-3.5" />
                   {t("episode.compose.exportSrt")}
@@ -412,7 +412,7 @@ function ComposeTabContent() {
                   variant="outline"
                   size="sm"
                   onClick={() => void handleExport("zip")}
-                  className="gap-1.5 rounded-lg"
+                  className="gap-1.5"
                 >
                   <Download className="size-3.5" />
                   {t("episode.compose.exportZip")}
@@ -422,7 +422,7 @@ function ComposeTabContent() {
                     <Button
                       size="sm"
                       onClick={() => void handleDownloadVideo()}
-                      className="gap-1.5 rounded-lg"
+                      className="gap-1.5"
                     >
                       <Download className="size-3.5" />
                       {t("episode.compose.downloadVideo")}
@@ -432,7 +432,7 @@ function ComposeTabContent() {
                       size="sm"
                       onClick={() => setComposeConfirm(true)}
                       disabled={!canCompose || isComposing}
-                      className="gap-1.5 rounded-lg"
+                      className="gap-1.5"
                     >
                       {isComposing ? (
                         <Loader2 className="size-3.5 animate-spin" />
@@ -447,7 +447,7 @@ function ComposeTabContent() {
                     size="sm"
                     onClick={() => setComposeConfirm(true)}
                     disabled={!canCompose || isComposing}
-                    className="gap-1.5 rounded-lg bg-primary text-primary-foreground shadow-none hover:bg-primary/85 active:bg-primary/75"
+                    className="gap-1.5 bg-primary text-primary-foreground shadow-none hover:bg-primary/85 active:bg-primary/75"
                   >
                     {isComposing ? (
                       <Loader2 className="size-3.5 animate-spin" />
@@ -479,8 +479,8 @@ function ComposeTabContent() {
                 <div className="flex items-center gap-1.5">
                   <span className="text-[12px] text-muted-foreground">{t("episode.compose.resolution")}:</span>
                   <Select value={resolution} onValueChange={handleResolutionChange}>
-                    <SelectTrigger className="!h-7 w-28 rounded-lg border border-white/10 bg-transparent py-0 text-[12px] font-medium text-foreground/85">
-                      <SelectValue />
+                    <SelectTrigger className="!h-7 w-28 rounded-[6px] border border-white/10 bg-transparent py-0 text-[12px] font-medium text-foreground/85">
+                      <SelectValue>{() => resolutionLabel(resolution)}</SelectValue>
                     </SelectTrigger>
                     <SelectContent>
                       {resolutionOptions(orientation).map((value) => (
@@ -584,7 +584,7 @@ function BeatBlockerGrid({
           key={beatNum}
           type="button"
           onClick={() => jump(beatNum)}
-          className="group relative flex min-h-[92px] flex-col rounded-[12px] border border-white/10 bg-white/[0.03] px-6 py-3.5 text-left transition-all duration-[350ms] hover:scale-[1.015] hover:border-primary/30 hover:bg-primary/[0.06]"
+          className="group relative flex min-h-[92px] flex-col rounded-[8px] border border-white/10 bg-white/[0.03] px-6 py-3.5 text-left transition-all duration-[350ms] hover:scale-[1.015] hover:border-primary/30 hover:bg-primary/[0.06]"
         >
           <ArrowUpRight className="absolute right-3 top-3 size-3.5 text-muted-foreground opacity-0 transition-opacity duration-[350ms] group-hover:opacity-100" />
           <div className="space-y-2.5">

--- a/frontend/src/routes/_app/projects.$project/ingest.tsx
+++ b/frontend/src/routes/_app/projects.$project/ingest.tsx
@@ -14,6 +14,7 @@ import {
   CheckCircle2,
   FileText,
   FishSymbol,
+  Info,
   Loader2,
   Play,
   Plus,
@@ -31,6 +32,7 @@ import {
   type UploadResult,
 } from "@/lib/queries/ingest";
 import { FormatCheckDetailsDialog } from "@/components/ingest/FormatCheckDetailsDialog";
+import { NovelFormatDialog } from "@/components/ingest/NovelFormatDialog";
 import { useStyles } from "@/lib/queries/styles";
 import { useCharacters } from "@/lib/queries/characters";
 import { useCancelTask } from "@/lib/queries/tasks";
@@ -818,6 +820,7 @@ export function IngestPageContent({ project }: { project: string }) {
   const [uploadedFileSource, setUploadedFileSource] =
     useState<UploadedFileSource | null>(null);
   const [inputMode, setInputMode] = useState<InputMode>("upload");
+  const [novelFormatOpen, setNovelFormatOpen] = useState(false);
   const [pastedText, setPastedText] = useState("");
   const [ingestSubmitted, setIngestSubmitted] = useState(false);
   const [hideImportedPreview, setHideImportedPreview] = useState(() =>
@@ -1475,6 +1478,18 @@ export function IngestPageContent({ project }: { project: string }) {
                   </SelectContent>
                 </Select>
 
+                {/* 导入标准格式只对精品剧成立，解说剧走的是另一套解析。 */}
+                {settingsValues.spine_template === "drama" && (
+                  <button
+                    type="button"
+                    onClick={() => setNovelFormatOpen(true)}
+                    className="inline-flex shrink-0 items-center gap-1.5 whitespace-nowrap text-[13px] text-muted-foreground underline-offset-4 transition-colors hover:text-foreground [&:hover>span]:underline"
+                  >
+                    <Info className="size-3.5 shrink-0" />
+                    <span>{t("ingest.novelFormat.button")}</span>
+                  </button>
+                )}
+
                 <div className="col-span-2 flex w-full shrink-0 items-center justify-end gap-3 md:ml-auto md:w-auto">
                   <Button
                     type="button"
@@ -1772,6 +1787,7 @@ export function IngestPageContent({ project }: { project: string }) {
           if (!next) setFormatCheckDetails(null);
         }}
       />
+      <NovelFormatDialog open={novelFormatOpen} onOpenChange={setNovelFormatOpen} />
     </div>
   );
 }

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -17,3 +17,4 @@ interface ImportMeta {
 }
 
 declare const __APP_VERSION__: string;
+declare const __BUILD_ID__: string;

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -17,24 +17,37 @@ function datePrefix(d: Date = new Date()): string {
   return `${yy}${mm}${dd}-`;
 }
 
-// Resolve the app version at config-load time. CI sets VITE_APP_VERSION
-// explicitly (already carrying the date prefix — see deploy.yml). Local
-// `vite dev` and `vite build` outside CI fall back to `git describe` and
-// the date prefix is applied here.
+// The human-facing version, shown in the status bar. CI sets VITE_APP_VERSION
+// from the release tag; every other build shows the default. It is display-only
+// — never compare it across deploys (two builds can legitimately carry the same
+// version string), that's what BUILD_ID below is for.
+const DEFAULT_APP_VERSION = "v1.0.9";
+
 function resolveAppVersion(): string {
-  if (process.env.VITE_APP_VERSION) return process.env.VITE_APP_VERSION;
+  return process.env.VITE_APP_VERSION || DEFAULT_APP_VERSION;
+}
+
+// The deploy fingerprint. MUST differ between any two builds, because the
+// running app compares it against the deployed /version.json to decide whether
+// to nudge the user to refresh (see lib/version-update-watch.ts). Prefer
+// `git describe`, and fall back to the build timestamp so even a git-less
+// build still produces a value that changes — a constant here would silently
+// disable update detection.
+function resolveBuildId(): string {
   try {
     const described = execSync("git describe --tags --always --dirty", {
       encoding: "utf8",
       stdio: ["ignore", "pipe", "ignore"],
     }).trim();
-    return `${datePrefix()}${described}`;
+    if (described) return `${datePrefix()}${described}`;
   } catch {
-    return `${datePrefix()}unknown`;
+    // not a git checkout (e.g. source tarball) — fall through to the timestamp
   }
+  return `${datePrefix()}${Date.now()}`;
 }
 
 const APP_VERSION = resolveAppVersion();
+const BUILD_ID = resolveBuildId();
 const DEFAULT_API_TARGET = "http://127.0.0.1:8780";
 
 export default defineConfig(({ mode }) => {
@@ -47,23 +60,24 @@ export default defineConfig(({ mode }) => {
       react(),
       tailwindcss(),
       {
-        // Emit a tiny version manifest the running app polls to detect deploys.
-        // The version written here is the SAME compile-time constant baked into
-        // the bundle via `define` below, so the running code can compare its own
-        // APP_VERSION against the deployed version.json — no fetched baseline,
-        // hence no seed race.
+        // Emit a tiny manifest the running app polls to detect deploys. The
+        // buildId written here is the SAME compile-time constant baked into the
+        // bundle via `define` below, so the running code can compare its own
+        // BUILD_ID against the deployed version.json — no fetched baseline,
+        // hence no seed race. `version` rides along for display/debugging only.
         name: "emit-version-json",
         generateBundle() {
           this.emitFile({
             type: "asset",
             fileName: "version.json",
-            source: JSON.stringify({ version: APP_VERSION }),
+            source: JSON.stringify({ version: APP_VERSION, buildId: BUILD_ID }),
           });
         },
       },
     ],
     define: {
       __APP_VERSION__: JSON.stringify(APP_VERSION),
+      __BUILD_ID__: JSON.stringify(BUILD_ID),
     },
     resolve: {
       alias: {

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -9,6 +9,7 @@ export default defineConfig({
   // don't care about the real value — a stable placeholder is plenty.
   define: {
     __APP_VERSION__: JSON.stringify("test"),
+    __BUILD_ID__: JSON.stringify("test-build"),
   },
   test: {
     environment: "jsdom",

--- a/license-inventory.csv
+++ b/license-inventory.csv
@@ -1040,11 +1040,13 @@ frontend/src/lib/aspect-ratio.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.t
 frontend/src/lib/audio-type.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/lib/audioTranscode.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/lib/auth-mode.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
+frontend/src/lib/beat-markers.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/lib/browserDownload.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/lib/character-main-copy.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/lib/chunk-load-recovery.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/lib/cluster-config.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/lib/derive-beat-states.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
+frontend/src/lib/desktop-download.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/lib/dev-backend-watch.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/lib/dialog-styles.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/lib/dom-reconciliation-guard.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation

--- a/license-inventory.csv
+++ b/license-inventory.csv
@@ -604,6 +604,7 @@ frontend/src/components/episode/script-beat-preview.tsx,Elastic-2.0,2026 SuperTa
 frontend/src/components/episode/task-controller-provider.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/components/identity-picker-dialog.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/components/ingest/FormatCheckDetailsDialog.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
+frontend/src/components/ingest/NovelFormatDialog.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/components/layout/ai-assistant-panel.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/components/layout/brand-holiday-badge.css,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/components/layout/brand-holiday-badge.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation


### PR DESCRIPTION
## 背景

顶栏在「虾画 / 虾集」之间切换时明显卡顿——点下去要等一下才切过去,主线程在那一帧被冻住。画布规模是几十个节点、带图片/视频。

## 卡顿根因与修复

**主因:每次 canvas store 变更都会对整张图做一次 `JSON.stringify` 算内容签名。** 视口平移、选中、开关弹窗这些纯视图状态也住在同一个 store 里,于是它们同样触发全图序列化。改为:

- 按节点 / 边分片缓存签名(`WeakMap`),对象引用没变就不重算;
- `nodes`/`edges` 数组引用未变时在订阅者里直接早退,连签名都不算。

**次要:切页会整体卸载再挂载画布。** 重进时先用 store 里已有的内容画出来,不再白屏闪一下;hydrate 结果在 10 秒内(且期间无本地编辑)可复用,省掉来回切换的重复全量拉取。

## 同一批里修掉的正确性问题

上面的优化本身引入过几个坑,已在合入前修掉:

- **hydrate 未落地时画布不可编辑。** 加载遮罩改为真正拦截指针事件。否则这期间的编辑既不会入队保存(`triggerSave` 被 `hydratedRef` 挡住),又会被随后的 `setCanvasData(remote)` 整个覆盖——无声丢数据。
- **hydrate 复用窗口压到 10 秒。** 复用的 payload 连同它的 `revision` 一起被当成最新的;窗口一长,别的标签页/协作者改了同一张画布就会画出旧内容,之后保存还撞 409。10 秒够覆盖「切过去又立刻切回来」。
- **自动保存抑制标志在引用相等的早退分支里顺手消费掉。** 否则投影改写若产出原样未变的数组,标志会留到下一次,把用户真正的编辑连保存带草稿一起吞了。
- **旧草稿清理整页只跑一次且不随卸载取消。** 它要遍历解析整个 localStorage(草稿动辄几 MB),留在挂载关键路径上会卡住切页那一帧;而一旦随卸载取消,「进画布不到两秒就切走」这条最常见的路径就永远清理不到。

## 顺带

- 顶栏虾画/虾集菜单改为常驻表头行,去掉 portal 弹层及其滚动/resize 重定位逻辑。
- 导入页(精品剧)新增「小说格式」说明弹窗,展示标准格式与示例片段。
- 合入工作区其余在途改动:登录页 cinematic hero、桌面端下载入口与版本更新监听、beat 标记工具、sketch-section / 任务中心状态栏 / ImageGenNode 调整、i18n 与 vite/vitest 配置及文案补全。新增文件已登记进 license inventory。

## 验证

`tsc -b` 干净;`vitest run` 271 文件 / 1725 用例全过;`vite build` 通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)