### PR TITLE
feat: visualize imported knowledge graph

### DIFF
--- a/docker-compose.selfhosted.yml
+++ b/docker-compose.selfhosted.yml
@@ -24,6 +24,9 @@ services:
       ST_CELERY_BROKER_URL: ""
       ST_CELERY_RESULT_BACKEND: ""
       NOVELVIDEO_DATA_ROOT: /data
+      # Keep project outputs (including imported novel.txt) on the persistent
+      # ce-data volume even when .env.example sets the relative value "output".
+      NOVELVIDEO_OUTPUT_DIR: /data/output
       NOVELVIDEO_STATE_DIR: /data/state
       DRAMACLAW_CHAT_BACKEND: hermes
       HERMES_CLI_PATH: /root/.local/bin/hermes

--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -1341,6 +1341,17 @@
       "failed": "Import failed"
     },
     "previewHeading": "Novel Structure Preview",
+    "knowledgeGraph": {
+      "title": "Knowledge Graph",
+      "ready": "Ready",
+      "description": "Semantic relationships have been built from the source text to ground the downstream creative workflow.",
+      "uses": {
+        "characters": "Characters",
+        "scenes": "Scenes",
+        "props": "Props",
+        "episodes": "Episode planning"
+      }
+    },
     "scriptDetails": "Script details",
     "previewGenerating": "Generating structure preview...",
     "restoredFilename": "Imported novel",

--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -1343,14 +1343,17 @@
     "previewHeading": "Novel Structure Preview",
     "knowledgeGraph": {
       "title": "Knowledge Graph",
-      "ready": "Ready",
-      "description": "Semantic relationships have been built from the source text to ground the downstream creative workflow.",
-      "uses": {
-        "characters": "Characters",
-        "scenes": "Scenes",
-        "props": "Props",
-        "episodes": "Episode planning"
-      }
+      "stats": "{{nodes}} nodes · {{edges}} relationships",
+      "connections": "{{count}} connections",
+      "relationships": "Relationships",
+      "interactionHint": "Drag to pan · Scroll to zoom · Select a node for details",
+      "truncated": "Showing core relationships",
+      "zoomIn": "Zoom in",
+      "zoomOut": "Zoom out",
+      "resetView": "Reset view",
+      "expand": "Expand graph",
+      "loadFailed": "Knowledge graph is temporarily unavailable",
+      "loadFailedHint": "Your graph data is intact. Try loading it again shortly."
     },
     "scriptDetails": "Script details",
     "previewGenerating": "Generating structure preview...",

--- a/frontend/public/locales/zh/translation.json
+++ b/frontend/public/locales/zh/translation.json
@@ -1343,14 +1343,17 @@
     "previewHeading": "小说结构预览",
     "knowledgeGraph": {
       "title": "知识图谱",
-      "ready": "已构建",
-      "description": "已从原文建立语义关系，后续创作流程会基于这些上下文理解故事。",
-      "uses": {
-        "characters": "人物关系",
-        "scenes": "场景脉络",
-        "props": "道具线索",
-        "episodes": "剧集规划"
-      }
+      "stats": "{{nodes}} 个节点 · {{edges}} 条关系",
+      "connections": "{{count}} 条关联",
+      "relationships": "关联关系",
+      "interactionHint": "拖动画布 · 滚轮缩放 · 点击节点查看详情",
+      "truncated": "正在展示核心关系",
+      "zoomIn": "放大图谱",
+      "zoomOut": "缩小图谱",
+      "resetView": "重置视图",
+      "expand": "展开图谱",
+      "loadFailed": "知识图谱暂时无法显示",
+      "loadFailedHint": "图谱数据仍然保留，可以稍后重试。"
     },
     "scriptDetails": "剧本配置",
     "previewGenerating": "正在生成结构预览...",

--- a/frontend/public/locales/zh/translation.json
+++ b/frontend/public/locales/zh/translation.json
@@ -1341,6 +1341,17 @@
       "failed": "导入失败"
     },
     "previewHeading": "小说结构预览",
+    "knowledgeGraph": {
+      "title": "知识图谱",
+      "ready": "已构建",
+      "description": "已从原文建立语义关系，后续创作流程会基于这些上下文理解故事。",
+      "uses": {
+        "characters": "人物关系",
+        "scenes": "场景脉络",
+        "props": "道具线索",
+        "episodes": "剧集规划"
+      }
+    },
     "scriptDetails": "剧本配置",
     "previewGenerating": "正在生成结构预览...",
     "restoredFilename": "已导入小说",

