### PR TITLE
feat(canvas): 历史资产不再限制每类只显示 20 条

### DIFF
--- a/frontend/src/features/canvas/ui/CanvasHistoryAssetsModal.tsx
+++ b/frontend/src/features/canvas/ui/CanvasHistoryAssetsModal.tsx
@@ -65,17 +65,14 @@ const GENERATIVE_HISTORY_NODE_TYPES = new Set<string>([
   CANVAS_NODE_TYPES.threeDWorld,
 ]);
 
-// Cap how many recent records each tab shows. Records arrive newest-first
-// (backend sorts by recorded_at desc), so slicing keeps the latest.
-const HISTORY_DISPLAY_CAP = 20;
-
 /**
  * Map backend generation-history records into the asset-card shape the modal
  * already renders. Only completed records that carry a usable output url for an
  * image/video/audio surface; `recorded_at` drives date grouping (fixing the
  * old "未知日期" bucketing that the live-canvas scrape produced). Deduped by
- * (kind,url) so a restored/duplicated output shows once, then each kind is
- * capped to the {@link HISTORY_DISPLAY_CAP} most recent.
+ * (kind,url) so a restored/duplicated output shows once. No per-tab display cap
+ * — every record the backend returns (up to its own fetch limit) is shown, so
+ * the history browser never silently hides older assets.
  */
 /**
  * 可选的「节点元信息」解析器:用一条记录的 `node_id` 回到 live 画布,取该(世界)节点
@@ -154,12 +151,7 @@ export function recordsToAssetBuckets(
       timestamp: Number.isNaN(ts) ? null : ts,
     });
   }
-  return {
-    image: buckets.image.slice(0, HISTORY_DISPLAY_CAP),
-    video: buckets.video.slice(0, HISTORY_DISPLAY_CAP),
-    audio: buckets.audio.slice(0, HISTORY_DISPLAY_CAP),
-    model: buckets.model.slice(0, HISTORY_DISPLAY_CAP),
-  };
+  return buckets;
 }
 
 const TAB_ORDER: CanvasAssetKind[] = ['image', 'video', 'audio', 'model'];


### PR DESCRIPTION
## 背景

历史资产弹窗对图片 / 视频 / 音频 / 世界历史四个 tab 各自 `slice(0, 20)`，超过 20 条的旧资产被静默隐藏（tab 上恒显 `(20)`）。用户反馈"最多显示 20 条，不够，不要做数量限制"。

## 改动

`frontend/src/features/canvas/ui/CanvasHistoryAssetsModal.tsx`:
- 删除 `HISTORY_DISPLAY_CAP = 20` 常量
- `recordsToAssetBuckets` 直接返回 `buckets`，去掉四处 `.slice(0, 20)`

现在每个 tab 展示后端返回的全部记录，tab 计数显示真实总数。

## 边界说明

前端侧已彻底无限制。唯一天花板在上游取数：canvas 聚合接口 `fetchCanvasGenerationHistory` 默认 `limit=500`，对展示等同无限制。去重（by kind+url）与 completed 过滤逻辑不变。

## 验证

- `tsc -b` 通过
- `pnpm build` 通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)