### PR TITLE
feat(landing): 暂时隐藏桌面端下载入口

### DIFF
--- a/frontend/src/components/login/cinematic/LoginCinematicHero.tsx
+++ b/frontend/src/components/login/cinematic/LoginCinematicHero.tsx
@@ -19,6 +19,9 @@ const GITHUB_URL = "https://github.com/dramaclaw/dramaclaw";
 const GITHUB_REPO = "dramaclaw/dramaclaw";
 const FALLBACK_GITHUB_STARS = 574;
 
+// 桌面端下载入口暂时隐藏；组件与样式全部保留，改回 true 即可恢复。
+const SHOW_DESKTOP_DOWNLOAD = false;
+
 let cachedStars: number | null = null;
 
 function formatStars(count: number): string {
@@ -150,7 +153,8 @@ export function LoginCinematicHeader({
     >
       <Brand />
       <div className={styles.stageActions}>
-        <DesktopDownload />
+        {/* 桌面端下载入口暂时隐藏，改回 true 即可恢复（组件代码保留）。 */}
+        {SHOW_DESKTOP_DOWNLOAD && <DesktopDownload />}
         <div className={styles.businessWechat}>
           <button
             type="button"


### PR DESCRIPTION
## 背景
落地页头部的「桌面端」下载下拉（macOS / Windows）暂时下线，但后续还要恢复，所以只隐藏、不删除。

## 改动
- 在 `LoginCinematicHero.tsx` 新增特性开关 `SHOW_DESKTOP_DOWNLOAD = false`
- 头部渲染改为 `{SHOW_DESKTOP_DOWNLOAD && <DesktopDownload />}`
- `DesktopDownload` 组件、`AppleMark`/`WindowsMark`、`@/lib/desktop-download` 依赖全部保留，无孤立/未使用告警

## 恢复方式
把 `SHOW_DESKTOP_DOWNLOAD` 改回 `true` 即可。

## 验证
- `tsc -b` 通过
- `pnpm build` 通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)