### PR TITLE
chore: prepare v1.1.3 release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "supertale-ce"
-version = "1.1.2"
+version = "1.1.3"
 description = "SuperTale Community Edition API and video pipeline"
 readme = "README.md"
 requires-python = ">=3.11,<3.13"

--- a/src/novelvideo/release-notes.md
+++ b/src/novelvideo/release-notes.md
@@ -1,30 +1,31 @@
 ---
-version: 1.1.2
+version: 1.1.3
 attention: low
 ---
-# v1.1.2
+# v1.1.3
 
 ## User-facing Highlights (zh)
 
-- **虾格视频支持 HappyHorse 1.0**: 画布视频节点新增文生视频、首帧、图片参考和视频编辑四种 HappyHorse 模式,按上游节点自动切换。
-- **虾料导入更稳**: 上传小说时防误切走,导入中刷新或返回页面会自动恢复进度视图。
-- **自建模型链路统一**: CE 的 NewAPI 运行时与 Freezone 视觉路由统一,本地/自建网关的视频与视觉能力更一致。
+- **Piko 一下小游戏库**: 新增记忆翻牌、打砖块、滚动小球、飞行的 Piko、Piko 接物和 Piko 跃迁,支持键盘与鼠标操作、音效、计分和重新挑战。
+- **自定义风格预览可持久保存**: 用户上传的风格参考图会随项目保存,刷新后仍可在风格列表和详情中查看。
+- **生成失败提示更清楚**: 图片和视频生成失败时优先展示简洁的上游错误原因,同时保留完整诊断信息供复制排查。
 
 ## User-facing Highlights (en)
 
-- **HappyHorse 1.0 in Freezone video nodes**: Canvas video nodes now support HappyHorse text-to-video, first-frame, image-reference, and video-edit modes with automatic mode selection from upstream nodes.
-- **More reliable novel ingest**: Novel upload is protected from accidental navigation, and in-progress imports restore their progress view after refresh or returning to the page.
-- **Unified self-hosted model routing**: CE NewAPI runtime and Freezone vision routing are now aligned for more consistent video and vision behavior with local/self-hosted gateways.
+- **Piko mini game library**: Adds memory match, breakout, rolling ball, Flying Piko, Piko catch, and Piko leap with keyboard and pointer controls, sound, scoring, and replay.
+- **Persistent custom style previews**: User-uploaded style references are saved with the project and remain visible in style lists and details after refresh.
+- **Clearer generation failures**: Image and video failures now show concise provider messages while preserving complete diagnostics for troubleshooting.
 
 ## New Features
 
-- 新增 HappyHorse 1.0 视频四模式:文生视频、首帧、图片参考、视频编辑 (#141).
-
-## Improvements
-
-- 统一 CE NewAPI runtime 与 Freezone vision routing,并升级 bundled new-api image 到 `v1.0.0-rc.21` (#138, #140).
+- 扩展「Piko 一下」为可滚动的小游戏库,新增六款轻量小游戏及统一音效控制 (#155, #156).
 
 ## Bug Fixes
 
-- 修复虾料导入中切走、刷新后页面丢失进度视图的问题,并修复 stale-cache 与跨项目复用下的恢复漏洞 (#139, #142).
-- 统一关键帧提示词路由,移除无效的样式提取路径 (#143).
+- 修复自定义风格参考图刷新后丢失、预览地址错误及异常响应仍继续分析的问题 (#153, Fixes #152).
+- 优化图片和视频生成失败提示,保留完整错误与请求 ID 供复制排查 (#154).
+- 修复任务中心「图片反推提示词」显示为内部英文任务名的问题 (#146).
+
+## Improvements
+
+- 按运营计划下线猎魈人推广入口与相关展示,保留独立的社区作品内容 (#145).

--- a/tests/test_release_feed.py
+++ b/tests/test_release_feed.py
@@ -114,7 +114,7 @@ def test_built_wheel_contains_parseable_release_notes_artifact(tmp_path: Path) -
 def test_project_version_is_single_source_of_truth() -> None:
     pyproject = tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))
 
-    assert pyproject["project"]["version"] == "1.1.2"
+    assert pyproject["project"]["version"] == "1.1.3"
     assert importlib.metadata.version("supertale-ce") == pyproject["project"]["version"]
     assert "__version__" not in Path("src/novelvideo/__init__.py").read_text(encoding="utf-8")
 

--- a/uv.lock
+++ b/uv.lock
@@ -3419,7 +3419,7 @@ wheels = [
 
 [[package]]
 name = "supertale-ce"
-version = "1.1.2"
+version = "1.1.3"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## PR 类型 / Type of PR
- [ ] 🐞 Bug 修复 / Bug fix
- [ ] ✨ 新功能 / Feature
- [x] 📝 文档 / Documentation
- [x] 🧹 重构 / 清理 / Refactor or cleanup
- [x] ⚙️ 构建 / CI / Build or CI
- [ ] ⚠️ 破坏性变更 / Breaking change

## 改动说明 / What this PR does and why

- 将 `supertale-ce` 版本从 `1.1.2` 更新为 `1.1.3`
- 同步 `uv.lock` 和 Release Feed 的版本真源断言
- 按发布模板更新中英文包内 Release Notes
- 汇总 v1.1.2 之后合入的 #145、#146、#153、#154、#155、#156

## 关联 issue / Linked issues

N/A

## 给 reviewer 的说明 / Notes for the reviewer

请重点检查中英文 Highlights 是否准确反映本次用户可见变化，以及 `version` 在 `pyproject.toml`、`uv.lock`、包内 notes 和测试断言中是否一致。

## 面向用户的变更 / User-facing change

```release-note
新增 Piko 小游戏库，持久保存自定义风格预览，并提供更清楚的生成失败提示。
```

## 自检 / Checklist
- [x] 已自测，`uv run pytest` 通过 / Self-tested, `uv run pytest` passes
- [x] 必要的文档已更新 / Docs updated where needed
- [x] 提交信息清晰（建议 Conventional Commits）/ Clear commits (Conventional Commits suggested)
- [x] 每个 commit 都已 `git commit -s` 附 DCO 签署 / Every commit signed off with `git commit -s` (DCO)
- [x] 我已阅读并同意[贡献者协议](../CONTRIBUTING.md#贡献者协议) / I've read and agree to the [contributor terms](../CONTRIBUTING.md#贡献者协议)

## Verification

- `UV_CACHE_DIR=/claymorelab/.uv-cache uv lock`
- `UV_CACHE_DIR=/claymorelab/.uv-cache uv pip install -e .`
- `UV_CACHE_DIR=/claymorelab/.uv-cache uv run pytest tests/test_release_feed.py` — 12 passed
- `git diff --check`
