### PR TITLE
feat(canvas): 一键隐藏/显示画布连线（仅视觉，连线保留）

### DIFF
--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -2709,7 +2709,9 @@
       "lock": "Lock Canvas",
       "unlock": "Unlock Canvas",
       "organize": "Organize / Locate Canvas",
-      "organizeShortcut": "⌥⇧F"
+      "organizeShortcut": "⌥⇧F",
+      "hideEdges": "Hide connections",
+      "showEdges": "Show connections"
     },
     "quickbar": {
       "addNode": "Add Node",

--- a/frontend/public/locales/zh/translation.json
+++ b/frontend/public/locales/zh/translation.json
@@ -2709,7 +2709,9 @@
       "lock": "锁定画布",
       "unlock": "解锁画布",
       "organize": "整理 / 定位画布",
-      "organizeShortcut": "⌥⇧F"
+      "organizeShortcut": "⌥⇧F",
+      "hideEdges": "隐藏连线",
+      "showEdges": "显示连线"
     },
     "quickbar": {
       "addNode": "添加节点",

--- a/frontend/src/features/canvas/Canvas.tsx
+++ b/frontend/src/features/canvas/Canvas.tsx
@@ -112,6 +112,7 @@ import { NodeToolDialog } from './ui/NodeToolDialog';
 import { ImageViewerModal } from './ui/ImageViewerModal';
 import { VideoViewerModal } from './ui/VideoViewerModal';
 import { CanvasZoomControl } from './ui/CanvasZoomControl';
+import { useEdgeVisibilityStore } from './ui/edgeVisibilityStore';
 import { CanvasQuickActionBar } from './ui/CanvasQuickActionBar';
 import { BackToNodesHint } from './ui/BackToNodesHint';
 import { CanvasMinimapButton } from './ui/CanvasMinimapButton';
@@ -976,6 +977,9 @@ export function Canvas({
 
   const nodes = useCanvasStore((state) => state.nodes);
   const edges = useCanvasStore((state) => state.edges);
+  // 连线可见性：隐藏时只给 ReactFlow 的边打 `hidden`，真实 edges 一动不动（见
+  // edgeVisibilityStore）。持久化/自动布局/导出全部照用 store 里的真实连线。
+  const edgesHidden = useEdgeVisibilityStore((state) => state.hidden);
 
   // 预取 beat-context 节点引用到的剧集 beats/episode-detail,焐热缓存。配合 BeatContextNode
   // 里「仅选中时才查询」的门控,避免视口虚拟化下节点挂载即请求、卸载即被取消的 499 循环。
@@ -1093,6 +1097,13 @@ export function Canvas({
       };
     });
   }, [nodes, placementConfirmNodeId]);
