### PR TITLE
feat(login): 桌面端下载按钮接入真实安装包地址

### DIFF
--- a/frontend/src/components/login/cinematic/LoginCinematicHero.tsx
+++ b/frontend/src/components/login/cinematic/LoginCinematicHero.tsx
@@ -7,8 +7,9 @@ import Aurora from "@/components/react-bits/aurora";
 import SplitText from "@/components/react-bits/split-text";
 import { PRODUCT_MANUAL_URL } from "@/lib/product-manual";
 import {
-  DESKTOP_DOWNLOAD_URL,
+  FALLBACK_DOWNLOAD_URL,
   detectDesktopPlatform,
+  resolveDesktopDownloadUrl,
   type DesktopPlatform,
 } from "@/lib/desktop-download";
 import styles from "@/components/login/login.module.css";
@@ -54,6 +55,47 @@ function useGithubStars(repo: string): number {
   return stars;
 }
 
+let cachedDownloadUrls: Record<DesktopPlatform, string> | null = null;
+
+/**
+ * 按钮初始指向 GitHub Releases 兜底(永远可点),挂载后解析 CDN 上的版本
+ * 指针(latest*.yml)原地替换成当前安装包直链;解析失败保持兜底。模块级
+ * 缓存与 useGithubStars 同款:同一次会话只解析一遍。
+ */
+function useDesktopDownloadUrls(): Record<DesktopPlatform, string> {
+  const [urls, setUrls] = useState<Record<DesktopPlatform, string>>(
+    cachedDownloadUrls ?? {
+      mac: FALLBACK_DOWNLOAD_URL,
+      windows: FALLBACK_DOWNLOAD_URL,
+    },
+  );
+
+  useEffect(() => {
+    if (cachedDownloadUrls !== null) return;
+    let active = true;
+    Promise.all(
+      (["mac", "windows"] as const).map(
+        async (os) => [os, await resolveDesktopDownloadUrl(os)] as const,
+      ),
+    ).then((entries) => {
+      const next: Record<DesktopPlatform, string> = {
+        mac: FALLBACK_DOWNLOAD_URL,
+        windows: FALLBACK_DOWNLOAD_URL,
+      };
+      for (const [os, url] of entries) {
+        if (url) next[os] = url;
+      }
+      cachedDownloadUrls = next;
+      if (active) setUrls(next);
+    });
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  return urls;
+}
+
 function GithubMark() {
   return (
     <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
@@ -86,6 +128,7 @@ function WindowsMark() {
 function DesktopDownload() {
   const { t } = useTranslation();
   const [platform, setPlatform] = useState<DesktopPlatform>("mac");
+  const downloadUrls = useDesktopDownloadUrls();
 
   // Detect after mount so a cached/prerendered shell can't bake in the wrong
   // platform's ordering.
@@ -119,7 +162,7 @@ function DesktopDownload() {
               <a
                 key={os}
                 className={styles.desktopDownloadItem}
-                href={DESKTOP_DOWNLOAD_URL[os]}
+                href={downloadUrls[os]}
                 download
               >
                 <Mark />

--- a/frontend/src/lib/desktop-download.test.ts
+++ b/frontend/src/lib/desktop-download.test.ts
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: Elastic-2.0
+// Copyright (c) 2026 ClaymoreLab
+import { describe, expect, it } from "vitest";
+
+import {
+  detectDesktopPlatform,
+  pickInstallerFromManifest,
+} from "./desktop-download";
+
+// 与发布流水线产出的 electron-updater 清单同形状(url 字段带版本号文件名)。
+const WINDOWS_MANIFEST = `version: 1.1.0
+files:
+  - url: DramaClaw-Setup-1.1.0.exe
+    sha512: occFiM5M3gMp2RqWdM+5Fjw==
+    size: 883116200
+path: DramaClaw-Setup-1.1.0.exe
+sha512: occFiM5M3gMp2RqWdM+5Fjw==
+releaseDate: '2026-07-15T08:45:34.419Z'
+`;
+
+// macOS 清单同时列 zip(自动更新载体)与 dmg(首装载体)。
+const MAC_MANIFEST = `version: 1.1.0
+files:
+  - url: DramaClaw-1.1.0-arm64.zip
+    sha512: Bw4uOHg/lIXnqAlOKsuZMw==
+    size: 1003619976
+  - url: DramaClaw-1.1.0-arm64.dmg
+    sha512: 5xw1uPGkX0Yl3m2n4o5p6q==
+    size: 969342976
+path: DramaClaw-1.1.0-arm64.zip
+sha512: Bw4uOHg/lIXnqAlOKsuZMw==
+releaseDate: '2026-07-15T08:45:34.419Z'
+`;
+
+describe("pickInstallerFromManifest", () => {
+  it("picks the .exe from the Windows manifest", () => {
+    expect(pickInstallerFromManifest(WINDOWS_MANIFEST, "windows")).toBe(
+      "DramaClaw-Setup-1.1.0.exe",
+    );
+  });
+
+  it("picks the .dmg (not the auto-update .zip) from the mac manifest", () => {
+    expect(pickInstallerFromManifest(MAC_MANIFEST, "mac")).toBe(
+      "DramaClaw-1.1.0-arm64.dmg",
+    );
+  });
+
+  it("returns null when the wanted installer type is absent", () => {
+    expect(pickInstallerFromManifest(WINDOWS_MANIFEST, "mac")).toBeNull();
+    expect(pickInstallerFromManifest("", "windows")).toBeNull();
+  });
+});
+
+describe("detectDesktopPlatform", () => {
+  it("classifies Windows user agents", () => {
+    expect(
+      detectDesktopPlatform("Mozilla/5.0 (Windows NT 10.0; Win64; x64)"),
+    ).toBe("windows");
+  });
+
+  it("falls back to mac for everything else", () => {
+    expect(
+      detectDesktopPlatform("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)"),
+    ).toBe("mac");
+    expect(detectDesktopPlatform("")).toBe("mac");
+  });
+});

--- a/frontend/src/lib/desktop-download.ts
+++ b/frontend/src/lib/desktop-download.ts
@@ -3,15 +3,62 @@
 /**
  * Desktop installer downloads offered on the login hero.
  *
- * TODO(wx): 换成真实的安装包地址（OSS / GitHub Releases 均可）。在此之前按钮
- * 指向占位地址，先把版式和样式定下来。
+ * 安装包文件名带版本号(如 DramaClaw-Setup-1.1.0.exe),写死必随发版腐烂。
+ * 发布流水线维护着一对"当前版本指针"—— electron-updater 的 latest.yml /
+ * latest-mac.yml(CDN 对 *.yml 零缓存,即发即新)。这里按需解析指针拿到
+ * 当前安装包的真实文件名;文件名从清单的 url: 字段取,绝不自拼版本号,
+ * 将来命名模式变化时本文件无需跟改。
  */
 export type DesktopPlatform = "mac" | "windows";
 
-export const DESKTOP_DOWNLOAD_URL: Record<DesktopPlatform, string> = {
-  mac: "#download-mac-placeholder",
-  windows: "#download-windows-placeholder",
+const DOWNLOAD_BASE = "https://dramaclaw-dl.cdnfg.com/desktop/";
+
+const MANIFEST: Record<DesktopPlatform, string> = {
+  mac: "latest-mac.yml",
+  windows: "latest.yml",
 };
+
+// latest-mac.yml 同时列出 zip(自动更新的载体)与 dmg(首次安装的载体),
+// 官网必须发 dmg;Windows 清单里只有 exe。
+const INSTALLER_EXT: Record<DesktopPlatform, string> = {
+  mac: ".dmg",
+  windows: ".exe",
+};
+
+/**
+ * 指针解析失败(断网、CDN 故障、清单格式漂移)时的兜底:GitHub Releases
+ * 页含全部平台资产,慢但可达,按钮永远不会点了没反应。
+ */
+export const FALLBACK_DOWNLOAD_URL =
+  "https://github.com/dramaclaw/dramaclaw/releases/latest";
+
+/** 从 electron-updater 清单文本里挑出目标平台的安装包文件名。 */
+export function pickInstallerFromManifest(
+  manifest: string,
+  platform: DesktopPlatform,
+): string | null {
+  const ext = INSTALLER_EXT[platform];
+  for (const match of manifest.matchAll(/url:\s*(\S+)/g)) {
+    if (match[1].endsWith(ext)) return match[1];
+  }
+  return null;
+}
+
+/** 解析当前版本安装包的 CDN 直链;任何一步失败都返回 null(调用方走兜底)。 */
+export async function resolveDesktopDownloadUrl(
+  platform: DesktopPlatform,
+): Promise<string | null> {
+  try {
+    const res = await fetch(DOWNLOAD_BASE + MANIFEST[platform], {
+      cache: "no-store",
+    });
+    if (!res.ok) return null;
+    const file = pickInstallerFromManifest(await res.text(), platform);
+    return file ? DOWNLOAD_BASE + encodeURIComponent(file) : null;
+  } catch {
+    return null;
+  }
+}
 
 /**
  * Which installer to feature as the filled primary button. Falls back to macOS

--- a/license-inventory.csv
+++ b/license-inventory.csv
@@ -1049,6 +1049,7 @@ frontend/src/lib/character-main-copy.ts,Elastic-2.0,2026 SuperTale contributors,
 frontend/src/lib/chunk-load-recovery.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/lib/cluster-config.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/lib/derive-beat-states.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
+frontend/src/lib/desktop-download.test.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/lib/desktop-download.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/lib/dev-backend-watch.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/lib/dialog-styles.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation

--- a/sbom.spdx.json
+++ b/sbom.spdx.json
@@ -7,7 +7,7 @@
     ]
   },
   "dataLicense": "CC0-1.0",
-  "documentNamespace": "https://supertale.local/spdx/supertale-ce/d9183bc256d69dfb",
+  "documentNamespace": "https://supertale.local/spdx/supertale-ce/3fa29490b8b19059",
   "name": "supertale-ce-p0b-sbom",
   "packages": [
     {
@@ -18,7 +18,7 @@
       "licenseConcluded": "Elastic-2.0",
       "licenseDeclared": "Elastic-2.0",
       "name": "supertale-ce",
-      "versionInfo": "1.0.7"
+      "versionInfo": "1.1.0"
     },
     {
       "SPDXID": "SPDXRef-Package-aiofiles",


### PR DESCRIPTION
## PR 类型 / Type of PR

- [ ] 🐞 Bug 修复 / Bug fix
- [x] ✨ 新功能 / Feature
- [ ] 📝 文档 / Documentation
- [ ] 🧹 重构 / 清理 / Refactor or cleanup
- [ ] ⚙️ 构建 / CI / Build or CI
- [ ] ⚠️ 破坏性变更 / Breaking change

## 改动说明 / What this PR does and why

登录页右上角「桌面端」下拉的 macOS / Windows 按钮此前指向占位锚点(`#download-*-placeholder`),本 PR 接入真实安装包地址。

安装包文件名带版本号(如 `DramaClaw-Setup-1.1.0.exe`),写死必随发版腐烂。发布产物旁维护着 electron-updater 的版本指针 `latest.yml` / `latest-mac.yml`(分发 CDN 对 `*.yml` 零缓存,即发即新),故:

- **初始 href 指向 GitHub Releases 兜底** —— 指针解析失败(断网 / CDN 故障)时按钮永远可点;
- **挂载后解析指针**取当前安装包文件名(取清单 `url:` 字段,不自拼版本号,命名模式变化时前端无需跟改),原地替换为 CDN 直链;
- macOS 清单同时列 zip(自动更新载体)与 dmg(首装载体),官网发 **dmg**;
- 解析结果模块级缓存,与页内 GitHub star 数的实现同款。

## 测试 / Tests

- 新增 `desktop-download.test.ts`:清单解析(win 取 exe / mac 取 dmg 不取 zip / 缺失返回 null)+ UA 识别,5 例全过
- `pnpm build` 通过
- CDN 侧 CORS 已配置并实测生效(`access-control-allow-origin: *`)

## 给 reviewer 的说明 / Notes for the reviewer

指针 fetch 是跨子域请求,依赖对象存储的 CORS 规则(已上线);安装包下载本身是导航跳转,不受 CORS 约束。