--- a/frontend/src/__tests__/routes/ingest-settings-save.test.tsx
+++ b/frontend/src/__tests__/routes/ingest-settings-save.test.tsx
@@ -121,6 +121,7 @@ const mocks = vi.hoisted(() => ({
         data: {
           total_chars: number;
           count: number;
+          preview_only?: boolean;
           chapters: {
             number: number;
             title?: string | null;
@@ -247,7 +248,7 @@ vi.mock("@/lib/queries/ingest", () => ({
             total_nodes: 2,
             total_edges: 1,
             truncated: false,
-          },
+          }
         }
       : undefined,
     isLoading: false,
@@ -468,6 +469,28 @@ describe("IngestPage settings save", () => {
     expect(screen.getByText("2 nodes · 1 relationships")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "林昭, Entity" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "雨巷, Entity" })).toBeInTheDocument();
+  });
+
+  it("does not request or show the graph for an upload-only chapter preview", () => {
+    mocks.chaptersData = {
+      ok: true,
+      data: {
+        total_chars: 10,
+        count: 1,
+        preview_only: true,
+        chapters: [{ number: 1, title: "第一章", char_count: 10 }],
+      },
+    };
+
+    render(
+      <Wrapper>
+        <IngestPageContent project="demo" />
+      </Wrapper>,
+    );
+
+    expect(
+      screen.queryByRole("heading", { name: "Knowledge Graph" }),
+    ).not.toBeInTheDocument();
   });
 
   it("falls back to chapter content title and legacy char count in preview", () => {

--- a/frontend/src/__tests__/routes/ingest-settings-save.test.tsx
+++ b/frontend/src/__tests__/routes/ingest-settings-save.test.tsx
@@ -32,6 +32,8 @@ beforeAll(async () => {
             stop: "Stop",
             reupload: "Reupload",
             delete: "Delete",
+            close: "Close",
+            retry: "Retry",
           },
           ingest: {
             title: "Import Novel",
@@ -42,14 +44,17 @@ beforeAll(async () => {
             previewHeading: "Novel Structure Preview",
             knowledgeGraph: {
               title: "Knowledge Graph",
-              ready: "Ready",
-              description: "Semantic relationships are ready.",
-              uses: {
-                characters: "Characters",
-                scenes: "Scenes",
-                props: "Props",
-                episodes: "Episode planning",
-              },
+              stats: "{{nodes}} nodes · {{edges}} relationships",
+              connections: "{{count}} connections",
+              relationships: "Relationships",
+              interactionHint: "Drag to pan",
+              truncated: "Showing core relationships",
+              zoomIn: "Zoom in",
+              zoomOut: "Zoom out",
+              resetView: "Reset view",
+              expand: "Expand graph",
+              loadFailed: "Knowledge graph is unavailable",
+              loadFailedHint: "Try again later.",
             },
             inputMode: { upload: "Upload Novel", paste: "Paste Text" },
             sourceHint: {
@@ -132,6 +137,7 @@ const mocks = vi.hoisted(() => ({
   // 模拟 React Query 的 isFetchedAfterMount：默认 true（已挂载后刷到新数据）；
   // stale-cache 竞态用例把它设为 false，表示当前 data 还是挂载前的旧缓存。
   ingestTasksFetchedAfterMount: true,
+  refetchKnowledgeGraph: vi.fn(),
 }));
 
 vi.mock("@/components/ui/select", async () => {
@@ -208,6 +214,46 @@ vi.mock("@/lib/queries/projects", () => ({
 
 vi.mock("@/lib/queries/ingest", () => ({
   useChapters: () => ({ data: mocks.chaptersData, isFetching: false }),
+  useKnowledgeGraph: (_project: string, enabled: boolean) => ({
+    data: enabled
+      ? {
+          ok: true,
+          data: {
+            nodes: [
+              {
+                id: "node-1",
+                label: "林昭",
+                type: "Entity",
+                degree: 1,
+                properties: { description: "雨巷少年" },
+              },
+              {
+                id: "node-2",
+                label: "雨巷",
+                type: "Entity",
+                degree: 1,
+                properties: {},
+              },
+            ],
+            edges: [
+              {
+                id: "edge-1",
+                source: "node-1",
+                target: "node-2",
+                relation: "appears_in",
+                properties: {},
+              },
+            ],
+            total_nodes: 2,
+            total_edges: 1,
+            truncated: false,
+          },
+        }
+      : undefined,
+    isLoading: false,
+    isError: false,
+    refetch: mocks.refetchKnowledgeGraph,
+  }),
   useUploadNovel: () => ({ mutateAsync: mocks.uploadNovel, isPending: false }),
   useStartIngest: () => ({
     mutateAsync: mocks.startIngest,
@@ -419,9 +465,9 @@ describe("IngestPage settings save", () => {
     expect(
       screen.getByRole("heading", { name: "Knowledge Graph" }),
     ).toBeInTheDocument();
-    expect(screen.getByText("Ready")).toBeInTheDocument();
-    expect(screen.getByText("Characters")).toBeInTheDocument();
-    expect(screen.getByText("Episode planning")).toBeInTheDocument();
+    expect(screen.getByText("2 nodes · 1 relationships")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "林昭, Entity" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "雨巷, Entity" })).toBeInTheDocument();
   });
 
   it("falls back to chapter content title and legacy char count in preview", () => {

--- a/frontend/src/__tests__/routes/ingest-settings-save.test.tsx
+++ b/frontend/src/__tests__/routes/ingest-settings-save.test.tsx
@@ -40,6 +40,17 @@ beforeAll(async () => {
             supportedFormats: "Supports .txt / .md / .docx",
             restoredFilename: "Imported novel",
             previewHeading: "Novel Structure Preview",
+            knowledgeGraph: {
+              title: "Knowledge Graph",
+              ready: "Ready",
+              description: "Semantic relationships are ready.",
+              uses: {
+                characters: "Characters",
+                scenes: "Scenes",
+                props: "Props",
+                episodes: "Episode planning",
+              },
+            },
             inputMode: { upload: "Upload Novel", paste: "Paste Text" },
             sourceHint: {
               uploadActive: "Uploaded file active",
@@ -387,6 +398,30 @@ describe("IngestPage settings save", () => {
     // ...but file replacement/destructive actions are gone once import succeeded.
     expect(screen.queryByRole("button", { name: "Reupload" })).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Delete" })).not.toBeInTheDocument();
+  });
+
+  it("shows the knowledge graph result after content is imported", () => {
+    mocks.chaptersData = {
+      ok: true,
+      data: {
+        total_chars: 10,
+        count: 1,
+        chapters: [{ number: 1, title: "第一章", char_count: 10 }],
+      },
+    };
+
+    render(
+      <Wrapper>
+        <IngestPageContent project="demo" />
+      </Wrapper>,
+    );
+
+    expect(
+      screen.getByRole("heading", { name: "Knowledge Graph" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Ready")).toBeInTheDocument();
+    expect(screen.getByText("Characters")).toBeInTheDocument();
+    expect(screen.getByText("Episode planning")).toBeInTheDocument();
   });
 
   it("falls back to chapter content title and legacy char count in preview", () => {

--- a/frontend/src/components/ingest/KnowledgeGraphVisualization.tsx
+++ b/frontend/src/components/ingest/KnowledgeGraphVisualization.tsx
@@ -1,0 +1,377 @@
+// SPDX-License-Identifier: Elastic-2.0
+// Copyright (c) 2026 ClaymoreLab
+import { useId, useMemo, useRef, useState, type PointerEvent, type WheelEvent } from "react";
+import { Maximize2, Minus, Network, Plus, RotateCcw, X } from "lucide-react";
+import { useTranslation } from "react-i18next";
+
+import { Button } from "@/components/ui/button";
+import type {
+  KnowledgeGraphNode,
+  KnowledgeGraphSnapshot,
+} from "@/lib/queries/ingest";
+import { cn } from "@/lib/utils";
+
+const VIEW_WIDTH = 1000;
+const VIEW_HEIGHT = 520;
+
+const TYPE_COLORS: Record<string, string> = {
+  Entity: "#a78bfa",
+  EntityType: "#22d3ee",
+  TextSummary: "#f472b6",
+  Document: "#34d399",
+  DocumentChunk: "#f59e0b",
+};
+
+interface LayoutNode extends KnowledgeGraphNode {
+  x: number;
+  y: number;
+  radius: number;
+  color: string;
+}
+
+function hashText(value: string): number {
+  let hash = 2166136261;
+  for (let index = 0; index < value.length; index += 1) {
+    hash ^= value.charCodeAt(index);
+    hash = Math.imul(hash, 16777619);
+  }
+  return hash >>> 0;
+}
+
+export function buildKnowledgeGraphLayout(graph: KnowledgeGraphSnapshot): LayoutNode[] {
+  const nodes = graph.nodes.map((node, index) => {
+    const seed = hashText(node.id);
+    const angle = ((seed % 360) * Math.PI) / 180 + index * 2.399;
+    const radius = 45 + Math.sqrt(index + 1) * 27;
+    return {
+      ...node,
+      x: VIEW_WIDTH / 2 + Math.cos(angle) * radius,
+      y: VIEW_HEIGHT / 2 + Math.sin(angle) * radius * 0.58,
+      radius: Math.min(18, 7 + Math.sqrt(Math.max(1, node.degree)) * 1.8),
+      color: TYPE_COLORS[node.type] ?? "#60a5fa",
+      vx: 0,
+      vy: 0,
+    };
+  });
+  const indexById = new Map(nodes.map((node, index) => [node.id, index]));
+  const springs = graph.edges
+    .map((edge) => [indexById.get(edge.source), indexById.get(edge.target)] as const)
+    .filter((pair): pair is readonly [number, number] => pair[0] != null && pair[1] != null);
+
+  // A small deterministic force pass gives the real topology an organic layout
+  // without adding another runtime dependency or persisting presentation state.
+  for (let step = 0; step < 120; step += 1) {
+    for (let left = 0; left < nodes.length; left += 1) {
+      for (let right = left + 1; right < nodes.length; right += 1) {
+        const a = nodes[left];
+        const b = nodes[right];
+        let dx = b.x - a.x;
+        let dy = b.y - a.y;
+        const distanceSquared = Math.max(64, dx * dx + dy * dy);
+        const distance = Math.sqrt(distanceSquared);
+        dx /= distance;
+        dy /= distance;
+        const force = 1350 / distanceSquared;
+        a.vx -= dx * force;
+        a.vy -= dy * force;
+        b.vx += dx * force;
+        b.vy += dy * force;
+      }
+    }
+    for (const [sourceIndex, targetIndex] of springs) {
+      if (sourceIndex === targetIndex) continue;
+      const source = nodes[sourceIndex];
+      const target = nodes[targetIndex];
+      const dx = target.x - source.x;
+      const dy = target.y - source.y;
+      const distance = Math.max(1, Math.sqrt(dx * dx + dy * dy));
+      const force = (distance - 82) * 0.0024;
+      source.vx += (dx / distance) * force;
+      source.vy += (dy / distance) * force;
+      target.vx -= (dx / distance) * force;
+      target.vy -= (dy / distance) * force;
+    }
+    for (const node of nodes) {
+      node.vx += (VIEW_WIDTH / 2 - node.x) * 0.00045;
+      node.vy += (VIEW_HEIGHT / 2 - node.y) * 0.0008;
+      node.vx *= 0.84;
+      node.vy *= 0.84;
+      node.x = Math.min(VIEW_WIDTH - 35, Math.max(35, node.x + node.vx));
+      node.y = Math.min(VIEW_HEIGHT - 28, Math.max(28, node.y + node.vy));
+    }
+  }
+
+  return nodes.map(({ vx: _vx, vy: _vy, ...node }) => node);
+}
+
+function formatProperty(value: unknown): string {
+  if (value == null) return "—";
+  if (typeof value === "string") return value;
+  if (typeof value === "number" || typeof value === "boolean") return String(value);
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch {
+    return String(value);
+  }
+}
+
+export function KnowledgeGraphVisualization({
+  graph,
+  className,
+}: {
+  graph: KnowledgeGraphSnapshot;
+  className?: string;
+}) {
+  const { t } = useTranslation();
+  const filterId = useId().replace(/:/g, "");
+  const nodes = useMemo(() => buildKnowledgeGraphLayout(graph), [graph]);
+  const nodesById = useMemo(
+    () => new Map(nodes.map((node) => [node.id, node])),
+    [nodes],
+  );
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [expanded, setExpanded] = useState(false);
+  const [view, setView] = useState({ x: 0, y: 0, scale: 1 });
+  const dragRef = useRef<{
+    pointerId: number;
+    clientX: number;
+    clientY: number;
+    x: number;
+    y: number;
+  } | null>(null);
+  const selected = selectedId ? nodesById.get(selectedId) ?? null : null;
+  const selectedRelations = useMemo(() => {
+    if (!selectedId) return [];
+    return graph.edges
+      .filter((edge) => edge.source === selectedId || edge.target === selectedId)
+      .slice(0, 12)
+      .map((edge) => {
+        const neighborId = edge.source === selectedId ? edge.target : edge.source;
+        return {
+          id: edge.id,
+          relation: edge.relation,
+          neighbor: nodesById.get(neighborId)?.label ?? neighborId,
+        };
+      });
+  }, [graph.edges, nodesById, selectedId]);
+  const selectedNeighborIds = useMemo(() => {
+    if (!selectedId) return new Set<string>();
+    const result = new Set<string>();
+    for (const edge of graph.edges) {
+      if (edge.source === selectedId) result.add(edge.target);
+      if (edge.target === selectedId) result.add(edge.source);
+    }
+    return result;
+  }, [graph.edges, selectedId]);
+  const visibleLabels = useMemo(
+    () => new Set([...nodes].sort((a, b) => b.degree - a.degree).slice(0, 24).map((node) => node.id)),
+    [nodes],
+  );
+
+  const zoom = (factor: number) =>
+    setView((current) => ({
+      ...current,
+      scale: Math.min(2.6, Math.max(0.55, current.scale * factor)),
+    }));
+
+  const handlePointerDown = (event: PointerEvent<SVGSVGElement>) => {
+    if (event.button !== 0) return;
+    event.currentTarget.setPointerCapture(event.pointerId);
+    dragRef.current = {
+      pointerId: event.pointerId,
+      clientX: event.clientX,
+      clientY: event.clientY,
+      x: view.x,
+      y: view.y,
+    };
+  };
+
+  const handlePointerMove = (event: PointerEvent<SVGSVGElement>) => {
+    const drag = dragRef.current;
+    if (!drag || drag.pointerId !== event.pointerId) return;
+    const bounds = event.currentTarget.getBoundingClientRect();
+    setView((current) => ({
+      ...current,
+      x: drag.x + ((event.clientX - drag.clientX) / bounds.width) * VIEW_WIDTH,
+      y: drag.y + ((event.clientY - drag.clientY) / bounds.height) * VIEW_HEIGHT,
+    }));
+  };
+
+  const handlePointerUp = (event: PointerEvent<SVGSVGElement>) => {
+    if (dragRef.current?.pointerId === event.pointerId) dragRef.current = null;
+  };
+
+  const handleWheel = (event: WheelEvent<SVGSVGElement>) => {
+    event.preventDefault();
+    zoom(event.deltaY < 0 ? 1.12 : 0.89);
+  };
+
+  return (
+    <section
+      aria-label={t("ingest.knowledgeGraph.title")}
+      className={cn(
+        "relative overflow-hidden rounded-2xl border border-violet-300/10 bg-[#05050a] shadow-[0_24px_80px_rgba(76,29,149,0.16)]",
+        expanded ? "h-[680px]" : "h-[520px]",
+        className,
+      )}
+    >
+      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_50%_46%,rgba(109,40,217,0.18),transparent_42%),radial-gradient(circle_at_18%_22%,rgba(34,211,238,0.08),transparent_28%)]" />
+      <div className="absolute left-5 top-4 z-20 flex items-center gap-3">
+        <span className="flex size-9 items-center justify-center rounded-xl border border-violet-300/15 bg-violet-500/12 text-violet-300 shadow-[0_0_28px_rgba(139,92,246,0.28)]">
+          <Network className="size-[18px]" />
+        </span>
+        <div>
+          <h2 className="text-sm font-semibold tracking-wide text-white">
+            {t("ingest.knowledgeGraph.title")}
+          </h2>
+          <p className="mt-0.5 text-[11px] text-white/45">
+            {t("ingest.knowledgeGraph.stats", {
+              nodes: graph.total_nodes,
+              edges: graph.total_edges,
+            })}
+          </p>
+        </div>
+      </div>
+
+      <div className="absolute right-4 top-4 z-20 flex items-center gap-1 rounded-lg border border-white/10 bg-black/55 p-1 backdrop-blur-xl">
+        <Button type="button" variant="ghost" size="icon-xs" onClick={() => zoom(0.82)} aria-label={t("ingest.knowledgeGraph.zoomOut")}>
+          <Minus className="size-3.5" />
+        </Button>
+        <Button type="button" variant="ghost" size="icon-xs" onClick={() => setView({ x: 0, y: 0, scale: 1 })} aria-label={t("ingest.knowledgeGraph.resetView")}>
+          <RotateCcw className="size-3.5" />
+        </Button>
+        <Button type="button" variant="ghost" size="icon-xs" onClick={() => zoom(1.22)} aria-label={t("ingest.knowledgeGraph.zoomIn")}>
+          <Plus className="size-3.5" />
+        </Button>
+        <Button type="button" variant="ghost" size="icon-xs" onClick={() => setExpanded((value) => !value)} aria-label={t("ingest.knowledgeGraph.expand")}>
+          <Maximize2 className="size-3.5" />
+        </Button>
+      </div>
+
+      <svg
+        viewBox={`0 0 ${VIEW_WIDTH} ${VIEW_HEIGHT}`}
+        className="absolute inset-0 size-full cursor-grab touch-none active:cursor-grabbing"
+        onPointerDown={handlePointerDown}
+        onPointerMove={handlePointerMove}
+        onPointerUp={handlePointerUp}
+        onPointerCancel={handlePointerUp}
+        onWheel={handleWheel}
+        onClick={() => setSelectedId(null)}
+      >
+        <defs>
+          <pattern id={`${filterId}-grid`} width="36" height="36" patternUnits="userSpaceOnUse">
+            <circle cx="1" cy="1" r="0.8" fill="rgba(255,255,255,0.12)" />
+          </pattern>
+          <filter id={`${filterId}-glow`} x="-80%" y="-80%" width="260%" height="260%">
+            <feGaussianBlur stdDeviation="5" result="blur" />
+            <feMerge><feMergeNode in="blur" /><feMergeNode in="SourceGraphic" /></feMerge>
+          </filter>
+        </defs>
+        <rect width={VIEW_WIDTH} height={VIEW_HEIGHT} fill={`url(#${filterId}-grid)`} opacity="0.42" />
+        <g transform={`translate(${view.x} ${view.y}) scale(${view.scale})`}>
+          {graph.edges.map((edge, index) => {
+            const source = nodesById.get(edge.source);
+            const target = nodesById.get(edge.target);
+            if (!source || !target) return null;
+            const connected = selectedId === edge.source || selectedId === edge.target;
+            return (
+              <line
+                key={edge.id}
+                x1={source.x}
+                y1={source.y}
+                x2={target.x}
+                y2={target.y}
+                stroke={connected ? "#c4b5fd" : "#7c3aed"}
+                strokeWidth={connected ? 1.8 : 0.72}
+                strokeOpacity={selectedId ? (connected ? 0.82 : 0.08) : 0.26}
+                strokeDasharray={index < 90 ? "5 8" : undefined}
+              >
+                {index < 90 ? (
+                  <animate attributeName="stroke-dashoffset" from="26" to="0" dur={`${3.2 + (index % 7) * 0.35}s`} repeatCount="indefinite" />
+                ) : null}
+              </line>
+            );
+          })}
+          {nodes.map((node) => {
+            const active = selectedId === node.id;
+            const muted = selectedId != null && !active && !selectedNeighborIds.has(node.id);
+            return (
+              <g
+                key={node.id}
+                role="button"
+                tabIndex={0}
+                aria-label={`${node.label}, ${node.type}`}
+                transform={`translate(${node.x} ${node.y})`}
+                className="cursor-pointer outline-none"
+                opacity={muted ? 0.24 : 1}
+                onPointerDown={(event) => event.stopPropagation()}
+                onClick={(event) => {
+                  event.stopPropagation();
+                  setSelectedId(node.id);
+                }}
+                onKeyDown={(event) => {
+                  if (event.key === "Enter" || event.key === " ") setSelectedId(node.id);
+                }}
+              >
+                <title>{node.label}</title>
+                <circle r={node.radius * 2.1} fill={node.color} opacity={active ? 0.22 : 0.08} filter={`url(#${filterId}-glow)`} />
+                <circle r={node.radius} fill="#09090f" stroke={node.color} strokeWidth={active ? 3 : 1.4} />
+                <circle r={Math.max(2.8, node.radius * 0.28)} fill={node.color} filter={`url(#${filterId}-glow)`} />
+                {(visibleLabels.has(node.id) || active) && (
+                  <text y={node.radius + 14} textAnchor="middle" fill="rgba(255,255,255,0.78)" fontSize={active ? 11 : 9.5} fontWeight={active ? 600 : 450}>
+                    {node.label.length > 15 ? `${node.label.slice(0, 14)}…` : node.label}
+                  </text>
+                )}
+              </g>
+            );
+          })}
+        </g>
+      </svg>
+
+      {selected && (
+        <aside className="absolute bottom-4 right-4 top-16 z-30 w-[300px] overflow-y-auto rounded-xl border border-white/10 bg-[#0d0b16]/94 p-4 shadow-2xl backdrop-blur-xl">
+          <button type="button" onClick={() => setSelectedId(null)} className="absolute right-3 top-3 text-white/45 transition-colors hover:text-white" aria-label={t("common.close")}>
+            <X className="size-4" />
+          </button>
+          <span className="inline-flex rounded-full px-2 py-0.5 text-[10px] font-semibold" style={{ color: selected.color, backgroundColor: `${selected.color}18` }}>
+            {selected.type}
+          </span>
+          <h3 className="mt-3 pr-6 text-base font-semibold leading-6 text-white">{selected.label}</h3>
+          <p className="mt-1 text-[11px] text-white/40">
+            {t("ingest.knowledgeGraph.connections", { count: selected.degree })}
+          </p>
+          {selectedRelations.length > 0 && (
+            <div className="mt-4 border-t border-white/8 pt-4">
+              <p className="text-[10px] uppercase tracking-wider text-white/35">
+                {t("ingest.knowledgeGraph.relationships")}
+              </p>
+              <div className="mt-2 space-y-1.5">
+                {selectedRelations.map((relation) => (
+                  <div key={relation.id} className="flex items-center gap-2 text-[11px]">
+                    <span className="max-w-[118px] truncate rounded bg-violet-400/10 px-1.5 py-0.5 text-violet-200/75">
+                      {relation.relation}
+                    </span>
+                    <span className="truncate text-white/60">{relation.neighbor}</span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+          <div className="mt-4 space-y-3 border-t border-white/8 pt-4">
+            {Object.entries(selected.properties).slice(0, 10).map(([key, value]) => (
+              <div key={key}>
+                <p className="text-[10px] uppercase tracking-wider text-white/35">{key}</p>
+                <p className="mt-1 whitespace-pre-wrap break-words text-xs leading-5 text-white/72">{formatProperty(value)}</p>
+              </div>
+            ))}
+          </div>
+        </aside>
+      )}
+
+      <div className="pointer-events-none absolute bottom-4 left-5 z-20 flex items-center gap-4 text-[10px] text-white/35">
+        <span>{t("ingest.knowledgeGraph.interactionHint")}</span>
+        {graph.truncated && <span>{t("ingest.knowledgeGraph.truncated")}</span>}
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/lib/queries/ingest.ts
+++ b/frontend/src/lib/queries/ingest.ts
@@ -38,6 +38,8 @@ interface ChaptersResult {
   total_chars: number;
   billable_chars?: number;
   count?: number;
+  /** Client-only marker: upload parsing succeeded, but Cognee ingest has not completed. */
+  preview_only?: boolean;
 }
 
 export interface KnowledgeGraphNode {
@@ -93,6 +95,7 @@ export function useUploadNovel(project: string) {
               total_chars: preview.total_chars,
               billable_chars: preview.billable_chars,
               count: preview.count,
+              preview_only: true,
             },
           },
         );

--- a/frontend/src/lib/queries/ingest.ts
+++ b/frontend/src/lib/queries/ingest.ts
@@ -40,6 +40,30 @@ interface ChaptersResult {
   count?: number;
 }
 
+export interface KnowledgeGraphNode {
+  id: string;
+  label: string;
+  type: string;
+  degree: number;
+  properties: Record<string, unknown>;
+}
+
+export interface KnowledgeGraphEdge {
+  id: string;
+  source: string;
+  target: string;
+  relation: string;
+  properties: Record<string, unknown>;
+}
+
+export interface KnowledgeGraphSnapshot {
+  nodes: KnowledgeGraphNode[];
+  edges: KnowledgeGraphEdge[];
+  total_nodes: number;
+  total_edges: number;
+  truncated: boolean;
+}
+
 export function useUploadNovel(project: string) {
   const queryClient = useQueryClient();
   return useMutation({
@@ -88,6 +112,18 @@ export function useChapters(project: string, enabled = true) {
         .get(p`api/v1/projects/${project}/chapters`, { signal })
         .json<OkResponse<ChaptersResult>>(),
     enabled: !!project && enabled,
+  });
+}
+
+export function useKnowledgeGraph(project: string, enabled = true) {
+  return useQuery({
+    queryKey: queryKeys.knowledgeGraph(project),
+    queryFn: ({ signal }) =>
+      api
+        .get(p`api/v1/projects/${project}/ingest/graph`, { signal })
+        .json<OkResponse<KnowledgeGraphSnapshot>>(),
+    enabled: !!project && enabled,
+    staleTime: 30_000,
   });
 }
 

--- a/frontend/src/lib/query-keys.ts
+++ b/frontend/src/lib/query-keys.ts
@@ -49,6 +49,7 @@ export const queryKeys = {
   episodeDetail: (p: string, ep: number) =>
     ["projects", p, "episodes", ep, "detail"] as const,
   chapters: (p: string) => ["projects", p, "chapters"] as const,
+  knowledgeGraph: (p: string) => ["projects", p, "knowledge-graph"] as const,
   script: (p: string, ep: number) =>
     ["projects", p, "episodes", ep, "script"] as const,
   beats: (p: string, ep: number) =>

--- a/frontend/src/routes/_app/projects.$project/ingest.tsx
+++ b/frontend/src/routes/_app/projects.$project/ingest.tsx
@@ -898,6 +898,7 @@ export function IngestPageContent({ project }: { project: string }) {
   );
   const chaptersData = chaptersRes?.data;
   const hasImportedContent = (chaptersData?.chapters?.length ?? 0) > 0;
+  const isUploadOnlyPreview = chaptersData?.preview_only === true;
 
   const pastedBillableChars = useMemo(
     () => countBillableNovelChars(pastedText.trim()),
@@ -946,7 +947,7 @@ export function IngestPageContent({ project }: { project: string }) {
   const [reuploadConfirmOpen, setReuploadConfirmOpen] = useState(false);
   const knowledgeGraph = useKnowledgeGraph(
     project,
-    hasImportedContent && !ingestStarted,
+    hasImportedContent && !isUploadOnlyPreview && !ingestStarted,
   );
   const cancelTask = useCancelTask();
   const taskStream = useTaskStream({

--- a/frontend/src/routes/_app/projects.$project/ingest.tsx
+++ b/frontend/src/routes/_app/projects.$project/ingest.tsx
@@ -16,7 +16,6 @@ import {
   FishSymbol,
   Info,
   Loader2,
-  Network,
   Play,
   Plus,
   RefreshCw,
@@ -27,6 +26,7 @@ import {
 import { useProject, useUpdateProject } from "@/lib/queries/projects";
 import {
   useChapters,
+  useKnowledgeGraph,
   useStartIngest,
   useUploadNovel,
   type FormatCheck,
@@ -34,6 +34,7 @@ import {
 } from "@/lib/queries/ingest";
 import { FormatCheckDetailsDialog } from "@/components/ingest/FormatCheckDetailsDialog";
 import { NovelFormatDialog } from "@/components/ingest/NovelFormatDialog";
+import { KnowledgeGraphVisualization } from "@/components/ingest/KnowledgeGraphVisualization";
 import { useStyles } from "@/lib/queries/styles";
 import { useCancelTask, useTasks } from "@/lib/queries/tasks";
 import { useGenerationCreditCost } from "@/lib/queries/generation-credit-cost";
@@ -943,6 +944,10 @@ export function IngestPageContent({ project }: { project: string }) {
   const [ingestStarted, setIngestStarted] = useState(false);
   const [reimporting, setReimporting] = useState(false);
   const [reuploadConfirmOpen, setReuploadConfirmOpen] = useState(false);
+  const knowledgeGraph = useKnowledgeGraph(
+    project,
+    hasImportedContent && !ingestStarted,
+  );
   const cancelTask = useCancelTask();
   const taskStream = useTaskStream({
     taskType: "ingest_fast",
@@ -964,6 +969,9 @@ export function IngestPageContent({ project }: { project: string }) {
       await queryClient.refetchQueries({
         queryKey: queryKeys.chapters(project),
         type: "active",
+      });
+      await queryClient.invalidateQueries({
+        queryKey: queryKeys.knowledgeGraph(project),
       });
       toast.success(t("common.generate") + " ✓");
     },
@@ -1682,51 +1690,47 @@ export function IngestPageContent({ project }: { project: string }) {
               {/* Preview — populated */}
               {chaptersData && chapterCount > 0 && (
                 <div className="space-y-4">
-                  <section
-                    aria-labelledby="knowledge-graph-title"
-                    className={cn(
-                      "overflow-hidden rounded-xl border p-4",
-                      INGEST_SURFACE_SUBTLE_CLASS,
-                    )}
-                  >
-                    <div className="flex items-start gap-3">
-                      <span className="flex size-9 shrink-0 items-center justify-center rounded-lg bg-emerald-500/12 text-emerald-400">
-                        <Network className="size-[18px]" aria-hidden />
-                      </span>
-                      <div className="min-w-0 flex-1">
-                        <div className="flex flex-wrap items-center gap-2">
-                          <h2
-                            id="knowledge-graph-title"
-                            className="text-sm font-semibold text-foreground"
-                          >
-                            {t("ingest.knowledgeGraph.title")}
-                          </h2>
-                          <span className="inline-flex items-center gap-1 rounded-full bg-emerald-500/12 px-2 py-0.5 text-[11px] font-medium text-emerald-400">
-                            <CheckCircle2 className="size-3" aria-hidden />
-                            {t("ingest.knowledgeGraph.ready")}
-                          </span>
-                        </div>
-                        <p className="mt-1 text-xs leading-5 text-muted-foreground">
-                          {t("ingest.knowledgeGraph.description")}
-                        </p>
-                        <div className="mt-3 flex flex-wrap gap-1.5">
-                          {([
-                            "characters",
-                            "scenes",
-                            "props",
-                            "episodes",
-                          ] as const).map((item) => (
-                            <span
-                              key={item}
-                              className="rounded-md border border-white/[0.07] bg-white/[0.035] px-2 py-1 text-[11px] text-muted-foreground"
-                            >
-                              {t(`ingest.knowledgeGraph.uses.${item}`)}
-                            </span>
-                          ))}
+                  {knowledgeGraph.isLoading && (
+                    <div className="h-[520px] overflow-hidden rounded-2xl border border-violet-300/10 bg-[#05050a] p-5">
+                      <div className="flex items-center gap-3">
+                        <Skeleton className="size-9 rounded-xl" />
+                        <div className="space-y-2">
+                          <Skeleton className="h-3 w-24" />
+                          <Skeleton className="h-2.5 w-40" />
                         </div>
                       </div>
+                      <Skeleton className="mx-auto mt-16 size-72 rounded-full opacity-40" />
                     </div>
-                  </section>
+                  )}
+
+                  {knowledgeGraph.data?.data.nodes.length ? (
+                    <KnowledgeGraphVisualization graph={knowledgeGraph.data.data} />
+                  ) : null}
+
+                  {knowledgeGraph.isError && (
+                    <div className="flex min-h-28 items-center justify-between gap-4 rounded-xl border border-amber-300/15 bg-amber-500/[0.04] p-4">
+                      <div className="flex items-start gap-3">
+                        <AlertTriangle className="mt-0.5 size-4 shrink-0 text-amber-400" />
+                        <div>
+                          <p className="text-sm font-medium text-foreground">
+                            {t("ingest.knowledgeGraph.loadFailed")}
+                          </p>
+                          <p className="mt-1 text-xs text-muted-foreground">
+                            {t("ingest.knowledgeGraph.loadFailedHint")}
+                          </p>
+                        </div>
+                      </div>
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="sm"
+                        onClick={() => knowledgeGraph.refetch()}
+                      >
+                        <RefreshCw className="size-3.5" />
+                        {t("common.retry")}
+                      </Button>
+                    </div>
+                  )}
 
                   <h2 className="text-lg font-semibold text-foreground">
                     {t("ingest.previewHeading")}

--- a/frontend/src/routes/_app/projects.$project/ingest.tsx
+++ b/frontend/src/routes/_app/projects.$project/ingest.tsx
@@ -16,6 +16,7 @@ import {
   FishSymbol,
   Info,
   Loader2,
+  Network,
   Play,
   Plus,
   RefreshCw,
@@ -1681,6 +1682,52 @@ export function IngestPageContent({ project }: { project: string }) {
               {/* Preview — populated */}
               {chaptersData && chapterCount > 0 && (
                 <div className="space-y-4">
+                  <section
+                    aria-labelledby="knowledge-graph-title"
+                    className={cn(
+                      "overflow-hidden rounded-xl border p-4",
+                      INGEST_SURFACE_SUBTLE_CLASS,
+                    )}
+                  >
+                    <div className="flex items-start gap-3">
+                      <span className="flex size-9 shrink-0 items-center justify-center rounded-lg bg-emerald-500/12 text-emerald-400">
+                        <Network className="size-[18px]" aria-hidden />
+                      </span>
+                      <div className="min-w-0 flex-1">
+                        <div className="flex flex-wrap items-center gap-2">
+                          <h2
+                            id="knowledge-graph-title"
+                            className="text-sm font-semibold text-foreground"
+                          >
+                            {t("ingest.knowledgeGraph.title")}
+                          </h2>
+                          <span className="inline-flex items-center gap-1 rounded-full bg-emerald-500/12 px-2 py-0.5 text-[11px] font-medium text-emerald-400">
+                            <CheckCircle2 className="size-3" aria-hidden />
+                            {t("ingest.knowledgeGraph.ready")}
+                          </span>
+                        </div>
+                        <p className="mt-1 text-xs leading-5 text-muted-foreground">
+                          {t("ingest.knowledgeGraph.description")}
+                        </p>
+                        <div className="mt-3 flex flex-wrap gap-1.5">
+                          {([
+                            "characters",
+                            "scenes",
+                            "props",
+                            "episodes",
+                          ] as const).map((item) => (
+                            <span
+                              key={item}
+                              className="rounded-md border border-white/[0.07] bg-white/[0.035] px-2 py-1 text-[11px] text-muted-foreground"
+                            >
+                              {t(`ingest.knowledgeGraph.uses.${item}`)}
+                            </span>
+                          ))}
+                        </div>
+                      </div>
+                    </div>
+                  </section>
+
                   <h2 className="text-lg font-semibold text-foreground">
                     {t("ingest.previewHeading")}
                   </h2>

--- a/license-inventory.csv
+++ b/license-inventory.csv
@@ -609,6 +609,7 @@ frontend/src/components/episode/script-beat-preview.tsx,Elastic-2.0,2026 SuperTa
 frontend/src/components/episode/task-controller-provider.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/components/identity-picker-dialog.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/components/ingest/FormatCheckDetailsDialog.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
+frontend/src/components/ingest/KnowledgeGraphVisualization.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/components/ingest/NovelFormatDialog.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/components/layout/ai-assistant-panel.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/components/layout/brand-holiday-badge.css,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation

--- a/src/novelvideo/api/routes/ingest.py
+++ b/src/novelvideo/api/routes/ingest.py
@@ -12,6 +12,7 @@ from novelvideo.api.chapter_preview import (
     load_novel_text,
 )
 from novelvideo.api.deps import resolve_project_scope
+from novelvideo.api.deps import get_cognee_store
 from novelvideo.api.schemas import IngestStart
 from novelvideo.project_config import (
     default_aspect_ratio_for_spine_template,
@@ -36,6 +37,16 @@ from novelvideo.utils.upload_safety import (
 
 logger = logging.getLogger("novelvideo.api.ingest")
 router = APIRouter()
+
+
+@router.get("/projects/{project}/ingest/graph")
+async def get_ingest_knowledge_graph(
+    project: str,
+    store=Depends(get_cognee_store),
+):
+    """Return the imported project's real Cognee graph for visualization."""
+    snapshot = await store.get_graph_snapshot()
+    return {"ok": True, "data": snapshot}
 
 
 def _unsupported_format_response(filename: str) -> dict:

--- a/src/novelvideo/cognee/store.py
+++ b/src/novelvideo/cognee/store.py
@@ -12,6 +12,8 @@ from pathlib import Path
 from typing import Awaitable, Callable, Dict, List, Optional, Any, Iterable
 import json
 from importlib import import_module
+from datetime import date, datetime
+from uuid import UUID
 
 # 重要：必须先导入 config，在 cognee 被导入之前设置环境变量
 from .config import apply_cognee_project_storage_context, init_cognee  # noqa: F401
@@ -601,6 +603,111 @@ class CogneeStore:
             "char_count": len(content),
             "dataset": self.dataset_name,
             "status": "graph_ready",
+        }
+
+    async def get_graph_snapshot(self, max_nodes: int = 160) -> dict:
+        """Return a bounded, JSON-safe snapshot for the project graph viewer.
+
+        Cognee's graph may contain large chunk payloads and embedding metadata. The
+        viewer needs topology and concise human-readable properties, not the raw
+        storage representation, so this method ranks connected nodes and strips
+        oversized or vector-shaped values before returning them to the browser.
+        """
+
+        self._set_cognee_context()
+        with preserve_st_env():
+            from cognee.infrastructure.databases.graph import get_graph_engine
+
+        graph_engine = await get_graph_engine()
+        raw_nodes, raw_edges = await graph_engine.get_graph_data()
+
+        max_nodes = max(20, min(int(max_nodes), 240))
+        degree: Dict[str, int] = {}
+        for source, target, _relation, _properties in raw_edges:
+            source_id = str(source)
+            target_id = str(target)
+            degree[source_id] = degree.get(source_id, 0) + 1
+            degree[target_id] = degree.get(target_id, 0) + 1
+
+        type_priority = {
+            "Entity": 6,
+            "EntityType": 5,
+            "TextSummary": 4,
+            "Document": 3,
+            "DocumentChunk": 1,
+        }
+
+        ranked_nodes = sorted(
+            raw_nodes,
+            key=lambda item: (
+                degree.get(str(item[0]), 0) * 10
+                + type_priority.get(str((item[1] or {}).get("type") or ""), 2) * 3
+                + int(bool((item[1] or {}).get("name")))
+            ),
+            reverse=True,
+        )[:max_nodes]
+        selected_ids = {str(node_id) for node_id, _properties in ranked_nodes}
+
+        def compact(value: Any, *, depth: int = 0) -> Any:
+            if value is None or isinstance(value, (bool, int, float)):
+                return value
+            if isinstance(value, (UUID, date, datetime)):
+                return str(value)
+            if isinstance(value, str):
+                return value if len(value) <= 500 else value[:497] + "..."
+            if depth >= 2:
+                return str(value)[:500]
+            if isinstance(value, (list, tuple, set)):
+                return [compact(item, depth=depth + 1) for item in list(value)[:12]]
+            if isinstance(value, dict):
+                result = {}
+                for key, item in list(value.items())[:16]:
+                    key_text = str(key)
+                    if any(token in key_text.lower() for token in ("embedding", "vector")):
+                        continue
+                    result[key_text] = compact(item, depth=depth + 1)
+                return result
+            return str(value)[:500]
+
+        nodes = []
+        for node_id, properties in ranked_nodes:
+            props = dict(properties or {})
+            node_type = str(props.pop("type", "Unknown") or "Unknown")
+            label = str(props.pop("name", "") or node_id)
+            nodes.append(
+                {
+                    "id": str(node_id),
+                    "label": label[:160],
+                    "type": node_type[:80],
+                    "degree": degree.get(str(node_id), 0),
+                    "properties": compact(props),
+                }
+            )
+
+        edges = []
+        for index, (source, target, relation, properties) in enumerate(raw_edges):
+            source_id = str(source)
+            target_id = str(target)
+            if source_id not in selected_ids or target_id not in selected_ids:
+                continue
+            edges.append(
+                {
+                    "id": f"{source_id}:{target_id}:{index}",
+                    "source": source_id,
+                    "target": target_id,
+                    "relation": str(relation or "related_to")[:120],
+                    "properties": compact(properties or {}),
+                }
+            )
+            if len(edges) >= 600:
+                break
+
+        return {
+            "nodes": nodes,
+            "edges": edges,
+            "total_nodes": len(raw_nodes),
+            "total_edges": len(raw_edges),
+            "truncated": len(raw_nodes) > len(nodes) or len(raw_edges) > len(edges),
         }
 
     async def build_characters_from_graph(

--- a/src/novelvideo/cognee/store.py
+++ b/src/novelvideo/cognee/store.py
@@ -614,12 +614,7 @@ class CogneeStore:
         oversized or vector-shaped values before returning them to the browser.
         """
 
-        self._set_cognee_context()
-        with preserve_st_env():
-            from cognee.infrastructure.databases.graph import get_graph_engine
-
-        graph_engine = await get_graph_engine()
-        raw_nodes, raw_edges = await graph_engine.get_graph_data()
+        raw_nodes, raw_edges = await self._get_dataset_graph_data()
 
         max_nodes = max(20, min(int(max_nodes), 240))
         degree: Dict[str, int] = {}
@@ -709,6 +704,34 @@ class CogneeStore:
             "total_edges": len(raw_edges),
             "truncated": len(raw_nodes) > len(nodes) or len(raw_edges) > len(edges),
         }
+
+    async def _get_dataset_graph_data(self) -> tuple[list, list]:
+        """Read the graph through Cognee's project dataset context.
+
+        With backend access control enabled, Cognee stores each dataset in its
+        own graph database. Calling ``get_graph_engine()`` without first setting
+        that dataset context opens the empty global graph instead of the graph
+        populated by ``cognify()``.
+        """
+
+        self._set_cognee_context()
+        with preserve_st_env():
+            from cognee.context_global_variables import (
+                set_database_global_context_variables,
+            )
+            from cognee.infrastructure.databases.graph import get_graph_engine
+            from cognee.modules.data.methods import get_datasets_by_name
+            from cognee.modules.users.methods import get_default_user
+
+        user = await get_default_user()
+        datasets = await get_datasets_by_name(self.dataset_name, user.id)
+        if not datasets:
+            return [], []
+
+        dataset = datasets[0]
+        async with set_database_global_context_variables(dataset.id, dataset.owner_id):
+            graph_engine = await get_graph_engine()
+            return await graph_engine.get_graph_data()
 
     async def build_characters_from_graph(
         self,

--- a/tests/contract/test_m06_route_contracts.py
+++ b/tests/contract/test_m06_route_contracts.py
@@ -118,6 +118,38 @@ class _M06Store:
     async def get_episode_from_graph(self, episode: int):
         return self._episodes[episode]
 
+    async def get_graph_snapshot(self):
+        return {
+            "nodes": [
+                {
+                    "id": "character-1",
+                    "label": _CHARACTER,
+                    "type": "Entity",
+                    "degree": 1,
+                    "properties": {"description": "雨巷少年"},
+                },
+                {
+                    "id": "scene-1",
+                    "label": _SCENE,
+                    "type": "Entity",
+                    "degree": 1,
+                    "properties": {},
+                },
+            ],
+            "edges": [
+                {
+                    "id": "edge-1",
+                    "source": "character-1",
+                    "target": "scene-1",
+                    "relation": "appears_in",
+                    "properties": {},
+                }
+            ],
+            "total_nodes": 2,
+            "total_edges": 1,
+            "truncated": False,
+        }
+
     async def list_visual_beats(self):
         return []
 
@@ -325,6 +357,11 @@ def m06_client_factory(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
         app.dependency_overrides[api_auth.get_api_user] = lambda user=user: user
         app.dependency_overrides[ingest.get_api_user] = lambda user=user: user
         app.dependency_overrides[freezone.get_api_user] = lambda user=user: user
+
+        async def override_cognee_store():
+            yield store
+
+        app.dependency_overrides[ingest.get_cognee_store] = override_cognee_store
         return TestClient(app), task_backend, task_manager, project_dir, assets, store
 
     return build
@@ -407,6 +444,18 @@ def test_m06_ingest_upload_preview_and_unsupported_format(m06_client_factory):
     payload = response.json()
     assert payload["ok"] is False
     assert payload["error_type"] == "unsupported"
+
+
+def test_m06_ingest_exposes_real_knowledge_graph_snapshot(m06_client_factory):
+    client, _backend, _task_manager, _project_dir, _assets, _store = m06_client_factory("inline")
+
+    response = client.get(f"/api/v1/projects/{_PROJECT}/ingest/graph")
+    payload = _assert_ok(response)
+
+    assert payload["data"]["total_nodes"] == 2
+    assert payload["data"]["total_edges"] == 1
+    assert payload["data"]["nodes"][0]["label"] == _CHARACTER
+    assert payload["data"]["edges"][0]["relation"] == "appears_in"
 
 
 @pytest.mark.parametrize("backend", ["inline", "celery"])

--- a/tests/test_cognee_store_close.py
+++ b/tests/test_cognee_store_close.py
@@ -61,3 +61,39 @@ async def test_close_releases_cached_cognee_graph_engine(monkeypatch):
         "graph.close",
         "graph.cache_clear",
     ]
+
+
+@pytest.mark.asyncio
+async def test_graph_snapshot_is_bounded_ranked_and_json_safe(monkeypatch):
+    from novelvideo.cognee.store import CogneeStore
+
+    graph_module = import_module("cognee.infrastructure.databases.graph")
+
+    class FakeGraphEngine:
+        async def get_graph_data(self):
+            return (
+                [
+                    ("chunk", {"name": "原文章节", "type": "DocumentChunk", "embedding": [1, 2]}),
+                    ("hero", {"name": "林昭", "type": "Entity", "description": "主角"}),
+                    ("place", {"name": "雨巷", "type": "Entity"}),
+                ],
+                [
+                    ("hero", "place", "appears_in", {}),
+                    ("hero", "chunk", "mentioned_in", {"weight": 0.9}),
+                ],
+            )
+
+    async def fake_get_graph_engine():
+        return FakeGraphEngine()
+
+    monkeypatch.setattr(graph_module, "get_graph_engine", fake_get_graph_engine)
+
+    store = CogneeStore.__new__(CogneeStore)
+    store._set_cognee_context = lambda: None
+    snapshot = await store.get_graph_snapshot(max_nodes=20)
+
+    assert snapshot["total_nodes"] == 3
+    assert snapshot["total_edges"] == 2
+    assert snapshot["nodes"][0]["label"] == "林昭"
+    chunk = next(node for node in snapshot["nodes"] if node["id"] == "chunk")
+    assert "embedding" not in chunk["properties"]

--- a/tests/test_cognee_store_close.py
+++ b/tests/test_cognee_store_close.py
@@ -1,5 +1,6 @@
 import pytest
 from importlib import import_module
+from types import SimpleNamespace
 
 
 @pytest.mark.asyncio
@@ -67,29 +68,21 @@ async def test_close_releases_cached_cognee_graph_engine(monkeypatch):
 async def test_graph_snapshot_is_bounded_ranked_and_json_safe(monkeypatch):
     from novelvideo.cognee.store import CogneeStore
 
-    graph_module = import_module("cognee.infrastructure.databases.graph")
-
-    class FakeGraphEngine:
-        async def get_graph_data(self):
-            return (
-                [
-                    ("chunk", {"name": "原文章节", "type": "DocumentChunk", "embedding": [1, 2]}),
-                    ("hero", {"name": "林昭", "type": "Entity", "description": "主角"}),
-                    ("place", {"name": "雨巷", "type": "Entity"}),
-                ],
-                [
-                    ("hero", "place", "appears_in", {}),
-                    ("hero", "chunk", "mentioned_in", {"weight": 0.9}),
-                ],
-            )
-
-    async def fake_get_graph_engine():
-        return FakeGraphEngine()
-
-    monkeypatch.setattr(graph_module, "get_graph_engine", fake_get_graph_engine)
+    async def fake_get_dataset_graph_data():
+        return (
+            [
+                ("chunk", {"name": "原文章节", "type": "DocumentChunk", "embedding": [1, 2]}),
+                ("hero", {"name": "林昭", "type": "Entity", "description": "主角"}),
+                ("place", {"name": "雨巷", "type": "Entity"}),
+            ],
+            [
+                ("hero", "place", "appears_in", {}),
+                ("hero", "chunk", "mentioned_in", {"weight": 0.9}),
+            ],
+        )
 
     store = CogneeStore.__new__(CogneeStore)
-    store._set_cognee_context = lambda: None
+    store._get_dataset_graph_data = fake_get_dataset_graph_data
     snapshot = await store.get_graph_snapshot(max_nodes=20)
 
     assert snapshot["total_nodes"] == 3
@@ -97,3 +90,66 @@ async def test_graph_snapshot_is_bounded_ranked_and_json_safe(monkeypatch):
     assert snapshot["nodes"][0]["label"] == "林昭"
     chunk = next(node for node in snapshot["nodes"] if node["id"] == "chunk")
     assert "embedding" not in chunk["properties"]
+
+
+@pytest.mark.asyncio
+async def test_graph_snapshot_reads_the_project_dataset_database(monkeypatch):
+    from novelvideo.cognee.store import CogneeStore
+
+    context_module = import_module("cognee.context_global_variables")
+    graph_module = import_module("cognee.infrastructure.databases.graph")
+    data_methods = import_module("cognee.modules.data.methods")
+    user_methods = import_module("cognee.modules.users.methods")
+    calls = []
+    user = SimpleNamespace(id="user-id")
+    dataset = SimpleNamespace(id="dataset-id", owner_id="owner-id")
+
+    class FakeDatasetContext:
+        async def __aenter__(self):
+            calls.append("context.enter")
+
+        async def __aexit__(self, exc_type, exc, tb):
+            calls.append("context.exit")
+
+    class FakeGraphEngine:
+        async def get_graph_data(self):
+            calls.append("graph.read")
+            return [("hero", {"name": "林昭", "type": "Entity"})], []
+
+    async def fake_get_default_user():
+        return user
+
+    async def fake_get_datasets_by_name(name, user_id):
+        calls.append(("dataset.lookup", name, user_id))
+        return [dataset]
+
+    async def fake_get_graph_engine():
+        return FakeGraphEngine()
+
+    monkeypatch.setattr(user_methods, "get_default_user", fake_get_default_user)
+    monkeypatch.setattr(data_methods, "get_datasets_by_name", fake_get_datasets_by_name)
+    monkeypatch.setattr(
+        context_module,
+        "set_database_global_context_variables",
+        lambda dataset_id, owner_id: (
+            calls.append(("context.create", dataset_id, owner_id)) or FakeDatasetContext()
+        ),
+    )
+    monkeypatch.setattr(graph_module, "get_graph_engine", fake_get_graph_engine)
+
+    store = CogneeStore.__new__(CogneeStore)
+    store.dataset_name = "novelvideo_local/test"
+    store._set_cognee_context = lambda: calls.append("project.context")
+
+    nodes, edges = await store._get_dataset_graph_data()
+
+    assert nodes[0][1]["name"] == "林昭"
+    assert edges == []
+    assert calls == [
+        "project.context",
+        ("dataset.lookup", "novelvideo_local/test", "user-id"),
+        ("context.create", "dataset-id", "owner-id"),
+        "context.enter",
+        "graph.read",
+        "context.exit",
+    ]


### PR DESCRIPTION
Closes #163

## What

- expose a project-scoped, read-only snapshot of the real Cognee knowledge graph
- render an interactive glowing node graph directly below imported 虾料
- support pan, zoom, expand, node selection, relationship inspection, and property details
- bound large graphs to core connected nodes and strip embedding/vector payloads
- distinguish upload-only chapter previews from completed imports so the graph appears only after Cognee ingest succeeds
- persist CE project output under the existing `/data` volume so imported `novel.txt` survives API container rebuilds
- add Chinese and English UI copy plus backend/frontend regression coverage

## Why

Import already builds a Cognee knowledge graph, but the Story Source page did not let users see or explore it. This makes the graph itself visible instead of showing only a completion badge.

The upload endpoint also caches a parsed chapter preview before import. Treating that preview as imported content caused the graph to render too early and reuse the wrong fetch timing. The client now marks upload-only previews explicitly and enables the graph query only after the server-backed chapter result replaces that preview.

Cognee stores each project dataset in its own graph database when backend access control is enabled. The first viewer implementation opened the global default graph directly, so completed imports returned an empty snapshot. The viewer now resolves the project's real dataset and reads it inside Cognee's standard dataset context, matching cognify, memify, and search.

The self-hosted compose file previously inherited `NOVELVIDEO_OUTPUT_DIR=output` from `.env`, which resolved to the ephemeral `/app/output` directory despite `NOVELVIDEO_DATA_ROOT=/data`. It now pins output to `/data/output`, keeping output semantics unchanged while placing it on the existing persistent CE volume.

## Impact

- no model calls or additional credit consumption
- no graph mutation or ingest pipeline changes
- project viewer permission is required
- returns at most 160 core nodes and 600 edges to keep large novels responsive

## Checks

- 17 focused backend tests passed
- 24 focused frontend/i18n tests passed
- Ruff passed
- compliance inventory test passed
- API and Web production Docker images built successfully
- local CE API/Web containers are healthy on port 8080