+
+  // 隐藏连线时给每条边补 `hidden: true`——ReactFlow 会跳过渲染但边仍在图里，
+  // 连接、reconnect、持久化都不受影响。显示时直接透传真实 edges，零额外分配。
+  const renderedEdges = useMemo(() => {
+    if (!edgesHidden) return edges;
+    return edges.map((edge) => (edge.hidden ? edge : { ...edge, hidden: true }));
+  }, [edges, edgesHidden]);
 
   const clearMarqueeSelection = useCallback(() => {
     marqueeSelectionRef.current = null;
@@ -4507,7 +4518,7 @@ export function Canvas({
     >
       <ReactFlow
         nodes={renderedNodes}
-        edges={edges}
+        edges={renderedEdges}
         onNodesChange={handleNodesChange}
         onEdgesChange={handleEdgesChange}
         onEdgeClick={handleEdgeClick}

--- a/frontend/src/features/canvas/ui/CanvasZoomControl.tsx
+++ b/frontend/src/features/canvas/ui/CanvasZoomControl.tsx
@@ -1,13 +1,14 @@
 // SPDX-License-Identifier: Elastic-2.0
 // Copyright (c) 2026 ClaymoreLab
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { Wand2 } from 'lucide-react';
+import { Waypoints, Wand2 } from 'lucide-react';
 import { useReactFlow, useViewport } from '@xyflow/react';
 import { useTranslation } from 'react-i18next';
 
 import { isImmersiveViewerActive } from '@/features/viewer-kit/useViewerImmersiveBody';
 import { MOD_KEY_LABEL } from '@/lib/platform';
 import { CANVAS_CONTROL_GLASS_CLASS } from './canvasControlStyles';
+import { useEdgeVisibilityStore } from './edgeVisibilityStore';
 
 const ZOOM_STEP = 1.2;
 const ZOOM_MIN = 0.1;
@@ -39,6 +40,9 @@ export function CanvasZoomControl({
   const { zoomTo, getZoom, fitView } = useReactFlow();
   const { zoom } = useViewport();
   const { t } = useTranslation();
+
+  const edgesHidden = useEdgeVisibilityStore((state) => state.hidden);
+  const toggleEdgesHidden = useEdgeVisibilityStore((state) => state.toggle);
 
   const percent = Math.round(zoom * 100);
 
@@ -119,6 +123,9 @@ export function CanvasZoomControl({
   };
 
   const organizeTitle = `${t('canvas.toolbar.organize')} ${t('canvas.toolbar.organizeShortcut')}`;
+  const edgesToggleTitle = edgesHidden
+    ? t('canvas.toolbar.showEdges')
+    : t('canvas.toolbar.hideEdges');
   const isTop = placement === 'top-right';
 
   const menuItemClass =
@@ -135,6 +142,29 @@ export function CanvasZoomControl({
       <div
         className={`flex items-center gap-0.5 rounded-full px-1 py-0.5 text-text ${CANVAS_CONTROL_GLASS_CLASS}`}
       >
+        <span className="group relative inline-flex">
+          <button
+            type="button"
+            onClick={toggleEdgesHidden}
+            className={`flex h-5 w-5 items-center justify-center rounded-full transition ${
+              edgesHidden
+                ? 'bg-white/[0.16] text-text'
+                : 'text-text-muted hover:bg-white/10 hover:text-text'
+            }`}
+            aria-label={edgesToggleTitle}
+            aria-pressed={edgesHidden}
+          >
+            <Waypoints className="h-3 w-3" />
+          </button>
+          <span
+            className={`pointer-events-none absolute left-1/2 -translate-x-1/2 whitespace-nowrap rounded-md border border-[rgba(255,255,255,0.12)] bg-bg-dark/95 px-2 py-1 text-[11px] text-text-dark opacity-0 shadow-lg transition-opacity duration-100 group-hover:opacity-100 ${
+              isTop ? 'top-full mt-1.5' : 'bottom-full mb-1.5'
+            }`}
+          >
+            {edgesToggleTitle}
+          </span>
+        </span>
+        <span className="mx-0.5 h-3 w-px bg-white/10" aria-hidden />
         <span className="group relative inline-flex">
           <button
             type="button"

--- a/frontend/src/features/canvas/ui/edgeVisibilityStore.ts
+++ b/frontend/src/features/canvas/ui/edgeVisibilityStore.ts
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: Elastic-2.0
+// Copyright (c) 2026 ClaymoreLab
+import { create } from 'zustand';
+
+// 连线可见性：仅控制画布是否**渲染**节点之间的连线。连线数据始终保留在
+// canvas store 里（隐藏时给 ReactFlow 的边打 `hidden` 标记，不动真实 edges），
+// 所以隐藏纯粹是视觉层面的，切回来连线原样还在、持久化/导出也不受影响。
+// 独立成一个轻量 store，避免和 canvas 内容 store 混在一起——订阅它的按钮与
+// Canvas 派生逻辑不会因节点/边的内容变动而额外重渲染。
+
+const STORAGE_KEY = 'canvas.edges.hidden';
+
+function readPersistedHidden(): boolean {
+  if (typeof window === 'undefined') return false;
+  try {
+    return window.localStorage.getItem(STORAGE_KEY) === '1';
+  } catch {
+    return false;
+  }
+}
+
+function persistHidden(value: boolean): void {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(STORAGE_KEY, value ? '1' : '0');
+  } catch {
+    // localStorage 写不进去就算了，下次进来从默认值开始。
+  }
+}
+
+interface EdgeVisibilityState {
+  hidden: boolean;
+  toggle: () => void;
+}
+
+export const useEdgeVisibilityStore = create<EdgeVisibilityState>((set, get) => ({
+  hidden: readPersistedHidden(),
+  toggle: () => {
+    const next = !get().hidden;
+    persistHidden(next);
+    set({ hidden: next });
+  },
+}));

--- a/license-inventory.csv
+++ b/license-inventory.csv
@@ -911,6 +911,7 @@ frontend/src/features/canvas/ui/ZoomScaledToolbar.tsx,Elastic-2.0,2026 SuperTale
 frontend/src/features/canvas/ui/canvas-node-menu-shared.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/features/canvas/ui/canvasControlStyles.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/features/canvas/ui/closeButtonStyles.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
+frontend/src/features/canvas/ui/edgeVisibilityStore.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/features/canvas/ui/multi-angle-sphere.css,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/features/canvas/ui/nodeControlStyles.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/features/canvas/ui/nodeFrameStyles.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation


### PR DESCRIPTION
## 需求
在虾画画布右下角「整理画布」左侧加一个图标按钮，点击可显示/隐藏节点间的连线。**隐藏只是画布不绘制连线，连线数据真实存在。**

## 实现
- 右下角缩放胶囊内、整理画布(魔杖)左侧新增 `Waypoints`(连线)图标按钮，带 tooltip「隐藏连线 / 显示连线」，激活态高亮
- 隐藏为**纯视觉层**：Canvas 派生 `renderedEdges`，隐藏时给每条边补 `hidden: true` 交给 ReactFlow 跳过渲染；`useCanvasStore` 里的真实 `edges` 一动不动 —— 连接、reconnect、自动布局、持久化、导出全部照用真实连线
- 独立轻量 store `edgeVisibilityStore`，开关状态存 localStorage(`canvas.edges.hidden`)，刷新后保留；不与 canvas 内容 store 耦合，订阅方不会因节点/边变动而额外重渲染
- 中英文案已加(`canvas.toolbar.hideEdges` / `showEdges`)

## 验证
- `tsc -b` + `pnpm build` 通过
- 本地点击按钮：连线隐藏/恢复正常，期间连线关系始终真实存在(切回原样还在)；刷新后开关状态保留

🤖 Generated with [Claude Code](https://claude.com/claude-code)