### PR TITLE
chore: release v1.1.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "supertale-ce"
-version = "1.1.1"
+version = "1.1.2"
 description = "SuperTale Community Edition API and video pipeline"
 readme = "README.md"
 requires-python = ">=3.11,<3.13"

--- a/src/novelvideo/release-notes.md
+++ b/src/novelvideo/release-notes.md
@@ -1,36 +1,30 @@
 ---
-version: 1.1.1
+version: 1.1.2
 attention: low
 ---
-# v1.1.1
+# v1.1.2
 
 ## User-facing Highlights (zh)
 
-- **桌面端 · 下载与自动更新全面提速**: 安装包分发与应用内自动更新接入国内 CDN。本版起,检查更新与差分下载不再受国际链路影响;从 v1.1.0 升级到本版的这一次仍走原渠道,升级完成后即切换至加速通道。
-- **资产库升级**: 资产库支持多媒介类型并与主线同步;历史资产不再限制每类仅显示 20 条,创作素材一览无余。
-- **自建网关更省心**: 本地网关一键初始化流程简化,媒体模型命名与网关侧对齐;桌面端内置网关默认端口迁移至 18780,避开与常见开发工具端口 3000 的冲突。
+- **虾格视频支持 HappyHorse 1.0**: 画布视频节点新增文生视频、首帧、图片参考和视频编辑四种 HappyHorse 模式,按上游节点自动切换。
+- **虾料导入更稳**: 上传小说时防误切走,导入中刷新或返回页面会自动恢复进度视图。
+- **自建模型链路统一**: CE 的 NewAPI 运行时与 Freezone 视觉路由统一,本地/自建网关的视频与视觉能力更一致。
 
 ## User-facing Highlights (en)
 
-- **Desktop · Faster downloads and updates**: Installer distribution and in-app auto-updates now ride a China-friendly CDN. From this version onward, update checks and differential downloads are no longer throttled by cross-border links; the one-time upgrade from v1.1.0 still uses the original channel, after which the accelerated channel takes over.
-- **Asset library upgrade**: The asset library now supports multiple media types with mainline sync, and the 20-items-per-category display cap is removed.
-- **Smoother self-hosted gateway**: One-click local gateway setup is simplified, media model names are aligned with the gateway, and the desktop bundled gateway default port moves to 18780 to avoid clashing with common dev tools on port 3000.
+- **HappyHorse 1.0 in Freezone video nodes**: Canvas video nodes now support HappyHorse text-to-video, first-frame, image-reference, and video-edit modes with automatic mode selection from upstream nodes.
+- **More reliable novel ingest**: Novel upload is protected from accidental navigation, and in-progress imports restore their progress view after refresh or returning to the page.
+- **Unified self-hosted model routing**: CE NewAPI runtime and Freezone vision routing are now aligned for more consistent video and vision behavior with local/self-hosted gateways.
+
+## New Features
+
+- 新增 HappyHorse 1.0 视频四模式:文生视频、首帧、图片参考、视频编辑 (#141).
 
 ## Improvements
 
-- 画布连线支持一键隐藏/显示,仅视觉隐藏,连线关系保留 (#129).
-- 视频时长支持直接输入,生成面板视觉收敛 (#128).
-- 统一导航反馈与素材页控件交互 (#125).
-- 文本生成默认不再开启深度推理,响应更快 (#135).
+- 统一 CE NewAPI runtime 与 Freezone vision routing,并升级 bundled new-api image 到 `v1.0.0-rc.21` (#138, #140).
 
 ## Bug Fixes
 
-- 修复 FAQ 弹层在短视口下的重叠问题 (#128).
-- NewAPI 媒体模型命名对齐,修正自建网关下部分媒体模型无法命中的问题 (#131).
-- 本地开发态的兜底版本号改为从 git tag 派生,不再显示过期版本 (#126).
-
-## Known Issues 已知问题
-
-- 已使用「一键初始化自建网关」的用户:升级后请在设置页将网关地址更新为 `http://127.0.0.1:18780`,或清除自定义配置后重新初始化。网关端口已迁移;仅影响自定义网关模式,官方 DC Key 模式无感。
-- 桌面端 · Windows 首次启动时,系统防火墙会询问是否允许 `new-api.exe` 联网:这是一次性提示,选「允许访问」或「取消」均不影响使用,应用仅使用本机回环通信。
-- 桌面端 · Windows 安装包暂未代码签名,SmartScreen 可能提示「未知发布者」:点「更多信息 -> 仍要运行」即可。
+- 修复虾料导入中切走、刷新后页面丢失进度视图的问题,并修复 stale-cache 与跨项目复用下的恢复漏洞 (#139, #142).
+- 统一关键帧提示词路由,移除无效的样式提取路径 (#143).

--- a/tests/test_release_feed.py
+++ b/tests/test_release_feed.py
@@ -114,7 +114,7 @@ def test_built_wheel_contains_parseable_release_notes_artifact(tmp_path: Path) -
 def test_project_version_is_single_source_of_truth() -> None:
     pyproject = tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))
 
-    assert pyproject["project"]["version"] == "1.1.1"
+    assert pyproject["project"]["version"] == "1.1.2"
     assert importlib.metadata.version("supertale-ce") == pyproject["project"]["version"]
     assert "__version__" not in Path("src/novelvideo/__init__.py").read_text(encoding="utf-8")
 

--- a/uv.lock
+++ b/uv.lock
@@ -3419,7 +3419,7 @@ wheels = [
 
 [[package]]
 name = "supertale-ce"
-version = "1.1.1"
+version = "1.1.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary
- bump supertale-ce to v1.1.2
- update package release notes for v1.1.2
- update release feed SSOT test and uv.lock

## Verification
- UV_CACHE_DIR=/Users/newyue/claymorelab/.uv-cache uv pip install -e .
- UV_CACHE_DIR=/Users/newyue/claymorelab/.uv-cache uv run pytest tests/test_release_feed.py