### PR TITLE
chore: release v1.1.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "supertale-ce"
-version = "1.1.0"
+version = "1.1.1"
 description = "SuperTale Community Edition API and video pipeline"
 readme = "README.md"
 requires-python = ">=3.11,<3.13"

--- a/src/novelvideo/release-notes.md
+++ b/src/novelvideo/release-notes.md
@@ -1,21 +1,36 @@
 ---
-version: 1.1.0
+version: 1.1.1
 attention: low
 ---
-# v1.1.0
+# v1.1.1
 
 ## User-facing Highlights (zh)
 
-- **虾画与虾集切换更流畅**: 优化项目导航和画布同步,减少在创作工作区之间切换时的卡顿。
-- **虾导反馈更清楚**: 等待状态分级展示,更新提示体验同步优化,减少长任务中的不确定感。
-- **导入与登录更可靠**: 增加小说格式说明,登录头图视频改为 CDN 加载,提升首次访问稳定性。
+- **桌面端 · 下载与自动更新全面提速**: 安装包分发与应用内自动更新接入国内 CDN。本版起,检查更新与差分下载不再受国际链路影响;从 v1.1.0 升级到本版的这一次仍走原渠道,升级完成后即切换至加速通道。
+- **资产库升级**: 资产库支持多媒介类型并与主线同步;历史资产不再限制每类仅显示 20 条,创作素材一览无余。
+- **自建网关更省心**: 本地网关一键初始化流程简化,媒体模型命名与网关侧对齐;桌面端内置网关默认端口迁移至 18780,避开与常见开发工具端口 3000 的冲突。
 
 ## User-facing Highlights (en)
 
-- **Smoother Xiahua and Xiajie switching**: Project navigation and canvas synchronization are optimized to reduce lag while moving between creative workspaces.
-- **Clearer Xiaodao feedback**: Waiting states are presented by stage, with improved update notices to reduce uncertainty during longer tasks.
-- **More reliable import and login**: Novel-format guidance is added, and the login hero video now loads from a CDN for a more stable first visit.
+- **Desktop · Faster downloads and updates**: Installer distribution and in-app auto-updates now ride a China-friendly CDN. From this version onward, update checks and differential downloads are no longer throttled by cross-border links; the one-time upgrade from v1.1.0 still uses the original channel, after which the accelerated channel takes over.
+- **Asset library upgrade**: The asset library now supports multiple media types with mainline sync, and the 20-items-per-category display cap is removed.
+- **Smoother self-hosted gateway**: One-click local gateway setup is simplified, media model names are aligned with the gateway, and the desktop bundled gateway default port moves to 18780 to avoid clashing with common dev tools on port 3000.
 
-## Fixes
+## Improvements
 
-- 其余修复与内部改动见 GitHub Release 页的 Bug Fixes 与 What's Changed。
+- 画布连线支持一键隐藏/显示,仅视觉隐藏,连线关系保留 (#129).
+- 视频时长支持直接输入,生成面板视觉收敛 (#128).
+- 统一导航反馈与素材页控件交互 (#125).
+- 文本生成默认不再开启深度推理,响应更快 (#135).
+
+## Bug Fixes
+
+- 修复 FAQ 弹层在短视口下的重叠问题 (#128).
+- NewAPI 媒体模型命名对齐,修正自建网关下部分媒体模型无法命中的问题 (#131).
+- 本地开发态的兜底版本号改为从 git tag 派生,不再显示过期版本 (#126).
+
+## Known Issues 已知问题
+
+- 已使用「一键初始化自建网关」的用户:升级后请在设置页将网关地址更新为 `http://127.0.0.1:18780`,或清除自定义配置后重新初始化。网关端口已迁移;仅影响自定义网关模式,官方 DC Key 模式无感。
+- 桌面端 · Windows 首次启动时,系统防火墙会询问是否允许 `new-api.exe` 联网:这是一次性提示,选「允许访问」或「取消」均不影响使用,应用仅使用本机回环通信。
+- 桌面端 · Windows 安装包暂未代码签名,SmartScreen 可能提示「未知发布者」:点「更多信息 -> 仍要运行」即可。

--- a/tests/test_release_feed.py
+++ b/tests/test_release_feed.py
@@ -114,7 +114,7 @@ def test_built_wheel_contains_parseable_release_notes_artifact(tmp_path: Path) -
 def test_project_version_is_single_source_of_truth() -> None:
     pyproject = tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))
 
-    assert pyproject["project"]["version"] == "1.1.0"
+    assert pyproject["project"]["version"] == "1.1.1"
     assert importlib.metadata.version("supertale-ce") == pyproject["project"]["version"]
     assert "__version__" not in Path("src/novelvideo/__init__.py").read_text(encoding="utf-8")
 

--- a/uv.lock
+++ b/uv.lock
@@ -3419,7 +3419,7 @@ wheels = [
 
 [[package]]
 name = "supertale-ce"
-version = "1.1.0"
+version = "1.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## PR 类型 / Type of PR

- [ ] Bug 修复 / Bug fix
- [ ] 新功能 / Feature
- [ ] 文档 / Documentation
- [ ] 重构 / 清理 / Refactor or cleanup
- [x] 构建 / CI / Build or CI
- [ ] 破坏性变更 / Breaking change

## 改动说明 / What this PR does and why

将 CE 发行版本更新至 1.1.1，并同步打包元数据、锁文件、应用内双语发布说明和版本一致性断言。

## 关联 issue / Linked issues

N/A

## 给 reviewer 的说明 / Notes for the reviewer

发布说明覆盖 v1.1.0 之后已合入 main 的用户可见改动：桌面端下载与自动更新 CDN 加速、资产库多媒介与主线同步、历史资产展示放开、本地 NewAPI 初始化简化、媒体模型命名对齐、桌面端内置网关端口迁移至 18780、画布操作改进、文本生成默认关闭深度推理，以及相关已知问题提示；未包含功能代码变更。

## 面向用户的变更 / User-facing change

```release-note
v1.1.1 speeds up desktop downloads and updates, upgrades the asset library, simplifies self-hosted gateway setup, and improves canvas controls.
```

## 自检 / Checklist

- [x] 已自测，uv run pytest 通过 / Self-tested, uv run pytest passes
  - 已运行：UV_CACHE_DIR=/claymorelab/.uv-cache uv run pytest tests/test_release_feed.py（12 passed）
- [x] 必要的文档已更新 / Docs updated where needed
- [x] 提交信息清晰（建议 Conventional Commits）/ Clear commits (Conventional Commits suggested)
- [x] 每个 commit 都已 git commit -s 附 DCO 签署 / Every commit signed off with git commit -s (DCO)
- [x] 我已阅读并同意贡献者协议 / I've read and agree to the contributor terms
