### PR TITLE
chore(deps): bump self-hosted NewAPI image

### DIFF
--- a/docker-compose.selfhosted.yml
+++ b/docker-compose.selfhosted.yml
@@ -49,7 +49,7 @@ services:
   # 内置 newAPI 网关（OpenAI 兼容）。默认使用 newapi-data 卷里的 SQLite；DramaClaw
   # 通过共享卷自动初始化管理员、运行令牌、渠道与模型映射。
   newapi:
-    image: calciumion/new-api:v1.0.0-rc.15
+    image: calciumion/new-api:v1.0.0-rc.21
     restart: unless-stopped
     environment:
       TZ: Asia/Shanghai


### PR DESCRIPTION
## PR 类型 / Type of PR

- [ ] 🐞 Bug 修复 / Bug fix
- [ ] ✨ 新功能 / Feature
- [ ] 📝 文档 / Documentation
- [ ] 🧹 重构 / 清理 / Refactor or cleanup
- [x] ⚙️ 构建 / CI / Build or CI
- [ ] ⚠️ 破坏性变更 / Breaking change

## 改动说明 / What this PR does and why

将自托管 Docker Compose 中内置 NewAPI 网关镜像从 `calciumion/new-api:v1.0.0-rc.15` 升级到 `calciumion/new-api:v1.0.0-rc.21`，同步当前期望的 NewAPI 官方版本。

## 关联 issue / Linked issues

Fixes #137

## 给 reviewer 的说明 / Notes for the reviewer

仅修改 `docker-compose.selfhosted.yml` 的 `newapi` 服务镜像 tag，不改变端口、卷、环境变量或服务拓扑。

## 面向用户的变更 / User-facing change

```release-note
Self-hosted Docker Compose now uses NewAPI v1.0.0-rc.21 for the bundled local gateway.
```

## 自检 / Checklist

- [x] 已自测，`uv run pytest` 通过 / Self-tested, `uv run pytest` passes
  - 未运行：本次只更新 Docker Compose 镜像 tag，已改跑 Compose 配置校验。
- [x] 必要的文档已更新 / Docs updated where needed
  - N/A：无文档变更。
- [x] 提交信息清晰（建议 Conventional Commits）/ Clear commits (Conventional Commits suggested)
- [x] 每个 commit 都已 `git commit -s` 附 DCO 签署 / Every commit signed off with `git commit -s` (DCO)
- [x] 我已阅读并同意[贡献者协议](../CONTRIBUTING.md#贡献者协议) / I've read and agree to the [contributor terms](../CONTRIBUTING.md#贡献者协议)

## 验证 / Verification

- `git diff --check origin/main...HEAD`
- `docker compose -f docker-compose.selfhosted.yml config`
