### PR TITLE
fix(ingest): 虾料导入体验修复合集(防切走丢稿 + 格式警告去黄 + 恢复进度视图 + 去重导入警告)

### DIFF
--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -1303,6 +1303,8 @@
     "subtitle": "Upload a script and start your creative journey.",
     "dropzoneHint": "Click or drop your novel file here",
     "supportedFormats": "Supports .txt / .md / .docx · up to 10MB",
+    "uploadingTitle": "Uploading novel…",
+    "uploadingHint": "Please stay on this page until the upload finishes. It may take a moment on a slow connection.",
     "inputMode": {
       "upload": "Upload Novel",
       "paste": "Paste Text"

--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -1355,7 +1355,6 @@
     "tableTitle": "Title",
     "tableCharCount": "Words",
     "moreChapters": "… and {{count}} more chapter(s)",
-    "reimportWarning": "Re-importing will clear the existing graph and rebuild.",
     "reuploadConfirm": {
       "title": "Confirm re-import",
       "description": "Re-importing will rebuild the graph and may affect downstream pipeline results such as characters, episodes, scripts, and videos. Are you sure you want to re-import the novel/script?",

--- a/frontend/public/locales/zh/translation.json
+++ b/frontend/public/locales/zh/translation.json
@@ -1303,6 +1303,8 @@
     "subtitle": "上传剧本，开启你的创意之旅",
     "dropzoneHint": "点击或拖拽上传小说文件",
     "supportedFormats": "支持 .txt / .md / .docx，建议不超过 10MB",
+    "uploadingTitle": "正在上传小说…",
+    "uploadingHint": "上传完成前请勿离开本页面，网络较慢时可能需要多等一会儿。",
     "inputMode": {
       "upload": "上传小说",
       "paste": "粘贴文本"

--- a/frontend/public/locales/zh/translation.json
+++ b/frontend/public/locales/zh/translation.json
@@ -1355,7 +1355,6 @@
     "tableTitle": "标题",
     "tableCharCount": "字数",
     "moreChapters": "… 还有 {{count}} 个章节",
-    "reimportWarning": "重新导入将清空图谱并重建",
     "reuploadConfirm": {
       "title": "确认重新导入",
       "description": "重新导入会重建图谱，可能影响后续角色、剧集、脚本、视频等流水线结果，是否确认重新导入小说/剧本？",

--- a/frontend/src/__tests__/routes/ingest-settings-save.test.tsx
+++ b/frontend/src/__tests__/routes/ingest-settings-save.test.tsx
@@ -38,6 +38,8 @@ beforeAll(async () => {
             subtitle: "Upload your novel file.",
             dropzoneHint: "Click or drop your novel file here",
             supportedFormats: "Supports .txt / .md / .docx",
+            restoredFilename: "Imported novel",
+            previewHeading: "Novel Structure Preview",
             inputMode: { upload: "Upload Novel", paste: "Paste Text" },
             sourceHint: {
               uploadActive: "Uploaded file active",
@@ -115,6 +117,7 @@ const mocks = vi.hoisted(() => ({
     | undefined,
   toastSuccess: vi.fn(),
   toastError: vi.fn(),
+  ingestTasks: [] as { task_type: string; episode: number; status: string }[],
 }));
 
 vi.mock("@/components/ui/select", async () => {
@@ -204,6 +207,7 @@ vi.mock("@/lib/queries/characters", () => ({
 
 vi.mock("@/lib/queries/tasks", () => ({
   useCancelTask: () => ({ mutateAsync: vi.fn(), isPending: false }),
+  useTasks: () => ({ data: { ok: true, data: mocks.ingestTasks } }),
 }));
 
 vi.mock("@/hooks/use-task-stream", () => ({
@@ -252,6 +256,7 @@ beforeEach(() => {
   mocks.chaptersData = undefined;
   mocks.toastSuccess.mockReset();
   mocks.toastError.mockReset();
+  mocks.ingestTasks = [];
 });
 
 describe("IngestPage settings save", () => {
@@ -500,5 +505,50 @@ describe("IngestPage settings save", () => {
       await screen.findByText("知识图谱构建失败: provider error"),
     ).toBeInTheDocument();
     expect(mocks.toastError).toHaveBeenCalledWith("知识图谱构建失败: provider error");
+  });
+
+  it("restores the import progress view on mount when an ingest_fast task is still running", async () => {
+    // Bug: navigating away mid-import and back reset the local flags, so the
+    // page fell back to the empty upload zone even though the server task was
+    // still running (chapters not yet durably imported). Mount reconcile must
+    // re-open the progress view.
+    mocks.ingestTasks = [
+      { task_type: "ingest_fast", episode: 0, status: "running" },
+    ];
+
+    render(
+      <Wrapper>
+        <IngestPageContent project="demo" />
+      </Wrapper>,
+    );
+
+    // Progress view: restored file card with the "Importing" status badge.
+    // (Chapters aren't durably imported yet mid-import, so the structure
+    // preview section stays empty — the point is we don't fall back to the
+    // upload zone.)
+    expect(await screen.findByText("Importing")).toBeInTheDocument();
+    expect(screen.getByText("Imported novel")).toBeInTheDocument();
+    // The empty upload zone must be gone.
+    expect(
+      screen.queryByText("Supports .txt / .md / .docx"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("does not restore the import view when no ingest task is active", () => {
+    mocks.ingestTasks = [
+      { task_type: "ingest_fast", episode: 0, status: "completed" },
+    ];
+
+    render(
+      <Wrapper>
+        <IngestPageContent project="demo" />
+      </Wrapper>,
+    );
+
+    // Completed (not active) → stays on the normal upload zone.
+    expect(
+      screen.getByText("Supports .txt / .md / .docx"),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("Importing")).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/routes/_app/projects.$project/ingest.tsx
+++ b/frontend/src/routes/_app/projects.$project/ingest.tsx
@@ -34,8 +34,7 @@ import {
 import { FormatCheckDetailsDialog } from "@/components/ingest/FormatCheckDetailsDialog";
 import { NovelFormatDialog } from "@/components/ingest/NovelFormatDialog";
 import { useStyles } from "@/lib/queries/styles";
-import { useCharacters } from "@/lib/queries/characters";
-import { useCancelTask } from "@/lib/queries/tasks";
+import { useCancelTask, useTasks } from "@/lib/queries/tasks";
 import { useGenerationCreditCost } from "@/lib/queries/generation-credit-cost";
 import { useTaskStream } from "@/hooks/use-task-stream";
 import { queryKeys } from "@/lib/query-keys";
@@ -209,6 +208,15 @@ type IngestFileStatus =
   | "completed"
   | "stopped"
   | "failed";
+
+// 一个 ingest_fast 任务处于这些状态 = 导入尚在进行，切走再回来要恢复进度视图。
+const ACTIVE_INGEST_STATUSES = new Set([
+  "submitting",
+  "queued",
+  "pending",
+  "starting",
+  "running",
+]);
 
 const PASTE_TEXT_MAX_LENGTH = 1000;
 const HIDDEN_IMPORTED_PREVIEW_KEY_PREFIX =
@@ -889,9 +897,6 @@ export function IngestPageContent({ project }: { project: string }) {
   const chaptersData = chaptersRes?.data;
   const hasImportedContent = (chaptersData?.chapters?.length ?? 0) > 0;
 
-  // Re-import warning if characters already exist
-  const { data: charactersRes } = useCharacters(project);
-  const hasCharacters = (charactersRes?.data?.length ?? 0) > 0;
   const pastedBillableChars = useMemo(
     () => countBillableNovelChars(pastedText.trim()),
     [pastedText],
@@ -967,6 +972,30 @@ export function IngestPageContent({ project }: { project: string }) {
       setIngestError(error);
     },
   });
+
+  // Mount reconcile：导入实际在服务端(celery)跑。用户导入中切走再回来，本地
+  // 的 ingestStarted/ingestSubmitted 全部重置、SSE 也不重连，而此时章节尚未
+  // 持久化(chapters 为空)，页面便退回空上传页——「导入中的虾料不见了」。
+  // 挂载时与服务端任务列表对账一次：若 ingest_fast 仍活跃，就重开进度视图，
+  // 让 useTaskStream 重连(后端会在连接时补发运行进度)。
+  const { data: ingestTasksRes } = useTasks({ project, episode: 0 });
+  const ingestReconciledRef = useRef(false);
+  useEffect(() => {
+    if (ingestReconciledRef.current) return;
+    if (ingestTasksRes === undefined) return;
+    ingestReconciledRef.current = true;
+    const running = (ingestTasksRes.data ?? []).some(
+      (task) =>
+        task.task_type === "ingest_fast" &&
+        ACTIVE_INGEST_STATUSES.has(task.status),
+    );
+    if (running) {
+      setIngestSubmitted(true);
+      setIngestStarted(true);
+      setIngestFileStatus("importing");
+      setHideImportedPreview(false);
+    }
+  }, [ingestTasksRes, project]);
 
   const handleCancelIngest = useCallback(async () => {
     setIngestStarted(false);
@@ -1216,7 +1245,7 @@ export function IngestPageContent({ project }: { project: string }) {
   const shouldShowPreview = ingestSubmitted || shouldRestoreImportedPreview;
   const previewFile =
     uploadedFile ??
-    (shouldRestoreImportedPreview
+    (shouldRestoreImportedPreview || ingestSubmitted
       ? { filename: t("ingest.restoredFilename"), size: null }
       : null);
   const previewStatus: IngestFileStatus =
@@ -1618,14 +1647,6 @@ export function IngestPageContent({ project }: { project: string }) {
                   </AlertDialogFooter>
                 </AlertDialogContent>
               </AlertDialog>
-
-              {/* Re-import warning */}
-              {previewFile && hasCharacters && (
-                <div className="flex items-center gap-2 rounded-md bg-amber-300/[0.04] px-3 py-2.5 text-xs text-amber-200/75">
-                  <AlertTriangle className="size-4 shrink-0 text-amber-200/70" />
-                  <span>{t("ingest.reimportWarning")}</span>
-                </div>
-              )}
 
               {/* Preview — loading placeholder */}
               {!chaptersData && chaptersFetching && <ChapterPreviewSkeleton />}

--- a/frontend/src/routes/_app/projects.$project/ingest.tsx
+++ b/frontend/src/routes/_app/projects.$project/ingest.tsx
@@ -345,6 +345,45 @@ function UploadZone({
   );
 }
 
+// 全屏上传遮罩：网络慢时上传还在飞、用户一切菜单就卸载本页，upload 的 onSuccess
+// 便写不进 chapters 缓存，回来「刚上传的小说」就消失了。用 fixed inset-0 z-[1000]
+// 盖住整屏（含顶部菜单），上传期间挡住导航，逼用户等上传落地再离开。
+function UploadingOverlay() {
+  const { t } = useTranslation();
+  return (
+    <div
+      role="alertdialog"
+      aria-busy="true"
+      aria-live="assertive"
+      aria-label={t("ingest.uploadingTitle")}
+      className="fixed inset-0 z-[1000] flex items-center justify-center bg-background/80 px-6 text-foreground backdrop-blur-md"
+    >
+      <div className="flex w-full max-w-sm flex-col items-center rounded-2xl border border-border/60 bg-card/95 px-8 py-10 text-center shadow-2xl shadow-black/50">
+        <div className="relative mb-6 flex size-14 items-center justify-center">
+          <span
+            className="absolute inset-0 animate-ping rounded-full bg-primary/10"
+            aria-hidden="true"
+          />
+          <span
+            className="absolute inset-0 rounded-full bg-primary/10"
+            aria-hidden="true"
+          />
+          <Loader2
+            className="relative size-7 animate-spin text-primary"
+            aria-hidden="true"
+          />
+        </div>
+        <h2 className="text-lg font-semibold tracking-tight">
+          {t("ingest.uploadingTitle")}
+        </h2>
+        <p className="mt-2.5 max-w-[17rem] text-[13px] leading-6 text-muted-foreground">
+          {t("ingest.uploadingHint")}
+        </p>
+      </div>
+    </div>
+  );
+}
+
 // 格式风险常驻警告：文件在则警告在，替代一闪而过的 toast.warning。
 // boxed = 富卡片里的琥珀色警告条；plain = 上传表单提示行里的一行轻量文字。
 function FormatCheckWarning({
@@ -365,9 +404,7 @@ function FormatCheckWarning({
       onClick={onViewDetails}
       className={cn(
         "ml-1.5 whitespace-nowrap font-medium underline underline-offset-2 transition-colors",
-        variant === "boxed"
-          ? "text-amber-300 hover:text-amber-200"
-          : "text-foreground/80 hover:text-foreground",
+        "text-foreground/80 hover:text-foreground",
       )}
     >
       {t("aiAssistant.formatCheck.viewDetails")}
@@ -377,7 +414,7 @@ function FormatCheckWarning({
   if (variant === "plain") {
     return (
       <div className={cn("flex items-start gap-1.5", className)}>
-        <AlertTriangle className="mt-px size-3.5 shrink-0 text-amber-400" />
+        <AlertTriangle className="mt-px size-3.5 shrink-0 text-foreground/45" />
         <div className="min-w-0">
           <span>{formatCheck.summary || t("aiAssistant.formatCheck.title")}</span>
           {detailsButton}
@@ -389,12 +426,12 @@ function FormatCheckWarning({
   return (
     <div
       className={cn(
-        "flex items-start gap-2 rounded-md border border-amber-500/30 bg-amber-500/10 px-3 py-2",
+        "flex items-start gap-2 rounded-md border border-white/10 bg-white/[0.04] px-3 py-2",
         className,
       )}
     >
-      <AlertTriangle className="mt-0.5 size-3.5 shrink-0 text-amber-400" />
-      <div className="min-w-0 text-xs leading-5 text-amber-200/90">
+      <AlertTriangle className="mt-0.5 size-3.5 shrink-0 text-foreground/45" />
+      <div className="min-w-0 text-xs leading-5 text-foreground/70">
         <span>{formatCheck.summary || t("aiAssistant.formatCheck.title")}</span>
         {detailsButton}
       </div>
@@ -1225,6 +1262,7 @@ export function IngestPageContent({ project }: { project: string }) {
 
   return (
     <div className="-m-6 flex h-[calc(100%+3rem)] flex-col overflow-hidden">
+      {uploadMutation.isPending && <UploadingOverlay />}
       <div className="flex shrink-0 flex-col gap-3 border-b border-border/30 bg-background px-9 py-5 lg:flex-row lg:items-center lg:justify-between">
         <div className="flex min-w-0 items-start gap-3">
           <span className="mt-0.5 flex size-9 shrink-0 items-center justify-center rounded-md bg-primary text-primary-foreground">


### PR DESCRIPTION
## 背景
虾料(小说导入)页的一组体验修复。

## 改动
1. **上传全屏 loading,防切走丢稿**:上传过程中加全屏 loading 遮罩,避免用户切走导致「刚上传的小说」从缓存丢失。
2. **格式风险警告去黄**:格式检测警告横幅改用白/灰 + 透明度,不再刺眼黄字。
3. **导入中切走/刷新回来虾料不再空白**:导入实际跑在服务端 celery,此前进度视图仅由本地 `ingestStarted/ingestSubmitted` 门控,切走再回来或刷新时状态被重置、SSE 不重连,而 mid-import 章节未持久化,页面退回空上传页。改为挂载时用 `useTasks` 与服务端任务列表对账一次,存在活跃 `ingest_fast` 任务则重开进度视图并让 `useTaskStream` 重连(后端补发运行进度)。
4. **去掉导入完成后常驻的「重新导入将清空图谱」警告**:该警告仅在已导入成功的预览视图常驻,与重新上传确认弹窗重复,移除并清理连带失效的 `hasCharacters/useCharacters` 及孤儿 i18n key。

## 验证
- `pnpm build`(tsc -b + vite)✓
- ingest 测试 11 passed ✓(含新增 2 条挂载对账恢复用例)

🤖 Generated with [Claude Code](https://claude.com/claude-code)