### PR TITLE
fix: rename NewAPI media models

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -197,11 +197,11 @@ STAGING_PROP_TIMEOUT_SECONDS=120
 # 5. newAPI 图片模型
 # =============================================================================
 
-# DC-Image-2 逻辑模型；gpt-image-2/image-2 类模型会按场景透传 quality。
-NEWAPI_IMAGE_MODEL=gpt-image-2
+# LingShan-G2 逻辑模型；image2 类模型会按场景透传 quality。
+NEWAPI_IMAGE_MODEL=LingShan-G2
 
-# DC-Banana-2 逻辑模型；nano-banana-2/nb-2 不透传 quality。
-NEWAPI_NANOBANANA2_MODEL=nano-banana-2
+# LingShan-NB-2 逻辑模型；nano-banana/nb 类模型不透传 quality。
+NEWAPI_NANOBANANA2_MODEL=LingShan-NB-2
 
 # 角色图默认模型。
 DEFAULT_CHARACTER_IMAGE_SELECTION=newapi_gpt_image2
@@ -214,19 +214,19 @@ DEFAULT_RENDER_IMAGE_SELECTION=newapi_gpt_image2
 
 # 项目资产 / 道具三视图参考图 reference_3view.png。
 PROP_REF_IMAGE_PROVIDER=newapi
-PROP_REF_IMAGE_MODEL=gpt-image-2
+PROP_REF_IMAGE_MODEL=LingShan-G2
 
 # 项目资产 / 源图 master.png，纯文本生成。
 SCENE_MASTER_IMAGE_PROVIDER=newapi
-SCENE_MASTER_IMAGE_MODEL=nano-banana-2
+SCENE_MASTER_IMAGE_MODEL=LingShan-NB-2
 
 # 项目资产 / reverse_master.png，使用 master.png 作为参考图。
 SCENE_REVERSE_MASTER_IMAGE_PROVIDER=newapi
-SCENE_REVERSE_MASTER_IMAGE_MODEL=nano-banana-2
+SCENE_REVERSE_MASTER_IMAGE_MODEL=LingShan-NB-2
 
 # 项目资产 / pano_360.png，使用 master/reverse 参考图，2:1 全景。
 SCENE_360_IMAGE_PROVIDER=newapi
-SCENE_360_IMAGE_MODEL=gpt-image-2
+SCENE_360_IMAGE_MODEL=LingShan-G2
 
 
 # =============================================================================
@@ -246,7 +246,7 @@ IMAGE_DEFAULT_STYLE=chinese_period_drama
 VIDEO_BACKEND=newapi_seedance-1.0-pro-fast
 
 # 页面可选的 newAPI 视频模型。
-NEWAPI_VIDEO_MODELS=seedance-1.0-pro-fast,seedance-1.5-pro,seedance-2.0,seedance-2.0-fast,seedance-2.0-value,seedance-2.0-fast-value,happyhorse-1.0,grok-video-channel
+NEWAPI_VIDEO_MODELS=seedance-1.0-pro-fast,seedance-1.5-pro,seedance-2.0,seedance-2.0-fast,seedance-2.0-value,seedance-2.0-fast-value,happyhorse-1.0
 
 # 默认视频模型。
 DEFAULT_VIDEO_MODEL=seedance-1.0-pro-fast
@@ -262,7 +262,7 @@ NEWAPI_VIDEO_GENERATE_AUDIO=auto
 NEWAPI_VIDEO_AUDIO_MODELS=seedance-1.5-pro,seedance-2.0,seedance-2.0-fast,seedance-2.0-value,seedance-2.0-fast-value
 
 # 各视频模型允许的 duration 范围，单位秒。
-NEWAPI_VIDEO_DURATION_BOUNDS=seedance-1.0-pro-fast:2-12,seedance-1.5-pro:4-12,seedance-2.0:4-15,seedance-2.0-fast:4-15,seedance-2.0-value:4-15,seedance-2.0-fast-value:4-15,happyhorse-1.0:3-15,grok-video-channel:6-30
+NEWAPI_VIDEO_DURATION_BOUNDS=seedance-1.0-pro-fast:2-12,seedance-1.5-pro:4-12,seedance-2.0:4-15,seedance-2.0-fast:4-15,seedance-2.0-value:4-15,seedance-2.0-fast-value:4-15,happyhorse-1.0:3-15
 
 
 # =============================================================================
@@ -271,7 +271,7 @@ NEWAPI_VIDEO_DURATION_BOUNDS=seedance-1.0-pro-fast:2-12,seedance-1.5-pro:4-12,se
 
 # beat 音频生成使用 IndexTTS2；参考声线按 v2.0 逻辑传入。
 INDEXTTS2_PROVIDER=newapi
-INDEXTTS2_NEWAPI_MODEL=index-tts-2
+INDEXTTS2_NEWAPI_MODEL=LingShan-TTS-2
 
 # 音频生成 HTTP 超时时间，单位秒。
 INDEXTTS2_TIMEOUT_SECONDS=1800

--- a/frontend/src/__tests__/components/assets/props-panel.ce.test.tsx
+++ b/frontend/src/__tests__/components/assets/props-panel.ce.test.tsx
@@ -39,7 +39,7 @@ vi.mock("@/lib/queries/character-image-selection", () => ({
       data: {
         asset_kind: "prop",
         image_source_selection: "newapi_gpt_image2",
-        options: { newapi_gpt_image2: "DC-Image-2" },
+        options: { newapi_gpt_image2: "LingShan-G2" },
       },
     },
     isLoading: false,

--- a/frontend/src/__tests__/lib/queries/character-image-selection.test.tsx
+++ b/frontend/src/__tests__/lib/queries/character-image-selection.test.tsx
@@ -144,8 +144,8 @@ describe("character image selection query hooks", () => {
               asset_kind: "scene",
               image_source_selection: "newapi_gpt_image2",
               options: {
-                newapi_gpt_image2: "DC-Image-2",
-                newapi_nanobanana2: "DC-Banana-2",
+                newapi_gpt_image2: "LingShan-G2",
+                newapi_nanobanana2: "LingShan-NB-2",
               },
             },
           });
@@ -182,8 +182,8 @@ describe("character image selection query hooks", () => {
               asset_kind: "prop",
               image_source_selection: "newapi_nanobanana2",
               options: {
-                newapi_gpt_image2: "DC-Image-2",
-                newapi_nanobanana2: "DC-Banana-2",
+                newapi_gpt_image2: "LingShan-G2",
+                newapi_nanobanana2: "LingShan-NB-2",
               },
             },
           });

