### PR TITLE
fix(frontend): improve generation error notifications

### DIFF
--- a/frontend/src/__tests__/features/canvas/generation-task-arbitration.test.ts
+++ b/frontend/src/__tests__/features/canvas/generation-task-arbitration.test.ts
@@ -27,6 +27,20 @@ describe('generation task arbitration', () => {
     });
   });
 
+  it('keeps provider policy codes searchable after normalizing the displayed message', () => {
+    const policyCode = 'InputImageSensitiveContentDetected.PrivateInformation';
+    const rawError =
+      'video generation failed: request_id=req-sensitive; ' +
+      `body={"error":{"message":"Sensitive input image.","code":"${policyCode}"}}`;
+    const error = new TaskCompletionError(rawError, 'failed', 'task-current');
+    const displayMessage = backendErrorToastMessage(error, t);
+    const diagnostics = resolveGenerationErrorDiagnostics(error);
+
+    expect(displayMessage).toBe('Sensitive input image.');
+    expect(displayMessage).not.toContain(policyCode);
+    expect(`${displayMessage}\n${diagnostics.details ?? ''}`).toContain(policyCode);
+  });
+
   it('clears stale generation errors when an image generation succeeds', () => {
     expect(buildImageGenerationSuccessPatch('/outputs/image.png')).toEqual({
       imageUrl: '/outputs/image.png',

--- a/frontend/src/__tests__/features/canvas/generation-task-arbitration.test.ts
+++ b/frontend/src/__tests__/features/canvas/generation-task-arbitration.test.ts
@@ -8,8 +8,25 @@ import {
   isStaleGenerationTask,
   shouldWriteGenerationError,
 } from '@/features/canvas/application/generationTaskArbitration';
+import { resolveGenerationErrorDiagnostics } from '@/features/canvas/application/generationErrorReport';
+import { backendErrorToastMessage } from '@/lib/api-errors';
+
+const t = ((key: string) => key) as unknown as Parameters<typeof backendErrorToastMessage>[1];
 
 describe('generation task arbitration', () => {
+  it('shows a concise task error while preserving its raw response and request id', () => {
+    const rawError =
+      'video generation failed: request_id=req-123; ' +
+      'body={"error":{"message":"Content failed safety review.","code":"moderation_blocked"}}';
+    const error = new TaskCompletionError(rawError, 'failed', 'task-current');
+
+    expect(backendErrorToastMessage(error, t)).toBe('Content failed safety review.');
+    expect(resolveGenerationErrorDiagnostics(error)).toEqual({
+      details: rawError,
+      requestId: 'req-123',
+    });
+  });
+
   it('clears stale generation errors when an image generation succeeds', () => {
     expect(buildImageGenerationSuccessPatch('/outputs/image.png')).toEqual({
       imageUrl: '/outputs/image.png',
@@ -82,4 +99,3 @@ describe('generation task arbitration', () => {
     expect(shouldWrite).toBe(true);
   });
 });
-

--- a/frontend/src/__tests__/features/canvas/image-gen-error-notification.test.ts
+++ b/frontend/src/__tests__/features/canvas/image-gen-error-notification.test.ts
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: Elastic-2.0
+// Copyright (c) 2026 ClaymoreLab
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+function read(relativePath: string): string {
+  return readFileSync(resolve(process.cwd(), relativePath), "utf8");
+}
+
+describe("ImageGenNode error notification contract", () => {
+  it("stores the raw error separately from the displayed provider message", () => {
+    const source = read("src/features/canvas/nodes/ImageGenNode.tsx");
+
+    expect(source).toContain("generationError: displayErrorMessage");
+    expect(source).toContain("generationErrorDetails: rawErrorMessage");
+    expect(source).toContain("generationErrorRequestId: extractRequestId(rawErrorMessage)");
+  });
+
+  it("copies the preserved raw ImageGen error from the node toolbar", () => {
+    const source = read("src/features/canvas/ui/NodeActionToolbar.tsx");
+
+    expect(source).toContain("isExportImageNode(node) || isImageGenNode(node)");
+    expect(source).toContain("return generationErrorDetails || generationError");
+  });
+
+  it("copies the complete error from the request-id row instead of only the id", () => {
+    const source = read("src/features/canvas/nodes/ImageGenNode.tsx");
+
+    expect(source).toContain(
+      "const copyText = generationErrorDetails || generationError || generationErrorRequestId",
+    );
+    expect(source).toContain("navigator.clipboard.writeText(copyText)");
+    expect(source).not.toContain("navigator.clipboard.writeText(generationErrorRequestId)");
+  });
+});

--- a/frontend/src/__tests__/features/canvas/video-error-notification.test.ts
+++ b/frontend/src/__tests__/features/canvas/video-error-notification.test.ts
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: Elastic-2.0
+// Copyright (c) 2026 ClaymoreLab
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+function read(relativePath: string): string {
+  return readFileSync(resolve(process.cwd(), relativePath), "utf8");
+}
+
+describe("VideoNode error notification contract", () => {
+  it("uses preserved diagnostics for policy detection and dialog copy", () => {
+    const source = read("src/features/canvas/nodes/VideoNode.tsx");
+
+    expect(source).toContain(
+      'const haystack = `${displayErrorMessage}\\n${diagnostics.details ?? ""}`',
+    );
+    expect(source).toContain("diagnostics.details ?? undefined");
+    expect(source).not.toContain(
+      'const haystack = `${displayErrorMessage}\\n${resolved.details ?? ""}`',
+    );
+  });
+});

--- a/frontend/src/__tests__/lib/gateway-error-classify.test.ts
+++ b/frontend/src/__tests__/lib/gateway-error-classify.test.ts
@@ -2,7 +2,12 @@
 // Copyright (c) 2026 ClaymoreLab
 import { describe, expect, it } from "vitest";
 
-import { classifyGatewayError, humanizeTaskError } from "@/lib/api-errors";
+import {
+  backendErrorToastMessage,
+  classifyGatewayError,
+  humanizeTaskError,
+  providerErrorMessage,
+} from "@/lib/api-errors";
 
 // A stub TFunction: return the key, unless a `defaultValue` is supplied and
 // the key is unknown. Our two keys are "known", so return a marker per key.
@@ -20,6 +25,31 @@ const CHANNEL_POLICY_RAW =
 
 const REAL_429_RAW =
   'Render 重生未生成可用图片: HTTP 429: rate limit exceeded; body={"error":{"message":"Too Many Requests"}}';
+
+const MODERATION_RAW =
+  'DramaClawAPI image generation failed: HTTP 400: request_id=req-123; ' +
+  'body={"error":{"message":"Content failed safety review. / 内容未通过安全审核。",' +
+  '"type":"content_policy_violation","param":"","code":"moderation_blocked"}}';
+
+describe("providerErrorMessage", () => {
+  it("extracts a top-level message from a pure provider JSON error", () => {
+    expect(
+      providerErrorMessage(
+        '{"message":"Content failed safety review.","code":"moderation_blocked"}',
+      ),
+    ).toBe("Content failed safety review.");
+  });
+
+  it("extracts a nested provider message from a wrapped body without altering the raw input", () => {
+    expect(providerErrorMessage(MODERATION_RAW)).toBe(
+      "Content failed safety review. / 内容未通过安全审核。",
+    );
+  });
+
+  it("returns null when the raw error has no parseable provider JSON", () => {
+    expect(providerErrorMessage("disk full")).toBeNull();
+  });
+});
 
 describe("classifyGatewayError", () => {
   it("flags channel_policy rejections (route-layer skip, not throttling)", () => {
@@ -61,6 +91,15 @@ describe("humanizeTaskError", () => {
 
   it("passes unrelated errors through unchanged", () => {
     expect(humanizeTaskError("disk full", t)).toBe("disk full");
+  });
+
+  it("shows only the provider message for moderation failures", () => {
+    expect(humanizeTaskError(MODERATION_RAW, t)).toBe(
+      "Content failed safety review. / 内容未通过安全审核。",
+    );
+    expect(backendErrorToastMessage(new Error(MODERATION_RAW), t)).toBe(
+      "Content failed safety review. / 内容未通过安全审核。",
+    );
   });
 
   it("falls back to the generic error label when input is empty", () => {

--- a/frontend/src/__tests__/task-center/task-errors.test.ts
+++ b/frontend/src/__tests__/task-center/task-errors.test.ts
@@ -42,4 +42,16 @@ describe("taskErrorMessage", () => {
       defaultValue: "计费规则未配置，请联系管理员设置积分规则",
     });
   });
+
+  it("uses only the nested provider message in failure notifications", () => {
+    const t = vi.fn((key: string) => key) as unknown as TFunction;
+    const raw =
+      'DramaClawAPI image generation failed: HTTP 400: request_id=req-123; ' +
+      'body={"error":{"message":"Content failed safety review. / 内容未通过安全审核。",' +
+      '"type":"content_policy_violation","code":"moderation_blocked"}}';
+
+    expect(taskErrorMessage(task({ error: raw }), t)).toBe(
+      "Content failed safety review. / 内容未通过安全审核。",
+    );
+  });
 });

--- a/frontend/src/features/canvas/application/generationErrorReport.ts
+++ b/frontend/src/features/canvas/application/generationErrorReport.ts
@@ -52,6 +52,29 @@ export function extractRequestId(message: string | null | undefined): string | n
   return match ? match[1] : null;
 }
 
+export interface GenerationErrorDiagnostics {
+  details: string | null;
+  requestId: string | null;
+}
+
+export function resolveGenerationErrorDiagnostics(
+  error: unknown,
+  resolvedDetails?: string,
+): GenerationErrorDiagnostics {
+  const rawErrorMessage =
+    error instanceof Error && error.message
+      ? error.message.trim()
+      : typeof error === 'string'
+        ? error.trim()
+        : null;
+  const details = resolvedDetails?.trim() || rawErrorMessage || null;
+
+  return {
+    details,
+    requestId: extractRequestId(rawErrorMessage) ?? extractRequestId(resolvedDetails),
+  };
+}
+
 export function createReferenceImagePlaceholders(count: number): string[] {
   const safeCount = Math.max(0, Math.min(64, Math.floor(count)));
   return Array.from({ length: safeCount }, (_, index) => `[IMAGE_${index + 1}]`);

--- a/frontend/src/features/canvas/application/resumeGeneration.ts
+++ b/frontend/src/features/canvas/application/resumeGeneration.ts
@@ -19,6 +19,7 @@ import {
 } from '@/api/ops';
 import { awaitTaskCompletion, listTasks, type TaskState } from '@/api/tasks';
 import { resolveErrorContent } from '@/features/canvas/application/errorDialog';
+import { providerErrorMessage } from '@/lib/api-errors';
 import { extractRequestId } from '@/features/canvas/application/generationErrorReport';
 import {
   isStaleGenerationTask,
@@ -214,12 +215,13 @@ function buildErrorPatch(kind: ResumeKind, error: unknown): Record<string, unkno
   }
   if (kind === 'image' || kind === 'video') {
     const resolved = resolveErrorContent(error, kind === 'video' ? '视频生成失败' : '图像生成失败');
+    const rawMessage = resolved.message;
     return {
       ...CLEARED_TASK_FIELDS,
-      generationError: resolved.message,
-      generationErrorDetails: resolved.details ?? null,
+      generationError: providerErrorMessage(rawMessage) ?? rawMessage,
+      generationErrorDetails: resolved.details ?? rawMessage,
       generationErrorRequestId:
-        extractRequestId(resolved.message) ?? extractRequestId(resolved.details),
+        extractRequestId(rawMessage) ?? extractRequestId(resolved.details),
     };
   }
   // audio / script / reverse-prompt surface their own inline errors elsewhere;

--- a/frontend/src/features/canvas/nodes/ImageEditNode.tsx
+++ b/frontend/src/features/canvas/nodes/ImageEditNode.tsx
@@ -57,8 +57,8 @@ import {
   buildGenerationErrorReport,
   CURRENT_RUNTIME_SESSION_ID,
   createReferenceImagePlaceholders,
-  extractRequestId,
   getRuntimeDiagnostics,
+  resolveGenerationErrorDiagnostics,
   type GenerationDebugContext,
 } from '@/features/canvas/application/generationErrorReport';
 import {
@@ -741,6 +741,10 @@ export const ImageEditNode = memo(({ id, data, selected, width, height }: ImageE
     } catch (generationError) {
       const resolvedError = resolveErrorContent(generationError, t('ai.error'));
       const displayErrorMessage = backendErrorToastMessage(generationError, t);
+      const diagnostics = resolveGenerationErrorDiagnostics(
+        generationError,
+        resolvedError.details,
+      );
       const generationDebugContext: GenerationDebugContext = {
         sourceType: 'imageEdit',
         providerId: selectedModel.providerId,
@@ -759,14 +763,14 @@ export const ImageEditNode = memo(({ id, data, selected, width, height }: ImageE
       };
       const reportText = buildGenerationErrorReport({
         errorMessage: displayErrorMessage,
-        errorDetails: resolvedError.details,
+        errorDetails: diagnostics.details ?? undefined,
         context: generationDebugContext,
       });
       setError(displayErrorMessage);
       void showErrorDialog(
         displayErrorMessage,
         t('common.error'),
-        resolvedError.details,
+        diagnostics.details ?? undefined,
         reportText
       );
       updateNodeData(newNodeId, {
@@ -779,9 +783,8 @@ export const ImageEditNode = memo(({ id, data, selected, width, height }: ImageE
         // before a job is created.
         generationRequestPayload: regenerationPayload,
         generationError: displayErrorMessage,
-        generationErrorDetails: resolvedError.details ?? null,
-        generationErrorRequestId:
-          extractRequestId(displayErrorMessage) ?? extractRequestId(resolvedError.details),
+        generationErrorDetails: diagnostics.details,
+        generationErrorRequestId: diagnostics.requestId,
         generationDebugContext,
       });
     }

--- a/frontend/src/features/canvas/nodes/ImageGenNode.tsx
+++ b/frontend/src/features/canvas/nodes/ImageGenNode.tsx
@@ -299,6 +299,10 @@ export const ImageGenNode = memo(({ id, data, selected, width, height }: ImageGe
     typeof data.generationError === 'string' && data.generationError.length > 0
       ? data.generationError
       : null;
+  const generationErrorDetails =
+    typeof data.generationErrorDetails === 'string' && data.generationErrorDetails.length > 0
+      ? data.generationErrorDetails
+      : null;
   const generationErrorRequestId =
     typeof data.generationErrorRequestId === 'string' && data.generationErrorRequestId.length > 0
       ? data.generationErrorRequestId
@@ -315,18 +319,21 @@ export const ImageGenNode = memo(({ id, data, selected, width, height }: ImageGe
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [isUploading, setIsUploading] = useState(false);
   const [isTranslatingPrompt, setIsTranslatingPrompt] = useState(false);
-  const [requestIdCopied, setRequestIdCopied] = useState(false);
+  const [errorDetailsCopied, setErrorDetailsCopied] = useState(false);
 
-  const handleCopyRequestId = useCallback(async () => {
-    if (!generationErrorRequestId) return;
+  const handleCopyErrorDetails = useCallback(async () => {
+    // New failures keep the complete task/provider response in details. For
+    // older persisted nodes, generationError itself may still be the raw blob.
+    const copyText = generationErrorDetails || generationError || generationErrorRequestId;
+    if (!copyText) return;
     try {
-      await navigator.clipboard.writeText(generationErrorRequestId);
-      setRequestIdCopied(true);
-      window.setTimeout(() => setRequestIdCopied(false), 1200);
+      await navigator.clipboard.writeText(copyText);
+      setErrorDetailsCopied(true);
+      window.setTimeout(() => setErrorDetailsCopied(false), 1200);
     } catch (error) {
-      console.error('[image-gen] copy request id failed', error);
+      console.error('[image-gen] copy error details failed', error);
     }
-  }, [generationErrorRequestId]);
+  }, [generationError, generationErrorDetails, generationErrorRequestId]);
 
   const {
     models: availableModels,
@@ -907,6 +914,7 @@ export const ImageGenNode = memo(({ id, data, selected, width, height }: ImageGe
       isGenerating: true,
       generationStartedAt: Date.now(),
       generationError: null,
+      generationErrorDetails: null,
       generationErrorRequestId: null,
       generationBatch: null,
     });
@@ -992,13 +1000,20 @@ export const ImageGenNode = memo(({ id, data, selected, width, height }: ImageGe
         // submit — the request id is the handle support uses to trace it.
         // 只有 run 0 失败才终结 loading：非首 run 失败时 run 0 可能还在跑，
         // 它的成功补丁会清掉这里写的错误横幅。
+        const rawErrorMessage =
+          error instanceof Error && error.message
+            ? error.message
+            : String(error || t('common.error'));
         const displayErrorMessage = backendErrorToastMessage(error, t);
         updateNodeData(id, {
           ...(runIndex === 0
             ? { isGenerating: false, generationStartedAt: null }
             : {}),
           generationError: displayErrorMessage,
-          generationErrorRequestId: extractRequestId(displayErrorMessage),
+          // Keep the complete task/provider error for support copy. Only the
+          // concise provider `message` is rendered on the node.
+          generationErrorDetails: rawErrorMessage,
+          generationErrorRequestId: extractRequestId(rawErrorMessage),
         });
         // Re-throw so the caller can surface a single error dialog after all
         // concurrent attempts settle (rather than one dialog per failed image).
@@ -1490,10 +1505,10 @@ export const ImageGenNode = memo(({ id, data, selected, width, height }: ImageGe
                 </code>
                 <button
                   type="button"
-                  title={requestIdCopied ? t("node.imageNode.requestIdCopied") : t("node.imageNode.copyRequestId")}
+                  title={errorDetailsCopied ? t("nodeToolbar.copied") : t("nodeToolbar.copyErrorReport")}
                   onClick={(event) => {
                     event.stopPropagation();
-                    void handleCopyRequestId();
+                    void handleCopyErrorDetails();
                   }}
                   onPointerDown={(event) => event.stopPropagation()}
                   className="inline-flex h-5 w-5 shrink-0 items-center justify-center rounded text-text-muted/70 transition-colors hover:bg-white/10 hover:text-text-dark"

--- a/frontend/src/features/canvas/nodes/StoryboardGenNode.tsx
+++ b/frontend/src/features/canvas/nodes/StoryboardGenNode.tsx
@@ -43,8 +43,8 @@ import {
   buildGenerationErrorReport,
   CURRENT_RUNTIME_SESSION_ID,
   createReferenceImagePlaceholders,
-  extractRequestId,
   getRuntimeDiagnostics,
+  resolveGenerationErrorDiagnostics,
   type GenerationDebugContext,
 } from '@/features/canvas/application/generationErrorReport';
 import {
@@ -1181,6 +1181,10 @@ export const StoryboardGenNode = memo(({ id, data, selected, width, height }: St
     } catch (generationError) {
       const resolvedError = resolveErrorContent(generationError, '生成失败');
       const displayErrorMessage = backendErrorToastMessage(generationError, t);
+      const diagnostics = resolveGenerationErrorDiagnostics(
+        generationError,
+        resolvedError.details,
+      );
       const generationDebugContext: GenerationDebugContext = {
         sourceType: 'storyboardGen',
         providerId: selectedModel.providerId,
@@ -1199,11 +1203,16 @@ export const StoryboardGenNode = memo(({ id, data, selected, width, height }: St
       };
       const reportText = buildGenerationErrorReport({
         errorMessage: displayErrorMessage,
-        errorDetails: resolvedError.details,
+        errorDetails: diagnostics.details ?? undefined,
         context: generationDebugContext,
       });
       setError(displayErrorMessage);
-      void showErrorDialog(displayErrorMessage, t('common.error'), resolvedError.details, reportText);
+      void showErrorDialog(
+        displayErrorMessage,
+        t('common.error'),
+        diagnostics.details ?? undefined,
+        reportText,
+      );
       updateNodeData(newNodeId, {
         isGenerating: false,
         generationStartedAt: null,
@@ -1215,9 +1224,8 @@ export const StoryboardGenNode = memo(({ id, data, selected, width, height }: St
         generationRequestPayload: regenerationPayload,
         generationStoryboardMetadata: storyboardMetadata,
         generationError: displayErrorMessage,
-        generationErrorDetails: resolvedError.details ?? null,
-        generationErrorRequestId:
-          extractRequestId(displayErrorMessage) ?? extractRequestId(resolvedError.details),
+        generationErrorDetails: diagnostics.details,
+        generationErrorRequestId: diagnostics.requestId,
         generationDebugContext,
       });
     }

--- a/frontend/src/features/canvas/nodes/VideoNode.tsx
+++ b/frontend/src/features/canvas/nodes/VideoNode.tsx
@@ -94,7 +94,7 @@ import {
   showErrorDialog,
 } from "@/features/canvas/application/errorDialog";
 import { backendErrorToastMessage } from "@/lib/api-errors";
-import { extractRequestId } from "@/features/canvas/application/generationErrorReport";
+import { resolveGenerationErrorDiagnostics } from "@/features/canvas/application/generationErrorReport";
 import {
   PromptMentionEditor,
   type MentionCandidate,
@@ -2373,6 +2373,7 @@ export const VideoNode = memo(
             if (completedUrls.length > 0) return;
             const resolved = resolveErrorContent(error, "视频生成失败");
             const displayErrorMessage = backendErrorToastMessage(error, t);
+            const diagnostics = resolveGenerationErrorDiagnostics(error, resolved.details);
             // Persist the failure on the node so the 重新生成 entry survives after
             // the user dismisses the dialog (previously the error was dialog-only).
             // 只有 run 0 失败才终结 loading：非首 run 失败时 run 0 可能还在跑，
@@ -2382,9 +2383,8 @@ export const VideoNode = memo(
                 ? { isGenerating: false, generationStartedAt: null }
                 : {}),
               generationError: displayErrorMessage,
-              generationErrorDetails: resolved.details ?? null,
-              generationErrorRequestId:
-                extractRequestId(displayErrorMessage) ?? extractRequestId(resolved.details),
+              generationErrorDetails: diagnostics.details,
+              generationErrorRequestId: diagnostics.requestId,
             });
           }
         };

--- a/frontend/src/features/canvas/nodes/VideoNode.tsx
+++ b/frontend/src/features/canvas/nodes/VideoNode.tsx
@@ -2406,7 +2406,8 @@ export const VideoNode = memo(
           const firstError = runErrors[0];
           const resolved = resolveErrorContent(firstError, "视频生成失败");
           const displayErrorMessage = backendErrorToastMessage(firstError, t);
-          const haystack = `${displayErrorMessage}\n${resolved.details ?? ""}`;
+          const diagnostics = resolveGenerationErrorDiagnostics(firstError, resolved.details);
+          const haystack = `${displayErrorMessage}\n${diagnostics.details ?? ""}`;
           if (
             haystack.includes(
               "InputImageSensitiveContentDetected.PrivateInformation",
@@ -2416,10 +2417,14 @@ export const VideoNode = memo(
             void showErrorDialog(
               "素材包含真实人脸，已被内容安全策略拦截。请在下方打开「真人素材审核」开关后重试（可能增加审核时间，不保证通过）。",
               "素材被拦截",
-              resolved.details,
+              diagnostics.details ?? undefined,
             );
           } else {
-            void showErrorDialog(displayErrorMessage, t("common.error"), resolved.details);
+            void showErrorDialog(
+              displayErrorMessage,
+              t("common.error"),
+              diagnostics.details ?? undefined,
+            );
           }
         } else if (runErrors.length > 0) {
           toast.error(

--- a/frontend/src/features/canvas/ui/NodeActionToolbar.tsx
+++ b/frontend/src/features/canvas/ui/NodeActionToolbar.tsx
@@ -542,8 +542,10 @@ export const NodeActionToolbar = memo(
     const projectionStatus = useCanvasProjectionStatus(protectedProjectionKey);
     const projectionIsStale = projectionStatus?.stale === true;
     const extractableBeatContext = useMemo(() => beatContextFromNode(node), [node]);
+    const canExposeGenerationError =
+      isExportImageNode(node) || isImageGenNode(node);
     const generationError =
-      isExportImageNode(node) &&
+      canExposeGenerationError &&
       typeof (node.data as { generationError?: unknown }).generationError ===
         "string"
         ? (
@@ -551,7 +553,7 @@ export const NodeActionToolbar = memo(
           ).trim()
         : "";
     const generationErrorDetails =
-      isExportImageNode(node) &&
+      canExposeGenerationError &&
       typeof (node.data as { generationErrorDetails?: unknown })
         .generationErrorDetails === "string"
         ? (
@@ -560,16 +562,22 @@ export const NodeActionToolbar = memo(
           ).trim()
         : "";
     const canCopyGenerationError =
-      isExportImageNode(node) && generationError.length > 0;
+      canExposeGenerationError && generationError.length > 0;
     const generationErrorReport = useMemo(
-      () =>
-        buildGenerationErrorReport({
+      () => {
+        // ImageGen keeps the exact pre-normalization error in details: copy it
+        // verbatim. Export-image nodes retain their richer diagnostic report.
+        if (isImageGenNode(node)) {
+          return generationErrorDetails || generationError;
+        }
+        return buildGenerationErrorReport({
           errorMessage: generationError || t("ai.error"),
           errorDetails: generationErrorDetails || undefined,
           context: (node.data as { generationDebugContext?: unknown })
             .generationDebugContext,
-        }),
-      [generationError, generationErrorDetails, node.data, t],
+        });
+      },
+      [generationError, generationErrorDetails, node, t],
     );
 
     const closeDownloadMenu = useCallback(() => {}, []);

--- a/frontend/src/lib/api-errors.ts
+++ b/frontend/src/lib/api-errors.ts
@@ -194,6 +194,83 @@ export async function jsonWithBackendError<T>(request: Promise<Response>): Promi
  */
 export type GatewayErrorKind = "channel_policy" | "rate_limit";
 
+function parseJsonValueAt(text: string, start: number): unknown | null {
+  const opener = text[start];
+  if (opener !== "{" && opener !== "[") return null;
+
+  const stack: string[] = [];
+  let inString = false;
+  let escaped = false;
+  for (let index = start; index < text.length; index += 1) {
+    const char = text[index];
+    if (inString) {
+      if (escaped) {
+        escaped = false;
+      } else if (char === "\\") {
+        escaped = true;
+      } else if (char === '"') {
+        inString = false;
+      }
+      continue;
+    }
+    if (char === '"') {
+      inString = true;
+      continue;
+    }
+    if (char === "{" || char === "[") {
+      stack.push(char);
+      continue;
+    }
+    if (char !== "}" && char !== "]") continue;
+    const expected = char === "}" ? "{" : "[";
+    if (stack.pop() !== expected) return null;
+    if (stack.length === 0) {
+      try {
+        return JSON.parse(text.slice(start, index + 1));
+      } catch {
+        return null;
+      }
+    }
+  }
+  return null;
+}
+
+function providerErrorPayload(raw: string): unknown | null {
+  const text = raw.trim();
+  if (!text) return null;
+  try {
+    return JSON.parse(text);
+  } catch {
+    // Gateway failures commonly wrap the provider response as
+    // `HTTP ...; body={...}`. Preserve the wrapper for diagnostics while
+    // parsing only the JSON body for the user-facing message.
+  }
+
+  const bodyMatch = /\bbody\s*=\s*/gi.exec(text);
+  if (!bodyMatch) return null;
+  const jsonStart = bodyMatch.index + bodyMatch[0].length;
+  return parseJsonValueAt(text, jsonStart);
+}
+
+function messageFromPayload(payload: unknown): string | null {
+  if (!payload || typeof payload !== "object") return null;
+  const record = payload as Record<string, unknown>;
+  if (record.error && typeof record.error === "object") {
+    const nested = messageFromPayload(record.error);
+    if (nested) return nested;
+  }
+  if (typeof record.message === "string" && record.message.trim()) {
+    return record.message.trim();
+  }
+  return null;
+}
+
+/** Extract the provider's concise message without discarding the raw error. */
+export function providerErrorMessage(raw: string | null | undefined): string | null {
+  if (!raw) return null;
+  return messageFromPayload(providerErrorPayload(raw));
+}
+
 export function classifyGatewayError(
   raw: string | null | undefined,
 ): GatewayErrorKind | null {
@@ -226,7 +303,7 @@ export function humanizeTaskError(
     case "rate_limit":
       return t("common.generationRateLimited", { defaultValue: fallback });
     default:
-      return fallback;
+      return providerErrorMessage(raw) ?? fallback;
   }
 }
 
@@ -256,5 +333,8 @@ export function backendErrorToastMessage(error: unknown, t: TFunction): string {
       defaultValue: t("common.projectQueueFull", { queue: queueLabel }),
     });
   }
-  return error instanceof Error && error.message ? error.message : t("common.error");
+  if (error instanceof Error && error.message) {
+    return providerErrorMessage(error.message) ?? error.message;
+  }
+  return t("common.error");
 }

--- a/frontend/src/task-center/task-errors.ts
+++ b/frontend/src/task-center/task-errors.ts
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Elastic-2.0
 // Copyright (c) 2026 ClaymoreLab
 import type { TFunction } from "i18next";
+import { humanizeTaskError } from "@/lib/api-errors";
 import type { TaskState } from "./types";
 
 export function taskErrorMessage(task: TaskState, t: TFunction): string {
@@ -14,5 +15,5 @@ export function taskErrorMessage(task: TaskState, t: TFunction): string {
       defaultValue: task.error || t("common.error"),
     });
   }
-  return task.error || t("common.error");
+  return humanizeTaskError(task.error, t);
 }

--- a/license-inventory.csv
+++ b/license-inventory.csv
@@ -367,6 +367,7 @@ frontend/src/__tests__/features/canvas/three-d-world-node-source-scope.test.ts,E
 frontend/src/__tests__/features/canvas/timelineModel.test.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/__tests__/features/canvas/use-canvas-generation-history.test.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/__tests__/features/canvas/use-reference-mention-sync.test.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
+frontend/src/__tests__/features/canvas/video-error-notification.test.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/__tests__/features/canvas/viewport-bookmarks-domain.test.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/__tests__/features/companion/petdex-pets.test.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/__tests__/features/freezone/asset-library-panel-beat-context.test.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation

--- a/license-inventory.csv
+++ b/license-inventory.csv
@@ -340,6 +340,7 @@ frontend/src/__tests__/features/canvas/generation-task-arbitration.test.ts,Elast
 frontend/src/__tests__/features/canvas/group-selection-delete.test.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/__tests__/features/canvas/history-assets-buckets.test.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/__tests__/features/canvas/image-gen-director-world-entry.test.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
+frontend/src/__tests__/features/canvas/image-gen-error-notification.test.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/__tests__/features/canvas/image-gen-node-context-palette.test.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/__tests__/features/canvas/image-gen-prompt.test.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/__tests__/features/canvas/image-node-resize-min.test.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation


### PR DESCRIPTION
## What changed

- Extract concise provider `message` values from JSON and wrapped `body={...}` generation errors.
- Keep the complete raw provider/task response for support diagnostics and clipboard copy.
- Make ImageGen failure UI and resumed image/video tasks show the concise message while preserving request IDs.
- Reuse the normalized message in task-center failure notifications without changing billing, queue, rate-limit, or channel-policy handling.
- Let the ImageGen request-ID row and node toolbar copy the complete raw error response.

## Why

Content-policy failures were rendering the complete gateway response directly over generated media, exposing HTTP context and JSON fields in the normal UI. The nearby copy action only copied the request ID, leaving users without a convenient way to share the full diagnostic response.

## Impact

Generation failures now show a readable provider message. Full diagnostic information remains available through copy actions, and existing specialized messages such as insufficient credits remain unchanged.

## Verification

- `pnpm exec vitest run src/__tests__/features/canvas/image-gen-error-notification.test.ts src/__tests__/lib/gateway-error-classify.test.ts src/__tests__/task-center/task-errors.test.ts --reporter=dot`
- `pnpm exec vitest run src/__tests__/api/client.test.ts src/__tests__/task-center/provider.test.ts --reporter=dot`
- `pnpm run build`
- `git diff --check`
