### PR TITLE
feat(ui): 统一导航反馈与素材页控件

### DIFF
--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -1283,6 +1283,7 @@
     "use": "Use",
     "confirmExecute": "Confirm",
     "refresh": "Refresh",
+    "refreshDone": "Done",
     "preparing": "Preparing...",
     "removed": "(removed)",
     "new": "NEW",

--- a/frontend/public/locales/zh/translation.json
+++ b/frontend/public/locales/zh/translation.json
@@ -1283,6 +1283,7 @@
     "use": "使用",
     "confirmExecute": "确认执行",
     "refresh": "刷新",
+    "refreshDone": "已刷新",
     "preparing": "准备中...",
     "removed": "（已移除）",
     "new": "新",

--- a/frontend/src/__tests__/components/themed-toaster.test.tsx
+++ b/frontend/src/__tests__/components/themed-toaster.test.tsx
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: Elastic-2.0
+// Copyright (c) 2026 ClaymoreLab
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const routeState = vi.hoisted(() => ({ pathname: "/" }));
+
+vi.mock("@tanstack/react-router", () => ({
+  useRouterState: ({ select }: { select: (state: unknown) => unknown }) =>
+    select({ location: { pathname: routeState.pathname } }),
+}));
+
+vi.mock("sonner", () => ({
+  Toaster: ({ offset }: { offset: number }) => (
+    <div data-testid="toaster" data-offset={offset} />
+  ),
+}));
+
+import { ThemedToaster } from "@/components/themed-toaster";
+
+describe("ThemedToaster", () => {
+  beforeEach(() => {
+    routeState.pathname = "/";
+  });
+
+  it.each([
+    ["/", "60"],
+    ["/projects/demo/freezone", "60"],
+    ["/projects/demo/characters", "102"],
+    ["/login", "24"],
+    ["/watch/demo", "24"],
+  ])("uses the safe top offset for %s", (pathname, expectedOffset) => {
+    routeState.pathname = pathname;
+    render(<ThemedToaster />);
+    expect(screen.getByTestId("toaster")).toHaveAttribute(
+      "data-offset",
+      expectedOffset,
+    );
+  });
+});

