### PR TITLE
feat(frontend): expand Piko mini game library

### DIFF
--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -1682,6 +1682,19 @@
       "score": "Ideas {{score}}",
       "status": "Lives {{lives}} · {{seconds}}s",
       "result": "You collected {{score}} idea points"
+    },
+    "leap": {
+      "title": "Piko Leap",
+      "canvasLabel": "Piko Leap game board",
+      "hint": "Hold Space, mouse, or touch to charge, then release to jump to the next idea chip",
+      "start": "Start leaping",
+      "ready": "Ready for the next leap",
+      "lost": "Piko missed the landing",
+      "score": "Leap score {{score}}",
+      "combo": "Center combo ×{{combo}}",
+      "centerHint": "Land in the center for bonus points",
+      "chargeHint": "Hold to charge · release to jump",
+      "result": "You scored {{score}} points"
     }
   },
   "literalScript": {

--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -1574,12 +1574,15 @@
   "pikoMiniGame": {
     "statusEntry": "Piko Break",
     "statusTooltip": "Play a one-minute Piko game",
+    "libraryTitle": "Piko Break",
+    "librarySubtitle": "Choose a game",
     "title": "Piko a bit, find your spark",
     "idleHint": "Press Space to fire",
     "countdownHint": "Ready to go~",
     "start": "Start",
     "playAgain": "Play again",
     "backToWork": "Back to work",
+    "backToLibrary": "Back to game list",
     "audioOn": "Turn Piko game sound on",
     "audioOff": "Turn Piko game sound off",
     "score": "Idea power {{score}}",
@@ -1628,6 +1631,27 @@
         "jelly": "Time Jelly slowed the field"
       },
       "ultimate": "Idea burst"
+    },
+    "memory": {
+      "title": "Memory Match",
+      "hint": "Match cards with the same symbol",
+      "moves": "Moves",
+      "cardHidden": "Face-down card",
+      "cardVisible": "Card {{value}}",
+      "completed": "All pairs matched",
+      "resultMeta": "{{moves}} moves"
+    },
+    "breakout": {
+      "title": "Breakout",
+      "canvasLabel": "Breakout game board",
+      "hint": "Move the paddle with your mouse or touch, or use Arrow keys or A and D",
+      "start": "Start game",
+      "ready": "Clear every brick",
+      "lifeLost": "Keep going!",
+      "won": "Board cleared!",
+      "lost": "Game over",
+      "score": "Score {{score}}",
+      "lives": "Lives {{lives}}"
     }
   },
   "literalScript": {

--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -1670,6 +1670,18 @@
       "ready": "Ready for takeoff",
       "lost": "Piko hit an energy gate",
       "score": "Gates {{score}}"
+    },
+    "catch": {
+      "title": "Piko Catch",
+      "canvasLabel": "Piko Catch game board",
+      "hint": "Move Piko left and right, catch idea stars and crystals, and avoid red glitches",
+      "start": "Start catching",
+      "ready": "Catch the falling ideas",
+      "finished": "Idea collection complete",
+      "lost": "Piko needs a quick rest",
+      "score": "Ideas {{score}}",
+      "status": "Lives {{lives}} · {{seconds}}s",
+      "result": "You collected {{score}} idea points"
     }
   },
   "literalScript": {

--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -1652,6 +1652,15 @@
       "lost": "Game over",
       "score": "Score {{score}}",
       "lives": "Lives {{lives}}"
+    },
+    "rollingBall": {
+      "title": "Rolling Ball",
+      "canvasLabel": "Rolling Ball game board",
+      "hint": "Move left and right to land on the scrolling platforms",
+      "start": "Start game",
+      "ready": "Keep rolling down",
+      "lost": "The ball slipped away",
+      "score": "Landings {{score}}"
     }
   },
   "literalScript": {

--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -1661,6 +1661,15 @@
       "ready": "Keep rolling down",
       "lost": "The ball slipped away",
       "score": "Landings {{score}}"
+    },
+    "flying": {
+      "title": "Flying Piko",
+      "canvasLabel": "Flying Piko game board",
+      "hint": "Press Space, Arrow Up, or tap to fly Piko through the energy gates",
+      "start": "Start flying",
+      "ready": "Ready for takeoff",
+      "lost": "Piko hit an energy gate",
+      "score": "Gates {{score}}"
     }
   },
   "literalScript": {

--- a/frontend/public/locales/zh/translation.json
+++ b/frontend/public/locales/zh/translation.json
@@ -1661,6 +1661,15 @@
       "ready": "一路向下",
       "lost": "小球掉下去了",
       "score": "落台 {{score}}"
+    },
+    "flying": {
+      "title": "飞行的 Piko",
+      "canvasLabel": "飞行的 Piko 游戏区域",
+      "hint": "按空格、向上键或点击，让 Piko 向上飞并穿过能量门",
+      "start": "开始飞行",
+      "ready": "准备起飞",
+      "lost": "Piko 撞到能量门了",
+      "score": "穿越 {{score}}"
     }
   },
   "literalScript": {

--- a/frontend/public/locales/zh/translation.json
+++ b/frontend/public/locales/zh/translation.json
@@ -1682,6 +1682,19 @@
       "score": "灵感 {{score}}",
       "status": "生命 {{lives}} · {{seconds}} 秒",
       "result": "本局收集了 {{score}} 点灵感"
+    },
+    "leap": {
+      "title": "Piko 跃迁",
+      "canvasLabel": "Piko 跃迁游戏区域",
+      "hint": "长按空格、鼠标或屏幕蓄力，松开后跳向下一块灵感芯片",
+      "start": "开始跃迁",
+      "ready": "准备好下一跳",
+      "lost": "Piko 没有落稳",
+      "score": "跃迁 {{score}}",
+      "combo": "中心连击 ×{{combo}}",
+      "centerHint": "落在中心可获额外分数",
+      "chargeHint": "长按蓄力 · 松开跳跃",
+      "result": "本局获得 {{score}} 分"
     }
   },
   "literalScript": {

--- a/frontend/public/locales/zh/translation.json
+++ b/frontend/public/locales/zh/translation.json
@@ -1670,6 +1670,18 @@
       "ready": "准备起飞",
       "lost": "Piko 撞到能量门了",
       "score": "穿越 {{score}}"
+    },
+    "catch": {
+      "title": "Piko 接接乐",
+      "canvasLabel": "Piko 接物游戏区域",
+      "hint": "左右移动 Piko，接住灵感星和晶体，避开红色故障块",
+      "start": "开始接取",
+      "ready": "接住掉落的灵感",
+      "finished": "灵感收集完成",
+      "lost": "Piko 需要休息一下",
+      "score": "灵感 {{score}}",
+      "status": "生命 {{lives}} · {{seconds}} 秒",
+      "result": "本局收集了 {{score}} 点灵感"
     }
   },
   "literalScript": {

--- a/frontend/public/locales/zh/translation.json
+++ b/frontend/public/locales/zh/translation.json
@@ -1574,12 +1574,15 @@
   "pikoMiniGame": {
     "statusEntry": "Piko一下",
     "statusTooltip": "陪 Piko 玩 1 分钟小游戏",
+    "libraryTitle": "Piko一下",
+    "librarySubtitle": "选择一个小游戏",
     "title": "Piko一下，找回灵感",
     "idleHint": "按空格键发射子弹",
     "countdownHint": "准备开始咯～",
     "start": "开始补给",
     "playAgain": "再来一局",
     "backToWork": "回到创作",
+    "backToLibrary": "返回游戏列表",
     "audioOn": "开启 Piko 小游戏音效",
     "audioOff": "关闭 Piko 小游戏音效",
     "score": "灵感值 {{score}}",
@@ -1628,6 +1631,27 @@
         "jelly": "时间果冻放慢节奏"
       },
       "ultimate": "灵感爆发"
+    },
+    "memory": {
+      "title": "记忆翻牌",
+      "hint": "翻开相同图案完成配对",
+      "moves": "步数",
+      "cardHidden": "未翻开的卡片",
+      "cardVisible": "卡片 {{value}}",
+      "completed": "全部配对完成",
+      "resultMeta": "共用了 {{moves}} 步"
+    },
+    "breakout": {
+      "title": "打砖块",
+      "canvasLabel": "打砖块游戏区域",
+      "hint": "移动鼠标或触摸控制挡板，也可使用方向键或 A、D 键",
+      "start": "开始游戏",
+      "ready": "击碎所有砖块",
+      "lifeLost": "还有机会，继续！",
+      "won": "全部清除！",
+      "lost": "本局结束",
+      "score": "得分 {{score}}",
+      "lives": "生命 {{lives}}"
     }
   },
   "literalScript": {

--- a/frontend/public/locales/zh/translation.json
+++ b/frontend/public/locales/zh/translation.json
@@ -1652,6 +1652,15 @@
       "lost": "本局结束",
       "score": "得分 {{score}}",
       "lives": "生命 {{lives}}"
+    },
+    "rollingBall": {
+      "title": "滚动小球",
+      "canvasLabel": "滚动小球游戏区域",
+      "hint": "控制小球左右移动，落到不断滚动的平台上",
+      "start": "开始游戏",
+      "ready": "一路向下",
+      "lost": "小球掉下去了",
+      "score": "落台 {{score}}"
     }
   },
   "literalScript": {

--- a/frontend/src/features/piko-mini-game/PikoBreakoutGame.tsx
+++ b/frontend/src/features/piko-mini-game/PikoBreakoutGame.tsx
@@ -2,6 +2,7 @@
 // Copyright (c) 2026 ClaymoreLab
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { usePikoGameAudio } from "@/features/piko-mini-game/usePikoGameAudio";
 
 const BOARD_WIDTH = 800;
 const BOARD_HEIGHT = 520;
@@ -49,8 +50,6 @@ function initialBall(): Ball {
 export function PikoBreakoutGame({ onClose, muted }: { onClose: () => void; muted: boolean }) {
   const { t } = useTranslation();
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
-  const audioContextRef = useRef<AudioContext | null>(null);
-  const mutedRef = useRef(muted);
   const frameRef = useRef<number | null>(null);
   const previousTimeRef = useRef<number | null>(null);
   const statusRef = useRef<BreakoutStatus>("ready");
@@ -62,42 +61,7 @@ export function PikoBreakoutGame({ onClose, muted }: { onClose: () => void; mute
   const [status, setStatus] = useState<BreakoutStatus>("ready");
   const [score, setScore] = useState(0);
   const [lives, setLives] = useState(STARTING_LIVES);
-
-  const getAudioContext = useCallback(() => {
-    if (mutedRef.current) return null;
-    const AudioContextClass =
-      window.AudioContext ||
-      (window as typeof window & { webkitAudioContext?: typeof AudioContext }).webkitAudioContext;
-    if (!AudioContextClass) return null;
-    audioContextRef.current ??= new AudioContextClass();
-    if (audioContextRef.current.state === "suspended") void audioContextRef.current.resume();
-    return audioContextRef.current;
-  }, []);
-
-  const playTone = useCallback((
-    frequency: number,
-    duration: number,
-    volume: number,
-    type: OscillatorType = "sine",
-    delay = 0,
-    endFrequency?: number,
-  ) => {
-    const context = getAudioContext();
-    if (!context) return;
-    const oscillator = context.createOscillator();
-    const gain = context.createGain();
-    const startsAt = context.currentTime + delay;
-    oscillator.type = type;
-    oscillator.frequency.setValueAtTime(frequency, startsAt);
-    if (endFrequency) oscillator.frequency.exponentialRampToValueAtTime(endFrequency, startsAt + duration);
-    gain.gain.setValueAtTime(0.0001, startsAt);
-    gain.gain.exponentialRampToValueAtTime(volume, startsAt + 0.006);
-    gain.gain.exponentialRampToValueAtTime(0.0001, startsAt + duration);
-    oscillator.connect(gain);
-    gain.connect(context.destination);
-    oscillator.start(startsAt);
-    oscillator.stop(startsAt + duration + 0.02);
-  }, [getAudioContext]);
+  const playTone = usePikoGameAudio(muted);
 
   const playStartSound = useCallback(() => {
     playTone(392, 0.07, 0.06, "triangle");
@@ -135,22 +99,6 @@ export function PikoBreakoutGame({ onClose, muted }: { onClose: () => void; mute
     playTone(220, 0.3, 0.1, "sawtooth", 0, 62);
     playTone(110, 0.34, 0.06, "square", 0.08, 44);
   }, [playTone]);
-
-  useEffect(() => {
-    mutedRef.current = muted;
-    const context = audioContextRef.current;
-    if (!context) return;
-    if (muted && context.state === "running") void context.suspend();
-    if (!muted && context.state === "suspended") void context.resume();
-  }, [muted]);
-
-  useEffect(() => {
-    return () => {
-      const context = audioContextRef.current;
-      audioContextRef.current = null;
-      if (context && context.state !== "closed") void context.close();
-    };
-  }, []);
 
   const setGameStatus = useCallback((next: BreakoutStatus) => {
     statusRef.current = next;

--- a/frontend/src/features/piko-mini-game/PikoBreakoutGame.tsx
+++ b/frontend/src/features/piko-mini-game/PikoBreakoutGame.tsx
@@ -46,9 +46,11 @@ function initialBall(): Ball {
   return { x: BOARD_WIDTH / 2, y: PADDLE_Y - 18, vx: 250, vy: -310 };
 }
 
-export function PikoBreakoutGame({ onClose }: { onClose: () => void }) {
+export function PikoBreakoutGame({ onClose, muted }: { onClose: () => void; muted: boolean }) {
   const { t } = useTranslation();
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const audioContextRef = useRef<AudioContext | null>(null);
+  const mutedRef = useRef(muted);
   const frameRef = useRef<number | null>(null);
   const previousTimeRef = useRef<number | null>(null);
   const statusRef = useRef<BreakoutStatus>("ready");
@@ -60,6 +62,95 @@ export function PikoBreakoutGame({ onClose }: { onClose: () => void }) {
   const [status, setStatus] = useState<BreakoutStatus>("ready");
   const [score, setScore] = useState(0);
   const [lives, setLives] = useState(STARTING_LIVES);
+
+  const getAudioContext = useCallback(() => {
+    if (mutedRef.current) return null;
+    const AudioContextClass =
+      window.AudioContext ||
+      (window as typeof window & { webkitAudioContext?: typeof AudioContext }).webkitAudioContext;
+    if (!AudioContextClass) return null;
+    audioContextRef.current ??= new AudioContextClass();
+    if (audioContextRef.current.state === "suspended") void audioContextRef.current.resume();
+    return audioContextRef.current;
+  }, []);
+
+  const playTone = useCallback((
+    frequency: number,
+    duration: number,
+    volume: number,
+    type: OscillatorType = "sine",
+    delay = 0,
+    endFrequency?: number,
+  ) => {
+    const context = getAudioContext();
+    if (!context) return;
+    const oscillator = context.createOscillator();
+    const gain = context.createGain();
+    const startsAt = context.currentTime + delay;
+    oscillator.type = type;
+    oscillator.frequency.setValueAtTime(frequency, startsAt);
+    if (endFrequency) oscillator.frequency.exponentialRampToValueAtTime(endFrequency, startsAt + duration);
+    gain.gain.setValueAtTime(0.0001, startsAt);
+    gain.gain.exponentialRampToValueAtTime(volume, startsAt + 0.006);
+    gain.gain.exponentialRampToValueAtTime(0.0001, startsAt + duration);
+    oscillator.connect(gain);
+    gain.connect(context.destination);
+    oscillator.start(startsAt);
+    oscillator.stop(startsAt + duration + 0.02);
+  }, [getAudioContext]);
+
+  const playStartSound = useCallback(() => {
+    playTone(392, 0.07, 0.06, "triangle");
+    playTone(523.25, 0.08, 0.065, "triangle", 0.075);
+    playTone(783.99, 0.11, 0.07, "triangle", 0.155);
+  }, [playTone]);
+
+  const playWallSound = useCallback(() => {
+    playTone(310, 0.035, 0.025, "square", 0, 360);
+  }, [playTone]);
+
+  const playPaddleSound = useCallback(() => {
+    playTone(250, 0.065, 0.06, "triangle", 0, 520);
+    playTone(720, 0.05, 0.035, "sine", 0.035);
+  }, [playTone]);
+
+  const playBrickSound = useCallback((row: number) => {
+    const frequency = 540 + (BRICK_ROWS - row) * 74;
+    playTone(frequency, 0.055, 0.07, "square");
+    playTone(frequency * 1.5, 0.075, 0.038, "triangle", 0.028);
+  }, [playTone]);
+
+  const playLifeLostSound = useCallback(() => {
+    playTone(240, 0.24, 0.085, "sawtooth", 0, 85);
+  }, [playTone]);
+
+  const playWinSound = useCallback(() => {
+    playTone(523.25, 0.18, 0.07, "triangle");
+    playTone(659.25, 0.2, 0.065, "triangle", 0.1);
+    playTone(783.99, 0.22, 0.06, "triangle", 0.2);
+    playTone(1_046.5, 0.3, 0.055, "sine", 0.3);
+  }, [playTone]);
+
+  const playGameOverSound = useCallback(() => {
+    playTone(220, 0.3, 0.1, "sawtooth", 0, 62);
+    playTone(110, 0.34, 0.06, "square", 0.08, 44);
+  }, [playTone]);
+
+  useEffect(() => {
+    mutedRef.current = muted;
+    const context = audioContextRef.current;
+    if (!context) return;
+    if (muted && context.state === "running") void context.suspend();
+    if (!muted && context.state === "suspended") void context.resume();
+  }, [muted]);
+
+  useEffect(() => {
+    return () => {
+      const context = audioContextRef.current;
+      audioContextRef.current = null;
+      if (context && context.state !== "closed") void context.close();
+    };
+  }, []);
 
   const setGameStatus = useCallback((next: BreakoutStatus) => {
     statusRef.current = next;
@@ -87,8 +178,9 @@ export function PikoBreakoutGame({ onClose }: { onClose: () => void }) {
     }
     previousTimeRef.current = null;
     setGameStatus("playing");
+    playStartSound();
     canvasRef.current?.focus();
-  }, [resetGame, setGameStatus]);
+  }, [playStartSound, resetGame, setGameStatus]);
 
   const draw = useCallback(() => {
     const canvas = canvasRef.current;
@@ -173,9 +265,18 @@ export function PikoBreakoutGame({ onClose }: { onClose: () => void }) {
         ball.x += ball.vx * delta;
         ball.y += ball.vy * delta;
 
-        if (ball.x - BALL_RADIUS <= 0 && ball.vx < 0) ball.vx *= -1;
-        if (ball.x + BALL_RADIUS >= BOARD_WIDTH && ball.vx > 0) ball.vx *= -1;
-        if (ball.y - BALL_RADIUS <= 0 && ball.vy < 0) ball.vy *= -1;
+        if (ball.x - BALL_RADIUS <= 0 && ball.vx < 0) {
+          ball.vx *= -1;
+          playWallSound();
+        }
+        if (ball.x + BALL_RADIUS >= BOARD_WIDTH && ball.vx > 0) {
+          ball.vx *= -1;
+          playWallSound();
+        }
+        if (ball.y - BALL_RADIUS <= 0 && ball.vy < 0) {
+          ball.vy *= -1;
+          playWallSound();
+        }
 
         const paddleX = paddleXRef.current;
         if (
@@ -190,6 +291,7 @@ export function PikoBreakoutGame({ onClose }: { onClose: () => void }) {
           ball.vx = speed * Math.sin(hitOffset * 1.05);
           ball.vy = -Math.max(220, speed * Math.cos(hitOffset * 1.05));
           ball.y = PADDLE_Y - BALL_RADIUS - 1;
+          playPaddleSound();
         }
 
         const brickWidth = (BOARD_WIDTH - BRICK_SIDE * 2 - BRICK_GAP * (BRICK_COLUMNS - 1)) / BRICK_COLUMNS;
@@ -207,6 +309,7 @@ export function PikoBreakoutGame({ onClose }: { onClose: () => void }) {
           brick.alive = false;
           scoreRef.current += (BRICK_ROWS - brick.row) * 10;
           setScore(scoreRef.current);
+          playBrickSound(brick.row);
           const overlapLeft = ball.x + BALL_RADIUS - x;
           const overlapRight = x + brickWidth - (ball.x - BALL_RADIUS);
           const overlapTop = ball.y + BALL_RADIUS - y;
@@ -218,14 +321,17 @@ export function PikoBreakoutGame({ onClose }: { onClose: () => void }) {
 
         if (bricksRef.current.every((brick) => !brick.alive)) {
           setGameStatus("won");
+          playWinSound();
         } else if (ball.y - BALL_RADIUS > BOARD_HEIGHT) {
           livesRef.current -= 1;
           setLives(livesRef.current);
           if (livesRef.current <= 0) {
             setGameStatus("lost");
+            playGameOverSound();
           } else {
             resetBall();
             setGameStatus("paused");
+            playLifeLostSound();
           }
         }
       }
@@ -237,7 +343,17 @@ export function PikoBreakoutGame({ onClose }: { onClose: () => void }) {
     return () => {
       if (frameRef.current !== null) window.cancelAnimationFrame(frameRef.current);
     };
-  }, [draw, resetBall, setGameStatus]);
+  }, [
+    draw,
+    playBrickSound,
+    playGameOverSound,
+    playLifeLostSound,
+    playPaddleSound,
+    playWallSound,
+    playWinSound,
+    resetBall,
+    setGameStatus,
+  ]);
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {

--- a/frontend/src/features/piko-mini-game/PikoBreakoutGame.tsx
+++ b/frontend/src/features/piko-mini-game/PikoBreakoutGame.tsx
@@ -1,0 +1,315 @@
+// SPDX-License-Identifier: Elastic-2.0
+// Copyright (c) 2026 ClaymoreLab
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
+
+const BOARD_WIDTH = 800;
+const BOARD_HEIGHT = 520;
+const PADDLE_WIDTH = 112;
+const PADDLE_HEIGHT = 14;
+const PADDLE_Y = 476;
+const BALL_RADIUS = 7;
+const BRICK_ROWS = 6;
+const BRICK_COLUMNS = 10;
+const BRICK_GAP = 6;
+const BRICK_HEIGHT = 22;
+const BRICK_TOP = 62;
+const BRICK_SIDE = 32;
+const STARTING_LIVES = 3;
+
+type BreakoutStatus = "ready" | "playing" | "paused" | "won" | "lost";
+
+type Ball = {
+  x: number;
+  y: number;
+  vx: number;
+  vy: number;
+};
+
+type Brick = {
+  id: number;
+  row: number;
+  column: number;
+  alive: boolean;
+};
+
+function makeBricks(): Brick[] {
+  return Array.from({ length: BRICK_ROWS * BRICK_COLUMNS }, (_, id) => ({
+    id,
+    row: Math.floor(id / BRICK_COLUMNS),
+    column: id % BRICK_COLUMNS,
+    alive: true,
+  }));
+}
+
+function initialBall(): Ball {
+  return { x: BOARD_WIDTH / 2, y: PADDLE_Y - 18, vx: 250, vy: -310 };
+}
+
+export function PikoBreakoutGame({ onClose }: { onClose: () => void }) {
+  const { t } = useTranslation();
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const frameRef = useRef<number | null>(null);
+  const previousTimeRef = useRef<number | null>(null);
+  const statusRef = useRef<BreakoutStatus>("ready");
+  const ballRef = useRef<Ball>(initialBall());
+  const paddleXRef = useRef((BOARD_WIDTH - PADDLE_WIDTH) / 2);
+  const bricksRef = useRef<Brick[]>(makeBricks());
+  const scoreRef = useRef(0);
+  const livesRef = useRef(STARTING_LIVES);
+  const [status, setStatus] = useState<BreakoutStatus>("ready");
+  const [score, setScore] = useState(0);
+  const [lives, setLives] = useState(STARTING_LIVES);
+
+  const setGameStatus = useCallback((next: BreakoutStatus) => {
+    statusRef.current = next;
+    setStatus(next);
+  }, []);
+
+  const resetBall = useCallback(() => {
+    ballRef.current = initialBall();
+    paddleXRef.current = (BOARD_WIDTH - PADDLE_WIDTH) / 2;
+  }, []);
+
+  const resetGame = useCallback(() => {
+    bricksRef.current = makeBricks();
+    scoreRef.current = 0;
+    livesRef.current = STARTING_LIVES;
+    setScore(0);
+    setLives(STARTING_LIVES);
+    resetBall();
+    setGameStatus("ready");
+  }, [resetBall, setGameStatus]);
+
+  const startGame = useCallback(() => {
+    if (statusRef.current === "won" || statusRef.current === "lost") {
+      resetGame();
+    }
+    previousTimeRef.current = null;
+    setGameStatus("playing");
+    canvasRef.current?.focus();
+  }, [resetGame, setGameStatus]);
+
+  const draw = useCallback(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const context = canvas.getContext("2d");
+    if (!context) return;
+    const dpr = window.devicePixelRatio || 1;
+    const rect = canvas.getBoundingClientRect();
+    const pixelWidth = Math.round(rect.width * dpr);
+    const pixelHeight = Math.round(rect.height * dpr);
+    if (canvas.width !== pixelWidth || canvas.height !== pixelHeight) {
+      canvas.width = pixelWidth;
+      canvas.height = pixelHeight;
+    }
+    context.setTransform(pixelWidth / BOARD_WIDTH, 0, 0, pixelHeight / BOARD_HEIGHT, 0, 0);
+    context.clearRect(0, 0, BOARD_WIDTH, BOARD_HEIGHT);
+
+    const background = context.createLinearGradient(0, 0, 0, BOARD_HEIGHT);
+    background.addColorStop(0, "#121823");
+    background.addColorStop(1, "#080b10");
+    context.fillStyle = background;
+    context.fillRect(0, 0, BOARD_WIDTH, BOARD_HEIGHT);
+
+    context.strokeStyle = "rgba(165, 243, 252, 0.07)";
+    context.lineWidth = 1;
+    for (let x = 0; x <= BOARD_WIDTH; x += 40) {
+      context.beginPath();
+      context.moveTo(x, 0);
+      context.lineTo(x, BOARD_HEIGHT);
+      context.stroke();
+    }
+    for (let y = 0; y <= BOARD_HEIGHT; y += 40) {
+      context.beginPath();
+      context.moveTo(0, y);
+      context.lineTo(BOARD_WIDTH, y);
+      context.stroke();
+    }
+
+    const brickWidth = (BOARD_WIDTH - BRICK_SIDE * 2 - BRICK_GAP * (BRICK_COLUMNS - 1)) / BRICK_COLUMNS;
+    const rowColors = ["#67e8f9", "#a5f3fc", "#bef264", "#fde047", "#f9a8d4", "#c4b5fd"];
+    for (const brick of bricksRef.current) {
+      if (!brick.alive) continue;
+      const x = BRICK_SIDE + brick.column * (brickWidth + BRICK_GAP);
+      const y = BRICK_TOP + brick.row * (BRICK_HEIGHT + BRICK_GAP);
+      context.fillStyle = rowColors[brick.row];
+      context.globalAlpha = 0.82;
+      context.beginPath();
+      context.roundRect(x, y, brickWidth, BRICK_HEIGHT, 4);
+      context.fill();
+      context.globalAlpha = 1;
+    }
+
+    const paddleGradient = context.createLinearGradient(paddleXRef.current, 0, paddleXRef.current + PADDLE_WIDTH, 0);
+    paddleGradient.addColorStop(0, "#67e8f9");
+    paddleGradient.addColorStop(0.5, "#ecfeff");
+    paddleGradient.addColorStop(1, "#67e8f9");
+    context.fillStyle = paddleGradient;
+    context.shadowColor = "rgba(103, 232, 249, 0.45)";
+    context.shadowBlur = 16;
+    context.beginPath();
+    context.roundRect(paddleXRef.current, PADDLE_Y, PADDLE_WIDTH, PADDLE_HEIGHT, 7);
+    context.fill();
+
+    const ball = ballRef.current;
+    context.fillStyle = "#ffffff";
+    context.shadowColor = "rgba(165, 243, 252, 0.85)";
+    context.shadowBlur = 14;
+    context.beginPath();
+    context.arc(ball.x, ball.y, BALL_RADIUS, 0, Math.PI * 2);
+    context.fill();
+    context.shadowBlur = 0;
+  }, []);
+
+  useEffect(() => {
+    const tick = (time: number) => {
+      const previous = previousTimeRef.current ?? time;
+      previousTimeRef.current = time;
+      const delta = Math.min((time - previous) / 1000, 0.025);
+
+      if (statusRef.current === "playing") {
+        const ball = ballRef.current;
+        ball.x += ball.vx * delta;
+        ball.y += ball.vy * delta;
+
+        if (ball.x - BALL_RADIUS <= 0 && ball.vx < 0) ball.vx *= -1;
+        if (ball.x + BALL_RADIUS >= BOARD_WIDTH && ball.vx > 0) ball.vx *= -1;
+        if (ball.y - BALL_RADIUS <= 0 && ball.vy < 0) ball.vy *= -1;
+
+        const paddleX = paddleXRef.current;
+        if (
+          ball.vy > 0 &&
+          ball.y + BALL_RADIUS >= PADDLE_Y &&
+          ball.y - BALL_RADIUS <= PADDLE_Y + PADDLE_HEIGHT &&
+          ball.x >= paddleX - BALL_RADIUS &&
+          ball.x <= paddleX + PADDLE_WIDTH + BALL_RADIUS
+        ) {
+          const hitOffset = (ball.x - (paddleX + PADDLE_WIDTH / 2)) / (PADDLE_WIDTH / 2);
+          const speed = Math.min(Math.hypot(ball.vx, ball.vy) * 1.025, 540);
+          ball.vx = speed * Math.sin(hitOffset * 1.05);
+          ball.vy = -Math.max(220, speed * Math.cos(hitOffset * 1.05));
+          ball.y = PADDLE_Y - BALL_RADIUS - 1;
+        }
+
+        const brickWidth = (BOARD_WIDTH - BRICK_SIDE * 2 - BRICK_GAP * (BRICK_COLUMNS - 1)) / BRICK_COLUMNS;
+        for (const brick of bricksRef.current) {
+          if (!brick.alive) continue;
+          const x = BRICK_SIDE + brick.column * (brickWidth + BRICK_GAP);
+          const y = BRICK_TOP + brick.row * (BRICK_HEIGHT + BRICK_GAP);
+          if (
+            ball.x + BALL_RADIUS < x ||
+            ball.x - BALL_RADIUS > x + brickWidth ||
+            ball.y + BALL_RADIUS < y ||
+            ball.y - BALL_RADIUS > y + BRICK_HEIGHT
+          ) continue;
+
+          brick.alive = false;
+          scoreRef.current += (BRICK_ROWS - brick.row) * 10;
+          setScore(scoreRef.current);
+          const overlapLeft = ball.x + BALL_RADIUS - x;
+          const overlapRight = x + brickWidth - (ball.x - BALL_RADIUS);
+          const overlapTop = ball.y + BALL_RADIUS - y;
+          const overlapBottom = y + BRICK_HEIGHT - (ball.y - BALL_RADIUS);
+          if (Math.min(overlapLeft, overlapRight) < Math.min(overlapTop, overlapBottom)) ball.vx *= -1;
+          else ball.vy *= -1;
+          break;
+        }
+
+        if (bricksRef.current.every((brick) => !brick.alive)) {
+          setGameStatus("won");
+        } else if (ball.y - BALL_RADIUS > BOARD_HEIGHT) {
+          livesRef.current -= 1;
+          setLives(livesRef.current);
+          if (livesRef.current <= 0) {
+            setGameStatus("lost");
+          } else {
+            resetBall();
+            setGameStatus("paused");
+          }
+        }
+      }
+
+      draw();
+      frameRef.current = window.requestAnimationFrame(tick);
+    };
+    frameRef.current = window.requestAnimationFrame(tick);
+    return () => {
+      if (frameRef.current !== null) window.cancelAnimationFrame(frameRef.current);
+    };
+  }, [draw, resetBall, setGameStatus]);
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "ArrowLeft" || event.key.toLowerCase() === "a") {
+        event.preventDefault();
+        paddleXRef.current = Math.max(0, paddleXRef.current - 42);
+      } else if (event.key === "ArrowRight" || event.key.toLowerCase() === "d") {
+        event.preventDefault();
+        paddleXRef.current = Math.min(BOARD_WIDTH - PADDLE_WIDTH, paddleXRef.current + 42);
+      } else if (event.key === " " || event.key === "Enter") {
+        event.preventDefault();
+        if (statusRef.current !== "playing") startGame();
+      }
+    };
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [startGame]);
+
+  const movePaddle = (clientX: number) => {
+    const rect = canvasRef.current?.getBoundingClientRect();
+    if (!rect) return;
+    const boardX = ((clientX - rect.left) / rect.width) * BOARD_WIDTH;
+    paddleXRef.current = Math.max(0, Math.min(BOARD_WIDTH - PADDLE_WIDTH, boardX - PADDLE_WIDTH / 2));
+  };
+
+  const overlayKey = status === "won" ? "won" : status === "lost" ? "lost" : status === "paused" ? "lifeLost" : "ready";
+
+  return (
+    <div className="relative h-[520px] overflow-hidden border border-white/[0.08] bg-[#080b10]">
+      <canvas
+        ref={canvasRef}
+        className="h-full w-full touch-none outline-none"
+        tabIndex={0}
+        aria-label={t("pikoMiniGame.breakout.canvasLabel")}
+        onPointerMove={(event) => movePaddle(event.clientX)}
+        onPointerDown={(event) => {
+          movePaddle(event.clientX);
+          if (statusRef.current !== "playing") startGame();
+        }}
+      />
+
+      <div className="pointer-events-none absolute inset-x-4 top-4 flex items-center justify-between text-sm font-medium text-white/78">
+        <span>{t("pikoMiniGame.breakout.score", { score })}</span>
+        <span>{t("pikoMiniGame.breakout.lives", { lives })}</span>
+      </div>
+
+      {status !== "playing" ? (
+        <div className="absolute inset-0 grid place-items-center bg-black/52 px-5 backdrop-blur-[2px]">
+          <div className="max-w-sm rounded-2xl border border-white/[0.14] bg-black/68 px-7 py-6 text-center shadow-[0_24px_72px_rgba(0,0,0,0.48)]">
+            <h3 className="text-2xl font-semibold text-white">{t(`pikoMiniGame.breakout.${overlayKey}`)}</h3>
+            <p className="mt-2 text-sm leading-6 text-white/58">{t("pikoMiniGame.breakout.hint")}</p>
+            <div className="mt-6 flex justify-center gap-3">
+              {(status === "won" || status === "lost") ? (
+                <button
+                  type="button"
+                  className="h-10 rounded-full border border-white/[0.14] px-5 text-sm text-white/78 transition-colors hover:bg-white/[0.08] hover:text-white"
+                  onClick={onClose}
+                >
+                  {t("pikoMiniGame.backToWork")}
+                </button>
+              ) : null}
+              <button
+                type="button"
+                className="h-10 rounded-full bg-cyan-300 px-5 text-sm font-medium text-slate-950 transition-colors hover:bg-cyan-200"
+                onClick={startGame}
+              >
+                {status === "won" || status === "lost" ? t("pikoMiniGame.playAgain") : t("pikoMiniGame.breakout.start")}
+              </button>
+            </div>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/src/features/piko-mini-game/PikoCatchGame.tsx
+++ b/frontend/src/features/piko-mini-game/PikoCatchGame.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { PikoActionFigure } from "@/features/companion/PikoActionFigure";
+import { usePikoGameAudio } from "@/features/piko-mini-game/usePikoGameAudio";
 
 const BOARD_WIDTH = 800;
 const BOARD_HEIGHT = 520;
@@ -59,8 +60,6 @@ export function PikoCatchGame({ onClose, muted }: { onClose: () => void; muted: 
   const pointerTargetRef = useRef<number | null>(null);
   const scoreRef = useRef(0);
   const livesRef = useRef(STARTING_LIVES);
-  const audioContextRef = useRef<AudioContext | null>(null);
-  const mutedRef = useRef(muted);
   const hurtTimerRef = useRef<number | null>(null);
   const [status, setStatus] = useState<CatchStatus>("ready");
   const [pikoX, setPikoX] = useState(BOARD_WIDTH / 2);
@@ -68,47 +67,12 @@ export function PikoCatchGame({ onClose, muted }: { onClose: () => void; muted: 
   const [lives, setLives] = useState(STARTING_LIVES);
   const [timeLeft, setTimeLeft] = useState(GAME_DURATION_MS / 1000);
   const [isHurt, setIsHurt] = useState(false);
+  const playTone = usePikoGameAudio(muted);
 
   const setGameStatus = useCallback((next: CatchStatus) => {
     statusRef.current = next;
     setStatus(next);
   }, []);
-
-  const getAudioContext = useCallback(() => {
-    if (mutedRef.current) return null;
-    const AudioContextClass =
-      window.AudioContext ||
-      (window as typeof window & { webkitAudioContext?: typeof AudioContext }).webkitAudioContext;
-    if (!AudioContextClass) return null;
-    audioContextRef.current ??= new AudioContextClass();
-    if (audioContextRef.current.state === "suspended") void audioContextRef.current.resume();
-    return audioContextRef.current;
-  }, []);
-
-  const playTone = useCallback((
-    frequency: number,
-    duration: number,
-    volume: number,
-    type: OscillatorType = "sine",
-    delay = 0,
-    endFrequency?: number,
-  ) => {
-    const context = getAudioContext();
-    if (!context) return;
-    const oscillator = context.createOscillator();
-    const gain = context.createGain();
-    const startsAt = context.currentTime + delay;
-    oscillator.type = type;
-    oscillator.frequency.setValueAtTime(frequency, startsAt);
-    if (endFrequency) oscillator.frequency.exponentialRampToValueAtTime(endFrequency, startsAt + duration);
-    gain.gain.setValueAtTime(0.0001, startsAt);
-    gain.gain.exponentialRampToValueAtTime(volume, startsAt + 0.007);
-    gain.gain.exponentialRampToValueAtTime(0.0001, startsAt + duration);
-    oscillator.connect(gain);
-    gain.connect(context.destination);
-    oscillator.start(startsAt);
-    oscillator.stop(startsAt + duration + 0.02);
-  }, [getAudioContext]);
 
   const playStartSound = useCallback(() => {
     playTone(392, 0.08, 0.06, "triangle");
@@ -141,19 +105,8 @@ export function PikoCatchGame({ onClose, muted }: { onClose: () => void; muted: 
   }, [playTone]);
 
   useEffect(() => {
-    mutedRef.current = muted;
-    const context = audioContextRef.current;
-    if (!context) return;
-    if (muted && context.state === "running") void context.suspend();
-    if (!muted && context.state === "suspended") void context.resume();
-  }, [muted]);
-
-  useEffect(() => {
     return () => {
       if (hurtTimerRef.current !== null) window.clearTimeout(hurtTimerRef.current);
-      const context = audioContextRef.current;
-      audioContextRef.current = null;
-      if (context && context.state !== "closed") void context.close();
     };
   }, []);
 

--- a/frontend/src/features/piko-mini-game/PikoCatchGame.tsx
+++ b/frontend/src/features/piko-mini-game/PikoCatchGame.tsx
@@ -1,0 +1,444 @@
+// SPDX-License-Identifier: Elastic-2.0
+// Copyright (c) 2026 ClaymoreLab
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { PikoActionFigure } from "@/features/companion/PikoActionFigure";
+
+const BOARD_WIDTH = 800;
+const BOARD_HEIGHT = 520;
+const GAME_DURATION_MS = 45_000;
+const PIKO_Y = 458;
+const CATCH_X_RANGE = 42;
+const CATCH_Y_RANGE = 34;
+const STARTING_LIVES = 3;
+
+type CatchStatus = "ready" | "playing" | "finished" | "lost";
+type FallingKind = "spark" | "crystal" | "glitch";
+
+type FallingItem = {
+  id: number;
+  x: number;
+  y: number;
+  speed: number;
+  size: number;
+  rotation: number;
+  kind: FallingKind;
+};
+
+function makeItem(id: number, elapsed: number, forcedKind?: FallingKind): FallingItem {
+  const roll = Math.random();
+  const progress = Math.min(1, elapsed / GAME_DURATION_MS);
+  const glitchChance = 0.22 + progress * 0.16;
+  const crystalChance = 0.15;
+  const kind: FallingKind = forcedKind ?? (
+    roll < glitchChance ? "glitch" : roll < glitchChance + crystalChance ? "crystal" : "spark"
+  );
+  return {
+    id,
+    x: 36 + Math.random() * (BOARD_WIDTH - 72),
+    y: -24,
+    speed: 135 + Math.min(elapsed / 220, 125) + Math.random() * 75,
+    size: kind === "crystal" ? 15 : kind === "glitch" ? 14 : 11,
+    rotation: Math.random() * Math.PI * 2,
+    kind,
+  };
+}
+
+export function PikoCatchGame({ onClose, muted }: { onClose: () => void; muted: boolean }) {
+  const { t } = useTranslation();
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const frameRef = useRef<number | null>(null);
+  const previousTimeRef = useRef<number | null>(null);
+  const startedAtRef = useRef(0);
+  const lastSpawnRef = useRef(0);
+  const statusRef = useRef<CatchStatus>("ready");
+  const pikoXRef = useRef(BOARD_WIDTH / 2);
+  const itemsRef = useRef<FallingItem[]>([]);
+  const nextItemIdRef = useRef(0);
+  const heldKeysRef = useRef({ left: false, right: false });
+  const pointerTargetRef = useRef<number | null>(null);
+  const scoreRef = useRef(0);
+  const livesRef = useRef(STARTING_LIVES);
+  const audioContextRef = useRef<AudioContext | null>(null);
+  const mutedRef = useRef(muted);
+  const hurtTimerRef = useRef<number | null>(null);
+  const [status, setStatus] = useState<CatchStatus>("ready");
+  const [pikoX, setPikoX] = useState(BOARD_WIDTH / 2);
+  const [score, setScore] = useState(0);
+  const [lives, setLives] = useState(STARTING_LIVES);
+  const [timeLeft, setTimeLeft] = useState(GAME_DURATION_MS / 1000);
+  const [isHurt, setIsHurt] = useState(false);
+
+  const setGameStatus = useCallback((next: CatchStatus) => {
+    statusRef.current = next;
+    setStatus(next);
+  }, []);
+
+  const getAudioContext = useCallback(() => {
+    if (mutedRef.current) return null;
+    const AudioContextClass =
+      window.AudioContext ||
+      (window as typeof window & { webkitAudioContext?: typeof AudioContext }).webkitAudioContext;
+    if (!AudioContextClass) return null;
+    audioContextRef.current ??= new AudioContextClass();
+    if (audioContextRef.current.state === "suspended") void audioContextRef.current.resume();
+    return audioContextRef.current;
+  }, []);
+
+  const playTone = useCallback((
+    frequency: number,
+    duration: number,
+    volume: number,
+    type: OscillatorType = "sine",
+    delay = 0,
+    endFrequency?: number,
+  ) => {
+    const context = getAudioContext();
+    if (!context) return;
+    const oscillator = context.createOscillator();
+    const gain = context.createGain();
+    const startsAt = context.currentTime + delay;
+    oscillator.type = type;
+    oscillator.frequency.setValueAtTime(frequency, startsAt);
+    if (endFrequency) oscillator.frequency.exponentialRampToValueAtTime(endFrequency, startsAt + duration);
+    gain.gain.setValueAtTime(0.0001, startsAt);
+    gain.gain.exponentialRampToValueAtTime(volume, startsAt + 0.007);
+    gain.gain.exponentialRampToValueAtTime(0.0001, startsAt + duration);
+    oscillator.connect(gain);
+    gain.connect(context.destination);
+    oscillator.start(startsAt);
+    oscillator.stop(startsAt + duration + 0.02);
+  }, [getAudioContext]);
+
+  const playStartSound = useCallback(() => {
+    playTone(392, 0.08, 0.06, "triangle");
+    playTone(587.33, 0.09, 0.065, "triangle", 0.08);
+    playTone(783.99, 0.12, 0.07, "triangle", 0.17);
+  }, [playTone]);
+
+  const playCatchSound = useCallback((kind: FallingKind) => {
+    if (kind === "crystal") {
+      playTone(880, 0.08, 0.08, "triangle");
+      playTone(1_318.5, 0.13, 0.06, "sine", 0.05);
+      return;
+    }
+    playTone(660, 0.06, 0.06, "sine", 0, 880);
+  }, [playTone]);
+
+  const playHurtSound = useCallback(() => {
+    playTone(210, 0.22, 0.1, "sawtooth", 0, 68);
+    playTone(120, 0.2, 0.055, "square", 0.05, 52);
+  }, [playTone]);
+
+  const playFinishSound = useCallback((lost: boolean) => {
+    if (lost) {
+      playTone(220, 0.3, 0.09, "sawtooth", 0, 55);
+      return;
+    }
+    playTone(523.25, 0.18, 0.065, "triangle");
+    playTone(659.25, 0.2, 0.06, "triangle", 0.1);
+    playTone(783.99, 0.26, 0.055, "triangle", 0.2);
+  }, [playTone]);
+
+  useEffect(() => {
+    mutedRef.current = muted;
+    const context = audioContextRef.current;
+    if (!context) return;
+    if (muted && context.state === "running") void context.suspend();
+    if (!muted && context.state === "suspended") void context.resume();
+  }, [muted]);
+
+  useEffect(() => {
+    return () => {
+      if (hurtTimerRef.current !== null) window.clearTimeout(hurtTimerRef.current);
+      const context = audioContextRef.current;
+      audioContextRef.current = null;
+      if (context && context.state !== "closed") void context.close();
+    };
+  }, []);
+
+  const resetGame = useCallback(() => {
+    pikoXRef.current = BOARD_WIDTH / 2;
+    itemsRef.current = [];
+    nextItemIdRef.current = 0;
+    scoreRef.current = 0;
+    livesRef.current = STARTING_LIVES;
+    heldKeysRef.current = { left: false, right: false };
+    pointerTargetRef.current = null;
+    setPikoX(BOARD_WIDTH / 2);
+    setScore(0);
+    setLives(STARTING_LIVES);
+    setTimeLeft(GAME_DURATION_MS / 1000);
+    if (hurtTimerRef.current !== null) window.clearTimeout(hurtTimerRef.current);
+    hurtTimerRef.current = null;
+    setIsHurt(false);
+    setGameStatus("ready");
+  }, [setGameStatus]);
+
+  const startGame = useCallback(() => {
+    if (statusRef.current === "finished" || statusRef.current === "lost") resetGame();
+    const now = performance.now();
+    startedAtRef.current = now;
+    lastSpawnRef.current = now - 400;
+    previousTimeRef.current = null;
+    setGameStatus("playing");
+    playStartSound();
+    canvasRef.current?.focus();
+  }, [playStartSound, resetGame, setGameStatus]);
+
+  const draw = useCallback(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const context = canvas.getContext("2d");
+    if (!context) return;
+    const dpr = window.devicePixelRatio || 1;
+    const rect = canvas.getBoundingClientRect();
+    const pixelWidth = Math.round(rect.width * dpr);
+    const pixelHeight = Math.round(rect.height * dpr);
+    if (canvas.width !== pixelWidth || canvas.height !== pixelHeight) {
+      canvas.width = pixelWidth;
+      canvas.height = pixelHeight;
+    }
+    context.setTransform(pixelWidth / BOARD_WIDTH, 0, 0, pixelHeight / BOARD_HEIGHT, 0, 0);
+    context.clearRect(0, 0, BOARD_WIDTH, BOARD_HEIGHT);
+
+    const background = context.createLinearGradient(0, 0, 0, BOARD_HEIGHT);
+    background.addColorStop(0, "#101722");
+    background.addColorStop(1, "#070a0f");
+    context.fillStyle = background;
+    context.fillRect(0, 0, BOARD_WIDTH, BOARD_HEIGHT);
+
+    context.strokeStyle = "rgba(165,243,252,0.065)";
+    context.lineWidth = 1;
+    for (let x = 20; x < BOARD_WIDTH; x += 44) {
+      context.beginPath();
+      context.moveTo(x, 0);
+      context.lineTo(x, BOARD_HEIGHT);
+      context.stroke();
+    }
+
+    for (const item of itemsRef.current) {
+      context.save();
+      context.translate(item.x, item.y);
+      context.rotate(item.rotation);
+      context.shadowBlur = 16;
+      if (item.kind === "glitch") {
+        context.fillStyle = "#fb7185";
+        context.shadowColor = "rgba(251,113,133,0.55)";
+        context.fillRect(-item.size, -item.size, item.size * 2, item.size * 2);
+        context.fillStyle = "#111827";
+        context.fillRect(-item.size * 0.55, -2, item.size * 1.1, 4);
+      } else if (item.kind === "crystal") {
+        context.fillStyle = "#bef264";
+        context.shadowColor = "rgba(190,242,100,0.65)";
+        context.beginPath();
+        context.moveTo(0, -item.size);
+        context.lineTo(item.size * 0.78, 0);
+        context.lineTo(0, item.size);
+        context.lineTo(-item.size * 0.78, 0);
+        context.closePath();
+        context.fill();
+      } else {
+        context.fillStyle = "#a5f3fc";
+        context.shadowColor = "rgba(165,243,252,0.7)";
+        context.beginPath();
+        for (let point = 0; point < 8; point += 1) {
+          const angle = -Math.PI / 2 + point * Math.PI / 4;
+          const radius = point % 2 === 0 ? item.size : item.size * 0.38;
+          const x = Math.cos(angle) * radius;
+          const y = Math.sin(angle) * radius;
+          if (point === 0) context.moveTo(x, y);
+          else context.lineTo(x, y);
+        }
+        context.closePath();
+        context.fill();
+      }
+      context.restore();
+    }
+  }, []);
+
+  useEffect(() => {
+    const tick = (now: number) => {
+      const previous = previousTimeRef.current ?? now;
+      previousTimeRef.current = now;
+      const delta = Math.min((now - previous) / 1000, 0.025);
+
+      if (statusRef.current === "playing") {
+        const elapsed = now - startedAtRef.current;
+        const remaining = Math.max(0, GAME_DURATION_MS - elapsed);
+        const spawnInterval = Math.max(235, 570 - elapsed / 120);
+        let direction = Number(heldKeysRef.current.right) - Number(heldKeysRef.current.left);
+        const pointerTarget = pointerTargetRef.current;
+        if (direction === 0 && pointerTarget !== null) {
+          const distance = pointerTarget - pikoXRef.current;
+          direction = Math.abs(distance) < 7 ? 0 : Math.sign(distance);
+        }
+        pikoXRef.current = Math.max(34, Math.min(BOARD_WIDTH - 34, pikoXRef.current + direction * 345 * delta));
+
+        if (now - lastSpawnRef.current >= spawnInterval) {
+          lastSpawnRef.current = now;
+          itemsRef.current.push(makeItem(nextItemIdRef.current++, elapsed));
+          if (Math.random() < 0.6) {
+            const bonusKind: FallingKind = Math.random() < 0.3 ? "crystal" : "spark";
+            itemsRef.current.push(makeItem(nextItemIdRef.current++, elapsed, bonusKind));
+          }
+        }
+
+        const caughtIds = new Set<number>();
+        for (const item of itemsRef.current) {
+          item.y += item.speed * delta;
+          item.rotation += delta * (item.kind === "glitch" ? 3.8 : 2.2);
+          const caught =
+            Math.abs(item.x - pikoXRef.current) <= CATCH_X_RANGE + item.size / 2 &&
+            Math.abs(item.y - PIKO_Y) <= CATCH_Y_RANGE;
+          if (!caught) continue;
+          caughtIds.add(item.id);
+          if (item.kind === "glitch") {
+            livesRef.current -= 1;
+            setLives(livesRef.current);
+            setIsHurt(true);
+            if (hurtTimerRef.current !== null) window.clearTimeout(hurtTimerRef.current);
+            hurtTimerRef.current = window.setTimeout(() => {
+              setIsHurt(false);
+              hurtTimerRef.current = null;
+            }, 280);
+            playHurtSound();
+          } else {
+            const points = item.kind === "crystal" ? 3 : 1;
+            scoreRef.current += points;
+            setScore(scoreRef.current);
+            playCatchSound(item.kind);
+          }
+        }
+        itemsRef.current = itemsRef.current.filter((item) => !caughtIds.has(item.id) && item.y < BOARD_HEIGHT + 30);
+
+        setPikoX(pikoXRef.current);
+        setTimeLeft(Math.ceil(remaining / 1000));
+        if (livesRef.current <= 0) {
+          setGameStatus("lost");
+          playFinishSound(true);
+        } else if (remaining <= 0) {
+          setGameStatus("finished");
+          playFinishSound(false);
+        }
+      }
+
+      draw();
+      frameRef.current = window.requestAnimationFrame(tick);
+    };
+    frameRef.current = window.requestAnimationFrame(tick);
+    return () => {
+      if (frameRef.current !== null) window.cancelAnimationFrame(frameRef.current);
+    };
+  }, [draw, playCatchSound, playFinishSound, playHurtSound, setGameStatus]);
+
+  useEffect(() => {
+    const setKeyState = (event: KeyboardEvent, pressed: boolean) => {
+      const key = event.key.toLowerCase();
+      if (key === "arrowleft" || key === "a") {
+        event.preventDefault();
+        heldKeysRef.current.left = pressed;
+        pointerTargetRef.current = null;
+      } else if (key === "arrowright" || key === "d") {
+        event.preventDefault();
+        heldKeysRef.current.right = pressed;
+        pointerTargetRef.current = null;
+      } else if (pressed && (key === " " || key === "enter") && statusRef.current !== "playing") {
+        event.preventDefault();
+        startGame();
+      }
+    };
+    const handleKeyDown = (event: KeyboardEvent) => setKeyState(event, true);
+    const handleKeyUp = (event: KeyboardEvent) => setKeyState(event, false);
+    window.addEventListener("keydown", handleKeyDown);
+    window.addEventListener("keyup", handleKeyUp);
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown);
+      window.removeEventListener("keyup", handleKeyUp);
+    };
+  }, [startGame]);
+
+  const setPointerTarget = (clientX: number) => {
+    const rect = canvasRef.current?.getBoundingClientRect();
+    if (!rect) return;
+    pointerTargetRef.current = ((clientX - rect.left) / rect.width) * BOARD_WIDTH;
+  };
+
+  return (
+    <div className="relative h-[520px] overflow-hidden border border-white/[0.08] bg-[#070a0f]">
+      <canvas
+        ref={canvasRef}
+        className="h-full w-full touch-none outline-none"
+        tabIndex={0}
+        aria-label={t("pikoMiniGame.catch.canvasLabel")}
+        onPointerMove={(event) => setPointerTarget(event.clientX)}
+        onPointerDown={(event) => {
+          setPointerTarget(event.clientX);
+          if (statusRef.current !== "playing") startGame();
+        }}
+        onPointerLeave={() => {
+          pointerTargetRef.current = null;
+        }}
+      />
+
+      <div
+        className="pointer-events-none absolute size-[62px]"
+        style={{
+          left: `${(pikoX / BOARD_WIDTH) * 100}%`,
+          top: `${(PIKO_Y / BOARD_HEIGHT) * 100}%`,
+          transform: `translate(-50%, -50%) ${isHurt ? "rotate(8deg) scale(0.88)" : ""}`,
+        }}
+      >
+        <PikoActionFigure
+          action={isHurt ? "repair" : "idle"}
+          className="mybuddy-companion-anchor--preview !h-[62px]"
+          style={{ transform: "scale(0.82)", transformOrigin: "center" }}
+        />
+      </div>
+
+      <div className="pointer-events-none absolute inset-x-4 top-4 flex justify-between text-sm font-medium text-white/78">
+        <span>{t("pikoMiniGame.catch.score", { score })}</span>
+        <span>{t("pikoMiniGame.catch.status", { lives, seconds: timeLeft })}</span>
+      </div>
+
+      {status !== "playing" ? (
+        <div className="absolute inset-0 grid place-items-center bg-black/52 px-5 backdrop-blur-[2px]">
+          <div className="max-w-sm rounded-2xl border border-white/[0.14] bg-black/68 px-7 py-6 text-center shadow-[0_24px_72px_rgba(0,0,0,0.48)]">
+            <h3 className="text-2xl font-semibold text-white">
+              {t(
+                status === "finished"
+                  ? "pikoMiniGame.catch.finished"
+                  : status === "lost"
+                    ? "pikoMiniGame.catch.lost"
+                    : "pikoMiniGame.catch.ready",
+              )}
+            </h3>
+            <p className="mt-2 text-sm leading-6 text-white/58">
+              {status === "ready"
+                ? t("pikoMiniGame.catch.hint")
+                : t("pikoMiniGame.catch.result", { score })}
+            </p>
+            <div className="mt-6 flex justify-center gap-3">
+              {status === "finished" || status === "lost" ? (
+                <button
+                  type="button"
+                  className="h-10 rounded-full border border-white/[0.14] px-5 text-sm text-white/78 transition-colors hover:bg-white/[0.08] hover:text-white"
+                  onClick={onClose}
+                >
+                  {t("pikoMiniGame.backToWork")}
+                </button>
+              ) : null}
+              <button
+                type="button"
+                className="h-10 rounded-full bg-cyan-300 px-5 text-sm font-medium text-slate-950 transition-colors hover:bg-cyan-200"
+                onClick={startGame}
+              >
+                {status === "ready" ? t("pikoMiniGame.catch.start") : t("pikoMiniGame.playAgain")}
+              </button>
+            </div>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/src/features/piko-mini-game/PikoFlyingGame.tsx
+++ b/frontend/src/features/piko-mini-game/PikoFlyingGame.tsx
@@ -1,0 +1,376 @@
+// SPDX-License-Identifier: Elastic-2.0
+// Copyright (c) 2026 ClaymoreLab
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { PikoActionFigure } from "@/features/companion/PikoActionFigure";
+
+const BOARD_WIDTH = 800;
+const BOARD_HEIGHT = 520;
+const PIKO_X = 172;
+const PIKO_RADIUS = 18;
+const GRAVITY = 1_180;
+const FLAP_VELOCITY = -390;
+const GATE_WIDTH = 76;
+const GATE_GAP = 168;
+const GATE_SPACING = 285;
+
+type FlyingStatus = "ready" | "playing" | "lost";
+
+type Gate = {
+  id: number;
+  x: number;
+  gapY: number;
+  scored: boolean;
+};
+
+function randomGapY() {
+  return 135 + Math.random() * 250;
+}
+
+function makeGates(): Gate[] {
+  return Array.from({ length: 4 }, (_, index) => ({
+    id: index,
+    x: 650 + index * GATE_SPACING,
+    gapY: randomGapY(),
+    scored: false,
+  }));
+}
+
+export function PikoFlyingGame({ onClose, muted }: { onClose: () => void; muted: boolean }) {
+  const { t } = useTranslation();
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const audioContextRef = useRef<AudioContext | null>(null);
+  const mutedRef = useRef(muted);
+  const frameRef = useRef<number | null>(null);
+  const previousTimeRef = useRef<number | null>(null);
+  const statusRef = useRef<FlyingStatus>("ready");
+  const yRef = useRef(BOARD_HEIGHT / 2);
+  const velocityRef = useRef(0);
+  const gatesRef = useRef<Gate[]>(makeGates());
+  const nextGateIdRef = useRef(4);
+  const scoreRef = useRef(0);
+  const [status, setStatus] = useState<FlyingStatus>("ready");
+  const [pikoY, setPikoY] = useState(BOARD_HEIGHT / 2);
+  const [velocity, setVelocity] = useState(0);
+  const [score, setScore] = useState(0);
+
+  const getAudioContext = useCallback(() => {
+    if (mutedRef.current) return null;
+    const AudioContextClass =
+      window.AudioContext ||
+      (window as typeof window & { webkitAudioContext?: typeof AudioContext }).webkitAudioContext;
+    if (!AudioContextClass) return null;
+    audioContextRef.current ??= new AudioContextClass();
+    if (audioContextRef.current.state === "suspended") void audioContextRef.current.resume();
+    return audioContextRef.current;
+  }, []);
+
+  const playTone = useCallback((
+    frequency: number,
+    duration: number,
+    volume: number,
+    type: OscillatorType = "sine",
+    delay = 0,
+    endFrequency?: number,
+  ) => {
+    const context = getAudioContext();
+    if (!context) return;
+    const oscillator = context.createOscillator();
+    const gain = context.createGain();
+    const startsAt = context.currentTime + delay;
+    oscillator.type = type;
+    oscillator.frequency.setValueAtTime(frequency, startsAt);
+    if (endFrequency) oscillator.frequency.exponentialRampToValueAtTime(endFrequency, startsAt + duration);
+    gain.gain.setValueAtTime(0.0001, startsAt);
+    gain.gain.exponentialRampToValueAtTime(volume, startsAt + 0.008);
+    gain.gain.exponentialRampToValueAtTime(0.0001, startsAt + duration);
+    oscillator.connect(gain);
+    gain.connect(context.destination);
+    oscillator.start(startsAt);
+    oscillator.stop(startsAt + duration + 0.02);
+  }, [getAudioContext]);
+
+  const playFlapSound = useCallback(() => {
+    playTone(420, 0.075, 0.075, "triangle", 0, 760);
+    playTone(920, 0.045, 0.035, "sine", 0.04, 1_180);
+  }, [playTone]);
+
+  const playStartSound = useCallback(() => {
+    playTone(392, 0.08, 0.07, "triangle");
+    playTone(523.25, 0.09, 0.075, "triangle", 0.085);
+    playTone(783.99, 0.12, 0.08, "triangle", 0.18);
+  }, [playTone]);
+
+  const playScoreSound = useCallback((nextScore: number) => {
+    const lift = Math.min(nextScore, 12) * 12;
+    playTone(760 + lift, 0.07, 0.075, "sine");
+    playTone(1_120 + lift, 0.09, 0.055, "triangle", 0.045);
+    if (nextScore % 5 === 0) {
+      playTone(523.25, 0.18, 0.06, "triangle", 0.12);
+      playTone(659.25, 0.18, 0.055, "triangle", 0.17);
+      playTone(783.99, 0.22, 0.05, "triangle", 0.22);
+    }
+  }, [playTone]);
+
+  const playCollisionSound = useCallback(() => {
+    playTone(220, 0.24, 0.11, "sawtooth", 0, 72);
+    playTone(130, 0.28, 0.07, "square", 0.04, 55);
+  }, [playTone]);
+
+  useEffect(() => {
+    mutedRef.current = muted;
+    const context = audioContextRef.current;
+    if (!context) return;
+    if (muted && context.state === "running") void context.suspend();
+    if (!muted && context.state === "suspended") void context.resume();
+  }, [muted]);
+
+  useEffect(() => {
+    return () => {
+      const context = audioContextRef.current;
+      audioContextRef.current = null;
+      if (context && context.state !== "closed") void context.close();
+    };
+  }, []);
+
+  const setGameStatus = useCallback((next: FlyingStatus) => {
+    statusRef.current = next;
+    setStatus(next);
+  }, []);
+
+  const resetGame = useCallback(() => {
+    yRef.current = BOARD_HEIGHT / 2;
+    velocityRef.current = 0;
+    gatesRef.current = makeGates();
+    nextGateIdRef.current = 4;
+    scoreRef.current = 0;
+    setPikoY(BOARD_HEIGHT / 2);
+    setVelocity(0);
+    setScore(0);
+    setGameStatus("ready");
+  }, [setGameStatus]);
+
+  const flap = useCallback(() => {
+    if (statusRef.current !== "playing") return;
+    velocityRef.current = FLAP_VELOCITY;
+    setVelocity(FLAP_VELOCITY);
+    playFlapSound();
+  }, [playFlapSound]);
+
+  const startGame = useCallback(() => {
+    if (statusRef.current === "lost") resetGame();
+    previousTimeRef.current = null;
+    setGameStatus("playing");
+    velocityRef.current = FLAP_VELOCITY;
+    setVelocity(FLAP_VELOCITY);
+    playStartSound();
+    canvasRef.current?.focus();
+  }, [playStartSound, resetGame, setGameStatus]);
+
+  const draw = useCallback(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const context = canvas.getContext("2d");
+    if (!context) return;
+    const dpr = window.devicePixelRatio || 1;
+    const rect = canvas.getBoundingClientRect();
+    const pixelWidth = Math.round(rect.width * dpr);
+    const pixelHeight = Math.round(rect.height * dpr);
+    if (canvas.width !== pixelWidth || canvas.height !== pixelHeight) {
+      canvas.width = pixelWidth;
+      canvas.height = pixelHeight;
+    }
+    context.setTransform(pixelWidth / BOARD_WIDTH, 0, 0, pixelHeight / BOARD_HEIGHT, 0, 0);
+    context.clearRect(0, 0, BOARD_WIDTH, BOARD_HEIGHT);
+
+    const background = context.createLinearGradient(0, 0, 0, BOARD_HEIGHT);
+    background.addColorStop(0, "#111827");
+    background.addColorStop(0.58, "#0b1220");
+    background.addColorStop(1, "#070a0f");
+    context.fillStyle = background;
+    context.fillRect(0, 0, BOARD_WIDTH, BOARD_HEIGHT);
+
+    for (let index = 0; index < 38; index += 1) {
+      const x = (index * 137 + 41) % BOARD_WIDTH;
+      const y = (index * 79 + 27) % BOARD_HEIGHT;
+      context.fillStyle = index % 4 === 0 ? "rgba(190,242,100,0.38)" : "rgba(165,243,252,0.28)";
+      context.fillRect(x, y, index % 5 === 0 ? 2 : 1, index % 5 === 0 ? 2 : 1);
+    }
+
+    for (const gate of gatesRef.current) {
+      const gapTop = gate.gapY - GATE_GAP / 2;
+      const gapBottom = gate.gapY + GATE_GAP / 2;
+      const gradient = context.createLinearGradient(gate.x, 0, gate.x + GATE_WIDTH, 0);
+      gradient.addColorStop(0, "rgba(8,145,178,0.48)");
+      gradient.addColorStop(0.5, "rgba(103,232,249,0.82)");
+      gradient.addColorStop(1, "rgba(30,64,175,0.45)");
+      context.fillStyle = gradient;
+      context.shadowColor = "rgba(103,232,249,0.32)";
+      context.shadowBlur = 18;
+      context.fillRect(gate.x, 0, GATE_WIDTH, gapTop);
+      context.fillRect(gate.x, gapBottom, GATE_WIDTH, BOARD_HEIGHT - gapBottom);
+
+      context.fillStyle = "rgba(236,254,255,0.92)";
+      context.shadowBlur = 22;
+      context.fillRect(gate.x - 7, gapTop - 8, GATE_WIDTH + 14, 8);
+      context.fillRect(gate.x - 7, gapBottom, GATE_WIDTH + 14, 8);
+      context.shadowBlur = 0;
+
+      context.strokeStyle = "rgba(236,254,255,0.18)";
+      context.lineWidth = 1;
+      for (let y = 18; y < gapTop - 12; y += 28) {
+        context.beginPath();
+        context.moveTo(gate.x + 12, y);
+        context.lineTo(gate.x + GATE_WIDTH - 12, y);
+        context.stroke();
+      }
+      for (let y = gapBottom + 20; y < BOARD_HEIGHT; y += 28) {
+        context.beginPath();
+        context.moveTo(gate.x + 12, y);
+        context.lineTo(gate.x + GATE_WIDTH - 12, y);
+        context.stroke();
+      }
+    }
+  }, []);
+
+  useEffect(() => {
+    const tick = (time: number) => {
+      const previousTime = previousTimeRef.current ?? time;
+      previousTimeRef.current = time;
+      const delta = Math.min((time - previousTime) / 1000, 0.025);
+
+      if (statusRef.current === "playing") {
+        velocityRef.current += GRAVITY * delta;
+        yRef.current += velocityRef.current * delta;
+        const gateSpeed = Math.min(190 + scoreRef.current * 5, 310);
+        for (const gate of gatesRef.current) gate.x -= gateSpeed * delta;
+
+        for (const gate of gatesRef.current) {
+          if (!gate.scored && gate.x + GATE_WIDTH < PIKO_X - PIKO_RADIUS) {
+            gate.scored = true;
+            scoreRef.current += 1;
+            setScore(scoreRef.current);
+            playScoreSound(scoreRef.current);
+          }
+        }
+
+        const passedGates = gatesRef.current.filter((gate) => gate.x + GATE_WIDTH < -10);
+        if (passedGates.length > 0) {
+          gatesRef.current = gatesRef.current.filter((gate) => gate.x + GATE_WIDTH >= -10);
+          let nextX = Math.max(...gatesRef.current.map((gate) => gate.x), BOARD_WIDTH) + GATE_SPACING;
+          for (let index = 0; index < passedGates.length; index += 1) {
+            gatesRef.current.push({
+              id: nextGateIdRef.current++,
+              x: nextX,
+              gapY: randomGapY(),
+              scored: false,
+            });
+            nextX += GATE_SPACING;
+          }
+        }
+
+        const hitGate = gatesRef.current.some((gate) => {
+          const overlapsX =
+            PIKO_X + PIKO_RADIUS > gate.x && PIKO_X - PIKO_RADIUS < gate.x + GATE_WIDTH;
+          if (!overlapsX) return false;
+          return (
+            yRef.current - PIKO_RADIUS < gate.gapY - GATE_GAP / 2 ||
+            yRef.current + PIKO_RADIUS > gate.gapY + GATE_GAP / 2
+          );
+        });
+        const outsideBoard =
+          yRef.current - PIKO_RADIUS <= 0 || yRef.current + PIKO_RADIUS >= BOARD_HEIGHT;
+        if (hitGate || outsideBoard) {
+          setGameStatus("lost");
+          playCollisionSound();
+        }
+
+        setPikoY(yRef.current);
+        setVelocity(velocityRef.current);
+      }
+
+      draw();
+      frameRef.current = window.requestAnimationFrame(tick);
+    };
+    frameRef.current = window.requestAnimationFrame(tick);
+    return () => {
+      if (frameRef.current !== null) window.cancelAnimationFrame(frameRef.current);
+    };
+  }, [draw, playCollisionSound, playScoreSound, setGameStatus]);
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== " " && event.key !== "ArrowUp") return;
+      event.preventDefault();
+      if (statusRef.current === "playing") flap();
+      else startGame();
+    };
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [flap, startGame]);
+
+  const pikoRotation = Math.max(-18, Math.min(28, velocity / 18));
+
+  return (
+    <div className="relative h-[520px] overflow-hidden border border-white/[0.08] bg-[#070a0f]">
+      <canvas
+        ref={canvasRef}
+        className="h-full w-full touch-none outline-none"
+        tabIndex={0}
+        aria-label={t("pikoMiniGame.flying.canvasLabel")}
+        onPointerDown={() => {
+          if (statusRef.current === "playing") flap();
+          else startGame();
+        }}
+      />
+
+      <div
+        className="pointer-events-none absolute size-[58px]"
+        style={{
+          left: `${(PIKO_X / BOARD_WIDTH) * 100}%`,
+          top: `${(pikoY / BOARD_HEIGHT) * 100}%`,
+          transform: `translate(-50%, -50%) rotate(${pikoRotation}deg)`,
+        }}
+      >
+        <PikoActionFigure
+          action="idle"
+          className="mybuddy-companion-anchor--preview !h-[58px]"
+          style={{ transform: "scale(0.78)", transformOrigin: "center" }}
+        />
+      </div>
+
+      <div className="pointer-events-none absolute left-4 top-4 text-sm font-medium text-white/78">
+        {t("pikoMiniGame.flying.score", { score })}
+      </div>
+
+      {status !== "playing" ? (
+        <div className="absolute inset-0 grid place-items-center bg-black/52 px-5 backdrop-blur-[2px]">
+          <div className="max-w-sm rounded-2xl border border-white/[0.14] bg-black/68 px-7 py-6 text-center shadow-[0_24px_72px_rgba(0,0,0,0.48)]">
+            <h3 className="text-2xl font-semibold text-white">
+              {t(status === "lost" ? "pikoMiniGame.flying.lost" : "pikoMiniGame.flying.ready")}
+            </h3>
+            <p className="mt-2 text-sm leading-6 text-white/58">{t("pikoMiniGame.flying.hint")}</p>
+            <div className="mt-6 flex justify-center gap-3">
+              {status === "lost" ? (
+                <button
+                  type="button"
+                  className="h-10 rounded-full border border-white/[0.14] px-5 text-sm text-white/78 transition-colors hover:bg-white/[0.08] hover:text-white"
+                  onClick={onClose}
+                >
+                  {t("pikoMiniGame.backToWork")}
+                </button>
+              ) : null}
+              <button
+                type="button"
+                className="h-10 rounded-full bg-cyan-300 px-5 text-sm font-medium text-slate-950 transition-colors hover:bg-cyan-200"
+                onClick={startGame}
+              >
+                {status === "lost" ? t("pikoMiniGame.playAgain") : t("pikoMiniGame.flying.start")}
+              </button>
+            </div>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/src/features/piko-mini-game/PikoFlyingGame.tsx
+++ b/frontend/src/features/piko-mini-game/PikoFlyingGame.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { PikoActionFigure } from "@/features/companion/PikoActionFigure";
+import { usePikoGameAudio } from "@/features/piko-mini-game/usePikoGameAudio";
 
 const BOARD_WIDTH = 800;
 const BOARD_HEIGHT = 520;
@@ -39,8 +40,6 @@ function makeGates(): Gate[] {
 export function PikoFlyingGame({ onClose, muted }: { onClose: () => void; muted: boolean }) {
   const { t } = useTranslation();
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
-  const audioContextRef = useRef<AudioContext | null>(null);
-  const mutedRef = useRef(muted);
   const frameRef = useRef<number | null>(null);
   const previousTimeRef = useRef<number | null>(null);
   const statusRef = useRef<FlyingStatus>("ready");
@@ -53,42 +52,7 @@ export function PikoFlyingGame({ onClose, muted }: { onClose: () => void; muted:
   const [pikoY, setPikoY] = useState(BOARD_HEIGHT / 2);
   const [velocity, setVelocity] = useState(0);
   const [score, setScore] = useState(0);
-
-  const getAudioContext = useCallback(() => {
-    if (mutedRef.current) return null;
-    const AudioContextClass =
-      window.AudioContext ||
-      (window as typeof window & { webkitAudioContext?: typeof AudioContext }).webkitAudioContext;
-    if (!AudioContextClass) return null;
-    audioContextRef.current ??= new AudioContextClass();
-    if (audioContextRef.current.state === "suspended") void audioContextRef.current.resume();
-    return audioContextRef.current;
-  }, []);
-
-  const playTone = useCallback((
-    frequency: number,
-    duration: number,
-    volume: number,
-    type: OscillatorType = "sine",
-    delay = 0,
-    endFrequency?: number,
-  ) => {
-    const context = getAudioContext();
-    if (!context) return;
-    const oscillator = context.createOscillator();
-    const gain = context.createGain();
-    const startsAt = context.currentTime + delay;
-    oscillator.type = type;
-    oscillator.frequency.setValueAtTime(frequency, startsAt);
-    if (endFrequency) oscillator.frequency.exponentialRampToValueAtTime(endFrequency, startsAt + duration);
-    gain.gain.setValueAtTime(0.0001, startsAt);
-    gain.gain.exponentialRampToValueAtTime(volume, startsAt + 0.008);
-    gain.gain.exponentialRampToValueAtTime(0.0001, startsAt + duration);
-    oscillator.connect(gain);
-    gain.connect(context.destination);
-    oscillator.start(startsAt);
-    oscillator.stop(startsAt + duration + 0.02);
-  }, [getAudioContext]);
+  const playTone = usePikoGameAudio(muted);
 
   const playFlapSound = useCallback(() => {
     playTone(420, 0.075, 0.075, "triangle", 0, 760);
@@ -116,22 +80,6 @@ export function PikoFlyingGame({ onClose, muted }: { onClose: () => void; muted:
     playTone(220, 0.24, 0.11, "sawtooth", 0, 72);
     playTone(130, 0.28, 0.07, "square", 0.04, 55);
   }, [playTone]);
-
-  useEffect(() => {
-    mutedRef.current = muted;
-    const context = audioContextRef.current;
-    if (!context) return;
-    if (muted && context.state === "running") void context.suspend();
-    if (!muted && context.state === "suspended") void context.resume();
-  }, [muted]);
-
-  useEffect(() => {
-    return () => {
-      const context = audioContextRef.current;
-      audioContextRef.current = null;
-      if (context && context.state !== "closed") void context.close();
-    };
-  }, []);
 
   const setGameStatus = useCallback((next: FlyingStatus) => {
     statusRef.current = next;

--- a/frontend/src/features/piko-mini-game/PikoInspirationStation.tsx
+++ b/frontend/src/features/piko-mini-game/PikoInspirationStation.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from "react-i18next";
 import { ArrowLeft, Gamepad2, Volume2, VolumeX, X } from "lucide-react";
 import { PikoActionFigure } from "@/features/companion/PikoActionFigure";
 import { PikoBreakoutGame } from "@/features/piko-mini-game/PikoBreakoutGame";
+import { PikoFlyingGame } from "@/features/piko-mini-game/PikoFlyingGame";
 import { PikoRollingBallGame } from "@/features/piko-mini-game/PikoRollingBallGame";
 import { cn } from "@/lib/utils";
 
@@ -92,7 +93,7 @@ type HitSpark = {
 
 type GameStatus = "idle" | "countdown" | "playing" | "finished";
 type StationView = "library" | "game";
-type PikoGameId = "inspiration-station" | "memory-match" | "breakout" | "rolling-ball";
+type PikoGameId = "inspiration-station" | "memory-match" | "breakout" | "rolling-ball" | "flying";
 
 type PikoInspirationStationProps = {
   open: boolean;
@@ -115,6 +116,10 @@ const PIKO_GAME_LIBRARY = [
   {
     id: "rolling-ball",
     titleKey: "pikoMiniGame.rollingBall.title",
+  },
+  {
+    id: "flying",
+    titleKey: "pikoMiniGame.flying.title",
   },
 ] as const;
 
@@ -838,7 +843,9 @@ export function PikoInspirationStation({ open, onClose }: PikoInspirationStation
         ? "pikoMiniGame.breakout.title"
         : activeGameId === "rolling-ball"
           ? "pikoMiniGame.rollingBall.title"
-        : "pikoMiniGame.title";
+          : activeGameId === "flying"
+            ? "pikoMiniGame.flying.title"
+            : "pikoMiniGame.title";
 
   useEffect(() => {
     setPikoAudioMuted(isAudioMuted);
@@ -1560,7 +1567,7 @@ export function PikoInspirationStation({ open, onClose }: PikoInspirationStation
             )}
           </div>
           <div className="flex items-center gap-1">
-            {stationView === "game" && activeGameId === "inspiration-station" ? (
+            {stationView === "game" && (activeGameId === "inspiration-station" || activeGameId === "flying") ? (
               <button
                 type="button"
                 className="inline-flex size-9 items-center justify-center rounded-full text-white/68 transition-colors hover:bg-white/[0.08] hover:text-white"
@@ -1608,6 +1615,8 @@ export function PikoInspirationStation({ open, onClose }: PikoInspirationStation
             <PikoBreakoutGame onClose={onClose} />
           ) : activeGameId === "rolling-ball" ? (
             <PikoRollingBallGame onClose={onClose} />
+          ) : activeGameId === "flying" ? (
+            <PikoFlyingGame onClose={onClose} muted={isAudioMuted} />
           ) : (
             <div
               ref={boardRef}

--- a/frontend/src/features/piko-mini-game/PikoInspirationStation.tsx
+++ b/frontend/src/features/piko-mini-game/PikoInspirationStation.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from "react-i18next";
 import { ArrowLeft, Gamepad2, Volume2, VolumeX, X } from "lucide-react";
 import { PikoActionFigure } from "@/features/companion/PikoActionFigure";
 import { PikoBreakoutGame } from "@/features/piko-mini-game/PikoBreakoutGame";
+import { PikoCatchGame } from "@/features/piko-mini-game/PikoCatchGame";
 import { PikoFlyingGame } from "@/features/piko-mini-game/PikoFlyingGame";
 import { PikoRollingBallGame } from "@/features/piko-mini-game/PikoRollingBallGame";
 import { cn } from "@/lib/utils";
@@ -93,7 +94,7 @@ type HitSpark = {
 
 type GameStatus = "idle" | "countdown" | "playing" | "finished";
 type StationView = "library" | "game";
-type PikoGameId = "inspiration-station" | "memory-match" | "breakout" | "rolling-ball" | "flying";
+type PikoGameId = "inspiration-station" | "memory-match" | "breakout" | "rolling-ball" | "flying" | "catch";
 
 type PikoInspirationStationProps = {
   open: boolean;
@@ -120,6 +121,10 @@ const PIKO_GAME_LIBRARY = [
   {
     id: "flying",
     titleKey: "pikoMiniGame.flying.title",
+  },
+  {
+    id: "catch",
+    titleKey: "pikoMiniGame.catch.title",
   },
 ] as const;
 
@@ -845,6 +850,8 @@ export function PikoInspirationStation({ open, onClose }: PikoInspirationStation
           ? "pikoMiniGame.rollingBall.title"
           : activeGameId === "flying"
             ? "pikoMiniGame.flying.title"
+            : activeGameId === "catch"
+              ? "pikoMiniGame.catch.title"
             : "pikoMiniGame.title";
 
   useEffect(() => {
@@ -1567,7 +1574,7 @@ export function PikoInspirationStation({ open, onClose }: PikoInspirationStation
             )}
           </div>
           <div className="flex items-center gap-1">
-            {stationView === "game" && (activeGameId === "inspiration-station" || activeGameId === "breakout" || activeGameId === "rolling-ball" || activeGameId === "flying") ? (
+            {stationView === "game" && (activeGameId === "inspiration-station" || activeGameId === "breakout" || activeGameId === "rolling-ball" || activeGameId === "flying" || activeGameId === "catch") ? (
               <button
                 type="button"
                 className="inline-flex size-9 items-center justify-center rounded-full text-white/68 transition-colors hover:bg-white/[0.08] hover:text-white"
@@ -1617,6 +1624,8 @@ export function PikoInspirationStation({ open, onClose }: PikoInspirationStation
             <PikoRollingBallGame onClose={onClose} muted={isAudioMuted} />
           ) : activeGameId === "flying" ? (
             <PikoFlyingGame onClose={onClose} muted={isAudioMuted} />
+          ) : activeGameId === "catch" ? (
+            <PikoCatchGame onClose={onClose} muted={isAudioMuted} />
           ) : (
             <div
               ref={boardRef}

--- a/frontend/src/features/piko-mini-game/PikoInspirationStation.tsx
+++ b/frontend/src/features/piko-mini-game/PikoInspirationStation.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from "react-i18next";
 import { ArrowLeft, Gamepad2, Volume2, VolumeX, X } from "lucide-react";
 import { PikoActionFigure } from "@/features/companion/PikoActionFigure";
 import { PikoBreakoutGame } from "@/features/piko-mini-game/PikoBreakoutGame";
+import { PikoRollingBallGame } from "@/features/piko-mini-game/PikoRollingBallGame";
 import { cn } from "@/lib/utils";
 
 const GAME_DURATION_MS = 60_000;
@@ -91,7 +92,7 @@ type HitSpark = {
 
 type GameStatus = "idle" | "countdown" | "playing" | "finished";
 type StationView = "library" | "game";
-type PikoGameId = "inspiration-station" | "memory-match" | "breakout";
+type PikoGameId = "inspiration-station" | "memory-match" | "breakout" | "rolling-ball";
 
 type PikoInspirationStationProps = {
   open: boolean;
@@ -110,6 +111,10 @@ const PIKO_GAME_LIBRARY = [
   {
     id: "breakout",
     titleKey: "pikoMiniGame.breakout.title",
+  },
+  {
+    id: "rolling-ball",
+    titleKey: "pikoMiniGame.rollingBall.title",
   },
 ] as const;
 
@@ -831,6 +836,8 @@ export function PikoInspirationStation({ open, onClose }: PikoInspirationStation
       ? "pikoMiniGame.memory.title"
       : activeGameId === "breakout"
         ? "pikoMiniGame.breakout.title"
+        : activeGameId === "rolling-ball"
+          ? "pikoMiniGame.rollingBall.title"
         : "pikoMiniGame.title";
 
   useEffect(() => {
@@ -1599,6 +1606,8 @@ export function PikoInspirationStation({ open, onClose }: PikoInspirationStation
             <PikoMemoryMatchGame onClose={onClose} />
           ) : activeGameId === "breakout" ? (
             <PikoBreakoutGame onClose={onClose} />
+          ) : activeGameId === "rolling-ball" ? (
+            <PikoRollingBallGame onClose={onClose} />
           ) : (
             <div
               ref={boardRef}

--- a/frontend/src/features/piko-mini-game/PikoInspirationStation.tsx
+++ b/frontend/src/features/piko-mini-game/PikoInspirationStation.tsx
@@ -1567,7 +1567,7 @@ export function PikoInspirationStation({ open, onClose }: PikoInspirationStation
             )}
           </div>
           <div className="flex items-center gap-1">
-            {stationView === "game" && (activeGameId === "inspiration-station" || activeGameId === "flying") ? (
+            {stationView === "game" && (activeGameId === "inspiration-station" || activeGameId === "breakout" || activeGameId === "rolling-ball" || activeGameId === "flying") ? (
               <button
                 type="button"
                 className="inline-flex size-9 items-center justify-center rounded-full text-white/68 transition-colors hover:bg-white/[0.08] hover:text-white"
@@ -1612,9 +1612,9 @@ export function PikoInspirationStation({ open, onClose }: PikoInspirationStation
           ) : activeGameId === "memory-match" ? (
             <PikoMemoryMatchGame onClose={onClose} />
           ) : activeGameId === "breakout" ? (
-            <PikoBreakoutGame onClose={onClose} />
+            <PikoBreakoutGame onClose={onClose} muted={isAudioMuted} />
           ) : activeGameId === "rolling-ball" ? (
-            <PikoRollingBallGame onClose={onClose} />
+            <PikoRollingBallGame onClose={onClose} muted={isAudioMuted} />
           ) : activeGameId === "flying" ? (
             <PikoFlyingGame onClose={onClose} muted={isAudioMuted} />
           ) : (

--- a/frontend/src/features/piko-mini-game/PikoInspirationStation.tsx
+++ b/frontend/src/features/piko-mini-game/PikoInspirationStation.tsx
@@ -2,8 +2,9 @@
 // Copyright (c) 2026 ClaymoreLab
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { Volume2, VolumeX, X } from "lucide-react";
+import { ArrowLeft, Gamepad2, Volume2, VolumeX, X } from "lucide-react";
 import { PikoActionFigure } from "@/features/companion/PikoActionFigure";
+import { PikoBreakoutGame } from "@/features/piko-mini-game/PikoBreakoutGame";
 import { cn } from "@/lib/utils";
 
 const GAME_DURATION_MS = 60_000;
@@ -89,11 +90,28 @@ type HitSpark = {
 };
 
 type GameStatus = "idle" | "countdown" | "playing" | "finished";
+type StationView = "library" | "game";
+type PikoGameId = "inspiration-station" | "memory-match" | "breakout";
 
 type PikoInspirationStationProps = {
   open: boolean;
   onClose: () => void;
 };
+
+const PIKO_GAME_LIBRARY = [
+  {
+    id: "inspiration-station",
+    titleKey: "pikoMiniGame.title",
+  },
+  {
+    id: "memory-match",
+    titleKey: "pikoMiniGame.memory.title",
+  },
+  {
+    id: "breakout",
+    titleKey: "pikoMiniGame.breakout.title",
+  },
+] as const;
 
 const KIND_LABEL: Record<FallingKind, string> = {
   spark: "✦",
@@ -134,6 +152,11 @@ const BGM_FADE_MS = 2_200;
 const BGM_RESTART_BEFORE_END_SECONDS = 3.2;
 
 type ResultSoundKind = "combo" | "wild" | "burst" | "rain" | "high" | "medium" | "soft";
+type MemoryCard = {
+  id: number;
+  value: string;
+  matched: boolean;
+};
 
 let hitAudioContext: AudioContext | null = null;
 let pikoAudioMuted = false;
@@ -151,6 +174,20 @@ function clamp(value: number, min: number, max: number) {
 
 function randomBetween(min: number, max: number) {
   return min + Math.random() * (max - min);
+}
+
+function shuffleMemoryCards(cards: MemoryCard[]) {
+  return [...cards].sort(() => Math.random() - 0.5);
+}
+
+function makeMemoryDeck() {
+  const values = ["✦", "◆", "✚", "✹", "◇", "◌"];
+  return shuffleMemoryCards(
+    values.flatMap((value, index) => [
+      { id: index * 2, value, matched: false },
+      { id: index * 2 + 1, value, matched: false },
+    ]),
+  );
 }
 
 function panFromX(x: number) {
@@ -566,6 +603,135 @@ function playCountdownSound(count: number) {
   playTone(frequency * 2, 0.06, 0.045, "sine", 0.035);
 }
 
+function PikoMemoryMatchGame({ onClose }: { onClose: () => void }) {
+  const { t } = useTranslation();
+  const timersRef = useRef<Set<number>>(new Set());
+  const [cards, setCards] = useState<MemoryCard[]>(() => makeMemoryDeck());
+  const [flippedIds, setFlippedIds] = useState<number[]>([]);
+  const [moves, setMoves] = useState(0);
+  const matchedCount = cards.filter((card) => card.matched).length;
+  const isComplete = matchedCount === cards.length;
+
+  const clearTimers = useCallback(() => {
+    for (const timer of timersRef.current) {
+      window.clearTimeout(timer);
+    }
+    timersRef.current.clear();
+  }, []);
+
+  const resetMemoryGame = useCallback(() => {
+    clearTimers();
+    setCards(makeMemoryDeck());
+    setFlippedIds([]);
+    setMoves(0);
+  }, [clearTimers]);
+
+  useEffect(() => {
+    return () => {
+      clearTimers();
+    };
+  }, [clearTimers]);
+
+  const flipCard = useCallback(
+    (card: MemoryCard) => {
+      if (card.matched || flippedIds.includes(card.id) || flippedIds.length >= 2 || isComplete) return;
+
+      const nextFlippedIds = [...flippedIds, card.id];
+      setFlippedIds(nextFlippedIds);
+
+      if (nextFlippedIds.length !== 2) return;
+
+      const [firstId, secondId] = nextFlippedIds;
+      const firstCard = cards.find((candidate) => candidate.id === firstId);
+      const secondCard = cards.find((candidate) => candidate.id === secondId);
+      setMoves((current) => current + 1);
+
+      const timer = window.setTimeout(() => {
+        if (firstCard && secondCard && firstCard.value === secondCard.value) {
+          setCards((current) =>
+            current.map((candidate) =>
+              candidate.id === firstCard.id || candidate.id === secondCard.id
+                ? { ...candidate, matched: true }
+                : candidate,
+            ),
+          );
+        }
+        setFlippedIds([]);
+        timersRef.current.delete(timer);
+      }, firstCard?.value === secondCard?.value ? 360 : 720);
+      timersRef.current.add(timer);
+    },
+    [cards, flippedIds, isComplete],
+  );
+
+  return (
+    <div className="relative h-[520px] overflow-hidden border border-white/[0.08] bg-white/[0.03]">
+      <div className="flex h-full flex-col px-5 py-5">
+        <div className="flex items-center justify-between gap-4">
+          <div className="min-w-0">
+            <h3 className="text-xl font-semibold text-white">{t("pikoMiniGame.memory.title")}</h3>
+            <p className="mt-1 text-sm text-white/56">{t("pikoMiniGame.memory.hint")}</p>
+          </div>
+          <div className="shrink-0 text-right">
+            <div className="text-xs text-white/48">{t("pikoMiniGame.memory.moves")}</div>
+            <div className="mt-0.5 text-lg font-semibold text-white">{moves}</div>
+          </div>
+        </div>
+
+        <div className="mt-6 grid flex-1 grid-cols-4 gap-3">
+          {cards.map((card) => {
+            const visible = card.matched || flippedIds.includes(card.id);
+            return (
+              <button
+                key={card.id}
+                type="button"
+                className={cn(
+                  "grid min-h-0 place-items-center rounded-2xl border text-3xl font-semibold leading-none transition-[background-color,border-color,transform,opacity]",
+                  visible
+                    ? "border-cyan-100/30 bg-cyan-200/[0.12] text-cyan-50 shadow-[0_0_22px_rgba(103,232,249,0.12)]"
+                    : "border-white/[0.12] bg-white/[0.05] text-white/30 hover:-translate-y-0.5 hover:border-cyan-100/24 hover:bg-white/[0.08]",
+                  card.matched && "opacity-58",
+                )}
+                aria-label={visible ? t("pikoMiniGame.memory.cardVisible", { value: card.value }) : t("pikoMiniGame.memory.cardHidden")}
+                onClick={() => flipCard(card)}
+              >
+                {visible ? card.value : <Gamepad2 className="size-7" />}
+              </button>
+            );
+          })}
+        </div>
+
+        {isComplete ? (
+          <div className="absolute inset-0 grid place-items-center bg-black/58 px-5 backdrop-blur-md">
+            <div className="max-w-sm rounded-2xl border border-white/[0.16] bg-black/64 px-7 py-6 text-center shadow-[0_24px_72px_rgba(0,0,0,0.5)]">
+              <div className="text-sm font-medium text-cyan-100/78">
+                {t("pikoMiniGame.memory.resultMeta", { moves })}
+              </div>
+              <h3 className="mt-2 text-2xl font-semibold text-white">{t("pikoMiniGame.memory.completed")}</h3>
+              <div className="mt-6 flex justify-center gap-3">
+                <button
+                  type="button"
+                  className="h-10 rounded-full border border-white/[0.14] px-5 text-sm text-white/78 transition-colors hover:bg-white/[0.08] hover:text-white"
+                  onClick={onClose}
+                >
+                  {t("pikoMiniGame.backToWork")}
+                </button>
+                <button
+                  type="button"
+                  className="h-10 rounded-full bg-cyan-300 px-5 text-sm font-medium text-slate-950 transition-colors hover:bg-cyan-200"
+                  onClick={resetMemoryGame}
+                >
+                  {t("pikoMiniGame.playAgain")}
+                </button>
+              </div>
+            </div>
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
 export function PikoInspirationStation({ open, onClose }: PikoInspirationStationProps) {
   const { t } = useTranslation();
   const boardRef = useRef<HTMLDivElement | null>(null);
@@ -643,6 +809,8 @@ export function PikoInspirationStation({ open, onClose }: PikoInspirationStation
   const [maxCombo, setMaxCombo] = useState(0);
   const [burstHits, setBurstHits] = useState(0);
   const [rainEvents, setRainEvents] = useState(0);
+  const [stationView, setStationView] = useState<StationView>("library");
+  const [activeGameId, setActiveGameId] = useState<PikoGameId>("inspiration-station");
 
   const resultKind = useMemo(
     () => resultKindFor(score, maxCombo, burstHits, rainEvents),
@@ -658,11 +826,17 @@ export function PikoInspirationStation({ open, onClose }: PikoInspirationStation
     return "pikoMiniGame.insight.soft";
   }, [burstHits, maxCombo, powerUpUses.jelly, rainEvents, score]);
   const activePowerUpLabel = activePowerUp ? t(`pikoMiniGame.powerUps.${activePowerUp}`) : null;
+  const activeGameTitleKey =
+    activeGameId === "memory-match"
+      ? "pikoMiniGame.memory.title"
+      : activeGameId === "breakout"
+        ? "pikoMiniGame.breakout.title"
+        : "pikoMiniGame.title";
 
   useEffect(() => {
     setPikoAudioMuted(isAudioMuted);
     window.localStorage.setItem("st.pikoMiniGame.muted", String(isAudioMuted));
-    if (!open || isAudioMuted) {
+    if (!open || stationView !== "game" || activeGameId !== "inspiration-station" || isAudioMuted) {
       stopBgm();
       return;
     }
@@ -670,7 +844,7 @@ export function PikoInspirationStation({ open, onClose }: PikoInspirationStation
     return () => {
       stopBgm();
     };
-  }, [isAudioMuted, open]);
+  }, [activeGameId, isAudioMuted, open, stationView]);
 
   const stopFrame = useCallback(() => {
     if (frameRef.current !== null) {
@@ -866,6 +1040,20 @@ export function PikoInspirationStation({ open, onClose }: PikoInspirationStation
     setStatus("countdown");
   }, [requestPointerLock, resetGame]);
 
+  const openGame = useCallback((gameId: PikoGameId) => {
+    resetGame();
+    setStatus("idle");
+    setActiveGameId(gameId);
+    setStationView("game");
+  }, [resetGame]);
+
+  const backToLibrary = useCallback(() => {
+    resetGame();
+    setStatus("idle");
+    setActiveGameId("inspiration-station");
+    setStationView("library");
+  }, [resetGame]);
+
   const beginPlaying = useCallback(() => {
     startedAtRef.current = performance.now();
     const openingItems = makeOpeningItems();
@@ -988,6 +1176,8 @@ export function PikoInspirationStation({ open, onClose }: PikoInspirationStation
     if (!open) return;
     resetGame();
     setStatus("idle");
+    setActiveGameId("inspiration-station");
+    setStationView("library");
     return () => {
       stopFrame();
       exitPointerLock();
@@ -1289,57 +1479,90 @@ export function PikoInspirationStation({ open, onClose }: PikoInspirationStation
       <div className="w-full max-w-[900px] overflow-hidden rounded-[22px] border border-white/[0.12] bg-[#0b0d10]/92 shadow-[0_26px_90px_rgba(0,0,0,0.48)]">
         <div className="flex items-start justify-between gap-4 px-6 pb-4 pt-5">
           <h2 id="piko-mini-game-title" className="sr-only">
-            {t("pikoMiniGame.title")}
+            {stationView === "library" ? t("pikoMiniGame.libraryTitle") : t(activeGameTitleKey)}
           </h2>
-          <div className="flex min-h-9 items-center gap-4">
-            <span
-              className={cn(
-                "inline-flex items-center text-sm text-white/78 transition-transform duration-200",
-                scorePulse && "animate-[piko-mini-score-pulse_260ms_cubic-bezier(0.2,1.25,0.3,1)_both]",
-              )}
-            >
-              <span className="mr-1 text-cyan-200" aria-hidden>
-                ✦
-              </span>
-              {t("pikoMiniGame.score", { score })}
-            </span>
-            <div className="flex items-center gap-2">
-              <span className="text-xs font-medium text-white/58">{t("pikoMiniGame.energy")}</span>
-              <div
-                className={cn(
-                  "h-1.5 w-28 overflow-hidden rounded-full bg-white/[0.1] transition-shadow duration-200",
-                  energy >= ENERGY_MAX && "shadow-[0_0_16px_rgba(103,232,249,0.32)] ring-1 ring-cyan-100/35",
-                )}
-              >
-                <div
-                  className={cn(
-                    "h-full rounded-full bg-cyan-300 transition-[width,filter] duration-200",
-                    energy >= ENERGY_MAX && "animate-[piko-mini-energy-ready_820ms_ease-in-out_infinite]",
-                  )}
-                  style={{ width: `${energy}%` }}
-                />
+          <div className="flex min-h-9 min-w-0 items-center gap-4">
+            {stationView === "library" ? (
+              <div className="min-w-0">
+                <div className="text-base font-semibold text-white">{t("pikoMiniGame.libraryTitle")}</div>
+                <div className="mt-1 text-xs text-white/48">{t("pikoMiniGame.librarySubtitle")}</div>
               </div>
-              <span
-                className={cn(
-                  "rounded-full border px-2 py-0.5 text-[10px] font-semibold leading-none transition-[background-color,border-color,color,transform,box-shadow] duration-200",
-                  energy >= ENERGY_MAX
-                    ? "scale-110 border-cyan-100/60 bg-cyan-200/[0.18] text-cyan-50 shadow-[0_0_14px_rgba(103,232,249,0.34)] animate-[piko-mini-energy-ready_820ms_ease-in-out_infinite]"
-                    : "border-white/10 text-white/38",
-                )}
-              >
-                Q
-              </span>
-            </div>
+            ) : activeGameId === "inspiration-station" ? (
+              <>
+                <button
+                  type="button"
+                  className="inline-flex size-9 shrink-0 items-center justify-center rounded-full text-white/68 transition-colors hover:bg-white/[0.08] hover:text-white"
+                  aria-label={t("pikoMiniGame.backToLibrary")}
+                  onClick={backToLibrary}
+                >
+                  <ArrowLeft className="size-4" />
+                </button>
+                <span
+                  className={cn(
+                    "inline-flex items-center text-sm text-white/78 transition-transform duration-200",
+                    scorePulse && "animate-[piko-mini-score-pulse_260ms_cubic-bezier(0.2,1.25,0.3,1)_both]",
+                  )}
+                >
+                  <span className="mr-1 text-cyan-200" aria-hidden>
+                    ✦
+                  </span>
+                  {t("pikoMiniGame.score", { score })}
+                </span>
+                <div className="flex items-center gap-2">
+                  <span className="text-xs font-medium text-white/58">{t("pikoMiniGame.energy")}</span>
+                  <div
+                    className={cn(
+                      "h-1.5 w-28 overflow-hidden rounded-full bg-white/[0.1] transition-shadow duration-200",
+                      energy >= ENERGY_MAX && "shadow-[0_0_16px_rgba(103,232,249,0.32)] ring-1 ring-cyan-100/35",
+                    )}
+                  >
+                    <div
+                      className={cn(
+                        "h-full rounded-full bg-cyan-300 transition-[width,filter] duration-200",
+                        energy >= ENERGY_MAX && "animate-[piko-mini-energy-ready_820ms_ease-in-out_infinite]",
+                      )}
+                      style={{ width: `${energy}%` }}
+                    />
+                  </div>
+                  <span
+                    className={cn(
+                      "rounded-full border px-2 py-0.5 text-[10px] font-semibold leading-none transition-[background-color,border-color,color,transform,box-shadow] duration-200",
+                      energy >= ENERGY_MAX
+                        ? "scale-110 border-cyan-100/60 bg-cyan-200/[0.18] text-cyan-50 shadow-[0_0_14px_rgba(103,232,249,0.34)] animate-[piko-mini-energy-ready_820ms_ease-in-out_infinite]"
+                        : "border-white/10 text-white/38",
+                    )}
+                  >
+                    Q
+                  </span>
+                </div>
+              </>
+            ) : (
+              <>
+                <button
+                  type="button"
+                  className="inline-flex size-9 shrink-0 items-center justify-center rounded-full text-white/68 transition-colors hover:bg-white/[0.08] hover:text-white"
+                  aria-label={t("pikoMiniGame.backToLibrary")}
+                  onClick={backToLibrary}
+                >
+                  <ArrowLeft className="size-4" />
+                </button>
+                <div className="min-w-0">
+                  <div className="text-base font-semibold text-white">{t(activeGameTitleKey)}</div>
+                </div>
+              </>
+            )}
           </div>
           <div className="flex items-center gap-1">
-            <button
-              type="button"
-              className="inline-flex size-9 items-center justify-center rounded-full text-white/68 transition-colors hover:bg-white/[0.08] hover:text-white"
-              aria-label={isAudioMuted ? t("pikoMiniGame.audioOn") : t("pikoMiniGame.audioOff")}
-              onClick={() => setIsAudioMuted((current) => !current)}
-            >
-              {isAudioMuted ? <VolumeX className="size-4" /> : <Volume2 className="size-4" />}
-            </button>
+            {stationView === "game" && activeGameId === "inspiration-station" ? (
+              <button
+                type="button"
+                className="inline-flex size-9 items-center justify-center rounded-full text-white/68 transition-colors hover:bg-white/[0.08] hover:text-white"
+                aria-label={isAudioMuted ? t("pikoMiniGame.audioOn") : t("pikoMiniGame.audioOff")}
+                onClick={() => setIsAudioMuted((current) => !current)}
+              >
+                {isAudioMuted ? <VolumeX className="size-4" /> : <Volume2 className="size-4" />}
+              </button>
+            ) : null}
             <button
               type="button"
               className="inline-flex size-9 items-center justify-center rounded-full text-white/68 transition-colors hover:bg-white/[0.08] hover:text-white"
@@ -1352,12 +1575,37 @@ export function PikoInspirationStation({ open, onClose }: PikoInspirationStation
         </div>
 
         <div className="px-6 pb-6">
-          <div
-            ref={boardRef}
-            className="relative h-[520px] overflow-hidden"
-            onPointerMove={handlePointerMove}
-            onPointerDown={handlePointerDown}
-          >
+          {stationView === "library" ? (
+            <div className="h-[520px] overflow-y-auto pr-1">
+              <div className="grid grid-cols-3 gap-3 sm:gap-4">
+                {PIKO_GAME_LIBRARY.map((game) => (
+                  <button
+                    key={game.id}
+                    type="button"
+                    className="group flex aspect-square min-h-0 flex-col items-center justify-center gap-3 rounded-2xl border border-white/[0.12] bg-white/[0.04] p-3 text-center transition-[border-color,background-color,transform] hover:-translate-y-0.5 hover:border-cyan-200/40 hover:bg-cyan-200/[0.08] focus:outline-none focus:ring-2 focus:ring-cyan-200/45"
+                    onClick={() => openGame(game.id)}
+                  >
+                    <span className="grid size-14 place-items-center rounded-2xl border border-cyan-100/24 bg-cyan-200/[0.1] text-cyan-100 shadow-[0_0_24px_rgba(103,232,249,0.14)] transition-colors group-hover:border-cyan-100/40 group-hover:bg-cyan-200/[0.16]">
+                      <Gamepad2 className="size-7" />
+                    </span>
+                    <span className="max-w-full break-words text-xs font-medium leading-snug text-white/82 sm:text-sm">
+                      {t(game.titleKey)}
+                    </span>
+                  </button>
+                ))}
+              </div>
+            </div>
+          ) : activeGameId === "memory-match" ? (
+            <PikoMemoryMatchGame onClose={onClose} />
+          ) : activeGameId === "breakout" ? (
+            <PikoBreakoutGame onClose={onClose} />
+          ) : (
+            <div
+              ref={boardRef}
+              className="relative h-[520px] overflow-hidden"
+              onPointerMove={handlePointerMove}
+              onPointerDown={handlePointerDown}
+            >
             <div className="absolute right-4 top-4 z-10 text-sm text-white/78">
               <span>{t("pikoMiniGame.timeLeft", { seconds: timeLeft })}</span>
             </div>
@@ -1599,6 +1847,7 @@ export function PikoInspirationStation({ open, onClose }: PikoInspirationStation
               </div>
             ) : null}
           </div>
+          )}
         </div>
       </div>
     </div>

--- a/frontend/src/features/piko-mini-game/PikoInspirationStation.tsx
+++ b/frontend/src/features/piko-mini-game/PikoInspirationStation.tsx
@@ -7,6 +7,7 @@ import { PikoActionFigure } from "@/features/companion/PikoActionFigure";
 import { PikoBreakoutGame } from "@/features/piko-mini-game/PikoBreakoutGame";
 import { PikoCatchGame } from "@/features/piko-mini-game/PikoCatchGame";
 import { PikoFlyingGame } from "@/features/piko-mini-game/PikoFlyingGame";
+import { PikoLeapGame } from "@/features/piko-mini-game/PikoLeapGame";
 import { PikoRollingBallGame } from "@/features/piko-mini-game/PikoRollingBallGame";
 import { cn } from "@/lib/utils";
 
@@ -94,7 +95,7 @@ type HitSpark = {
 
 type GameStatus = "idle" | "countdown" | "playing" | "finished";
 type StationView = "library" | "game";
-type PikoGameId = "inspiration-station" | "memory-match" | "breakout" | "rolling-ball" | "flying" | "catch";
+type PikoGameId = "inspiration-station" | "memory-match" | "breakout" | "rolling-ball" | "flying" | "catch" | "leap";
 
 type PikoInspirationStationProps = {
   open: boolean;
@@ -125,6 +126,10 @@ const PIKO_GAME_LIBRARY = [
   {
     id: "catch",
     titleKey: "pikoMiniGame.catch.title",
+  },
+  {
+    id: "leap",
+    titleKey: "pikoMiniGame.leap.title",
   },
 ] as const;
 
@@ -852,6 +857,8 @@ export function PikoInspirationStation({ open, onClose }: PikoInspirationStation
             ? "pikoMiniGame.flying.title"
             : activeGameId === "catch"
               ? "pikoMiniGame.catch.title"
+              : activeGameId === "leap"
+                ? "pikoMiniGame.leap.title"
             : "pikoMiniGame.title";
 
   useEffect(() => {
@@ -1574,7 +1581,7 @@ export function PikoInspirationStation({ open, onClose }: PikoInspirationStation
             )}
           </div>
           <div className="flex items-center gap-1">
-            {stationView === "game" && (activeGameId === "inspiration-station" || activeGameId === "breakout" || activeGameId === "rolling-ball" || activeGameId === "flying" || activeGameId === "catch") ? (
+            {stationView === "game" && (activeGameId === "inspiration-station" || activeGameId === "breakout" || activeGameId === "rolling-ball" || activeGameId === "flying" || activeGameId === "catch" || activeGameId === "leap") ? (
               <button
                 type="button"
                 className="inline-flex size-9 items-center justify-center rounded-full text-white/68 transition-colors hover:bg-white/[0.08] hover:text-white"
@@ -1626,6 +1633,8 @@ export function PikoInspirationStation({ open, onClose }: PikoInspirationStation
             <PikoFlyingGame onClose={onClose} muted={isAudioMuted} />
           ) : activeGameId === "catch" ? (
             <PikoCatchGame onClose={onClose} muted={isAudioMuted} />
+          ) : activeGameId === "leap" ? (
+            <PikoLeapGame onClose={onClose} muted={isAudioMuted} />
           ) : (
             <div
               ref={boardRef}

--- a/frontend/src/features/piko-mini-game/PikoLeapGame.tsx
+++ b/frontend/src/features/piko-mini-game/PikoLeapGame.tsx
@@ -1,0 +1,561 @@
+// SPDX-License-Identifier: Elastic-2.0
+// Copyright (c) 2026 ClaymoreLab
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { PikoActionFigure } from "@/features/companion/PikoActionFigure";
+import { usePikoGameAudio } from "@/features/piko-mini-game/usePikoGameAudio";
+
+const BOARD_WIDTH = 800;
+const BOARD_HEIGHT = 520;
+const ANCHOR_X = 170;
+const ANCHOR_Y = 365;
+const MAX_CHARGE_MS = 1_250;
+const MIN_JUMP_DISTANCE = 72;
+const MAX_JUMP_DISTANCE = 335;
+const CAMERA_MOVE_MS = 560;
+
+type LeapStatus = "ready" | "playing" | "charging" | "jumping" | "landed" | "lost";
+
+type Point = {
+  x: number;
+  y: number;
+};
+
+type Platform = Point & {
+  id: number;
+  width: number;
+  depth: number;
+  height: number;
+  bonus: boolean;
+};
+
+type JumpState = {
+  startedAt: number;
+  duration: number;
+  start: Point;
+  end: Point;
+  targetId: number;
+};
+
+type CameraMove = {
+  startedAt: number;
+  targetId: number;
+  landingPoint: Point;
+  offset: Point;
+};
+
+function initialPlatforms(): Platform[] {
+  const first: Platform = {
+    id: 0,
+    x: ANCHOR_X,
+    y: ANCHOR_Y,
+    width: 132,
+    depth: 74,
+    height: 24,
+    bonus: false,
+  };
+  const second = makeNextPlatform(1, first, 0);
+  const third = makeNextPlatform(2, second, 1);
+  return [first, second, { ...third, bonus: true }];
+}
+
+function distanceBetween(first: Point, second: Point) {
+  return Math.hypot(second.x - first.x, second.y - first.y);
+}
+
+function makeNextPlatform(id: number, previous: Platform, score: number): Platform {
+  const distanceRoll = Math.random();
+  const longJumpChance = Math.min(0.2 + score * 0.018, 0.48);
+  const distance = distanceRoll < longJumpChance
+    ? 250 + Math.random() * 48
+    : distanceRoll < 0.68
+      ? 190 + Math.random() * 48
+      : 142 + Math.random() * 38;
+  let verticalDirection = Math.random() < 0.5 ? -1 : 1;
+  if (previous.y < 225) verticalDirection = 1;
+  if (previous.y > 405) verticalDirection = -1;
+  const desiredVerticalShift = verticalDirection * (38 + Math.random() * 88);
+  const nextY = Math.max(165, Math.min(425, previous.y + desiredVerticalShift));
+  const verticalShift = nextY - previous.y;
+  const horizontalShift = Math.sqrt(Math.max(0, distance ** 2 - verticalShift ** 2));
+  const sizeVariance = Math.random() * 34;
+  return {
+    id,
+    x: previous.x + horizontalShift,
+    y: nextY,
+    width: Math.max(70, 138 - score * 1.25 - sizeVariance),
+    depth: Math.max(46, 78 - score * 0.6 - sizeVariance * 0.45),
+    height: 12 + Math.random() * 36,
+    bonus: id % 5 === 0,
+  };
+}
+
+function isPointOnPlatform(point: Point, platform: Platform) {
+  const normalized =
+    Math.abs(point.x - platform.x) / (platform.width / 2) +
+    Math.abs(point.y - platform.y) / (platform.depth / 2);
+  return normalized <= 1;
+}
+
+export function PikoLeapGame({ onClose, muted }: { onClose: () => void; muted: boolean }) {
+  const { t } = useTranslation();
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const frameRef = useRef<number | null>(null);
+  const statusRef = useRef<LeapStatus>("ready");
+  const platformsRef = useRef<Platform[]>(initialPlatforms());
+  const currentPlatformIdRef = useRef(0);
+  const nextPlatformIdRef = useRef(3);
+  const pikoPositionRef = useRef<Point>({ x: ANCHOR_X, y: ANCHOR_Y });
+  const chargeStartedAtRef = useRef(0);
+  const jumpRef = useRef<JumpState | null>(null);
+  const scoreRef = useRef(0);
+  const comboRef = useRef(0);
+  const cameraOffsetRef = useRef<Point>({ x: 0, y: 0 });
+  const cameraMoveRef = useRef<CameraMove | null>(null);
+  const [status, setStatus] = useState<LeapStatus>("ready");
+  const [pikoPosition, setPikoPosition] = useState<Point>({ x: ANCHOR_X, y: ANCHOR_Y });
+  const [score, setScore] = useState(0);
+  const [combo, setCombo] = useState(0);
+  const playTone = usePikoGameAudio(muted);
+
+  const setGameStatus = useCallback((next: LeapStatus) => {
+    statusRef.current = next;
+    setStatus(next);
+  }, []);
+
+  const playChargeSound = useCallback(() => {
+    playTone(190, 0.16, 0.045, "triangle", 0, 390);
+  }, [playTone]);
+
+  const playJumpSound = useCallback((power: number) => {
+    playTone(330 + power * 120, 0.11, 0.075, "triangle", 0, 760 + power * 180);
+    playTone(920, 0.07, 0.035, "sine", 0.055, 1_260);
+  }, [playTone]);
+
+  const playLandSound = useCallback((centered: boolean, bonus: boolean) => {
+    playTone(230, 0.075, 0.065, "sine", 0, 145);
+    playTone(centered ? 880 : 620, 0.11, 0.065, "triangle", 0.04);
+    if (centered || bonus) {
+      playTone(1_176, 0.14, 0.05, "sine", 0.1);
+      playTone(1_568, 0.16, 0.04, "sine", 0.16);
+    }
+  }, [playTone]);
+
+  const playFallSound = useCallback(() => {
+    playTone(260, 0.36, 0.1, "sawtooth", 0, 58);
+    playTone(130, 0.3, 0.055, "square", 0.07, 44);
+  }, [playTone]);
+
+  const resetGame = useCallback(() => {
+    const nextPlatforms = initialPlatforms();
+    platformsRef.current = nextPlatforms;
+    currentPlatformIdRef.current = 0;
+    nextPlatformIdRef.current = 3;
+    pikoPositionRef.current = { x: ANCHOR_X, y: ANCHOR_Y };
+    jumpRef.current = null;
+    cameraOffsetRef.current = { x: 0, y: 0 };
+    cameraMoveRef.current = null;
+    scoreRef.current = 0;
+    comboRef.current = 0;
+    setPikoPosition({ x: ANCHOR_X, y: ANCHOR_Y });
+    setScore(0);
+    setCombo(0);
+    setGameStatus("ready");
+  }, [setGameStatus]);
+
+  const startGame = useCallback(() => {
+    if (statusRef.current === "lost") resetGame();
+    setGameStatus("playing");
+    window.requestAnimationFrame(() => canvasRef.current?.focus());
+  }, [resetGame, setGameStatus]);
+
+  const beginCharge = useCallback(() => {
+    if (statusRef.current === "ready") {
+      startGame();
+    }
+    if (statusRef.current !== "playing") return;
+    chargeStartedAtRef.current = performance.now();
+    setGameStatus("charging");
+    playChargeSound();
+  }, [playChargeSound, setGameStatus, startGame]);
+
+  const cancelCharge = useCallback(() => {
+    if (statusRef.current !== "charging") return;
+    setGameStatus("playing");
+  }, [setGameStatus]);
+
+  const releaseJump = useCallback(() => {
+    if (statusRef.current !== "charging") return;
+    const power = Math.max(0.08, Math.min(1, (performance.now() - chargeStartedAtRef.current) / MAX_CHARGE_MS));
+    const currentPlatform = platformsRef.current.find(
+      (platform) => platform.id === currentPlatformIdRef.current,
+    );
+    const targetPlatform = platformsRef.current.find(
+      (platform) => platform.id === currentPlatformIdRef.current + 1,
+    );
+    if (!currentPlatform || !targetPlatform) return;
+    const targetDistance = distanceBetween(currentPlatform, targetPlatform);
+    const direction = {
+      x: (targetPlatform.x - currentPlatform.x) / targetDistance,
+      y: (targetPlatform.y - currentPlatform.y) / targetDistance,
+    };
+    const jumpDistance = MIN_JUMP_DISTANCE + power * (MAX_JUMP_DISTANCE - MIN_JUMP_DISTANCE);
+    const end = {
+      x: currentPlatform.x + direction.x * jumpDistance,
+      y: currentPlatform.y + direction.y * jumpDistance,
+    };
+    jumpRef.current = {
+      startedAt: performance.now(),
+      duration: 470 + power * 210,
+      start: { ...pikoPositionRef.current },
+      end,
+      targetId: targetPlatform.id,
+    };
+    setGameStatus("jumping");
+    playJumpSound(power);
+  }, [playJumpSound, setGameStatus]);
+
+  const settleOnPlatform = useCallback((target: Platform, landingPoint: Point) => {
+    const centerDistance = distanceBetween(landingPoint, target);
+    const centered = centerDistance <= Math.min(target.width, target.depth) * 0.18;
+    const gained = 1 + (centered ? 2 : 0) + (target.bonus ? 2 : 0);
+    comboRef.current = centered ? comboRef.current + 1 : 0;
+    scoreRef.current += gained;
+    setScore(scoreRef.current);
+    setCombo(comboRef.current);
+    setGameStatus("landed");
+    playLandSound(centered, target.bonus);
+
+    cameraMoveRef.current = {
+      startedAt: performance.now(),
+      targetId: target.id,
+      landingPoint,
+      offset: { x: ANCHOR_X - target.x, y: ANCHOR_Y - target.y },
+    };
+  }, [playLandSound, setGameStatus]);
+
+  const draw = useCallback(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const context = canvas.getContext("2d");
+    if (!context) return;
+    const dpr = window.devicePixelRatio || 1;
+    const rect = canvas.getBoundingClientRect();
+    const pixelWidth = Math.round(rect.width * dpr);
+    const pixelHeight = Math.round(rect.height * dpr);
+    if (canvas.width !== pixelWidth || canvas.height !== pixelHeight) {
+      canvas.width = pixelWidth;
+      canvas.height = pixelHeight;
+    }
+    context.setTransform(pixelWidth / BOARD_WIDTH, 0, 0, pixelHeight / BOARD_HEIGHT, 0, 0);
+    context.clearRect(0, 0, BOARD_WIDTH, BOARD_HEIGHT);
+
+    const background = context.createLinearGradient(0, 0, 0, BOARD_HEIGHT);
+    background.addColorStop(0, "#111827");
+    background.addColorStop(1, "#070a0f");
+    context.fillStyle = background;
+    context.fillRect(0, 0, BOARD_WIDTH, BOARD_HEIGHT);
+
+    context.strokeStyle = "rgba(165,243,252,0.065)";
+    context.lineWidth = 1;
+    for (let x = -BOARD_HEIGHT; x < BOARD_WIDTH + BOARD_HEIGHT; x += 46) {
+      context.beginPath();
+      context.moveTo(x, BOARD_HEIGHT);
+      context.lineTo(x + BOARD_HEIGHT, 0);
+      context.stroke();
+    }
+
+    context.save();
+    context.translate(cameraOffsetRef.current.x, cameraOffsetRef.current.y);
+    const orderedPlatforms = [...platformsRef.current].sort((a, b) => a.y - b.y);
+    for (const platform of orderedPlatforms) {
+      const halfWidth = platform.width / 2;
+      const halfDepth = platform.depth / 2;
+      const height = platform.height;
+      context.fillStyle = platform.bonus ? "rgba(101,163,13,0.52)" : "rgba(8,145,178,0.45)";
+      context.beginPath();
+      context.moveTo(platform.x - halfWidth, platform.y);
+      context.lineTo(platform.x, platform.y + halfDepth);
+      context.lineTo(platform.x, platform.y + halfDepth + height);
+      context.lineTo(platform.x - halfWidth, platform.y + height);
+      context.closePath();
+      context.fill();
+      context.fillStyle = platform.bonus ? "rgba(77,124,15,0.58)" : "rgba(30,64,175,0.42)";
+      context.beginPath();
+      context.moveTo(platform.x + halfWidth, platform.y);
+      context.lineTo(platform.x, platform.y + halfDepth);
+      context.lineTo(platform.x, platform.y + halfDepth + height);
+      context.lineTo(platform.x + halfWidth, platform.y + height);
+      context.closePath();
+      context.fill();
+
+      const gradient = context.createLinearGradient(
+        platform.x - halfWidth,
+        platform.y - halfDepth,
+        platform.x + halfWidth,
+        platform.y + halfDepth,
+      );
+      gradient.addColorStop(0, platform.bonus ? "#d9f99d" : "#cffafe");
+      gradient.addColorStop(1, platform.bonus ? "#84cc16" : "#22d3ee");
+      context.fillStyle = gradient;
+      context.shadowColor = platform.bonus ? "rgba(190,242,100,0.4)" : "rgba(103,232,249,0.34)";
+      context.shadowBlur = 16;
+      context.beginPath();
+      context.moveTo(platform.x, platform.y - halfDepth);
+      context.lineTo(platform.x + halfWidth, platform.y);
+      context.lineTo(platform.x, platform.y + halfDepth);
+      context.lineTo(platform.x - halfWidth, platform.y);
+      context.closePath();
+      context.fill();
+      context.shadowBlur = 0;
+
+      context.strokeStyle = "rgba(255,255,255,0.62)";
+      context.lineWidth = 2;
+      context.beginPath();
+      context.ellipse(platform.x, platform.y, 7, 4, 0, 0, Math.PI * 2);
+      context.stroke();
+    }
+    context.restore();
+  }, []);
+
+  useEffect(() => {
+    const tick = (now: number) => {
+      if (statusRef.current === "charging") {
+        // The charge bar runs on the browser compositor; jump power is calculated on release.
+      } else if (statusRef.current === "jumping" && jumpRef.current) {
+        const jump = jumpRef.current;
+        const progress = Math.min(1, (now - jump.startedAt) / jump.duration);
+        const arc = Math.sin(progress * Math.PI) * (75 + distanceBetween(jump.start, jump.end) * 0.14);
+        const position = {
+          x: jump.start.x + (jump.end.x - jump.start.x) * progress,
+          y: jump.start.y + (jump.end.y - jump.start.y) * progress - arc,
+        };
+        pikoPositionRef.current = position;
+        setPikoPosition(position);
+        if (progress >= 1) {
+          const target = platformsRef.current.find((platform) => platform.id === jump.targetId);
+          jumpRef.current = null;
+          if (target && isPointOnPlatform(jump.end, target)) {
+            pikoPositionRef.current = jump.end;
+            setPikoPosition(jump.end);
+            settleOnPlatform(target, jump.end);
+          } else {
+            setGameStatus("lost");
+            comboRef.current = 0;
+            setCombo(0);
+            playFallSound();
+          }
+        }
+      } else if (statusRef.current === "landed" && cameraMoveRef.current) {
+        const cameraMove = cameraMoveRef.current;
+        const progress = Math.min(1, (now - cameraMove.startedAt) / CAMERA_MOVE_MS);
+        const eased = 1 - Math.pow(1 - progress, 3);
+        const offset = {
+          x: cameraMove.offset.x * eased,
+          y: cameraMove.offset.y * eased,
+        };
+        cameraOffsetRef.current = offset;
+        const position = {
+          x: cameraMove.landingPoint.x + offset.x +
+            (ANCHOR_X - cameraMove.landingPoint.x - cameraMove.offset.x) * eased,
+          y: cameraMove.landingPoint.y + offset.y +
+            (ANCHOR_Y - cameraMove.landingPoint.y - cameraMove.offset.y) * eased,
+        };
+        pikoPositionRef.current = position;
+        setPikoPosition(position);
+
+        if (progress >= 1) {
+          let nextPlatforms = platformsRef.current
+            .filter((platform) => platform.id >= cameraMove.targetId)
+            .map((platform) => ({
+              ...platform,
+              x: platform.x + cameraMove.offset.x,
+              y: platform.y + cameraMove.offset.y,
+            }));
+          while (nextPlatforms.length < 3) {
+            const previous = nextPlatforms[nextPlatforms.length - 1];
+            nextPlatforms.push(
+              makeNextPlatform(nextPlatformIdRef.current++, previous, scoreRef.current),
+            );
+          }
+          platformsRef.current = nextPlatforms;
+          currentPlatformIdRef.current = cameraMove.targetId;
+          cameraOffsetRef.current = { x: 0, y: 0 };
+          cameraMoveRef.current = null;
+          pikoPositionRef.current = { x: ANCHOR_X, y: ANCHOR_Y };
+          setPikoPosition({ x: ANCHOR_X, y: ANCHOR_Y });
+          setGameStatus("playing");
+        }
+      }
+      draw();
+      frameRef.current = window.requestAnimationFrame(tick);
+    };
+    frameRef.current = window.requestAnimationFrame(tick);
+    return () => {
+      if (frameRef.current !== null) window.cancelAnimationFrame(frameRef.current);
+    };
+  }, [draw, playFallSound, setGameStatus, settleOnPlatform]);
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== " " || event.repeat) return;
+      event.preventDefault();
+      event.stopPropagation();
+      beginCharge();
+    };
+    const handleKeyUp = (event: KeyboardEvent) => {
+      if (event.key !== " ") return;
+      event.preventDefault();
+      event.stopPropagation();
+      releaseJump();
+    };
+    const handleVisibilityChange = () => {
+      if (document.hidden) cancelCharge();
+    };
+    window.addEventListener("keydown", handleKeyDown, true);
+    window.addEventListener("keyup", handleKeyUp, true);
+    window.addEventListener("blur", cancelCharge);
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown, true);
+      window.removeEventListener("keyup", handleKeyUp, true);
+      window.removeEventListener("blur", cancelCharge);
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+    };
+  }, [beginCharge, cancelCharge, releaseJump]);
+
+  const pikoAction =
+    status === "charging" ? "stretch" : status === "jumping" ? "watch-meteor" : status === "landed" ? "flag" : "idle";
+
+  return (
+    <div
+      className="relative h-[520px] select-none overflow-hidden border border-white/[0.08] bg-[#070a0f]"
+      onPointerDown={(event) => {
+        if ((event.target as HTMLElement).closest("button")) return;
+        event.currentTarget.setPointerCapture(event.pointerId);
+        beginCharge();
+      }}
+      onPointerUp={(event) => {
+        if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+          event.currentTarget.releasePointerCapture(event.pointerId);
+        }
+        releaseJump();
+      }}
+      onPointerCancel={cancelCharge}
+    >
+      <canvas
+        ref={canvasRef}
+        className="h-full w-full touch-none outline-none"
+        tabIndex={0}
+        aria-label={t("pikoMiniGame.leap.canvasLabel")}
+      />
+
+      <style>{`
+        @keyframes piko-leap-energy-ring {
+          0% { opacity: 0.2; transform: scale(0.68); }
+          100% { opacity: 0.9; transform: scale(1.14); }
+        }
+        @keyframes piko-leap-energy-tick {
+          0%, 99% { background: rgba(255,255,255,0.16); box-shadow: none; transform: scale(0.72); }
+          100% { background: #67e8f9; box-shadow: 0 0 12px rgba(103,232,249,0.95); transform: scale(1); }
+        }
+        @keyframes piko-leap-compress {
+          0% { transform: scaleX(1) scaleY(1); }
+          100% { transform: scaleX(1.18) scaleY(0.72); }
+        }
+      `}</style>
+
+      <div
+        className="pointer-events-none absolute size-[62px]"
+        style={{
+          left: `${(pikoPosition.x / BOARD_WIDTH) * 100}%`,
+          top: `${(pikoPosition.y / BOARD_HEIGHT) * 100}%`,
+          transform: "translate(-50%, -78%)",
+        }}
+      >
+        {status === "charging" ? (
+          <div
+            className="absolute -inset-7 rounded-full border-2 border-cyan-300/55"
+            style={{ animation: `piko-leap-energy-ring ${MAX_CHARGE_MS}ms linear forwards` }}
+          >
+            {Array.from({ length: 10 }, (_, index) => (
+              <span
+                key={index}
+                className="absolute left-1/2 top-1/2 size-2"
+                style={{ transform: `translate(-50%, -50%) rotate(${index * 36}deg) translateY(-47px)` }}
+              >
+                <span
+                  className="block size-2 rounded-full bg-white/15"
+                  style={{
+                    animation: "piko-leap-energy-tick 1ms linear forwards",
+                    animationDelay: `${index * (MAX_CHARGE_MS / 10)}ms`,
+                  }}
+                />
+              </span>
+            ))}
+          </div>
+        ) : null}
+        <div
+          className="relative size-full"
+          style={status === "charging" ? {
+            animation: `piko-leap-compress ${MAX_CHARGE_MS}ms linear forwards`,
+            transformOrigin: "center bottom",
+          } : undefined}
+        >
+          <PikoActionFigure
+            action={pikoAction}
+            className="mybuddy-companion-anchor--preview !h-[62px]"
+            style={{ transform: "scale(0.82)", transformOrigin: "center" }}
+          />
+        </div>
+      </div>
+
+      <div className="pointer-events-none absolute inset-x-4 top-4 flex justify-between text-sm font-medium text-white/78">
+        <span>{t("pikoMiniGame.leap.score", { score })}</span>
+        <span>{combo > 0 ? t("pikoMiniGame.leap.combo", { combo }) : t("pikoMiniGame.leap.centerHint")}</span>
+      </div>
+
+      {status === "playing" ? (
+        <div className="pointer-events-none absolute bottom-5 left-1/2 -translate-x-1/2 text-center text-xs text-white/48">
+          {t("pikoMiniGame.leap.chargeHint")}
+        </div>
+      ) : null}
+
+      {status === "ready" || status === "lost" ? (
+        <div className="absolute inset-0 grid place-items-center bg-black/52 px-5 backdrop-blur-[2px]">
+          <div className="max-w-sm rounded-2xl border border-white/[0.14] bg-black/68 px-7 py-6 text-center shadow-[0_24px_72px_rgba(0,0,0,0.48)]">
+            <h3 className="text-2xl font-semibold text-white">
+              {t(status === "lost" ? "pikoMiniGame.leap.lost" : "pikoMiniGame.leap.ready")}
+            </h3>
+            <p className="mt-2 text-sm leading-6 text-white/58">
+              {status === "lost"
+                ? t("pikoMiniGame.leap.result", { score })
+                : t("pikoMiniGame.leap.hint")}
+            </p>
+            <div className="mt-6 flex justify-center gap-3">
+              {status === "lost" ? (
+                <button
+                  type="button"
+                  className="h-10 rounded-full border border-white/[0.14] px-5 text-sm text-white/78 transition-colors hover:bg-white/[0.08] hover:text-white"
+                  onClick={onClose}
+                >
+                  {t("pikoMiniGame.backToWork")}
+                </button>
+              ) : null}
+              <button
+                type="button"
+                className="h-10 rounded-full bg-cyan-300 px-5 text-sm font-medium text-slate-950 transition-colors hover:bg-cyan-200"
+                onClick={(event) => {
+                  event.currentTarget.blur();
+                  startGame();
+                }}
+              >
+                {status === "lost" ? t("pikoMiniGame.playAgain") : t("pikoMiniGame.leap.start")}
+              </button>
+            </div>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/src/features/piko-mini-game/PikoRollingBallGame.tsx
+++ b/frontend/src/features/piko-mini-game/PikoRollingBallGame.tsx
@@ -52,9 +52,11 @@ function initialBall(): Ball {
   return { x: BOARD_WIDTH / 2, y: 388, vx: 0, vy: 0 };
 }
 
-export function PikoRollingBallGame({ onClose }: { onClose: () => void }) {
+export function PikoRollingBallGame({ onClose, muted }: { onClose: () => void; muted: boolean }) {
   const { t } = useTranslation();
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const audioContextRef = useRef<AudioContext | null>(null);
+  const mutedRef = useRef(muted);
   const frameRef = useRef<number | null>(null);
   const previousTimeRef = useRef<number | null>(null);
   const statusRef = useRef<RollingBallStatus>("ready");
@@ -66,6 +68,85 @@ export function PikoRollingBallGame({ onClose }: { onClose: () => void }) {
   const pointerTargetXRef = useRef<number | null>(null);
   const [status, setStatus] = useState<RollingBallStatus>("ready");
   const [score, setScore] = useState(0);
+
+  const getAudioContext = useCallback(() => {
+    if (mutedRef.current) return null;
+    const AudioContextClass =
+      window.AudioContext ||
+      (window as typeof window & { webkitAudioContext?: typeof AudioContext }).webkitAudioContext;
+    if (!AudioContextClass) return null;
+    audioContextRef.current ??= new AudioContextClass();
+    if (audioContextRef.current.state === "suspended") void audioContextRef.current.resume();
+    return audioContextRef.current;
+  }, []);
+
+  const playTone = useCallback((
+    frequency: number,
+    duration: number,
+    volume: number,
+    type: OscillatorType = "sine",
+    delay = 0,
+    endFrequency?: number,
+  ) => {
+    const context = getAudioContext();
+    if (!context) return;
+    const oscillator = context.createOscillator();
+    const gain = context.createGain();
+    const startsAt = context.currentTime + delay;
+    oscillator.type = type;
+    oscillator.frequency.setValueAtTime(frequency, startsAt);
+    if (endFrequency) oscillator.frequency.exponentialRampToValueAtTime(endFrequency, startsAt + duration);
+    gain.gain.setValueAtTime(0.0001, startsAt);
+    gain.gain.exponentialRampToValueAtTime(volume, startsAt + 0.008);
+    gain.gain.exponentialRampToValueAtTime(0.0001, startsAt + duration);
+    oscillator.connect(gain);
+    gain.connect(context.destination);
+    oscillator.start(startsAt);
+    oscillator.stop(startsAt + duration + 0.02);
+  }, [getAudioContext]);
+
+  const playStartSound = useCallback(() => {
+    playTone(330, 0.08, 0.065, "triangle");
+    playTone(440, 0.09, 0.07, "triangle", 0.08);
+    playTone(659.25, 0.12, 0.075, "triangle", 0.17);
+  }, [playTone]);
+
+  const playLandingSound = useCallback(() => {
+    playTone(190, 0.075, 0.065, "sine", 0, 120);
+    playTone(430, 0.055, 0.035, "triangle", 0.025, 560);
+  }, [playTone]);
+
+  const playScoreSound = useCallback((nextScore: number) => {
+    const lift = Math.min(nextScore, 12) * 10;
+    playTone(520 + lift, 0.08, 0.075, "triangle", 0, 720 + lift);
+    playTone(860 + lift, 0.1, 0.05, "sine", 0.055);
+    if (nextScore % 5 === 0) {
+      playTone(523.25, 0.2, 0.055, "triangle", 0.12);
+      playTone(659.25, 0.2, 0.05, "triangle", 0.17);
+      playTone(783.99, 0.24, 0.045, "triangle", 0.22);
+    }
+  }, [playTone]);
+
+  const playFallSound = useCallback(() => {
+    playTone(260, 0.34, 0.1, "sawtooth", 0, 62);
+    playTone(150, 0.3, 0.06, "square", 0.06, 48);
+  }, [playTone]);
+
+  useEffect(() => {
+    mutedRef.current = muted;
+    const context = audioContextRef.current;
+    if (!context) return;
+    if (muted && context.state === "running") void context.suspend();
+    if (!muted && context.state === "suspended") void context.resume();
+  }, [muted]);
+
+  useEffect(() => {
+    return () => {
+      const context = audioContextRef.current;
+      audioContextRef.current = null;
+      if (context && context.state !== "closed") void context.close();
+    };
+  }, []);
 
   const setGameStatus = useCallback((next: RollingBallStatus) => {
     statusRef.current = next;
@@ -88,8 +169,9 @@ export function PikoRollingBallGame({ onClose }: { onClose: () => void }) {
     previousTimeRef.current = null;
     ballRef.current.vy = 70;
     setGameStatus("playing");
+    playStartSound();
     canvasRef.current?.focus();
-  }, [resetGame, setGameStatus]);
+  }, [playStartSound, resetGame, setGameStatus]);
 
   const draw = useCallback(() => {
     const canvas = canvasRef.current;
@@ -199,6 +281,9 @@ export function PikoRollingBallGame({ onClose }: { onClose: () => void }) {
                 platform.scored = true;
                 scoreRef.current += 1;
                 setScore(scoreRef.current);
+                playScoreSound(scoreRef.current);
+              } else {
+                playLandingSound();
               }
               break;
             }
@@ -212,7 +297,10 @@ export function PikoRollingBallGame({ onClose }: { onClose: () => void }) {
           platformsRef.current.push(makePlatform(nextPlatformIdRef.current++, lowestY));
         }
 
-        if (ball.y - BALL_RADIUS > BOARD_HEIGHT) setGameStatus("lost");
+        if (ball.y - BALL_RADIUS > BOARD_HEIGHT) {
+          setGameStatus("lost");
+          playFallSound();
+        }
       }
 
       draw();
@@ -222,7 +310,7 @@ export function PikoRollingBallGame({ onClose }: { onClose: () => void }) {
     return () => {
       if (frameRef.current !== null) window.cancelAnimationFrame(frameRef.current);
     };
-  }, [draw, setGameStatus]);
+  }, [draw, playFallSound, playLandingSound, playScoreSound, setGameStatus]);
 
   useEffect(() => {
     const setKeyState = (event: KeyboardEvent, pressed: boolean) => {

--- a/frontend/src/features/piko-mini-game/PikoRollingBallGame.tsx
+++ b/frontend/src/features/piko-mini-game/PikoRollingBallGame.tsx
@@ -1,0 +1,310 @@
+// SPDX-License-Identifier: Elastic-2.0
+// Copyright (c) 2026 ClaymoreLab
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
+
+const BOARD_WIDTH = 800;
+const BOARD_HEIGHT = 520;
+const BALL_RADIUS = 10;
+const GRAVITY = 920;
+const MOVE_ACCELERATION = 820;
+const MAX_HORIZONTAL_SPEED = 310;
+const PLATFORM_HEIGHT = 12;
+const PLATFORM_GAP = 82;
+
+type RollingBallStatus = "ready" | "playing" | "lost";
+
+type Ball = {
+  x: number;
+  y: number;
+  vx: number;
+  vy: number;
+};
+
+type Platform = {
+  id: number;
+  x: number;
+  y: number;
+  width: number;
+  scored: boolean;
+};
+
+function makePlatform(id: number, y: number, x?: number, width?: number): Platform {
+  const platformWidth = width ?? 112 + Math.random() * 90;
+  return {
+    id,
+    x: x ?? 28 + Math.random() * (BOARD_WIDTH - platformWidth - 56),
+    y,
+    width: platformWidth,
+    scored: id === 0,
+  };
+}
+
+function makeInitialPlatforms() {
+  const platforms = [makePlatform(0, 420, BOARD_WIDTH / 2 - 82, 164)];
+  for (let index = 1; index < 7; index += 1) {
+    platforms.push(makePlatform(index, 420 + index * PLATFORM_GAP));
+  }
+  return platforms;
+}
+
+function initialBall(): Ball {
+  return { x: BOARD_WIDTH / 2, y: 388, vx: 0, vy: 0 };
+}
+
+export function PikoRollingBallGame({ onClose }: { onClose: () => void }) {
+  const { t } = useTranslation();
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const frameRef = useRef<number | null>(null);
+  const previousTimeRef = useRef<number | null>(null);
+  const statusRef = useRef<RollingBallStatus>("ready");
+  const ballRef = useRef<Ball>(initialBall());
+  const platformsRef = useRef<Platform[]>(makeInitialPlatforms());
+  const nextPlatformIdRef = useRef(7);
+  const scoreRef = useRef(0);
+  const heldKeysRef = useRef({ left: false, right: false });
+  const pointerTargetXRef = useRef<number | null>(null);
+  const [status, setStatus] = useState<RollingBallStatus>("ready");
+  const [score, setScore] = useState(0);
+
+  const setGameStatus = useCallback((next: RollingBallStatus) => {
+    statusRef.current = next;
+    setStatus(next);
+  }, []);
+
+  const resetGame = useCallback(() => {
+    ballRef.current = initialBall();
+    platformsRef.current = makeInitialPlatforms();
+    nextPlatformIdRef.current = 7;
+    scoreRef.current = 0;
+    heldKeysRef.current = { left: false, right: false };
+    pointerTargetXRef.current = null;
+    setScore(0);
+    setGameStatus("ready");
+  }, [setGameStatus]);
+
+  const startGame = useCallback(() => {
+    if (statusRef.current === "lost") resetGame();
+    previousTimeRef.current = null;
+    ballRef.current.vy = 70;
+    setGameStatus("playing");
+    canvasRef.current?.focus();
+  }, [resetGame, setGameStatus]);
+
+  const draw = useCallback(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const context = canvas.getContext("2d");
+    if (!context) return;
+    const dpr = window.devicePixelRatio || 1;
+    const rect = canvas.getBoundingClientRect();
+    const pixelWidth = Math.round(rect.width * dpr);
+    const pixelHeight = Math.round(rect.height * dpr);
+    if (canvas.width !== pixelWidth || canvas.height !== pixelHeight) {
+      canvas.width = pixelWidth;
+      canvas.height = pixelHeight;
+    }
+    context.setTransform(pixelWidth / BOARD_WIDTH, 0, 0, pixelHeight / BOARD_HEIGHT, 0, 0);
+    context.clearRect(0, 0, BOARD_WIDTH, BOARD_HEIGHT);
+
+    const background = context.createLinearGradient(0, 0, 0, BOARD_HEIGHT);
+    background.addColorStop(0, "#10151f");
+    background.addColorStop(1, "#070a0f");
+    context.fillStyle = background;
+    context.fillRect(0, 0, BOARD_WIDTH, BOARD_HEIGHT);
+
+    context.strokeStyle = "rgba(165, 243, 252, 0.075)";
+    context.lineWidth = 1;
+    for (let y = 28; y < BOARD_HEIGHT; y += 42) {
+      context.beginPath();
+      context.moveTo(0, y);
+      context.lineTo(BOARD_WIDTH, y);
+      context.stroke();
+    }
+
+    for (const platform of platformsRef.current) {
+      const gradient = context.createLinearGradient(platform.x, 0, platform.x + platform.width, 0);
+      gradient.addColorStop(0, "rgba(103, 232, 249, 0.45)");
+      gradient.addColorStop(0.5, "rgba(236, 254, 255, 0.92)");
+      gradient.addColorStop(1, "rgba(190, 242, 100, 0.5)");
+      context.fillStyle = gradient;
+      context.shadowColor = "rgba(103, 232, 249, 0.22)";
+      context.shadowBlur = 12;
+      context.beginPath();
+      context.roundRect(platform.x, platform.y, platform.width, PLATFORM_HEIGHT, 6);
+      context.fill();
+    }
+
+    const ball = ballRef.current;
+    const ballGradient = context.createRadialGradient(ball.x - 3, ball.y - 4, 1, ball.x, ball.y, BALL_RADIUS);
+    ballGradient.addColorStop(0, "#ffffff");
+    ballGradient.addColorStop(0.38, "#a5f3fc");
+    ballGradient.addColorStop(1, "#0891b2");
+    context.fillStyle = ballGradient;
+    context.shadowColor = "rgba(103, 232, 249, 0.8)";
+    context.shadowBlur = 18;
+    context.beginPath();
+    context.arc(ball.x, ball.y, BALL_RADIUS, 0, Math.PI * 2);
+    context.fill();
+    context.shadowBlur = 0;
+  }, []);
+
+  useEffect(() => {
+    const tick = (time: number) => {
+      const previousTime = previousTimeRef.current ?? time;
+      previousTimeRef.current = time;
+      const delta = Math.min((time - previousTime) / 1000, 0.025);
+
+      if (statusRef.current === "playing") {
+        const ball = ballRef.current;
+        const previousBottom = ball.y + BALL_RADIUS;
+        const scrollSpeed = Math.min(62 + scoreRef.current * 1.5, 145);
+        const pointerTarget = pointerTargetXRef.current;
+        let direction = Number(heldKeysRef.current.right) - Number(heldKeysRef.current.left);
+        if (direction === 0 && pointerTarget !== null) {
+          const distance = pointerTarget - ball.x;
+          direction = Math.abs(distance) < 8 ? 0 : Math.sign(distance);
+        }
+
+        if (direction !== 0) ball.vx += direction * MOVE_ACCELERATION * delta;
+        else ball.vx *= Math.pow(0.12, delta);
+        ball.vx = Math.max(-MAX_HORIZONTAL_SPEED, Math.min(MAX_HORIZONTAL_SPEED, ball.vx));
+        ball.vy += GRAVITY * delta;
+        ball.x += ball.vx * delta;
+        ball.y += ball.vy * delta;
+
+        if (ball.x - BALL_RADIUS < 0) {
+          ball.x = BALL_RADIUS;
+          ball.vx = Math.abs(ball.vx) * 0.65;
+        } else if (ball.x + BALL_RADIUS > BOARD_WIDTH) {
+          ball.x = BOARD_WIDTH - BALL_RADIUS;
+          ball.vx = -Math.abs(ball.vx) * 0.65;
+        }
+
+        for (const platform of platformsRef.current) platform.y -= scrollSpeed * delta;
+
+        if (ball.vy >= 0) {
+          for (const platform of platformsRef.current) {
+            const platformTopBeforeScroll = platform.y + scrollSpeed * delta;
+            if (
+              previousBottom <= platformTopBeforeScroll + 3 &&
+              ball.y + BALL_RADIUS >= platform.y &&
+              ball.y - BALL_RADIUS <= platform.y + PLATFORM_HEIGHT &&
+              ball.x + BALL_RADIUS >= platform.x &&
+              ball.x - BALL_RADIUS <= platform.x + platform.width
+            ) {
+              ball.y = platform.y - BALL_RADIUS;
+              ball.vy = -410;
+              if (!platform.scored) {
+                platform.scored = true;
+                scoreRef.current += 1;
+                setScore(scoreRef.current);
+              }
+              break;
+            }
+          }
+        }
+
+        platformsRef.current = platformsRef.current.filter((platform) => platform.y + PLATFORM_HEIGHT > -8);
+        let lowestY = Math.max(...platformsRef.current.map((platform) => platform.y), 0);
+        while (lowestY < BOARD_HEIGHT + PLATFORM_GAP) {
+          lowestY += PLATFORM_GAP;
+          platformsRef.current.push(makePlatform(nextPlatformIdRef.current++, lowestY));
+        }
+
+        if (ball.y - BALL_RADIUS > BOARD_HEIGHT) setGameStatus("lost");
+      }
+
+      draw();
+      frameRef.current = window.requestAnimationFrame(tick);
+    };
+    frameRef.current = window.requestAnimationFrame(tick);
+    return () => {
+      if (frameRef.current !== null) window.cancelAnimationFrame(frameRef.current);
+    };
+  }, [draw, setGameStatus]);
+
+  useEffect(() => {
+    const setKeyState = (event: KeyboardEvent, pressed: boolean) => {
+      const key = event.key.toLowerCase();
+      if (key === "arrowleft" || key === "a") {
+        event.preventDefault();
+        heldKeysRef.current.left = pressed;
+        pointerTargetXRef.current = null;
+      } else if (key === "arrowright" || key === "d") {
+        event.preventDefault();
+        heldKeysRef.current.right = pressed;
+        pointerTargetXRef.current = null;
+      } else if (pressed && (key === " " || key === "enter") && statusRef.current !== "playing") {
+        event.preventDefault();
+        startGame();
+      }
+    };
+    const handleKeyDown = (event: KeyboardEvent) => setKeyState(event, true);
+    const handleKeyUp = (event: KeyboardEvent) => setKeyState(event, false);
+    window.addEventListener("keydown", handleKeyDown);
+    window.addEventListener("keyup", handleKeyUp);
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown);
+      window.removeEventListener("keyup", handleKeyUp);
+    };
+  }, [startGame]);
+
+  const setPointerTarget = (clientX: number) => {
+    const rect = canvasRef.current?.getBoundingClientRect();
+    if (!rect) return;
+    pointerTargetXRef.current = ((clientX - rect.left) / rect.width) * BOARD_WIDTH;
+  };
+
+  return (
+    <div className="relative h-[520px] overflow-hidden border border-white/[0.08] bg-[#070a0f]">
+      <canvas
+        ref={canvasRef}
+        className="h-full w-full touch-none outline-none"
+        tabIndex={0}
+        aria-label={t("pikoMiniGame.rollingBall.canvasLabel")}
+        onPointerMove={(event) => setPointerTarget(event.clientX)}
+        onPointerDown={(event) => {
+          setPointerTarget(event.clientX);
+          if (statusRef.current !== "playing") startGame();
+        }}
+        onPointerLeave={() => {
+          pointerTargetXRef.current = null;
+        }}
+      />
+
+      <div className="pointer-events-none absolute left-4 top-4 text-sm font-medium text-white/78">
+        {t("pikoMiniGame.rollingBall.score", { score })}
+      </div>
+
+      {status !== "playing" ? (
+        <div className="absolute inset-0 grid place-items-center bg-black/52 px-5 backdrop-blur-[2px]">
+          <div className="max-w-sm rounded-2xl border border-white/[0.14] bg-black/68 px-7 py-6 text-center shadow-[0_24px_72px_rgba(0,0,0,0.48)]">
+            <h3 className="text-2xl font-semibold text-white">
+              {t(status === "lost" ? "pikoMiniGame.rollingBall.lost" : "pikoMiniGame.rollingBall.ready")}
+            </h3>
+            <p className="mt-2 text-sm leading-6 text-white/58">{t("pikoMiniGame.rollingBall.hint")}</p>
+            <div className="mt-6 flex justify-center gap-3">
+              {status === "lost" ? (
+                <button
+                  type="button"
+                  className="h-10 rounded-full border border-white/[0.14] px-5 text-sm text-white/78 transition-colors hover:bg-white/[0.08] hover:text-white"
+                  onClick={onClose}
+                >
+                  {t("pikoMiniGame.backToWork")}
+                </button>
+              ) : null}
+              <button
+                type="button"
+                className="h-10 rounded-full bg-cyan-300 px-5 text-sm font-medium text-slate-950 transition-colors hover:bg-cyan-200"
+                onClick={startGame}
+              >
+                {status === "lost" ? t("pikoMiniGame.playAgain") : t("pikoMiniGame.rollingBall.start")}
+              </button>
+            </div>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/src/features/piko-mini-game/PikoRollingBallGame.tsx
+++ b/frontend/src/features/piko-mini-game/PikoRollingBallGame.tsx
@@ -2,6 +2,7 @@
 // Copyright (c) 2026 ClaymoreLab
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { usePikoGameAudio } from "@/features/piko-mini-game/usePikoGameAudio";
 
 const BOARD_WIDTH = 800;
 const BOARD_HEIGHT = 520;
@@ -55,8 +56,6 @@ function initialBall(): Ball {
 export function PikoRollingBallGame({ onClose, muted }: { onClose: () => void; muted: boolean }) {
   const { t } = useTranslation();
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
-  const audioContextRef = useRef<AudioContext | null>(null);
-  const mutedRef = useRef(muted);
   const frameRef = useRef<number | null>(null);
   const previousTimeRef = useRef<number | null>(null);
   const statusRef = useRef<RollingBallStatus>("ready");
@@ -68,42 +67,7 @@ export function PikoRollingBallGame({ onClose, muted }: { onClose: () => void; m
   const pointerTargetXRef = useRef<number | null>(null);
   const [status, setStatus] = useState<RollingBallStatus>("ready");
   const [score, setScore] = useState(0);
-
-  const getAudioContext = useCallback(() => {
-    if (mutedRef.current) return null;
-    const AudioContextClass =
-      window.AudioContext ||
-      (window as typeof window & { webkitAudioContext?: typeof AudioContext }).webkitAudioContext;
-    if (!AudioContextClass) return null;
-    audioContextRef.current ??= new AudioContextClass();
-    if (audioContextRef.current.state === "suspended") void audioContextRef.current.resume();
-    return audioContextRef.current;
-  }, []);
-
-  const playTone = useCallback((
-    frequency: number,
-    duration: number,
-    volume: number,
-    type: OscillatorType = "sine",
-    delay = 0,
-    endFrequency?: number,
-  ) => {
-    const context = getAudioContext();
-    if (!context) return;
-    const oscillator = context.createOscillator();
-    const gain = context.createGain();
-    const startsAt = context.currentTime + delay;
-    oscillator.type = type;
-    oscillator.frequency.setValueAtTime(frequency, startsAt);
-    if (endFrequency) oscillator.frequency.exponentialRampToValueAtTime(endFrequency, startsAt + duration);
-    gain.gain.setValueAtTime(0.0001, startsAt);
-    gain.gain.exponentialRampToValueAtTime(volume, startsAt + 0.008);
-    gain.gain.exponentialRampToValueAtTime(0.0001, startsAt + duration);
-    oscillator.connect(gain);
-    gain.connect(context.destination);
-    oscillator.start(startsAt);
-    oscillator.stop(startsAt + duration + 0.02);
-  }, [getAudioContext]);
+  const playTone = usePikoGameAudio(muted);
 
   const playStartSound = useCallback(() => {
     playTone(330, 0.08, 0.065, "triangle");
@@ -131,22 +95,6 @@ export function PikoRollingBallGame({ onClose, muted }: { onClose: () => void; m
     playTone(260, 0.34, 0.1, "sawtooth", 0, 62);
     playTone(150, 0.3, 0.06, "square", 0.06, 48);
   }, [playTone]);
-
-  useEffect(() => {
-    mutedRef.current = muted;
-    const context = audioContextRef.current;
-    if (!context) return;
-    if (muted && context.state === "running") void context.suspend();
-    if (!muted && context.state === "suspended") void context.resume();
-  }, [muted]);
-
-  useEffect(() => {
-    return () => {
-      const context = audioContextRef.current;
-      audioContextRef.current = null;
-      if (context && context.state !== "closed") void context.close();
-    };
-  }, []);
 
   const setGameStatus = useCallback((next: RollingBallStatus) => {
     statusRef.current = next;

--- a/frontend/src/features/piko-mini-game/usePikoGameAudio.ts
+++ b/frontend/src/features/piko-mini-game/usePikoGameAudio.ts
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: Elastic-2.0
+// Copyright (c) 2026 ClaymoreLab
+import { useCallback, useEffect, useRef } from "react";
+
+export function usePikoGameAudio(muted: boolean) {
+  const audioContextRef = useRef<AudioContext | null>(null);
+  const mutedRef = useRef(muted);
+
+  const getAudioContext = useCallback(() => {
+    if (mutedRef.current) return null;
+    const AudioContextClass =
+      window.AudioContext ||
+      (window as typeof window & { webkitAudioContext?: typeof AudioContext }).webkitAudioContext;
+    if (!AudioContextClass) return null;
+    audioContextRef.current ??= new AudioContextClass();
+    if (audioContextRef.current.state === "suspended") void audioContextRef.current.resume();
+    return audioContextRef.current;
+  }, []);
+
+  const playTone = useCallback((
+    frequency: number,
+    duration: number,
+    volume: number,
+    type: OscillatorType = "sine",
+    delay = 0,
+    endFrequency?: number,
+  ) => {
+    const context = getAudioContext();
+    if (!context) return;
+    const oscillator = context.createOscillator();
+    const gain = context.createGain();
+    const startsAt = context.currentTime + delay;
+    oscillator.type = type;
+    oscillator.frequency.setValueAtTime(frequency, startsAt);
+    if (endFrequency) oscillator.frequency.exponentialRampToValueAtTime(endFrequency, startsAt + duration);
+    gain.gain.setValueAtTime(0.0001, startsAt);
+    gain.gain.exponentialRampToValueAtTime(volume, startsAt + 0.007);
+    gain.gain.exponentialRampToValueAtTime(0.0001, startsAt + duration);
+    oscillator.connect(gain);
+    gain.connect(context.destination);
+    oscillator.start(startsAt);
+    oscillator.stop(startsAt + duration + 0.02);
+  }, [getAudioContext]);
+
+  useEffect(() => {
+    mutedRef.current = muted;
+    const context = audioContextRef.current;
+    if (!context) return;
+    if (muted && context.state === "running") void context.suspend();
+    if (!muted && context.state === "suspended") void context.resume();
+  }, [muted]);
+
+  useEffect(() => {
+    return () => {
+      const context = audioContextRef.current;
+      audioContextRef.current = null;
+      if (context && context.state !== "closed") void context.close();
+    };
+  }, []);
+
+  return playTone;
+}

--- a/license-inventory.csv
+++ b/license-inventory.csv
@@ -388,7 +388,6 @@ frontend/src/__tests__/features/freezone/projections.test.ts,Elastic-2.0,2026 Su
 frontend/src/__tests__/features/freezone/scene-director-world-commit.test.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/__tests__/features/freezone/skill-node-inputs.test.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/__tests__/features/freezone/use-canvas-sync.test.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
-frontend/src/__tests__/features/liexiaoren/entry-overlay.test.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/__tests__/features/rewards/reward-events-store.test.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/__tests__/features/superchat/composer-waiting-status.test.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/__tests__/features/superchat/spec-extract.test.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
@@ -985,13 +984,13 @@ frontend/src/features/freezone/projections.ts,Elastic-2.0,2026 SuperTale contrib
 frontend/src/features/freezone/referenceRoles.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/features/freezone/shotMetadataStore.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/features/freezone/useCanvasSync.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
-frontend/src/features/liexiaoren/LiexiaorenEntryOverlay.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
-frontend/src/features/liexiaoren/LiexiaorenSkinPreview.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
-frontend/src/features/liexiaoren/liexiaoren-assets.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
-frontend/src/features/liexiaoren/liexiaoren-entry-overlay.module.css,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
-frontend/src/features/liexiaoren/liexiaoren-events.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
-frontend/src/features/liexiaoren/liexiaoren-skin-preview.module.css,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
+frontend/src/features/piko-mini-game/PikoBreakoutGame.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
+frontend/src/features/piko-mini-game/PikoCatchGame.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
+frontend/src/features/piko-mini-game/PikoFlyingGame.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/features/piko-mini-game/PikoInspirationStation.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
+frontend/src/features/piko-mini-game/PikoLeapGame.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
+frontend/src/features/piko-mini-game/PikoRollingBallGame.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
+frontend/src/features/piko-mini-game/usePikoGameAudio.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/features/rewards/AccessoryUnlockPrompt.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/features/rewards/accessory-unlock.css,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/features/rewards/reward-events-store.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation


### PR DESCRIPTION
## Summary

- replace the single Piko break experience with a scrollable mini game library
- add memory match, breakout, rolling ball, Flying Piko, Piko catch, and Piko leap games
- add keyboard and pointer controls, synthesized sound effects, mute support, scoring, and replay states
- share Web Audio lifecycle and tone generation across the new games
- add Chinese and English UI copy

## User impact

Users can open "Piko 一下" and choose from a broader set of lightweight games. Piko leap includes charge feedback, smooth camera tracking, randomized platform spacing, platform height variation, and progressive difficulty.

## Validation

- `cd frontend && pnpm build` (passed)
- `git diff --check origin/main...HEAD` (passed)
- `cd frontend && pnpm test` (1754/1759 passed; the 5 failures are existing `local-storage-quota` tests affected by the current Node 25 experimental `localStorage` environment and do not touch these game files)
- all six commits include DCO `Signed-off-by` trailers

## Notes

Canvas game interactions currently rely on manual gameplay verification; this change does not add automated canvas interaction tests.
