### PR TITLE
fix(version): 本地兜底版本号从 git tag 派生

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -17,14 +17,29 @@ function datePrefix(d: Date = new Date()): string {
   return `${yy}${mm}${dd}-`;
 }
 
-// The human-facing version, shown in the status bar. CI sets VITE_APP_VERSION
-// from the release tag; every other build shows the default. It is display-only
-// — never compare it across deploys (two builds can legitimately carry the same
+// The human-facing version, shown in the status bar. It is display-only —
+// never compare it across deploys (two builds can legitimately carry the same
 // version string), that's what BUILD_ID below is for.
-const DEFAULT_APP_VERSION = "v1.0.9";
+// Resolution order:
+//   1. VITE_APP_VERSION — set by release CI from the tag.
+//   2. the nearest git tag (`git describe --tags --abbrev=0`) — so a local
+//      checkout shows the SAME version the release stamped, automatically,
+//      once you pull the code that carries the new tag. No manual bump needed.
+//   3. DEFAULT_APP_VERSION — last resort for a git-less build (source tarball).
+const DEFAULT_APP_VERSION = "v1.1.0";
 
 function resolveAppVersion(): string {
-  return process.env.VITE_APP_VERSION || DEFAULT_APP_VERSION;
+  if (process.env.VITE_APP_VERSION) return process.env.VITE_APP_VERSION;
+  try {
+    const tag = execSync("git describe --tags --abbrev=0", {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+    if (tag) return tag;
+  } catch {
+    // not a git checkout, or no tags — fall through to the constant
+  }
+  return DEFAULT_APP_VERSION;
 }
 
 // The deploy fingerprint. MUST differ between any two builds, because the


### PR DESCRIPTION
## 问题

状态栏版本号(`APP_VERSION`)在没有 `VITE_APP_VERSION` 注入时,回落到 `vite.config.ts` 里的硬编码常量 `DEFAULT_APP_VERSION = "v1.0.9"`。发布 v1.1.0 时该常量没同步更新,导致**本地开发拉了最新代码后仍显示 v1.0.9**,与线上(CI 从 tag 注入 → 1.1.0)不一致。

## 改动

`resolveAppVersion()` 解析顺序改为:

1. `VITE_APP_VERSION` env —— 线上 release CI 从 tag 注入(不变)
2. **最近的 git tag**(`git describe --tags --abbrev=0`)—— 本地开发自动读到当前 tag
3. `DEFAULT_APP_VERSION` 常量 —— 仅 git-less(源码 tarball)最后兜底,顺带更到 `v1.1.0`

这样线上发新版打 tag 后,本地 `git pull` 拉到带新 tag 的代码、重启 dev server,版本号即自动与线上一致,无需再手动 bump 常量或传 env。

## 验证

- `tsc -b` ✅ / `pnpm build` ✅
- 浏览器实测:dev 下编译后 `APP_VERSION === "v1.1.0"`
- 构建产物 `dist/version.json` → `{"version":"v1.1.0",...}`(无 env 注入,纯 tag 派生)

## 备注

- 版本号在 dev server **启动时**解析一次,`git pull` 后需**重启**才刷新(不热更)。
- 本 PR 不影响线上显示逻辑(env 优先级最高);线上 `dramaclaw.cdnfg.com` 显示构建指纹(如 `260715-ce-a12dbeb`)是另一问题——其云端私有流水线把指纹塞进了 `VITE_APP_VERSION`,需在那边改为传 release tag。

🤖 Generated with [Claude Code](https://claude.com/claude-code)