--- a/frontend/src/__tests__/components/ui/header-refresh-button.test.tsx
+++ b/frontend/src/__tests__/components/ui/header-refresh-button.test.tsx
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: Elastic-2.0
+// Copyright (c) 2026 ClaymoreLab
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const toastError = vi.hoisted(() => vi.fn());
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => (key === "common.refreshDone" ? "Done" : "Error"),
+  }),
+}));
+
+vi.mock("sonner", () => ({ toast: { error: toastError } }));
+
+import { HeaderRefreshButton } from "@/components/ui/header-refresh-button";
+
+describe("HeaderRefreshButton", () => {
+  beforeEach(() => {
+    toastError.mockClear();
+  });
+
+  it("shows an inline confirmation after a successful refresh", async () => {
+    const user = userEvent.setup();
+    const onRefresh = vi.fn().mockResolvedValue(true);
+    render(
+      <HeaderRefreshButton
+        label="Refresh"
+        onRefresh={onRefresh}
+        refreshing={false}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Refresh" }));
+
+    expect(onRefresh).toHaveBeenCalledOnce();
+    expect(await screen.findByRole("button", { name: "Done" })).toBeInTheDocument();
+  });
+
+  it("reports unexpected refresh failures without confirming success", async () => {
+    const user = userEvent.setup();
+    const onRefresh = vi.fn().mockRejectedValue(new Error("network"));
+    render(
+      <HeaderRefreshButton
+        label="Refresh"
+        onRefresh={onRefresh}
+        refreshing={false}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Refresh" }));
+
+    expect(toastError).toHaveBeenCalledWith("Error");
+    expect(screen.getByRole("button", { name: "Refresh" })).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/assets/asset-card-styles.ts
+++ b/frontend/src/components/assets/asset-card-styles.ts
@@ -1,0 +1,5 @@
+// SPDX-License-Identifier: Elastic-2.0
+// Copyright (c) 2026 ClaymoreLab
+
+export const ASSET_CARD_META_BADGE_CLASS =
+  "inline-flex h-5 shrink-0 items-center gap-1 rounded-[6px] border border-white/10 bg-white/[0.03] px-1.5 py-0 text-[11px] font-normal leading-none text-muted-foreground";

--- a/frontend/src/components/assets/prop-asset-card.tsx
+++ b/frontend/src/components/assets/prop-asset-card.tsx
@@ -14,6 +14,7 @@ import {
 import { useTranslation } from "react-i18next";
 
 import { LightboxImage } from "@/components/lightbox-image";
+import { ASSET_CARD_META_BADGE_CLASS } from "@/components/assets/asset-card-styles";
 import { UsageCountBadge } from "@/components/assets/usage-count-badge";
 import { CopyAssetLinkButton } from "@/components/assets/copy-asset-link-button";
 import { CreditCostInline } from "@/components/credit-cost-inline";
@@ -79,11 +80,11 @@ export function PropAssetCard({
             <CardTitle className="truncate">{prop.name}</CardTitle>
             <div className="flex shrink-0 flex-wrap items-center gap-1">
               {propTypeLabel && (
-                <span className="rounded-[4px] border border-border bg-background/40 px-1 py-0 text-[10px] text-muted-foreground">
+                <span className={ASSET_CARD_META_BADGE_CLASS}>
                   {propTypeLabel}
                 </span>
               )}
-              <span className="rounded-[4px] border border-border bg-background/40 px-1 py-0 text-[10px] text-muted-foreground">
+              <span className={ASSET_CARD_META_BADGE_CLASS}>
                 {t("assets.props.reference")}{" "}
                 {referenceUrl ? t("assets.common.generated") : t("assets.common.missing")}
               </span>

--- a/frontend/src/components/assets/props-panel.tsx
+++ b/frontend/src/components/assets/props-panel.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Elastic-2.0
 // Copyright (c) 2026 ClaymoreLab
 import { useEffect, useMemo, useState } from "react";
-import { Loader2, Package, Plus, RefreshCw, Sparkles } from "lucide-react";
+import { Loader2, Package, Plus, Sparkles } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 
@@ -27,6 +27,8 @@ import { useAssetImageSourceSelection } from "@/lib/queries/character-image-sele
 import { useAssetFocus } from "@/hooks/use-asset-focus";
 import { StageProgressPanel } from "@/components/stage-progress-panel";
 import { Button } from "@/components/ui/button";
+import { SUBTLE_HEADER_ACTION_BUTTON_CLASS } from "@/components/ui/header-action-styles";
+import { HeaderRefreshButton } from "@/components/ui/header-refresh-button";
 import {
   Tooltip,
   TooltipContent,
@@ -54,6 +56,7 @@ import { Textarea } from "@/components/ui/textarea";
 import { useTaskController } from "@/hooks/use-task-controller";
 import { propReferenceAssetScope } from "@/lib/task-scope";
 import { backendErrorToastMessage } from "@/lib/api-errors";
+import { cn } from "@/lib/utils";
 import {
   useBatchGeneratePropReferences,
   useCreateProp,
@@ -420,22 +423,25 @@ export function PropsPanel({
     <div className="flex min-h-0 flex-1 flex-col overflow-hidden bg-background">
       <AssetHeaderActions>
         <CharacterImageSourceSelect project={project} kind="prop" />
-        <Button
-          size="sm"
-          variant="outline"
-          onClick={async () => { await props.refetch(); toast.success(t("common.refreshed")); }}
+        <HeaderRefreshButton
+          label={t("common.refresh")}
+          onRefresh={async () => {
+            const result = await props.refetch();
+            if (result.isError) {
+              toast.error(t("common.error"));
+              return false;
+            }
+            return true;
+          }}
+          refreshing={props.isRefetching}
           data-props-refresh
-          className="h-8 gap-1.5 rounded-[8px] border-white/10 bg-transparent px-3 text-xs font-normal shadow-none transition-transform hover:bg-white/[0.04] active:scale-95 dark:bg-transparent"
-        >
-          <RefreshCw className="size-3.5" />
-          {t("common.refresh")}
-        </Button>
+        />
         <Button
           variant="outline"
           size="sm"
           onClick={handleBatchGenerate}
           disabled={batchGenerate.isPending}
-          className="relative h-8 gap-1.5 rounded-[8px] border-white/10 bg-transparent px-3 text-xs font-normal shadow-none hover:bg-white/[0.04] dark:bg-transparent"
+          className={cn(SUBTLE_HEADER_ACTION_BUTTON_CLASS, "relative")}
         >
           {batchGenerate.isPending ? (
             <Loader2 className="size-3.5 animate-spin" />

--- a/frontend/src/components/assets/scene-asset-card.tsx
+++ b/frontend/src/components/assets/scene-asset-card.tsx
@@ -23,6 +23,7 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import { UsageCountBadge } from "@/components/assets/usage-count-badge";
+import { ASSET_CARD_META_BADGE_CLASS } from "@/components/assets/asset-card-styles";
 import { CopyAssetLinkButton } from "@/components/assets/copy-asset-link-button";
 import { CreditCostInline } from "@/components/credit-cost-inline";
 import { resolveMediaUrl } from "@/lib/media-url";
@@ -224,24 +225,29 @@ export function SceneAssetCard({
               {/* Compact status chips inline with title */}
               <div className="flex shrink-0 flex-wrap items-center gap-1">
                 {scene.scene_type && (
-                  <span className="rounded-[4px] border border-border bg-background/40 px-1 py-0 text-[10px] text-muted-foreground">
+                  <span className={ASSET_CARD_META_BADGE_CLASS}>
                     {sceneTypeLabel(scene.scene_type)}
                   </span>
                 )}
                 {derivedBase && (
-                  <span className="rounded-[4px] border border-sky-500/30 bg-sky-500/10 px-1 py-0 text-[10px] text-sky-700 dark:text-sky-300">
+                  <span
+                    className={cn(
+                      ASSET_CARD_META_BADGE_CLASS,
+                      "border-sky-500/30 bg-sky-500/10 text-sky-700 dark:text-sky-300",
+                    )}
+                  >
                     {t("assets.scenes.derivedFrom", { base: derivedBase })}
                   </span>
                 )}
-                <span className="rounded-[4px] border border-border bg-background/40 px-1 py-0 text-[10px] text-muted-foreground">
+                <span className={ASSET_CARD_META_BADGE_CLASS}>
                   {t("assets.scenes.master")}{" "}
                   {hasMaster ? t("assets.common.generated") : t("assets.common.missing")}
                 </span>
-                <span className="rounded-[4px] border border-border bg-background/40 px-1 py-0 text-[10px] text-muted-foreground">
+                <span className={ASSET_CARD_META_BADGE_CLASS}>
                   {t("assets.scenes.reverse")}{" "}
                   {hasReverse ? t("assets.common.generated") : t("assets.common.missing")}
                 </span>
-                <span className="rounded-[4px] border border-border bg-background/40 px-1 py-0 text-[10px] text-muted-foreground">
+                <span className={ASSET_CARD_META_BADGE_CLASS}>
                   {t("assets.scenes.pano")}{" "}
                   {hasPano ? t("assets.common.generated") : t("assets.common.missing")}
                 </span>

--- a/frontend/src/components/assets/scenes-panel.tsx
+++ b/frontend/src/components/assets/scenes-panel.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Elastic-2.0
 // Copyright (c) 2026 ClaymoreLab
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { Loader2, Map, Plus, RefreshCw, Sparkles } from "lucide-react";
+import { Loader2, Map, Plus, Sparkles } from "lucide-react";
 import { useQueryClient } from "@tanstack/react-query";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
@@ -42,6 +42,8 @@ import {
 } from "@/lib/api-errors";
 import { CreditCostInline } from "@/components/credit-cost-inline";
 import { Button } from "@/components/ui/button";
+import { SUBTLE_HEADER_ACTION_BUTTON_CLASS } from "@/components/ui/header-action-styles";
+import { HeaderRefreshButton } from "@/components/ui/header-refresh-button";
 import { EMPTY_STATE_ACTION_BUTTON_CLASS } from "@/components/ui/empty-state-styles";
 import {
   Dialog,
@@ -1269,19 +1271,19 @@ export function ScenesPanel({
     <div className="flex min-h-0 flex-1 flex-col overflow-hidden bg-background">
       <AssetHeaderActions>
         <CharacterImageSourceSelect project={project} kind="scene" />
-        <Button
-          size="sm"
-          variant="outline"
-          onClick={async () => {
-            await scenes.refetch();
-            toast.success(t("common.refreshed"));
+        <HeaderRefreshButton
+          label={t("common.refresh")}
+          onRefresh={async () => {
+            const result = await scenes.refetch();
+            if (result.isError) {
+              toast.error(t("common.error"));
+              return false;
+            }
+            return true;
           }}
+          refreshing={scenes.isRefetching}
           data-scenes-refresh
-          className="h-8 gap-1.5 rounded-[8px] border-white/10 bg-transparent px-3 text-xs font-normal shadow-none transition-transform hover:bg-white/[0.04] active:scale-95 dark:bg-transparent"
-        >
-          <RefreshCw className="size-3.5" />
-          {t("common.refresh")}
-        </Button>
+        />
         <Button
           variant="outline"
           size="sm"
@@ -1290,7 +1292,7 @@ export function ScenesPanel({
             setDraftSeed(null);
             setDialogOpen(true);
           }}
-          className="h-8 gap-1.5 rounded-[8px] border-white/10 bg-transparent px-3 text-xs font-normal shadow-none hover:bg-white/[0.04] dark:bg-transparent"
+          className={SUBTLE_HEADER_ACTION_BUTTON_CLASS}
         >
           <Plus className="size-3.5" />
           {t("assets.scenes.newScene")}

--- a/frontend/src/components/assets/usage-count-badge.tsx
+++ b/frontend/src/components/assets/usage-count-badge.tsx
@@ -4,6 +4,7 @@ import { Film } from "lucide-react";
 import { useTranslation } from "react-i18next";
 
 import { cn } from "@/lib/utils";
+import { ASSET_CARD_META_BADGE_CLASS } from "@/components/assets/asset-card-styles";
 
 /**
  * Compact "used in N beats" indicator for asset cards. Renders nothing when the
@@ -23,7 +24,7 @@ export function UsageCountBadge({
   return (
     <span
       className={cn(
-        "inline-flex items-center gap-1 rounded-[6px] border border-border bg-background/40 px-1.5 py-0.5 text-[11px] text-muted-foreground",
+        ASSET_CARD_META_BADGE_CLASS,
         className,
       )}
     >

--- a/frontend/src/components/layout/project-header-navigation.tsx
+++ b/frontend/src/components/layout/project-header-navigation.tsx
@@ -165,7 +165,7 @@ export function ProjectXiajiMenu({ project }: { project: string }) {
     <div className="flex justify-center px-4 pb-2">
       <nav
         aria-label={t("nav.xiajiMenu")}
-        className="flex items-center gap-3 whitespace-nowrap rounded-full border border-white/[0.08] bg-white/[0.04] px-3.5 py-[3px] text-sidebar-foreground"
+        className="flex items-center gap-3 whitespace-nowrap rounded-full border border-white/[0.08] bg-white/[0.04] px-3.5 py-0.5 text-sidebar-foreground"
       >
         {xiajiMenuItems.map((item) => {
           const target =
@@ -250,7 +250,7 @@ export function ProjectHeaderNavigation({ project }: { project: string }) {
   return (
     <nav
       aria-label={t("nav.creationMode")}
-      className="absolute left-1/2 top-1/2 z-30 flex -translate-x-1/2 translate-y-[calc(-50%+4px)] items-center"
+      className="absolute left-1/2 top-1/2 z-30 flex -translate-x-1/2 -translate-y-1/2 items-center"
     >
       <div className="relative flex h-8 items-center rounded-full bg-white/[0.07]">
         <span

--- a/frontend/src/components/task-center/status-bar.tsx
+++ b/frontend/src/components/task-center/status-bar.tsx
@@ -110,15 +110,6 @@ export function TaskStatusBar({ onOpenPikoStation }: TaskStatusBarProps) {
       onKeyDown={onBarKeyDown}
     >
       <div className="flex min-w-0 items-center gap-1.5">
-        <span
-          className="shrink-0 bg-gradient-to-r from-cyan-200 via-violet-200 to-rose-200 bg-clip-text font-medium tabular-nums text-transparent opacity-90"
-          title={APP_VERSION}
-        >
-          {APP_VERSION}
-        </span>
-        <span className="shrink-0 text-muted-foreground/45" aria-hidden>
-          ·
-        </span>
         <span className="inline-flex shrink-0 items-center gap-1 text-muted-foreground/90">
           <ChevronUp
             className={cn(
@@ -211,6 +202,12 @@ export function TaskStatusBar({ onOpenPikoStation }: TaskStatusBarProps) {
             {t(`taskCenter.statusBar.${health}`)}
           </span>
           <span aria-hidden="true">{t(`taskCenter.statusBar.${health}`)}</span>
+        </span>
+        <span
+          className="shrink-0 font-normal tabular-nums text-muted-foreground"
+          title={APP_VERSION}
+        >
+          {APP_VERSION}
         </span>
         <RegionBadge />
       </div>

--- a/frontend/src/components/themed-toaster.tsx
+++ b/frontend/src/components/themed-toaster.tsx
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: Elastic-2.0
+// Copyright (c) 2026 ClaymoreLab
+import type { CSSProperties } from "react";
+import { useRouterState } from "@tanstack/react-router";
+import { Toaster } from "sonner";
+
+import { projectSectionFromPath } from "@/components/layout/project-navigation-routes";
+
+const APP_HEADER_HEIGHT = 48;
+const XIAJI_SUBNAV_ROW_HEIGHT = 42;
+const TOAST_SAFE_GAP = 12;
+
+export function ThemedToaster() {
+  const pathname = useRouterState({ select: (state) => state.location.pathname });
+  const projectSection = projectSectionFromPath(pathname);
+  const isAppRoute = pathname === "/" || pathname.startsWith("/projects/");
+  const hasXiajiSubnav = projectSection !== null && projectSection !== "freezone";
+  const topOffset = isAppRoute
+    ? APP_HEADER_HEIGHT + (hasXiajiSubnav ? XIAJI_SUBNAV_ROW_HEIGHT : 0) + TOAST_SAFE_GAP
+    : 24;
+
+  return (
+    <Toaster
+      position="top-center"
+      theme="dark"
+      closeButton={false}
+      duration={2200}
+      visibleToasts={1}
+      offset={topOffset}
+      toastOptions={{
+        style: {
+          "--width": "auto",
+          minWidth: 0,
+        } as CSSProperties,
+        className:
+          "!min-h-0 !rounded-sm !border !border-white/10 !bg-white/[0.06] !px-4 !py-2 !text-sm !text-white/80 !shadow-none",
+      }}
+    />
+  );
+}

--- a/frontend/src/components/ui/header-action-styles.ts
+++ b/frontend/src/components/ui/header-action-styles.ts
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: Elastic-2.0
+// Copyright (c) 2026 ClaymoreLab
+
+/**
+ * Page-header secondary actions share one quiet visual hierarchy: transparent
+ * surface, a translucent white border, and restrained hover/press feedback.
+ */
+export const SUBTLE_HEADER_ACTION_BUTTON_CLASS =
+  "h-8 gap-1.5 rounded-[8px] border-white/10 bg-transparent px-3 text-xs font-normal shadow-none transition-[background-color,border-color,transform] hover:border-white/15 hover:bg-white/[0.04] active:scale-95 dark:border-white/10 dark:bg-transparent dark:hover:border-white/15 dark:hover:bg-white/[0.04]";

--- a/frontend/src/components/ui/header-refresh-button.tsx
+++ b/frontend/src/components/ui/header-refresh-button.tsx
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: Elastic-2.0
+// Copyright (c) 2026 ClaymoreLab
+import { useState, type ComponentProps } from "react";
+import { Check, Loader2, RefreshCw } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import { toast } from "sonner";
+
+import { Button } from "@/components/ui/button";
+import { SUBTLE_HEADER_ACTION_BUTTON_CLASS } from "@/components/ui/header-action-styles";
+import { useTransientConfirmation } from "@/hooks/use-transient-confirmation";
+import { cn } from "@/lib/utils";
+
+type HeaderRefreshButtonProps = Omit<
+  ComponentProps<typeof Button>,
+  "children" | "disabled" | "onClick" | "size" | "variant"
+> & {
+  label: string;
+  onRefresh: () => Promise<boolean>;
+  refreshing: boolean;
+  disabled?: boolean;
+};
+
+export function HeaderRefreshButton({
+  label,
+  onRefresh,
+  refreshing,
+  disabled = false,
+  className,
+  ...buttonProps
+}: HeaderRefreshButtonProps) {
+  const { t } = useTranslation();
+  const confirmation = useTransientConfirmation();
+  const [locallyPending, setLocallyPending] = useState(false);
+  const pending = refreshing || locallyPending;
+  const confirmationLabel = t("common.refreshDone");
+
+  return (
+    <Button
+      {...buttonProps}
+      variant="outline"
+      size="sm"
+      onClick={async () => {
+        if (pending) return;
+        confirmation.clearConfirmation();
+        setLocallyPending(true);
+        try {
+          if (await onRefresh()) confirmation.showConfirmation();
+        } catch {
+          toast.error(t("common.error"));
+        } finally {
+          setLocallyPending(false);
+        }
+      }}
+      disabled={disabled || pending}
+      className={cn(SUBTLE_HEADER_ACTION_BUTTON_CLASS, className)}
+    >
+      {pending ? (
+        <Loader2 className="size-3.5 animate-spin" aria-hidden="true" />
+      ) : confirmation.confirmed ? (
+        <Check className="size-3.5" aria-hidden="true" />
+      ) : (
+        <RefreshCw className="size-3.5" aria-hidden="true" />
+      )}
+      <span className="grid" aria-live="polite">
+        <span
+          className="invisible col-start-1 row-start-1"
+          aria-hidden="true"
+        >
+          {label}
+        </span>
+        <span
+          className="invisible col-start-1 row-start-1"
+          aria-hidden="true"
+        >
+          {confirmationLabel}
+        </span>
+        <span className="col-start-1 row-start-1">
+          {confirmation.confirmed ? confirmationLabel : label}
+        </span>
+      </span>
+    </Button>
+  );
+}

--- a/frontend/src/hooks/use-transient-confirmation.ts
+++ b/frontend/src/hooks/use-transient-confirmation.ts
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: Elastic-2.0
+// Copyright (c) 2026 ClaymoreLab
+import { useCallback, useEffect, useRef, useState } from "react";
+
+export function useTransientConfirmation(duration = 1400) {
+  const [confirmed, setConfirmed] = useState(false);
+  const timerRef = useRef<number | null>(null);
+
+  const clearConfirmation = useCallback(() => {
+    if (timerRef.current !== null) window.clearTimeout(timerRef.current);
+    timerRef.current = null;
+    setConfirmed(false);
+  }, []);
+
+  const showConfirmation = useCallback(() => {
+    if (timerRef.current !== null) window.clearTimeout(timerRef.current);
+    setConfirmed(true);
+    timerRef.current = window.setTimeout(() => {
+      setConfirmed(false);
+      timerRef.current = null;
+    }, duration);
+  }, [duration]);
+
+  useEffect(
+    () => () => {
+      if (timerRef.current !== null) window.clearTimeout(timerRef.current);
+    },
+    [],
+  );
+
+  return { clearConfirmation, confirmed, showConfirmation };
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -3,7 +3,6 @@
 import { StrictMode } from "react";
 import { RouterProvider, createRouter } from "@tanstack/react-router";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { Toaster } from "sonner";
 import { routeTree } from "./routeTree.gen";
 import { ThemeProvider } from "./components/theme-provider";
 import { loadClusterConfig } from "@/lib/cluster-config";
@@ -72,27 +71,6 @@ declare module "@tanstack/react-router" {
   }
 }
 
-function ThemedToaster() {
-  return (
-    <Toaster
-      position="top-center"
-      theme="dark"
-      closeButton={false}
-      duration={2200}
-      visibleToasts={1}
-      offset={24}
-      toastOptions={{
-        style: {
-          "--width": "auto",
-          minWidth: 0,
-        } as React.CSSProperties,
-        className:
-          "!py-2 !px-4 !text-sm !min-h-0 !bg-white/[0.06] !border !border-white/10 !rounded-sm !shadow-none !text-white/80",
-      }}
-    />
-  );
-}
-
 // Give the api module a handle to the QueryClient so its 400 no_region
 // handler can fan out a full cache purge via resetRegionState().
 setApiQueryClient(queryClient);
@@ -121,7 +99,6 @@ async function bootstrap() {
       <QueryClientProvider client={queryClient}>
         <ThemeProvider>
           <AppRouterShell />
-          <ThemedToaster />
         </ThemeProvider>
       </QueryClientProvider>
     </StrictMode>,

--- a/frontend/src/routes/__root.tsx
+++ b/frontend/src/routes/__root.tsx
@@ -4,6 +4,7 @@ import { createRootRoute, Outlet, useRouterState, type ErrorComponentProps } fro
 import { useEffect, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import { AppUpdateRequired } from "@/components/app-update-required";
+import { ThemedToaster } from "@/components/themed-toaster";
 import { isChunkLoadError } from "@/lib/chunk-load-recovery";
 
 /**
@@ -32,6 +33,7 @@ function RootLayout() {
     <>
       <RouteFocusManager />
       <Outlet />
+      <ThemedToaster />
     </>
   );
 }

--- a/frontend/src/routes/_app/projects.$project/characters.lazy.tsx
+++ b/frontend/src/routes/_app/projects.$project/characters.lazy.tsx
@@ -106,6 +106,7 @@ import {
 } from "@/lib/character-main-copy";
 import type { FreezonePresetCanvasRequest } from "@/api/canvas";
 import { Button } from "@/components/ui/button";
+import { SUBTLE_HEADER_ACTION_BUTTON_CLASS } from "@/components/ui/header-action-styles";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Progress } from "@/components/ui/progress";
@@ -589,7 +590,7 @@ function CharactersPageHeader({
               variant="outline"
               size="sm"
               onClick={onAdd}
-              className="h-8 gap-1.5 rounded-[8px] border-white/10 bg-transparent px-3 text-xs font-normal shadow-none hover:bg-white/[0.04] dark:bg-transparent"
+              className={SUBTLE_HEADER_ACTION_BUTTON_CLASS}
             >
               <Plus className="size-3.5" />
               {t("characters.addCharacter")}

--- a/frontend/src/routes/_app/projects.$project/episodes.tsx
+++ b/frontend/src/routes/_app/projects.$project/episodes.tsx
@@ -21,7 +21,6 @@ import {
   MapPinned,
   Package,
   Play,
-  RefreshCw,
   Sparkles,
   Users,
   type LucideIcon,
@@ -65,6 +64,8 @@ import { StageProgressPanel } from "@/components/stage-progress-panel";
 import { CreditCostInline } from "@/components/credit-cost-inline";
 import { EpisodeListSkeleton } from "@/components/skeletons";
 import { Button } from "@/components/ui/button";
+import { SUBTLE_HEADER_ACTION_BUTTON_CLASS } from "@/components/ui/header-action-styles";
+import { HeaderRefreshButton } from "@/components/ui/header-refresh-button";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -270,7 +271,7 @@ function TopBar({
   planPending: boolean;
   planCostDisplay?: string | null;
   showRefresh: boolean;
-  onRefresh: () => void;
+  onRefresh: () => Promise<boolean>;
   refreshPending: boolean;
   selectedEpisode: Episode | null;
   episodes: Episode[];
@@ -331,20 +332,11 @@ function TopBar({
       </div>
       <div className="flex shrink-0 flex-wrap items-center gap-2 lg:justify-end">
         {showRefresh && (
-          <Button
-            variant="ghost"
-            size="sm"
-            onClick={onRefresh}
-            disabled={refreshPending}
-            className="h-8 gap-1.5 rounded-[8px] px-3 text-xs font-normal shadow-none hover:bg-white/[0.04]"
-          >
-            {refreshPending ? (
-              <Loader2 className="size-3.5 animate-spin" />
-            ) : (
-              <RefreshCw className="size-3.5" />
-            )}
-            {t("episode.list.refresh")}
-          </Button>
+          <HeaderRefreshButton
+            label={t("episode.list.refresh")}
+            onRefresh={onRefresh}
+            refreshing={refreshPending}
+          />
         )}
         {showReplan && (
           <Button
@@ -391,7 +383,7 @@ function TopBar({
             variant="outline"
             size="sm"
             onClick={onBack}
-            className="h-8 gap-1.5 rounded-[8px] border-white/10 bg-transparent px-3 text-xs font-normal shadow-none hover:bg-white/[0.04] dark:bg-transparent"
+            className={SUBTLE_HEADER_ACTION_BUTTON_CLASS}
           >
             <ArrowLeft className="size-3.5" />
             {t("episode.list.backToEpisodes")}
@@ -941,9 +933,10 @@ function EpisodesPage() {
         );
       }
       await Promise.all(invalidations);
-      toast.success(t("episode.list.refreshed"));
+      return true;
     } catch {
       toast.error(t("common.error"));
+      return false;
     }
   };
 

--- a/frontend/src/routes/_app/projects.$project/styles.tsx
+++ b/frontend/src/routes/_app/projects.$project/styles.tsx
@@ -15,7 +15,6 @@ import {
   Pencil,
   Paintbrush,
   Plus,
-  RefreshCw,
   Save,
   Sparkles,
   Trash2,
@@ -31,6 +30,7 @@ import {
 } from "@/lib/queries/styles";
 import { useProject, useUpdateProject } from "@/lib/queries/projects";
 import { Button } from "@/components/ui/button";
+import { HeaderRefreshButton } from "@/components/ui/header-refresh-button";
 import {
   Dialog,
   DialogContent,
@@ -209,7 +209,7 @@ function Section({
 
 // ─── Top bar ────────────────────────────────────────────────────────────────
 
-function TopBar({ onCreate, onRefresh, refreshing }: { onCreate: () => void; onRefresh: () => Promise<void>; refreshing: boolean }) {
+function TopBar({ onCreate, onRefresh, refreshing }: { onCreate: () => void; onRefresh: () => Promise<boolean>; refreshing: boolean }) {
   const { t } = useTranslation();
 
   return (
@@ -229,20 +229,11 @@ function TopBar({ onCreate, onRefresh, refreshing }: { onCreate: () => void; onR
       </div>
 
       <div className="flex shrink-0 flex-wrap items-center gap-2 lg:justify-end">
-        <Button
-          variant="outline"
-          size="sm"
-          onClick={onRefresh}
-          disabled={refreshing}
-          className="h-8 gap-1.5 rounded-[8px] border-white/10 bg-transparent px-3 text-xs font-normal shadow-none transition-transform hover:bg-white/[0.04] active:scale-95 dark:bg-transparent"
-        >
-          {refreshing ? (
-            <Loader2 className="size-3.5 animate-spin" />
-          ) : (
-            <RefreshCw className="size-3.5" />
-          )}
-          {t("common.refresh")}
-        </Button>
+        <HeaderRefreshButton
+          label={t("common.refresh")}
+          onRefresh={onRefresh}
+          refreshing={refreshing}
+        />
         <Button
           size="sm"
           onClick={onCreate}
@@ -973,7 +964,16 @@ function StylesPage() {
 
   return (
     <div className="-m-6 flex h-[calc(100%+3rem)] flex-col overflow-hidden">
-      <TopBar onCreate={() => setCreateOpen(true)} onRefresh={async () => { await refetch(); toast.success(t("common.refreshed")); }} refreshing={isRefetching} />
+      <TopBar
+        onCreate={() => setCreateOpen(true)}
+        onRefresh={async () => {
+          const result = await refetch();
+          if (!result.isError) return true;
+          toast.error(t("common.error"));
+          return false;
+        }}
+        refreshing={isRefetching}
+      />
 
       <div className="flex min-h-0 flex-1 flex-col lg:flex-row">
         {/* LEFT: list */}

--- a/license-inventory.csv
+++ b/license-inventory.csv
@@ -319,6 +319,8 @@ frontend/src/__tests__/components/task-center/task-detail.test.tsx,Elastic-2.0,2
 frontend/src/__tests__/components/task-center/task-list.test.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/__tests__/components/task-center/task-logs.test.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/__tests__/components/task-center/task-row.test.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
+frontend/src/__tests__/components/themed-toaster.test.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
+frontend/src/__tests__/components/ui/header-refresh-button.test.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/__tests__/features/canvas/asset-drag-director-bundle.test.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/__tests__/features/canvas/asset-drag-hydrate.test.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/__tests__/features/canvas/audio-music-settings.test.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
@@ -546,6 +548,7 @@ frontend/src/components/account/avatar-upload-dialog.tsx,Elastic-2.0,2026 SuperT
 frontend/src/components/app-update-available.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/components/app-update-required.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/components/assets/asset-beat-references.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
+frontend/src/components/assets/asset-card-styles.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/components/assets/asset-header-actions-slot.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/components/assets/asset-search-box.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/components/assets/character-image-source-select.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
@@ -688,6 +691,7 @@ frontend/src/components/task-center/task-logs.tsx,Elastic-2.0,2026 SuperTale con
 frontend/src/components/task-center/task-row.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/components/theme-provider.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/components/theme-toggle.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
+frontend/src/components/themed-toaster.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/components/ui/alert-dialog.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/components/ui/avatar.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/components/ui/badge.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
@@ -697,6 +701,8 @@ frontend/src/components/ui/checkbox.tsx,Elastic-2.0,2026 SuperTale contributors,
 frontend/src/components/ui/dialog.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/components/ui/dropdown-menu.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/components/ui/empty-state-styles.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
+frontend/src/components/ui/header-action-styles.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
+frontend/src/components/ui/header-refresh-button.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/components/ui/index.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/components/ui/input.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/components/ui/label.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
@@ -1030,6 +1036,7 @@ frontend/src/hooks/use-selection.ts,Elastic-2.0,2026 SuperTale contributors,REUS
 frontend/src/hooks/use-stage-task.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/hooks/use-task-controller.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/hooks/use-task-stream.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
+frontend/src/hooks/use-transient-confirmation.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/hooks/use-view-toggles.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/i18n/index.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/index.css,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation


### PR DESCRIPTION
## 概述

统一各页头部的「刷新」交互与反馈,并抽离 Toaster 组件,使导航反馈在整个应用内一致。以 UI 一致性重构为主,不涉及后端 / 数据逻辑。

## 主要改动

- **新增 `HeaderRefreshButton`**:统一刷新按钮的 loading / 完成(内联打勾 1.4s)/ 失败(toast)反馈;`onRefresh` 契约改为 `() => Promise<boolean>`(成功 `true`、失败 `false`)。
- **新增 `useTransientConfirmation` hook**:短暂确认态,计时器带 cleanup。
- **接入页**:`episodes` / `styles` / `props-panel` 改用统一刷新按钮,返回值同步为 `Promise<boolean>`;刷新成功不再每次弹 toast,改为按钮内联反馈。
- **Toaster 抽离为 `ThemedToaster`**:从 `main.tsx`(router 外)移入 `__root.tsx`(router 内),因其依赖 `useRouterState` 按当前路由动态计算 top offset,避免压住 header / 虾集子导航。
- **状态栏版本号**:从左下角(渐变色)移至右侧健康状态之后,样式改为低调灰。显示逻辑不变。
- **头部导航 / 素材卡片**:统一 `SUBTLE_HEADER_ACTION_BUTTON_CLASS` 样式,像素级对齐微调。
- i18n 新增 `common.refreshDone`(EN `Done` / ZH `已刷新`)。

## 验证

- `tsc -b` ✅ 通过
- `pnpm build` ✅ 通过
- 相关单测 ✅ 3 文件 / 12 用例通过(`themed-toaster` / `header-refresh-button` / `status-bar`)

## 备注

- DCO 已签署。
- 本 PR 未修复线上版本号显示为构建指纹(`260715-ce-a12dbeb`)的问题——该根因在云端构建流水线(`VITE_APP_VERSION` 注入了指纹而非 release tag),本 PR 仅调整了版本号在状态栏的位置与样式。

🤖 Generated with [Claude Code](https://claude.com/claude-code)