--- a/frontend/src/__tests__/routes/characters.ce.test.tsx
+++ b/frontend/src/__tests__/routes/characters.ce.test.tsx
@@ -90,7 +90,7 @@ vi.mock("@/lib/queries/character-image-selection", () => ({
       data: {
         asset_kind: "character",
         image_source_selection: "newapi_gpt_image2",
-        options: { newapi_gpt_image2: "DC-Image-2" },
+        options: { newapi_gpt_image2: "LingShan-G2" },
       },
     },
     isLoading: false,

--- a/frontend/src/api/ops.ts
+++ b/frontend/src/api/ops.ts
@@ -1896,7 +1896,7 @@ export async function submitFreezoneAudioSpeech(
 
 /**
  * 文本生成音乐请求。除 input 外全部可选，不传走后端默认。
- * model / response_format / output_format 不需要前端传（走后端默认 eleven-music / mp3 /
+ * model / response_format / output_format 不需要前端传（走后端默认 LingShan-MU-11 / mp3 /
  * mp3_44100_128），故不在此暴露。
  */
 export interface FreezoneAudioMusicPayload {
@@ -1914,7 +1914,7 @@ export interface FreezoneAudioMusicPayload {
 }
 
 /**
- * 文本生成音乐（eleven-music）。返回异步任务句柄，结果用
+ * 文本生成音乐。返回异步任务句柄，结果用
  * fetchFreezoneJobResult('freezone_audio_eleven_music') 取。
  */
 export async function submitFreezoneAudioMusic(

--- a/frontend/src/components/settings/settings-dialog.tsx
+++ b/frontend/src/components/settings/settings-dialog.tsx
@@ -664,16 +664,15 @@ const MEDIA_MODEL_ROWS: readonly {
   kind: "image" | "video" | "audio";
   officialOnly?: boolean;
 }[] = [
-  { model: "gpt-image-2", kind: "image" },
-  { model: "nano-banana-2", kind: "image" },
+  { model: "LingShan-G2", kind: "image" },
+  { model: "LingShan-NB-2", kind: "image" },
   { model: "seedance-1.0-pro-fast", kind: "video" },
   { model: "seedance-1.5-pro", kind: "video" },
   { model: "seedance-2.0", kind: "video" },
   { model: "seedance-2.0-fast", kind: "video" },
   { model: "happyhorse-1.0", kind: "video" },
-  { model: "grok-video-channel", kind: "video" },
-  { model: "index-tts-2", kind: "audio" },
-  { model: "eleven-music", kind: "audio" },
+  { model: "LingShan-TTS-2", kind: "audio" },
+  { model: "LingShan-MU-11", kind: "audio" },
   { model: "seedance-2.0-value", kind: "video", officialOnly: true },
   { model: "seedance-2.0-fast-value", kind: "video", officialOnly: true },
 ];

--- a/frontend/src/features/canvas/nodes/ImageGenNode.tsx
+++ b/frontend/src/features/canvas/nodes/ImageGenNode.tsx
@@ -237,7 +237,7 @@ const IMAGE_PARAM_ROW_CLASS = 'mb-4 flex gap-2';
 const NODE_COUNT_OPTION_BASE_CLASS =
   'flex w-full items-center justify-center rounded-[6px] px-3 py-1.5 text-xs transition-colors';
 
-// 「画质」选项只对 image2 系模型（DC-Image-2 / gpt-image-2 等）生效，
+// 「画质」选项只对 image2 系模型（LingShan-G2 / gpt-image-2 等）生效，
 // 后端也只在 gpt-image-2 上识别该字段。其余模型隐藏该选择器。
 function isImage2Model(apiModel: string | null | undefined): boolean {
   return /image[-_]?2/i.test(apiModel ?? '');
@@ -382,7 +382,7 @@ export const ImageGenNode = memo(({ id, data, selected, width, height }: ImageGe
   // `DEFAULT_SHARED_MODEL_ID` (`huimeng/gpt-image-2`), which is normally NOT in
   // the live `/freezone/image/models` list. Trusting it blindly is the bug:
   // ProviderModelPicker silently falls back to showing `availableModels[0]`
-  // (e.g. DC-Image-2) when the id isn't found, while submit resolves the stale
+  // (e.g. LingShan-G2) when the id isn't found, while submit resolves the stale
   // id through SHARED_MODELS to `huimeng_gpt_image2` — display ≠ value sent.
   // Reconciling here keeps them in lockstep: an unknown persisted id falls back
   // to the first live model (exactly what the picker shows).

--- a/frontend/src/features/canvas/ui/ProviderModelPicker.tsx
+++ b/frontend/src/features/canvas/ui/ProviderModelPicker.tsx
@@ -138,15 +138,6 @@ export const VIDEO_MODELS: ModelOption[] = [
     minDuration: 2,
     maxDuration: 12,
   },
-  {
-    id: 'newapi_grok-video-channel',
-    providerId: 'huimeng',
-    apiModel: 'newapi_grok-video-channel',
-    label: 'Grok Video Channel',
-    resolutionOptions: ['720p', '480p'],
-    minDuration: 6,
-    maxDuration: 30,
-  },
 ];
 
 // Matches the backend `FreezoneVideoGenRequest.model` default. The picker

--- a/src/novelvideo/api/routes/model_credits.py
+++ b/src/novelvideo/api/routes/model_credits.py
@@ -61,7 +61,7 @@ def _clean_quantity(value: object) -> int:
 def _image_model_supports_quality(model: str) -> bool:
     model_name = str(model or "").strip().lower()
     return (
-        model_name in {"gpt-image-2", "image-2", "image-2-official"}
+        model_name in {"lingshan-g2", "gpt-image-2", "image-2", "image-2-official"}
         or "gpt-image" in model_name
     )
 
@@ -232,7 +232,7 @@ def _generation_credit_cost_model(kind: str, value: str) -> str:
 
         return INDEXTTS2_RECORD_MODEL.strip()
     if kind == "freezone_audio_music":
-        return "eleven-music"
+        return "LingShan-MU-11"
     if kind == "freezone_image_reverse_prompt":
         from novelvideo.config import get_newapi_text_model_name
 

--- a/src/novelvideo/api/routes/model_gateway.py
+++ b/src/novelvideo/api/routes/model_gateway.py
@@ -43,15 +43,15 @@ router = APIRouter(prefix="/model-gateway")
 
 
 CUSTOM_MEDIA_MODEL_NAMES = {
-    "gpt-image-2",
-    "nano-banana-2",
+    "LingShan-G2",
+    "LingShan-NB-2",
     "seedance-1.0-pro-fast",
     "seedance-1.5-pro",
     "seedance-2.0",
     "seedance-2.0-fast",
     "happyhorse-1.0",
-    "index-tts-2",
-    "eleven-music",
+    "LingShan-TTS-2",
+    "LingShan-MU-11",
 }
 OFFICIAL_ONLY_MEDIA_MODEL_NAMES = {
     "seedance-2.0-value",

--- a/src/novelvideo/api/schemas.py
+++ b/src/novelvideo/api/schemas.py
@@ -1467,7 +1467,7 @@ class FreezoneAudioMusicRequest(BaseModel):
         description="音乐描述 prompt。",
         examples=["cinematic rain-soaked suspense music"],
     )
-    model: str = Field(default="eleven-music", description="音乐模型，默认 eleven-music。")
+    model: str = Field(default="LingShan-MU-11", description="音乐模型，默认 LingShan-MU-11。")
     response_format: Literal["mp3", "opus", "pcm", "ulaw", "alaw"] = Field(
         default="mp3",
         description="音频返回格式。mp3 会自动映射为 mp3_44100_128。",

--- a/src/novelvideo/config.py
+++ b/src/novelvideo/config.py
@@ -559,11 +559,11 @@ def get_newapi_runtime_credentials(
     return api_key, base_url
 
 
-INDEXTTS2_NEWAPI_MODEL = os.environ.get("INDEXTTS2_NEWAPI_MODEL", "index-tts-2")
+INDEXTTS2_NEWAPI_MODEL = os.environ.get("INDEXTTS2_NEWAPI_MODEL", "LingShan-TTS-2")
 INDEXTTS2_RECORD_PROVIDER = "newapi" if INDEXTTS2_PROVIDER == "newapi" else "fal.ai"
 INDEXTTS2_RECORD_MODEL = INDEXTTS2_NEWAPI_MODEL if INDEXTTS2_PROVIDER == "newapi" else "IndexTTS2"
-NEWAPI_IMAGE_MODEL = os.environ.get("NEWAPI_IMAGE_MODEL", "gpt-image-2")
-NEWAPI_NANOBANANA2_MODEL = os.environ.get("NEWAPI_NANOBANANA2_MODEL", "nano-banana-2")
+NEWAPI_IMAGE_MODEL = os.environ.get("NEWAPI_IMAGE_MODEL", "LingShan-G2")
+NEWAPI_NANOBANANA2_MODEL = os.environ.get("NEWAPI_NANOBANANA2_MODEL", "LingShan-NB-2")
 SCENE_MASTER_IMAGE_PROVIDER = (
     os.environ.get("SCENE_MASTER_IMAGE_PROVIDER", "").strip().lower() or "newapi"
 )
@@ -806,7 +806,7 @@ def _csv_env(name: str, default: str) -> list[str]:
 # newAPI 视频网关。VIDEO_BACKEND 使用 newapi_<model> 时会通过 NEWAPI_BASE_URL 调用。
 NEWAPI_VIDEO_MODELS = _csv_env(
     "NEWAPI_VIDEO_MODELS",
-    "seedance-1.0-pro-fast,seedance-1.5-pro,seedance-2.0,seedance-2.0-fast,seedance-2.0-value,seedance-2.0-fast-value,happyhorse-1.0,grok-video-channel",
+    "seedance-1.0-pro-fast,seedance-1.5-pro,seedance-2.0,seedance-2.0-fast,seedance-2.0-value,seedance-2.0-fast-value,happyhorse-1.0",
 )
 DEFAULT_VIDEO_MODEL = os.environ.get(
     "DEFAULT_VIDEO_MODEL",
@@ -820,7 +820,7 @@ NEWAPI_VIDEO_AUDIO_MODELS = _csv_env(
 )
 NEWAPI_VIDEO_DURATION_BOUNDS = os.environ.get(
     "NEWAPI_VIDEO_DURATION_BOUNDS",
-    "seedance-1.0-pro-fast:2-12,seedance-1.5-pro:4-12,seedance-2.0:4-15,seedance-2.0-fast:4-15,seedance-2.0-value:4-15,seedance-2.0-fast-value:4-15,happyhorse-1.0:3-15,grok-video-channel:6-30",
+    "seedance-1.0-pro-fast:2-12,seedance-1.5-pro:4-12,seedance-2.0:4-15,seedance-2.0-fast:4-15,seedance-2.0-value:4-15,seedance-2.0-fast-value:4-15,happyhorse-1.0:3-15",
 ).strip()
 
 # 视频生成后端: newapi_seedance-1.0-pro-fast (默认), newapi_seedance-2.0-fast,
@@ -973,12 +973,12 @@ IMAGE_GENERATION_SELECTIONS: dict[str, dict[str, str]] = {
         "model": OPENROUTER_NANOBANANA2_MODEL,
     },
     "newapi_gpt_image2": {
-        "label": "DC-Image-2",
+        "label": "LingShan-G2",
         "provider": "newapi",
         "model": NEWAPI_IMAGE_MODEL,
     },
     "newapi_nanobanana2": {
-        "label": "DC-Banana-2",
+        "label": "LingShan-NB-2",
         "provider": "newapi",
         "model": NEWAPI_NANOBANANA2_MODEL,
     },

--- a/src/novelvideo/freezone/audio_node.py
+++ b/src/novelvideo/freezone/audio_node.py
@@ -592,7 +592,7 @@ async def generate_freezone_audio_eleven_music(
     respect_sections_durations: bool = True,
     output_format: str = "mp3_44100_128",
     response_format: str = "mp3",
-    model: str = "eleven-music",
+    model: str = "LingShan-MU-11",
 ) -> FreezoneAudioSpeechResult:
     """Generate standalone Freezone music through NewAPI's audio/speech endpoint."""
     clean_prompt = str(prompt or "").strip()
@@ -614,7 +614,7 @@ async def generate_freezone_audio_eleven_music(
         "output_format": str(output_format or "mp3_44100_128").strip() or "mp3_44100_128",
     }
 
-    model_name = str(model or "eleven-music").strip() or "eleven-music"
+    model_name = str(model or "LingShan-MU-11").strip() or "LingShan-MU-11"
     reservation_id = ""
     try:
         reservation_id = await _reserve_music_model_call(
@@ -645,6 +645,6 @@ async def generate_freezone_audio_eleven_music(
         duration_ms=_duration_ms(output_path) or length,
         mime_type=_audio_mime_type(fmt),
         model=model_name,
-        voice_source="eleven-music",
+        voice_source=model_name,
         voice_sha256="",
     )

--- a/src/novelvideo/freezone/video_node.py
+++ b/src/novelvideo/freezone/video_node.py
@@ -112,8 +112,8 @@ FREEZONE_NEWAPI_VIDEO_BACKENDS = {
     "newapi_seedance-1.0-pro-fast",
     "newapi_seedance-1.5-pro",
     "newapi_happyhorse-1.0",
-    "newapi_grok-video-channel",
 }
+FREEZONE_DISABLED_VIDEO_BACKENDS = {"newapi_grok-video-channel"}
 
 
 def get_video_camera_templates() -> list[dict[str, str]]:
@@ -252,7 +252,6 @@ def _freezone_newapi_video_options() -> dict[str, str]:
         if key in FREEZONE_NEWAPI_VIDEO_BACKENDS
     }
     options.setdefault("newapi_happyhorse-1.0", "HappyHorse 1.0")
-    options.setdefault("newapi_grok-video-channel", "Grok Video Channel")
     if FREEZONE_DEFAULT_VIDEO_BACKEND not in options:
         return options
     ordered = {FREEZONE_DEFAULT_VIDEO_BACKEND: options[FREEZONE_DEFAULT_VIDEO_BACKEND]}
@@ -309,6 +308,8 @@ def resolve_freezone_video_backend(model: str | None) -> str:
         )
     if text in options:
         return text
+    if text in FREEZONE_DISABLED_VIDEO_BACKENDS:
+        raise ValueError(f"unknown video model: {text}")
 
     folded = text.casefold()
     for backend, label in options.items():
@@ -324,7 +325,7 @@ def resolve_freezone_video_backend(model: str | None) -> str:
 
     from novelvideo.generators.video_generator import parse_newapi_video_backend
 
-    if parse_newapi_video_backend(text):
+    if parse_newapi_video_backend(text) and text not in FREEZONE_DISABLED_VIDEO_BACKENDS:
         return text
     raise ValueError(f"unknown video model: {text}")
 

--- a/src/novelvideo/generators/nanobanana_grid.py
+++ b/src/novelvideo/generators/nanobanana_grid.py
@@ -334,7 +334,12 @@ def _newapi_resolution_from_image_size(image_size: str | None) -> str:
 
 def _newapi_image_model_supports_quality(model: str | None) -> bool:
     model_name = str(model or "").strip().lower()
-    return model_name in {"gpt-image-2", "image-2", "image-2-official"} or "gpt-image" in model_name
+    return model_name in {
+        "lingshan-g2",
+        "gpt-image-2",
+        "image-2",
+        "image-2-official",
+    } or "gpt-image" in model_name
 
 
 def _image_credit_billing_params(

--- a/src/novelvideo/generators/scene_reference_images.py
+++ b/src/novelvideo/generators/scene_reference_images.py
@@ -589,7 +589,12 @@ def _scene_image_config(model: str) -> dict[str, str]:
         "image_size": "1K",
         "output_format": "png",
     }
-    if str(model or "").strip().lower() in {"gpt-image-2", "image-2", "image-2-official"}:
+    if str(model or "").strip().lower() in {
+        "lingshan-g2",
+        "gpt-image-2",
+        "image-2",
+        "image-2-official",
+    }:
         image_config["quality"] = "low"
     return image_config
 

--- a/src/novelvideo/generators/video_generator.py
+++ b/src/novelvideo/generators/video_generator.py
@@ -3526,6 +3526,7 @@ NEWAPI_MAINLINE_SEEDANCE2_MODELS = (
     "seedance-2.0-value",
     "seedance-2.0-fast-value",
 )
+NEWAPI_DISABLED_VIDEO_MODELS = {"grok-video-channel"}
 
 
 def parse_newapi_video_backend(backend: str | None) -> str | None:
@@ -3543,7 +3544,7 @@ def parse_newapi_video_backend(backend: str | None) -> str | None:
 def newapi_video_backend_options(*, include_seedance2_variants: bool = False) -> dict[str, str]:
     from novelvideo.config import NEWAPI_VIDEO_MODELS
 
-    models = list(NEWAPI_VIDEO_MODELS)
+    models = [model for model in NEWAPI_VIDEO_MODELS if model not in NEWAPI_DISABLED_VIDEO_MODELS]
     if include_seedance2_variants:
         for model in NEWAPI_MAINLINE_SEEDANCE2_MODELS:
             if model not in models:

--- a/src/novelvideo/task_backend/runners/freezone.py
+++ b/src/novelvideo/task_backend/runners/freezone.py
@@ -989,7 +989,7 @@ async def _run_freezone_audio_eleven_music_async(
         project_dir=project_dir,
         job_id=job_id,
         prompt=str(payload.get("input") or ""),
-        model=str(payload.get("model") or "eleven-music"),
+        model=str(payload.get("model") or "LingShan-MU-11"),
         response_format=str(payload.get("response_format") or "mp3"),
         music_length_ms=int(payload.get("music_length_ms") or 30_000),
         force_instrumental=bool(payload.get("force_instrumental", True)),

--- a/tests/test_api_model_credit_cost.py
+++ b/tests/test_api_model_credit_cost.py
@@ -168,9 +168,9 @@ async def test_generation_credit_cost_route_resolves_beat_tts(monkeypatch):
     from novelvideo import config
     from novelvideo.api.routes import model_credits
 
-    monkeypatch.setattr(config, "INDEXTTS2_RECORD_MODEL", "index-tts-2")
+    monkeypatch.setattr(config, "INDEXTTS2_RECORD_MODEL", "LingShan-TTS-2")
 
-    patch_quote(monkeypatch, model_credits, expected_model="index-tts-2", cost=3)
+    patch_quote(monkeypatch, model_credits, expected_model="LingShan-TTS-2", cost=3)
 
     result = await model_credits.get_generation_credit_cost(
         kind="beat_tts",
@@ -189,7 +189,7 @@ async def test_generation_credit_cost_route_resolves_freezone_audio_music(monkey
         monkeypatch,
         model_credits,
         expected_kind="audio",
-        expected_model="eleven-music",
+        expected_model="LingShan-MU-11",
         expected_params={},
         expected_quantity=30,
         cost=90,

--- a/tests/test_api_render_settings.py
+++ b/tests/test_api_render_settings.py
@@ -95,8 +95,8 @@ def test_render_settings_returns_current_selection_and_options(monkeypatch, tmp_
     assert body["ok"] is True
     assert body["data"]["render_image_selection"] == "newapi_nanobanana2"
     assert body["data"]["options"] == {
-        "newapi_gpt_image2": "DC-Image-2",
-        "newapi_nanobanana2": "DC-Banana-2",
+        "newapi_gpt_image2": "LingShan-G2",
+        "newapi_nanobanana2": "LingShan-NB-2",
     }
     assert body["data"]["sketch_aspect_padding"] is True
     assert "force_half_k" not in body["data"]
@@ -173,8 +173,8 @@ def test_sketch_settings_returns_current_selection_and_options(monkeypatch, tmp_
     assert body["ok"] is True
     assert body["data"]["sketch_image_selection"] == "newapi_nanobanana2"
     assert body["data"]["options"] == {
-        "newapi_gpt_image2": "DC-Image-2",
-        "newapi_nanobanana2": "DC-Banana-2",
+        "newapi_gpt_image2": "LingShan-G2",
+        "newapi_nanobanana2": "LingShan-NB-2",
     }
 
 

--- a/tests/test_freezone_audio_backend.py
+++ b/tests/test_freezone_audio_backend.py
@@ -135,7 +135,7 @@ async def test_newapi_audio_uses_saved_custom_gateway_before_env(
         output_path = tmp_path / "audio.mp3"
         await audio_node._write_newapi_audio_speech(
             output_path=output_path,
-            model="eleven-music",
+            model="LingShan-MU-11",
             input_text="quiet piano",
         )
 
@@ -381,13 +381,13 @@ async def test_freezone_audio_eleven_music_uses_newapi_music_metadata(
         output_format="mp3_44100_128",
     )
 
-    assert result.model == "eleven-music"
+    assert result.model == "LingShan-MU-11"
     assert result.duration_ms == 30_000
-    assert result.voice_source == "eleven-music"
+    assert result.voice_source == "LingShan-MU-11"
     assert calls == [
         {
             "output_path": freezone_audio_eleven_music_output_path(tmp_path, "music-1"),
-            "model": "eleven-music",
+            "model": "LingShan-MU-11",
             "input_text": "Mysterious original soundtrack, rainforest.",
             "response_format": "mp3",
             "metadata": {

--- a/tests/test_freezone_image_backend.py
+++ b/tests/test_freezone_image_backend.py
@@ -5744,7 +5744,7 @@ async def test_freezone_image_models_returns_selection_keys(
             "provider": "newapi",
             "apiModel": "newapi_gpt_image2",
             "api_model": "newapi_gpt_image2",
-            "label": "DC-Image-2",
+            "label": "LingShan-G2",
         },
         {
             "id": "newapi_nanobanana2",
@@ -5752,7 +5752,7 @@ async def test_freezone_image_models_returns_selection_keys(
             "provider": "newapi",
             "apiModel": "newapi_nanobanana2",
             "api_model": "newapi_nanobanana2",
-            "label": "DC-Banana-2",
+            "label": "LingShan-NB-2",
         },
     ]
 

--- a/tests/test_freezone_video_backend.py
+++ b/tests/test_freezone_video_backend.py
@@ -9,6 +9,7 @@ from novelvideo.generators.video_generator import (
     HuimengVideoGenerator,
     Seedance2VideoGenerator,
     ShotReference,
+    newapi_video_backend_options,
 )
 from novelvideo.generators.video_generator import VideoGenResult, VideoGenStatus
 from novelvideo.freezone.video_node import (
@@ -157,8 +158,8 @@ def test_video_model_options_and_resolution_work() -> None:
         "newapi_seedance-2.0-fast",
         "newapi_seedance-1.0-pro-fast",
         "newapi_seedance-1.5-pro",
-        "newapi_grok-video-channel",
     }.issubset(names)
+    assert "newapi_grok-video-channel" not in names
     assert ids == set(names)
     assert api_models == set(names)
     assert all(item["providerId"] == "newapi" for item in options)
@@ -166,18 +167,28 @@ def test_video_model_options_and_resolution_work() -> None:
     assert "Seedance1.5 Pro" in labels
     assert "Seedance2.0 Fast" in labels
     assert "HappyHorse 1.0" in labels
-    assert "Grok Video Channel" in labels
+    assert "Grok Video Channel" not in labels
     assert normalize_video_resolution("720P") == "720p"
     happyhorse = next(item for item in options if item["id"] == "newapi_happyhorse-1.0")
     assert happyhorse["resolutionOptions"] == ["720p", "1080p"]
     assert happyhorse["minDuration"] == 3
     assert happyhorse["maxDuration"] == 15
     assert normalize_video_resolution_for_backend("newapi_happyhorse-1.0", "480p") == "720p"
-    grok = next(item for item in options if item["id"] == "newapi_grok-video-channel")
-    assert grok["resolutionOptions"] == ["720p", "480p"]
-    assert grok["minDuration"] == 6
-    assert grok["maxDuration"] == 30
-    assert normalize_video_resolution_for_backend("newapi_grok-video-channel", "1080p") == "720p"
+
+
+def test_grok_video_channel_is_not_exposed_even_if_configured(monkeypatch: pytest.MonkeyPatch) -> None:
+    from novelvideo import config
+
+    monkeypatch.setattr(
+        config,
+        "NEWAPI_VIDEO_MODELS",
+        ["seedance-2.0-fast", "grok-video-channel"],
+    )
+
+    assert "newapi_grok-video-channel" not in newapi_video_backend_options()
+    assert "newapi_grok-video-channel" not in get_freezone_video_model_names()
+    with pytest.raises(ValueError, match="unknown video model"):
+        resolve_freezone_video_backend("newapi_grok-video-channel")
 
 
 def test_resolve_freezone_video_backend_accepts_id_and_label() -> None:

--- a/tests/test_indextts2_beat_audio_task.py
+++ b/tests/test_indextts2_beat_audio_task.py
@@ -206,7 +206,7 @@ async def test_indextts2_selected_runner_generates_narration_and_dialogue(tmp_pa
     assert rows == [
         (
             "newapi",
-            "index-tts-2",
+            "LingShan-TTS-2",
             "audio_generation_indextts2",
             "ep001:beat_01:__narrator__",
             1,
@@ -214,7 +214,7 @@ async def test_indextts2_selected_runner_generates_narration_and_dialogue(tmp_pa
         ),
         (
             "newapi",
-            "index-tts-2",
+            "LingShan-TTS-2",
             "audio_generation_indextts2",
             "ep001:beat_02:谢铮_青年时期",
             1,

--- a/tests/test_indextts2_fal.py
+++ b/tests/test_indextts2_fal.py
@@ -57,14 +57,14 @@ async def test_reserve_tts_model_call_uses_audio_billing_kind(monkeypatch):
     monkeypatch.setattr(indextts2_fal, "get_usage_meter", lambda: FakeUsageMeter())
 
     reservation_id = await indextts2_fal._reserve_tts_model_call(
-        "index-tts-2",
+        "LingShan-TTS-2",
         source="indextts2_newapi",
     )
 
     assert reservation_id == "reservation_1"
     assert calls == [
         {
-            "model": "index-tts-2",
+            "model": "LingShan-TTS-2",
             "billing_kind": "audio",
             "metadata": {"source": "indextts2_newapi"},
         }
@@ -114,7 +114,7 @@ async def test_indextts2_newapi_posts_audio_speech_schema(monkeypatch, tmp_path)
         provider="newapi",
         api_key="newapi-test-key",
         endpoint="http://newapi.test/v1",
-        model="index-tts-2",
+        model="LingShan-TTS-2",
         timeout_seconds=12,
     )
     result = await client.generate(
@@ -126,10 +126,10 @@ async def test_indextts2_newapi_posts_audio_speech_schema(monkeypatch, tmp_path)
 
     assert result.success is True
     assert output_path.read_bytes() == b"generated-wav"
-    assert reserved == [{"model": "index-tts-2", "source": "indextts2_newapi"}]
+    assert reserved == [{"model": "LingShan-TTS-2", "source": "indextts2_newapi"}]
     assert confirmed == [
         {
-            "model": "index-tts-2",
+            "model": "LingShan-TTS-2",
             "reservation_id": "reservation_1",
             "provider_request_id": "req_tts_1",
             "response_id": "",
@@ -145,7 +145,7 @@ async def test_indextts2_newapi_posts_audio_speech_schema(monkeypatch, tmp_path)
                 "Content-Type": "application/json",
             },
             {
-                "model": "index-tts-2",
+                "model": "LingShan-TTS-2",
                 "input": "你终于来了。",
                 "metadata": {
                     "audio_url": "data:audio/wav;base64,abc",
@@ -270,7 +270,7 @@ async def test_indextts2_refunds_reserved_credit_on_generation_failure(monkeypat
         provider="newapi",
         api_key="newapi-test-key",
         endpoint="http://newapi.test/v1",
-        model="index-tts-2",
+        model="LingShan-TTS-2",
         timeout_seconds=12,
     )
     result = await client.generate(
@@ -305,7 +305,7 @@ async def test_indextts2_reraises_insufficient_credit(monkeypatch, tmp_path):
         provider="newapi",
         api_key="newapi-test-key",
         endpoint="http://newapi.test/v1",
-        model="index-tts-2",
+        model="LingShan-TTS-2",
         timeout_seconds=12,
     )
 

--- a/tests/test_model_gateway_settings.py
+++ b/tests/test_model_gateway_settings.py
@@ -1747,7 +1747,7 @@ def test_custom_newapi_media_models_groups_by_provider_and_persists_mapping(
         json={
             "newApiBaseUrl": "http://new-api:3000",
             "models": {
-                "gpt-image-2": {
+                "LingShan-G2": {
                     "provider": "openai",
                     "upstreamModel": "gpt-image-upstream",
                 },
@@ -1759,13 +1759,13 @@ def test_custom_newapi_media_models_groups_by_provider_and_persists_mapping(
                     "provider": "volcengine",
                     "upstreamModel": "",
                 },
-                "index-tts-2": {
+                "LingShan-TTS-2": {
                     "provider": "volcengine",
-                    "upstreamModel": "index-tts-2-upstream",
+                    "upstreamModel": "lingshan-tts-upstream",
                 },
-                "eleven-music": {
+                "LingShan-MU-11": {
                     "provider": "volcengine",
-                    "upstreamModel": "eleven-music-upstream",
+                    "upstreamModel": "lingshan-mu-upstream",
                 },
             },
         },
@@ -1778,13 +1778,13 @@ def test_custom_newapi_media_models_groups_by_provider_and_persists_mapping(
     assert len(payloads) == 2
     by_name = {payload["channel"]["name"]: payload["channel"] for payload in payloads}
     assert json.loads(by_name["DC-openai"]["model_mapping"]) == {
-        "gpt-image-2": "gpt-image-upstream",
+        "LingShan-G2": "gpt-image-upstream",
     }
     assert json.loads(by_name["DC-volcengine"]["model_mapping"]) == {
         "seedance-1.5-pro": "doubao-seedance-1-5",
         "seedance-2.0-fast": "seedance-2.0-fast",
-        "index-tts-2": "index-tts-2-upstream",
-        "eleven-music": "eleven-music-upstream",
+        "LingShan-TTS-2": "lingshan-tts-upstream",
+        "LingShan-MU-11": "lingshan-mu-upstream",
     }
     assert by_name["DC-openai"]["key"] == "sk-openai-upstream-secret"
     assert by_name["DC-volcengine"]["base_url"] == "https://ark.example.com"
@@ -1794,7 +1794,7 @@ def test_custom_newapi_media_models_groups_by_provider_and_persists_mapping(
     config_response = client.get("/model-gateway/config")
     media_models = config_response.json()["data"]["provisioner"]["mediaModels"]
     assert media_models == {
-        "gpt-image-2": {
+        "LingShan-G2": {
             "provider": "openai",
             "upstreamModel": "gpt-image-upstream",
         },
@@ -1806,13 +1806,13 @@ def test_custom_newapi_media_models_groups_by_provider_and_persists_mapping(
             "provider": "volcengine",
             "upstreamModel": "",
         },
-        "index-tts-2": {
+        "LingShan-TTS-2": {
             "provider": "volcengine",
-            "upstreamModel": "index-tts-2-upstream",
+            "upstreamModel": "lingshan-tts-upstream",
         },
-        "eleven-music": {
+        "LingShan-MU-11": {
             "provider": "volcengine",
-            "upstreamModel": "eleven-music-upstream",
+            "upstreamModel": "lingshan-mu-upstream",
         },
     }
 

--- a/tests/test_newapi_image_gateway.py
+++ b/tests/test_newapi_image_gateway.py
@@ -38,42 +38,42 @@ def test_dc_image_2_selection_maps_to_newapi_gpt_image2(monkeypatch, tmp_path):
     _isolate_settings_db(monkeypatch, tmp_path)
     monkeypatch.setenv("NEWAPI_API_KEY", "newapi-token")
     monkeypatch.setenv("NEWAPI_BASE_URL", "http://newapi.test/v1")
-    monkeypatch.setenv("NEWAPI_IMAGE_MODEL", "gpt-image-2")
+    monkeypatch.setenv("NEWAPI_IMAGE_MODEL", "LingShan-G2")
     monkeypatch.setenv("DEFAULT_CHARACTER_IMAGE_SELECTION", "newapi_gpt_image2")
 
     import novelvideo.config as config
 
     config = importlib.reload(config)
 
-    assert config.character_image_selection_options()["newapi_gpt_image2"] == "DC-Image-2"
+    assert config.character_image_selection_options()["newapi_gpt_image2"] == "LingShan-G2"
     assert config.get_character_image_selection() == "newapi_gpt_image2"
 
     image_config = config.get_grid_generation_config(selection_override="newapi_gpt_image2")
     assert image_config["provider"] == "newapi"
     assert image_config["api_key"] == "newapi-token"
     assert image_config["base_url"] == "http://newapi.test/v1"
-    assert image_config["model"] == "gpt-image-2"
+    assert image_config["model"] == "LingShan-G2"
 
 
 def test_dc_banana_2_selection_maps_to_newapi_nanobanana2(monkeypatch, tmp_path):
     _isolate_settings_db(monkeypatch, tmp_path)
     monkeypatch.setenv("NEWAPI_API_KEY", "newapi-token")
     monkeypatch.setenv("NEWAPI_BASE_URL", "http://newapi.test/v1")
-    monkeypatch.setenv("NEWAPI_NANOBANANA2_MODEL", "nano-banana-2")
+    monkeypatch.setenv("NEWAPI_NANOBANANA2_MODEL", "LingShan-NB-2")
     monkeypatch.setenv("DEFAULT_CHARACTER_IMAGE_SELECTION", "newapi_nanobanana2")
 
     import novelvideo.config as config
 
     config = importlib.reload(config)
 
-    assert config.character_image_selection_options()["newapi_nanobanana2"] == "DC-Banana-2"
+    assert config.character_image_selection_options()["newapi_nanobanana2"] == "LingShan-NB-2"
     assert config.get_character_image_selection() == "newapi_nanobanana2"
 
     image_config = config.get_grid_generation_config(selection_override="newapi_nanobanana2")
     assert image_config["provider"] == "newapi"
     assert image_config["api_key"] == "newapi-token"
     assert image_config["base_url"] == "http://newapi.test/v1"
-    assert image_config["model"] == "nano-banana-2"
+    assert image_config["model"] == "LingShan-NB-2"
 
 
 def test_fixed_asset_image_providers_default_to_newapi_when_env_is_empty(monkeypatch):
@@ -84,7 +84,7 @@ def test_fixed_asset_image_providers_default_to_newapi_when_env_is_empty(monkeyp
         "SCENE_360_IMAGE_PROVIDER",
     ):
         monkeypatch.setenv(key, "")
-    monkeypatch.setenv("NEWAPI_IMAGE_MODEL", "gpt-image-2")
+    monkeypatch.setenv("NEWAPI_IMAGE_MODEL", "LingShan-G2")
 
     import novelvideo.config as config
 
@@ -100,7 +100,7 @@ def test_fixed_asset_image_providers_default_to_newapi_when_env_is_empty(monkeyp
     nanobanana_prop = importlib.reload(nanobanana_prop)
     scene_reference_images = importlib.reload(scene_reference_images)
 
-    assert nanobanana_prop.resolve_prop_reference_image_model() == "gpt-image-2"
+    assert nanobanana_prop.resolve_prop_reference_image_model() == "LingShan-G2"
     assert scene_reference_images._scene_image_provider("master", None) == "newapi"
     assert scene_reference_images._scene_image_provider("reverse_master", None) == "newapi"
 
@@ -140,7 +140,7 @@ def test_newapi_sketch_config_defaults_to_dc_image2_low_quality(monkeypatch):
 
     monkeypatch.setenv("NEWAPI_API_KEY", "newapi-token")
     monkeypatch.setenv("NEWAPI_BASE_URL", "http://newapi.test/v1")
-    monkeypatch.setenv("NEWAPI_IMAGE_MODEL", "gpt-image-2")
+    monkeypatch.setenv("NEWAPI_IMAGE_MODEL", "LingShan-G2")
     monkeypatch.setenv("DEFAULT_SKETCH_IMAGE_SELECTION", "newapi_gpt_image2")
     monkeypatch.setattr(httpx, "AsyncClient", FakeAsyncClient)
 
@@ -148,7 +148,7 @@ def test_newapi_sketch_config_defaults_to_dc_image2_low_quality(monkeypatch):
     sketch_config = config.get_sketch_generation_config()
 
     assert sketch_config["provider"] == "newapi"
-    assert sketch_config["model"] == "gpt-image-2"
+    assert sketch_config["model"] == "LingShan-G2"
     assert sketch_config["image_size"] == "1K"
     assert sketch_config["openai_image_quality"] == "low"
 
@@ -171,7 +171,7 @@ def test_newapi_sketch_config_defaults_to_dc_image2_low_quality(monkeypatch):
     assert image_bytes == b"sketch"
     assert error == ""
     assert posted["timeout"] == nanobanana_grid.NEWAPI_IMAGE_HTTP_TIMEOUT_SECONDS == 1800.0
-    assert posted["json"]["model"] == "gpt-image-2"
+    assert posted["json"]["model"] == "LingShan-G2"
     assert posted["json"]["quality"] == "low"
     assert posted["json"]["extra_fields"] == {
         "aspect_ratio": "2:3",
@@ -212,7 +212,7 @@ def test_newapi_sketch_config_can_use_dc_banana2_without_quality(monkeypatch):
 
     monkeypatch.setenv("NEWAPI_API_KEY", "newapi-token")
     monkeypatch.setenv("NEWAPI_BASE_URL", "http://newapi.test/v1")
-    monkeypatch.setenv("NEWAPI_NANOBANANA2_MODEL", "nano-banana-2")
+    monkeypatch.setenv("NEWAPI_NANOBANANA2_MODEL", "LingShan-NB-2")
     monkeypatch.setenv("DEFAULT_SKETCH_IMAGE_SELECTION", "newapi_nanobanana2")
     monkeypatch.setattr(httpx, "AsyncClient", FakeAsyncClient)
 
@@ -220,7 +220,7 @@ def test_newapi_sketch_config_can_use_dc_banana2_without_quality(monkeypatch):
     sketch_config = config.get_sketch_generation_config()
 
     assert sketch_config["provider"] == "newapi"
-    assert sketch_config["model"] == "nano-banana-2"
+    assert sketch_config["model"] == "LingShan-NB-2"
     assert sketch_config["image_size"] == "1K"
 
     image_bytes, _text, error = run_async(
@@ -239,7 +239,7 @@ def test_newapi_sketch_config_can_use_dc_banana2_without_quality(monkeypatch):
 
     assert image_bytes == b"sketch"
     assert error == ""
-    assert posted["json"]["model"] == "nano-banana-2"
+    assert posted["json"]["model"] == "LingShan-NB-2"
     assert "quality" not in posted["json"]
     assert posted["json"]["extra_fields"] == {
         "aspect_ratio": "2:3",
@@ -282,7 +282,7 @@ def test_newapi_image_call_sends_gpt_image2_params(monkeypatch):
     image_bytes, _text, error = run_async(
         nanobanana_grid._call_newapi_image_api(
             api_key="newapi-token",
-            model="gpt-image-2",
+            model="LingShan-G2",
             prompt="portrait prompt",
             image_config={
                 "aspect_ratio": "3:4",
@@ -297,7 +297,7 @@ def test_newapi_image_call_sends_gpt_image2_params(monkeypatch):
     assert error == ""
     assert posted["url"] == "http://newapi.test/v1/images/generations"
     assert posted["headers"]["Authorization"] == "Bearer newapi-token"
-    assert posted["json"]["model"] == "gpt-image-2"
+    assert posted["json"]["model"] == "LingShan-G2"
     assert posted["json"]["prompt"] == "portrait prompt"
     assert posted["json"]["quality"] == "medium"
     assert posted["json"]["extra_fields"] == {
@@ -330,7 +330,7 @@ def test_newapi_image_call_reports_transport_exception_type(monkeypatch):
     image_bytes, _text, error = run_async(
         nanobanana_grid._call_newapi_image_api(
             api_key="newapi-token",
-            model="gpt-image-2",
+            model="LingShan-G2",
             prompt="portrait prompt",
             image_config={"aspect_ratio": "16:9", "image_size": "1K"},
             base_url="http://newapi.test/v1",
@@ -340,7 +340,7 @@ def test_newapi_image_call_reports_transport_exception_type(monkeypatch):
     assert image_bytes is None
     assert "请求异常: ReadTimeout" in error
     assert "endpoint=http://newapi.test/v1" in error
-    assert "model=gpt-image-2" in error
+    assert "model=LingShan-G2" in error
 
 
 def test_newapi_image_call_reraises_insufficient_credit(monkeypatch):
@@ -356,7 +356,7 @@ def test_newapi_image_call_reraises_insufficient_credit(monkeypatch):
         run_async(
             nanobanana_grid._call_newapi_image_api(
                 api_key="newapi-token",
-                model="gpt-image-2",
+                model="LingShan-G2",
                 prompt="portrait prompt",
                 base_url="http://newapi.test/v1",
             )
@@ -381,7 +381,7 @@ def test_newapi_sketch_grid_reraises_insufficient_credit(monkeypatch, tmp_path):
             "provider": "newapi",
             "api_key": "newapi-token",
             "base_url": "http://newapi.test/v1",
-            "model": "gpt-image-2",
+            "model": "LingShan-G2",
             "rows": 1,
             "cols": 1,
             "batch_size": 1,
@@ -446,7 +446,7 @@ def test_newapi_image_call_omits_quality_for_nanobanana2(monkeypatch):
     image_bytes, _text, error = run_async(
         nanobanana_grid._call_newapi_image_api(
             api_key="newapi-token",
-            model="nano-banana-2",
+            model="LingShan-NB-2",
             prompt="portrait prompt",
             image_config={
                 "aspect_ratio": "3:4",
@@ -459,7 +459,7 @@ def test_newapi_image_call_omits_quality_for_nanobanana2(monkeypatch):
 
     assert image_bytes == b"image-bytes"
     assert error == ""
-    assert posted["json"]["model"] == "nano-banana-2"
+    assert posted["json"]["model"] == "LingShan-NB-2"
     assert "quality" not in posted["json"]
     assert posted["json"]["extra_fields"] == {
         "aspect_ratio": "3:4",
@@ -506,7 +506,7 @@ def test_newapi_image_call_relays_reference_images(monkeypatch):
     image_bytes, _text, error = run_async(
         nanobanana_grid._call_newapi_image_api(
             api_key="newapi-token",
-            model="gpt-image-2",
+            model="LingShan-G2",
             prompt="identity prompt",
             reference_images=[b"ref-a", b"ref-b"],
             image_config={"aspect_ratio": "3:4", "image_size": "1K", "quality": "medium"},
@@ -562,7 +562,7 @@ def test_newapi_image_call_preserves_reference_image_extensions(monkeypatch):
     image_bytes, _text, error = run_async(
         nanobanana_grid._call_newapi_image_api(
             api_key="newapi-token",
-            model="gpt-image-2",
+            model="LingShan-G2",
             prompt="identity prompt",
             reference_images=[
                 ("face.jpg", b"jpg-bytes", "image/jpeg"),
@@ -639,7 +639,7 @@ def test_newapi_image_http_error_logs_redacted_request_context(monkeypatch, capl
     image_bytes, _text, error = run_async(
         nanobanana_grid._call_newapi_image_api(
             api_key="newapi-token",
-            model="gpt-image-2",
+            model="LingShan-G2",
             prompt="sensitive prompt body",
             reference_images=[b"ref-a"],
             image_config={"aspect_ratio": "2:1", "image_size": "2K", "quality": "medium"},
@@ -652,7 +652,7 @@ def test_newapi_image_http_error_logs_redacted_request_context(monkeypatch, capl
     assert image_bytes is None
     assert "request_id=req-123" in error
     assert "cf-ray-456" in error
-    assert "model=gpt-image-2" in error
+    assert "model=LingShan-G2" in error
     assert "extra_fields" in error
     assert "reference_image_count=1" in error
     assert "request_id=req-123" in log_text
@@ -720,7 +720,7 @@ def test_newapi_image_http_5xx_does_not_retry_in_app(monkeypatch):
     image_bytes, _text, error = run_async(
         nanobanana_grid._call_newapi_image_api(
             api_key="newapi-token",
-            model="gpt-image-2",
+            model="LingShan-G2",
             prompt="retry prompt",
             image_config={"aspect_ratio": "2:1", "image_size": "2K", "quality": "medium"},
             base_url="http://newapi.test/v1",
@@ -755,7 +755,7 @@ def test_newapi_identity_image_sends_portrait_then_costume_references(
         config={
             "provider": "newapi",
             "api_key": "newapi-token",
-            "model": "nano-banana-2",
+            "model": "LingShan-NB-2",
             "base_url": "http://newapi.test/v1",
         }
     )
@@ -778,7 +778,7 @@ def test_newapi_identity_image_sends_portrait_then_costume_references(
 
     assert image_bytes == b"identity-image"
     assert output_path.read_bytes() == b"identity-image"
-    assert captured["model"] == "nano-banana-2"
+    assert captured["model"] == "LingShan-NB-2"
     assert captured["base_url"] == "http://newapi.test/v1"
     assert captured["image_config"] == {
         "aspect_ratio": "16:9",
@@ -807,7 +807,7 @@ def test_newapi_character_portrait_reraises_insufficient_credit(monkeypatch, tmp
         config={
             "provider": "newapi",
             "api_key": "newapi-token",
-            "model": "gpt-image-2",
+            "model": "LingShan-G2",
             "base_url": "http://newapi.test/v1",
         }
     )
@@ -831,7 +831,7 @@ def test_newapi_character_portrait_raise_on_error_preserves_provider_detail(monk
 
     monkeypatch.setenv("NEWAPI_API_KEY", "newapi-token")
     monkeypatch.setenv("NEWAPI_BASE_URL", "http://newapi.test/v1")
-    monkeypatch.setenv("NEWAPI_IMAGE_MODEL", "gpt-image-2")
+    monkeypatch.setenv("NEWAPI_IMAGE_MODEL", "LingShan-G2")
     monkeypatch.setenv("DEFAULT_CHARACTER_IMAGE_SELECTION", "newapi_gpt_image2")
     importlib.reload(config)
     monkeypatch.setattr(
@@ -867,7 +867,7 @@ def test_newapi_scene_master_uses_text_only_nanobanana2(monkeypatch, tmp_path):
     monkeypatch.setenv("NEWAPI_API_KEY", "newapi-token")
     monkeypatch.setenv("NEWAPI_BASE_URL", "http://newapi.test/v1")
     monkeypatch.setenv("SCENE_MASTER_IMAGE_PROVIDER", "newapi")
-    monkeypatch.setenv("SCENE_MASTER_IMAGE_MODEL", "nano-banana-2")
+    monkeypatch.setenv("SCENE_MASTER_IMAGE_MODEL", "LingShan-NB-2")
     _patch_scene_newapi_gateway(monkeypatch)
     monkeypatch.setattr(
         scene_reference_images,
@@ -875,7 +875,7 @@ def test_newapi_scene_master_uses_text_only_nanobanana2(monkeypatch, tmp_path):
         fake_call_newapi_image_api,
     )
     monkeypatch.setattr(scene_reference_images, "SCENE_MASTER_IMAGE_PROVIDER", "newapi")
-    monkeypatch.setattr(scene_reference_images, "SCENE_MASTER_IMAGE_MODEL", "nano-banana-2")
+    monkeypatch.setattr(scene_reference_images, "SCENE_MASTER_IMAGE_MODEL", "LingShan-NB-2")
 
     scene = NovelScene(
         name="古董店",
@@ -898,7 +898,7 @@ def test_newapi_scene_master_uses_text_only_nanobanana2(monkeypatch, tmp_path):
     assert output_path.read_bytes() == b"scene-master"
     assert captured["api_key"] == "newapi-token"
     assert captured["base_url"] == "http://newapi.test/v1"
-    assert captured["model"] == "nano-banana-2"
+    assert captured["model"] == "LingShan-NB-2"
     assert captured["reference_images"] is None
     assert captured["image_config"] == {
         "aspect_ratio": "16:9",
@@ -930,7 +930,7 @@ def test_newapi_scene_time_plate_master_injects_time_and_base_reference(monkeypa
     )
     _patch_scene_newapi_gateway(monkeypatch)
     monkeypatch.setattr(scene_reference_images, "SCENE_MASTER_IMAGE_PROVIDER", "newapi")
-    monkeypatch.setattr(scene_reference_images, "SCENE_MASTER_IMAGE_MODEL", "nano-banana-2")
+    monkeypatch.setattr(scene_reference_images, "SCENE_MASTER_IMAGE_MODEL", "LingShan-NB-2")
 
     scene = NovelScene(
         name="古董店_夜晚",
@@ -979,7 +979,7 @@ def test_newapi_scene_variant_plate_master_keeps_described_lighting(monkeypatch,
     )
     _patch_scene_newapi_gateway(monkeypatch)
     monkeypatch.setattr(scene_reference_images, "SCENE_MASTER_IMAGE_PROVIDER", "newapi")
-    monkeypatch.setattr(scene_reference_images, "SCENE_MASTER_IMAGE_MODEL", "nano-banana-2")
+    monkeypatch.setattr(scene_reference_images, "SCENE_MASTER_IMAGE_MODEL", "LingShan-NB-2")
 
     scene = NovelScene(
         name="城市街道_雨夜版",
@@ -1033,7 +1033,7 @@ def test_newapi_reverse_master_uses_master_reference_nanobanana2(monkeypatch, tm
     monkeypatch.setattr(
         scene_reference_images,
         "SCENE_REVERSE_MASTER_IMAGE_MODEL",
-        "nano-banana-2",
+        "LingShan-NB-2",
     )
 
     scene = NovelScene(
@@ -1057,7 +1057,7 @@ def test_newapi_reverse_master_uses_master_reference_nanobanana2(monkeypatch, tm
     assert output_path.read_bytes() == b"scene-reverse"
     assert captured["api_key"] == "newapi-token"
     assert captured["base_url"] == "http://newapi.test/v1"
-    assert captured["model"] == "nano-banana-2"
+    assert captured["model"] == "LingShan-NB-2"
     assert captured["reference_images"] == [
         ("scene_master_master.png", b"master-bytes", "image/png")
     ]
@@ -1094,7 +1094,7 @@ def test_newapi_reverse_master_can_use_gpt_image2_quality_low(monkeypatch, tmp_p
     monkeypatch.setattr(
         scene_reference_images,
         "SCENE_REVERSE_MASTER_IMAGE_MODEL",
-        "gpt-image-2",
+        "LingShan-G2",
     )
 
     scene = NovelScene(
@@ -1111,7 +1111,7 @@ def test_newapi_reverse_master_can_use_gpt_image2_quality_low(monkeypatch, tmp_p
         )
     )
 
-    assert captured["model"] == "gpt-image-2"
+    assert captured["model"] == "LingShan-G2"
     assert captured["reference_images"] == [
         ("scene_master_master.png", b"master-bytes", "image/png")
     ]
@@ -1158,7 +1158,7 @@ def test_newapi_prop_reference_gpt_image2_sends_quality_medium(monkeypatch, tmp_
     monkeypatch.setenv("NEWAPI_API_KEY", "newapi-token")
     monkeypatch.setenv("NEWAPI_BASE_URL", "http://newapi.test/v1")
     monkeypatch.setenv("PROP_REF_IMAGE_PROVIDER", "newapi")
-    monkeypatch.setenv("PROP_REF_IMAGE_MODEL", "gpt-image-2")
+    monkeypatch.setenv("PROP_REF_IMAGE_MODEL", "LingShan-G2")
     importlib.reload(config)
     nanobanana_prop = importlib.reload(nanobanana_prop)
     monkeypatch.setattr(
@@ -1179,7 +1179,7 @@ def test_newapi_prop_reference_gpt_image2_sends_quality_medium(monkeypatch, tmp_
     assert output_path.read_bytes() == b"prop-ref"
     assert posted["url"] == "http://newapi.test/v1/images/generations"
     assert posted["headers"]["Authorization"] == "Bearer newapi-token"
-    assert posted["json"]["model"] == "gpt-image-2"
+    assert posted["json"]["model"] == "LingShan-G2"
     assert posted["json"]["quality"] == "medium"
     assert posted["json"]["extra_fields"] == {
         "aspect_ratio": "16:9",
@@ -1222,7 +1222,7 @@ def test_newapi_prop_reference_nanobanana2_omits_quality(monkeypatch, tmp_path):
     monkeypatch.setenv("NEWAPI_API_KEY", "newapi-token")
     monkeypatch.setenv("NEWAPI_BASE_URL", "http://newapi.test/v1")
     monkeypatch.setenv("PROP_REF_IMAGE_PROVIDER", "newapi")
-    monkeypatch.setenv("PROP_REF_IMAGE_MODEL", "nano-banana-2")
+    monkeypatch.setenv("PROP_REF_IMAGE_MODEL", "LingShan-NB-2")
     importlib.reload(config)
     nanobanana_prop = importlib.reload(nanobanana_prop)
     monkeypatch.setattr(
@@ -1241,7 +1241,7 @@ def test_newapi_prop_reference_nanobanana2_omits_quality(monkeypatch, tmp_path):
 
     assert result == str(output_path)
     assert output_path.read_bytes() == b"prop-ref"
-    assert posted["json"]["model"] == "nano-banana-2"
+    assert posted["json"]["model"] == "LingShan-NB-2"
     assert "quality" not in posted["json"]
     assert posted["json"]["extra_fields"] == {
         "aspect_ratio": "16:9",
@@ -1261,7 +1261,7 @@ def test_newapi_prop_reference_reraises_insufficient_credit(monkeypatch, tmp_pat
     monkeypatch.setenv("NEWAPI_API_KEY", "newapi-token")
     monkeypatch.setenv("NEWAPI_BASE_URL", "http://newapi.test/v1")
     monkeypatch.setenv("PROP_REF_IMAGE_PROVIDER", "newapi")
-    monkeypatch.setenv("PROP_REF_IMAGE_MODEL", "gpt-image-2")
+    monkeypatch.setenv("PROP_REF_IMAGE_MODEL", "LingShan-G2")
     importlib.reload(config)
     nanobanana_prop = importlib.reload(nanobanana_prop)
     monkeypatch.setattr(nanobanana_prop, "_call_newapi_image_api", fake_call_newapi_image_api)
@@ -1302,7 +1302,7 @@ def test_freezone_single_image_generation_routes_newapi(monkeypatch, tmp_path):
             config={
                 "provider": "newapi",
                 "api_key": "newapi-token",
-                "model": "gpt-image-2",
+                "model": "LingShan-G2",
                 "base_url": "http://newapi.test/v1",
                 "openai_image_quality": "medium",
                 "openai_sketch_image_quality": "low",
@@ -1318,7 +1318,7 @@ def test_freezone_single_image_generation_routes_newapi(monkeypatch, tmp_path):
     assert image_path == output_path
     assert output_path.read_bytes() == b"freezone-image"
     assert captured["api_key"] == "newapi-token"
-    assert captured["model"] == "gpt-image-2"
+    assert captured["model"] == "LingShan-G2"
     assert captured["prompt"] == "freezone prompt"
     assert captured["reference_images"] is None
     assert captured["base_url"] == "http://newapi.test/v1"


### PR DESCRIPTION
## Summary

- Rename NewAPI image/audio logical model names to LingShan names across backend defaults, Settings media model configuration, and tests.
- Remove the broken Grok Video Channel from Freezone video model exposure and hard-filter it from NewAPI video options.
- Keep route/task identifiers stable where they are not the NewAPI model name.

## Validation

- uv lock --check
- uv run python scripts/check_ce_port_closure.py
- uv run ruff check --output-format=github .
- uv run pytest -n auto
- pnpm --config.confirmModulesPurge=false build
- pnpm --config.confirmModulesPurge=false test
- uv run python scripts/lint_ce_imports.py
- uv run python scripts/lint_banned_words.py
- uv run python scripts/ce_allowlist.py
- uv run python scripts/lint_ee_terms.py
- uv run python scripts/check_dependency_licenses.py

Note: local gitleaks was not run because gitleaks is not installed on this machine.