### PR TITLE
fix: require imported novel before project builds

### DIFF
--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -1242,6 +1242,7 @@
     "loading": "Loading...",
     "back": "Back",
     "error": "Something went wrong",
+    "novelImportRequired": "Please import a novel first",
     "insufficientCredits": "Insufficient credits. Please contact your administrator to recharge.",
     "billingRuleNotConfigured": "Billing rule is not configured. Please contact an administrator to set credit pricing.",
     "billingRuleNotConfiguredShort": "Configure",

--- a/frontend/public/locales/zh/translation.json
+++ b/frontend/public/locales/zh/translation.json
@@ -1242,6 +1242,7 @@
     "loading": "加载中...",
     "back": "返回",
     "error": "出错了",
+    "novelImportRequired": "请先导入小说",
     "insufficientCredits": "积分不足，请联系管理员充值",
     "billingRuleNotConfigured": "计费规则未配置，请联系管理员设置积分规则",
     "billingRuleNotConfiguredShort": "需配置",

--- a/frontend/src/__tests__/routes/characters.ce.test.tsx
+++ b/frontend/src/__tests__/routes/characters.ce.test.tsx
@@ -11,6 +11,8 @@ import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 const runtimeState = vi.hoisted(() => ({ isCeRuntime: true }));
 const toastErrorMock = vi.hoisted(() => vi.fn());
 const mutation = vi.hoisted(() => () => ({ mutateAsync: vi.fn(), isPending: false }));
+const buildCharactersMutationMock = vi.hoisted(() => vi.fn());
+const taskStreamOptionsMock = vi.hoisted(() => vi.fn());
 
 vi.mock("@/lib/runtime-config", () => ({
   isCeRuntime: () => runtimeState.isCeRuntime,
@@ -52,13 +54,16 @@ vi.mock("@/hooks/use-task-controller", () => ({
 }));
 
 vi.mock("@/hooks/use-task-stream", () => ({
-  useTaskStream: () => ({
-    status: "idle",
-    progress: 0,
-    currentTask: "",
-    result: null,
-    error: null,
-  }),
+  useTaskStream: (options: unknown) => {
+    taskStreamOptionsMock(options);
+    return {
+      status: "idle",
+      progress: 0,
+      currentTask: "",
+      result: null,
+      error: null,
+    };
+  },
 }));
 
 vi.mock("@/hooks/use-media-query", () => ({
@@ -138,7 +143,10 @@ vi.mock("@/lib/queries/characters", () => ({
       ],
     },
   }),
-  useBuildCharacters: mutation,
+  useBuildCharacters: () => ({
+    mutateAsync: buildCharactersMutationMock,
+    isPending: false,
+  }),
   useCreateCharacter: mutation,
   useUpdateCharacter: mutation,
   useDeleteCharacter: mutation,
@@ -209,6 +217,18 @@ beforeAll(async () => {
   await i18n.use(initReactI18next).init({
     lng: "en",
     fallbackLng: "en",
+    resources: {
+      en: {
+        translation: {
+          common: { novelImportRequired: "Please import a novel first" },
+        },
+      },
+      zh: {
+        translation: {
+          common: { novelImportRequired: "请先导入小说" },
+        },
+      },
+    },
     interpolation: { escapeValue: false },
   });
 });
@@ -223,9 +243,12 @@ function renderCharactersPage() {
 }
 
 describe("characters page CE generation credit gating", () => {
-  beforeEach(() => {
+  beforeEach(async () => {
+    await i18n.changeLanguage("en");
     runtimeState.isCeRuntime = true;
     toastErrorMock.mockClear();
+    buildCharactersMutationMock.mockReset();
+    taskStreamOptionsMock.mockClear();
     Element.prototype.scrollTo = vi.fn();
     window.localStorage.clear();
   });
@@ -266,4 +289,38 @@ describe("characters page CE generation credit gating", () => {
       expect.stringMatching(/积分不足|credit|insufficient/i),
     );
   });
+
+  it.each([
+    ["en", "Please import a novel first"],
+    ["zh", "请先导入小说"],
+  ])(
+    "localizes the backend prerequisite error in %s without starting a missing task stream",
+    async (language, expectedMessage) => {
+      await i18n.changeLanguage(language);
+      buildCharactersMutationMock.mockResolvedValue({
+        ok: false,
+        code: "NOVEL_IMPORT_REQUIRED",
+        error: "请先导入小说",
+      });
+      const user = userEvent.setup();
+      renderCharactersPage();
+
+      await user.click(
+        await screen.findByRole("button", { name: /characters\.autoExtract/ }),
+      );
+      const dialog = await screen.findByRole("alertdialog");
+      await user.click(
+        within(dialog).getByRole("button", { name: "common.confirm" }),
+      );
+
+      await waitFor(() =>
+        expect(toastErrorMock).toHaveBeenCalledWith(expectedMessage),
+      );
+      expect(
+        taskStreamOptionsMock.mock.calls.some(
+          ([options]) => (options as { enabled?: boolean }).enabled === true,
+        ),
+      ).toBe(false);
+    },
+  );
 });

--- a/frontend/src/__tests__/task-center/task-errors.test.ts
+++ b/frontend/src/__tests__/task-center/task-errors.test.ts
@@ -20,6 +20,29 @@ function task(partial: Partial<TaskState>): TaskState {
 }
 
 describe("taskErrorMessage", () => {
+  it("uses i18n for a missing novel task error", () => {
+    const tMock = vi.fn((key: string, options?: { defaultValue?: string }) => {
+      if (key === "common.novelImportRequired") {
+        return "Please import a novel first";
+      }
+      return options?.defaultValue ?? key;
+    });
+    const t = tMock as unknown as TFunction;
+
+    expect(
+      taskErrorMessage(
+        task({
+          error_code: "NOVEL_IMPORT_REQUIRED",
+          error: "请先导入小说",
+        }),
+        t,
+      ),
+    ).toBe("Please import a novel first");
+    expect(tMock).toHaveBeenCalledWith("common.novelImportRequired", {
+      defaultValue: "请先导入小说",
+    });
+  });
+
   it("uses i18n for missing billing rule task errors", () => {
     const tMock = vi.fn((key: string, options?: { defaultValue?: string }) => {
       if (key === "common.billingRuleNotConfigured") {

--- a/frontend/src/components/assets/scenes-panel.tsx
+++ b/frontend/src/components/assets/scenes-panel.tsx
@@ -37,6 +37,7 @@ import { useAssetImageSourceSelection } from "@/lib/queries/character-image-sele
 import { useAssetFocus } from "@/hooks/use-asset-focus";
 import { useNavigateToAsset } from "@/hooks/use-assets-deep-link";
 import {
+  backendErrorResponseToastMessage,
   backendErrorToastMessage,
   BillingRuleNotConfiguredError,
 } from "@/lib/api-errors";
@@ -1250,7 +1251,7 @@ export function ScenesPanel({
       return;
     }
     if (isErrorResponse(res)) {
-      toast.error(backendErrorToastMessage(res.error, t));
+      toast.error(backendErrorResponseToastMessage(res, t));
       return;
     }
     toast.success(res.message);

--- a/frontend/src/hooks/use-task-stream.ts
+++ b/frontend/src/hooks/use-task-stream.ts
@@ -6,6 +6,7 @@ import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 import { useAuthStore } from "@/stores/auth-store";
 import {
+  backendErrorCodeToastMessage,
   backendErrorToastMessage,
   errorFromBackendBody,
   humanizeTaskError,
@@ -85,6 +86,8 @@ export function useTaskStream(options: UseTaskStreamOptions): TaskStreamState {
   const taskErrorMessage = useCallback(
     (data: Pick<TaskStreamEvent, "error" | "error_code">, fallback: string) => {
       const message = data.error || fallback;
+      const localized = backendErrorCodeToastMessage(data.error_code, message, t);
+      if (localized) return localized;
       const status = data.error_code === "INSUFFICIENT_CREDITS" ? 402 : 409;
       const parsed = data.error_code
         ? errorFromBackendBody(

--- a/frontend/src/lib/api-errors.ts
+++ b/frontend/src/lib/api-errors.ts
@@ -2,6 +2,30 @@
 // Copyright (c) 2026 ClaymoreLab
 import type { TFunction } from "i18next";
 import { HTTPError } from "ky";
+import type { ErrorResponse } from "@/types/api";
+
+export const NOVEL_IMPORT_REQUIRED_CODE = "NOVEL_IMPORT_REQUIRED";
+
+export function backendErrorCodeToastMessage(
+  errorCode: string | null | undefined,
+  fallback: string,
+  t: TFunction,
+): string | null {
+  if (errorCode === NOVEL_IMPORT_REQUIRED_CODE) {
+    return t("common.novelImportRequired", { defaultValue: fallback });
+  }
+  return null;
+}
+
+export function backendErrorResponseToastMessage(
+  response: Pick<ErrorResponse, "code" | "error">,
+  t: TFunction,
+): string {
+  return (
+    backendErrorCodeToastMessage(response.code, response.error, t) ??
+    backendErrorToastMessage(new Error(response.error), t)
+  );
+}
 
 export class ProjectQueueLimitError extends Error {
   queueKind: string;

--- a/frontend/src/lib/queries/characters.ts
+++ b/frontend/src/lib/queries/characters.ts
@@ -44,7 +44,7 @@ export function useCharacters(project: string) {
 export function useBuildCharacters(project: string) {
   return useMutation({
     mutationFn: () =>
-      jsonWithBackendError<TaskResponse>(
+      jsonWithBackendError<TaskResponse | ErrorResponse>(
         api.post(p`api/v1/projects/${project}/characters/build`, {
           json: {},
           throwHttpErrors: false,

--- a/frontend/src/routes/_app/projects.$project/characters.lazy.tsx
+++ b/frontend/src/routes/_app/projects.$project/characters.lazy.tsx
@@ -59,6 +59,7 @@ import {
   useUploadPortrait,
 } from "@/lib/queries/characters";
 import {
+  backendErrorResponseToastMessage,
   backendErrorToastMessage,
   BillingRuleNotConfiguredError,
 } from "@/lib/api-errors";
@@ -3167,7 +3168,11 @@ function CharactersPageContent() {
   const handleBuild = async () => {
     setRebuildDialogOpen(false);
     try {
-      await buildChars.mutateAsync();
+      const res = await buildChars.mutateAsync();
+      if (res.ok === false) {
+        toast.error(backendErrorResponseToastMessage(res, t));
+        return;
+      }
       setBuildStarted(true);
     } catch (error) {
       toast.error(backendErrorToastMessage(error, t));

--- a/frontend/src/routes/_app/projects.$project/episodes.tsx
+++ b/frontend/src/routes/_app/projects.$project/episodes.tsx
@@ -45,6 +45,7 @@ import { useTaskController } from "@/hooks/use-task-controller";
 import { TASK_TYPES } from "@/lib/task-types";
 import { queryKeys } from "@/lib/query-keys";
 import {
+  backendErrorResponseToastMessage,
   backendErrorToastMessage,
   BillingRuleNotConfiguredError,
 } from "@/lib/api-errors";
@@ -908,7 +909,7 @@ function EpisodesPage() {
     try {
       const res = await planEpisodes.mutateAsync({});
       if (res.ok === false) {
-        toast.error(backendErrorToastMessage(res.error, t));
+        toast.error(backendErrorResponseToastMessage(res, t));
         return;
       }
       planTask.start();

--- a/frontend/src/task-center/task-errors.ts
+++ b/frontend/src/task-center/task-errors.ts
@@ -1,10 +1,19 @@
 // SPDX-License-Identifier: Elastic-2.0
 // Copyright (c) 2026 ClaymoreLab
 import type { TFunction } from "i18next";
-import { humanizeTaskError } from "@/lib/api-errors";
+import {
+  backendErrorCodeToastMessage,
+  humanizeTaskError,
+} from "@/lib/api-errors";
 import type { TaskState } from "./types";
 
 export function taskErrorMessage(task: TaskState, t: TFunction): string {
+  const localized = backendErrorCodeToastMessage(
+    task.error_code,
+    task.error || t("common.error"),
+    t,
+  );
+  if (localized) return localized;
   if (task.error_code === "INSUFFICIENT_CREDITS") {
     return t("common.insufficientCredits", {
       defaultValue: task.error || t("common.error"),

--- a/license-inventory.csv
+++ b/license-inventory.csv
@@ -1391,6 +1391,7 @@ src/novelvideo/model_gateway_runtime.py,Elastic-2.0,2026 SuperTale contributors,
 src/novelvideo/model_gateway_settings.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 src/novelvideo/models.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 src/novelvideo/newapi_provisioner.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
+src/novelvideo/novel_source.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 src/novelvideo/official_defaults.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 src/novelvideo/ports/__init__.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 src/novelvideo/ports/audit.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
@@ -1615,6 +1616,7 @@ tests/test_api_grid_cut.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml ag
 tests/test_api_grid_upload_prompt.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_api_ingest_chapter_preview.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_api_model_credit_cost.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
+tests/test_api_novel_prerequisites.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_api_narrator_voice.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_api_pipeline_manual_shots.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_api_project_resolution.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation

--- a/src/novelvideo/agents/episode_planner.py
+++ b/src/novelvideo/agents/episode_planner.py
@@ -398,6 +398,7 @@ class EpisodePlannerAgent:
             规划的剧集列表
         """
         from novelvideo.cognee.pipeline import extract_episodes_with_characters
+        from novelvideo.novel_source import require_imported_novel
 
         def log(message: str):
             if on_log:
@@ -407,9 +408,7 @@ class EpisodePlannerAgent:
         log("使用旧方案（单次 LLM 调用）...")
 
         # 从文件加载原文
-        novel_content = self.store.load_novel_content()
-        if not novel_content:
-            raise ValueError("无法加载原文内容")
+        novel_content = require_imported_novel(self.store.project_dir)
 
         episodes = await extract_episodes_with_characters(
             novel_content,

--- a/src/novelvideo/api/routes/characters.py
+++ b/src/novelvideo/api/routes/characters.py
@@ -22,6 +22,7 @@ from novelvideo.api.deps import (
     resolve_project_scope,
 )
 from novelvideo.project_context import ProjectContext
+from novelvideo.novel_source import has_imported_novel, novel_import_required_response
 from novelvideo.ports import get_task_backend
 from novelvideo.task_identity import project_task_state_key
 from novelvideo.api.schemas import (
@@ -596,6 +597,8 @@ async def build_characters(project: str, user: dict = Depends(get_api_user)):
     ctx = resolved.ctx
     output_dir = resolved.output_dir
     if ctx is not None:
+        if not has_imported_novel(resolved.project_dir):
+            return novel_import_required_response()
         queued = await get_task_backend().enqueue_project_task(
             ctx,
             task_type="build_characters",

--- a/src/novelvideo/api/routes/episodes.py
+++ b/src/novelvideo/api/routes/episodes.py
@@ -14,6 +14,7 @@ from novelvideo.api.deps import (
     resolve_project_scope,
 )
 from novelvideo.api.schemas import EpisodePlanRequest, EpisodeUpdate, InsertManualShotRequest
+from novelvideo.novel_source import has_imported_novel, novel_import_required_response
 from novelvideo.ports import get_task_backend, get_usage_meter
 from novelvideo.task_identity import project_task_state_key
 
@@ -246,6 +247,8 @@ async def plan_episodes(project: str, body: EpisodePlanRequest, user: dict = Dep
     }
 
     if ctx is not None:
+        if not has_imported_novel(resolved.project_dir):
+            return novel_import_required_response()
         queued = await get_task_backend().enqueue_project_task(
             ctx,
             task_type="build_episodes",

--- a/src/novelvideo/api/routes/scenes.py
+++ b/src/novelvideo/api/routes/scenes.py
@@ -34,6 +34,7 @@ from novelvideo.models import (
     build_scene_effective_prompt,
     resolve_scene_plate_from_records,
 )
+from novelvideo.novel_source import has_imported_novel, novel_import_required_response
 from novelvideo.project_config import load_project_config_file
 from novelvideo.project_context import ProjectContext, resolve_project_context
 from novelvideo.sqlite_store import SQLiteStore
@@ -899,7 +900,7 @@ async def delete_scene(
 
 @router.post("/projects/{project}/scenes/build")
 async def build_scenes(project: str, user: dict = Depends(get_api_user)):
-    ctx, username, project_name, _project_dir, output_dir, store = (
+    ctx, username, project_name, project_dir, output_dir, store = (
         await _resolve_scene_project(
             project,
             user,
@@ -907,6 +908,8 @@ async def build_scenes(project: str, user: dict = Depends(get_api_user)):
         )
     )
     if ctx is not None:
+        if not has_imported_novel(project_dir):
+            return novel_import_required_response()
         queued = await get_task_backend().enqueue_project_task(
             ctx,
             task_type="build_scenes",

--- a/src/novelvideo/cognee/store.py
+++ b/src/novelvideo/cognee/store.py
@@ -25,6 +25,7 @@ with preserve_st_env():
 from rich.console import Console
 from novelvideo.config import get_newapi_reasoning_kwargs
 from novelvideo.official_defaults import DEFAULT_COGNEE_LLM_MODEL
+from novelvideo.novel_source import require_imported_novel
 from novelvideo.sqlite_store import SQLiteStore
 from novelvideo.utils.document_parsers import load_novel_text
 
@@ -624,10 +625,10 @@ class CogneeStore:
                 on_log(message)
             console.print(f"[dim]{message}[/dim]")
 
+        novel_text = require_imported_novel(self.project_dir)
         report(0.1, "从图谱提取人物节点...")
         log("从图谱提取角色候选...")
         self._set_cognee_context()
-        novel_text = self.load_novel_content()
         characters = await extract_characters_from_graph(
             dataset_name=self.dataset_name,
             project_name=self.project_name,
@@ -690,11 +691,8 @@ class CogneeStore:
 
         # 获取原文内容
         log("从文件加载原文...")
-        novel_content = self.load_novel_content()
-        if novel_content:
-            log(f"原文加载完成: {len(novel_content)} 字符")
-        else:
-            raise ValueError("请先导入小说（调用 ingest_novel_fast）")
+        novel_content = require_imported_novel(self.project_dir)
+        log(f"原文加载完成: {len(novel_content)} 字符")
 
         # 获取已确认的角色列表
         character_names = list(self._characters.keys())
@@ -760,9 +758,7 @@ class CogneeStore:
         # 获取小说原文
         if novel_text is None:
             log("从文件加载原文...")
-            novel_text = self.load_novel_content()
-            if not novel_text:
-                raise ValueError("请先导入小说（调用 ingest_novel_fast）")
+            novel_text = require_imported_novel(self.project_dir)
             log(f"原文加载完成: {len(novel_text)} 字符")
 
         # 清理剧集内容
@@ -878,9 +874,7 @@ class CogneeStore:
 
         # 1. 加载原文并检测章节
         log("从文件加载原文...")
-        novel_text = self.load_novel_content()
-        if not novel_text:
-            raise ValueError("请先导入小说（调用 ingest_novel_fast）")
+        novel_text = require_imported_novel(self.project_dir)
 
         log(f"原文加载完成: {len(novel_text)} 字符")
 
@@ -1713,11 +1707,7 @@ class CogneeStore:
             console.print(f"[dim]{message}[/dim]")
 
         report(0.1, "解析剧本提取场景...")
-        novel_text = self.load_novel_content()
-        if not novel_text:
-            log("⚠️ 未找到剧本原文（novel.txt），无法提取场景")
-            report(1.0, "提取失败：无原文")
-            return []
+        novel_text = require_imported_novel(self.project_dir)
 
         log(f"加载剧本原文: {len(novel_text)} 字符")
         scenes = await extract_scenes_from_script(

--- a/src/novelvideo/novel_source.py
+++ b/src/novelvideo/novel_source.py
@@ -1,0 +1,43 @@
+"""Canonical novel-source prerequisite checks."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+NOVEL_IMPORT_REQUIRED_MESSAGE = "请先导入小说"
+NOVEL_IMPORT_REQUIRED_CODE = "NOVEL_IMPORT_REQUIRED"
+
+
+class NovelImportRequiredError(ValueError):
+    error_code = NOVEL_IMPORT_REQUIRED_CODE
+
+    def __init__(self) -> None:
+        super().__init__(NOVEL_IMPORT_REQUIRED_MESSAGE)
+
+
+def novel_import_required_response() -> dict[str, str | bool]:
+    return {
+        "ok": False,
+        "code": NOVEL_IMPORT_REQUIRED_CODE,
+        "error": NOVEL_IMPORT_REQUIRED_MESSAGE,
+    }
+
+
+def load_imported_novel_content(project_dir: str | Path) -> str | None:
+    novel_path = Path(project_dir) / "novel.txt"
+    if not novel_path.exists():
+        return None
+    return novel_path.read_text(encoding="utf-8")
+
+
+def has_imported_novel(project_dir: str | Path) -> bool:
+    content = load_imported_novel_content(project_dir)
+    return bool(content and content.strip())
+
+
+def require_imported_novel(project_dir: str | Path) -> str:
+    content = load_imported_novel_content(project_dir)
+    if not content or not content.strip():
+        raise NovelImportRequiredError()
+    return content

--- a/src/novelvideo/sqlite_store.py
+++ b/src/novelvideo/sqlite_store.py
@@ -19,7 +19,6 @@ from typing import Any, Dict, List, Optional
 import aiosqlite
 from rich.console import Console
 
-from novelvideo.sqlite_pragmas import configure_sqlite_connection_async
 from novelvideo.models import (
     CharacterIdentity,
     NovelCharacter,
@@ -31,6 +30,8 @@ from novelvideo.models import (
     normalize_detected_props,
     sync_beat_asset_refs,
 )
+from novelvideo.novel_source import load_imported_novel_content
+from novelvideo.sqlite_pragmas import configure_sqlite_connection_async
 from novelvideo.utils.path_resolver import compute_identity_path
 
 console = Console()
@@ -479,10 +480,7 @@ class SQLiteStore:
         novel_path.write_text(content, encoding="utf-8")
 
     def load_novel_content(self) -> Optional[str]:
-        novel_path = Path(self.project_dir) / "novel.txt"
-        if novel_path.exists():
-            return novel_path.read_text(encoding="utf-8")
-        return None
+        return load_imported_novel_content(self.project_dir)
 
     async def save_episode_content(self, ep_num: int, content: str) -> None:
         db = await self._ensure_db()

--- a/src/novelvideo/task_backend/run_core.py
+++ b/src/novelvideo/task_backend/run_core.py
@@ -334,6 +334,11 @@ def _project_task_timeout_seconds() -> int:
 
 
 def _project_task_failure_for_exception(exc: BaseException) -> tuple[str, dict[str, Any], bool]:
+    from novelvideo.novel_source import NovelImportRequiredError
+
+    if isinstance(exc, NovelImportRequiredError):
+        return str(exc), {"error_code": exc.error_code}, True
+
     if isinstance(exc, TaskTimedOut):
         timeout_seconds = int(getattr(exc, "timeout_seconds", None) or 30 * 60)
         timeout_minutes = max(round(timeout_seconds / 60), 1)

--- a/src/novelvideo/task_backend/runners/graph_build.py
+++ b/src/novelvideo/task_backend/runners/graph_build.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 from typing import Any
 
+from novelvideo.novel_source import require_imported_novel
 from novelvideo.project_context import ProjectContext
 from novelvideo.task_backend.cancel import await_envelope_with_cancel_watch
 from novelvideo.task_backend.registry import register_project_task_runner
@@ -42,6 +43,7 @@ def run_build_characters(envelope: dict[str, Any], ctx: ProjectContext) -> dict[
 
 
 async def _run_build_characters(ctx: ProjectContext) -> dict[str, Any]:
+    require_imported_novel(ctx.output_dir)
     store = await _load_store(ctx)
     try:
         characters = await store.build_characters_from_graph(
@@ -58,6 +60,7 @@ def run_build_scenes(envelope: dict[str, Any], ctx: ProjectContext) -> dict[str,
 
 
 async def _run_build_scenes(ctx: ProjectContext) -> dict[str, Any]:
+    require_imported_novel(ctx.output_dir)
     store = await _load_store(ctx)
     try:
         scenes = await store.build_scenes_from_graph(
@@ -98,6 +101,7 @@ async def _run_build_episodes(envelope: dict[str, Any], ctx: ProjectContext) -> 
     use_agent = bool(config.get("use_agent_planner", True))
     planning_mode = str(config.get("planning_mode", "ai"))
     generate_metadata = bool(config.get("generate_metadata", False))
+    require_imported_novel(ctx.output_dir)
     store = await _load_store(ctx)
     try:
         def update(progress: float, task: str) -> None:

--- a/tests/contract/test_m03_episodes_scripts_content.py
+++ b/tests/contract/test_m03_episodes_scripts_content.py
@@ -191,6 +191,7 @@ def m03_client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     monkeypatch.delenv("ST_CONTROL_PLANE_DSN", raising=False)
     monkeypatch.setenv("ST_EDITION", "ce")
     monkeypatch.setenv("ST_LOCAL_USERNAME", "alice")
+    (tmp_path / "novel.txt").write_text("测试原文", encoding="utf-8")
 
     from novelvideo.api import auth as api_auth
     from novelvideo.api.deps import ProjectResolution

--- a/tests/contract/test_m03_task_completion.py
+++ b/tests/contract/test_m03_task_completion.py
@@ -60,6 +60,7 @@ def _completion_context(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     runtime_dir = tmp_path / "runtime" / "alice" / "m03_completion"
     for path in (output_dir, state_dir, runtime_dir):
         path.mkdir(parents=True, exist_ok=True)
+    (output_dir / "novel.txt").write_text("测试原文", encoding="utf-8")
     return ProjectContext(
         project_id="proj_m03_completion",
         project_name="m03_completion",
@@ -433,6 +434,7 @@ def test_seedance2_prompt_does_not_create_media_side_effects(m03_completion_clie
 def test_chapters_without_novel_returns_ok_false(m03_completion_client):
     client, ctx = m03_completion_client
     novel_path = ctx.output_dir / "novel.txt"
+    novel_path.unlink()
     assert not novel_path.exists()
 
     response = client.get("/api/v1/projects/proj_m03_completion/chapters")

--- a/tests/contract/test_m04_route_contracts.py
+++ b/tests/contract/test_m04_route_contracts.py
@@ -180,6 +180,7 @@ def m04_client_factory(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     runtime_dir = tmp_path / "runtime" / "alice" / _PROJECT
     for path in (project_dir, state_dir, runtime_dir):
         path.mkdir(parents=True, exist_ok=True)
+    (project_dir / "novel.txt").write_text("测试原文", encoding="utf-8")
     store.project_dir = str(project_dir)
     (project_dir / "assets" / "characters" / _CHARACTER).mkdir(parents=True, exist_ok=True)
     portrait = project_dir / "assets" / "characters" / _CHARACTER / "portrait.png"

--- a/tests/contract/test_m05_route_contracts.py
+++ b/tests/contract/test_m05_route_contracts.py
@@ -278,6 +278,7 @@ def m05_client_factory(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     runtime_dir = tmp_path / "runtime" / "alice" / _PROJECT
     for path in (project_dir, state_dir, runtime_dir):
         path.mkdir(parents=True, exist_ok=True)
+    (project_dir / "novel.txt").write_text("测试原文", encoding="utf-8")
 
     ctx = ProjectContext(
         project_id="proj_m05",

--- a/tests/contract/test_m07_tasks.py
+++ b/tests/contract/test_m07_tasks.py
@@ -108,6 +108,8 @@ async def test_ce_generation_submit_returns_inline_backend(monkeypatch, tmp_path
     from novelvideo.api.schemas import EpisodePlanRequest
 
     ctx = _ctx(tmp_path)
+    Path(ctx.output_dir).mkdir(parents=True, exist_ok=True)
+    (Path(ctx.output_dir) / "novel.txt").write_text("剧本文本", encoding="utf-8")
 
     async def fake_resolve_project_scope(project, user, *, required_role="viewer"):
         return SimpleNamespace(

--- a/tests/test_api_assets.py
+++ b/tests/test_api_assets.py
@@ -1605,6 +1605,7 @@ async def test_build_scenes_allows_supplement_when_derived_scenes_exist(
             NovelScene(name="故宫_下雪", base_scene_id="故宫", variant_id="下雪"),
         ]
     )
+    (tmp_path / "novel.txt").write_text("剧本文本", encoding="utf-8")
     _patch_project(monkeypatch, scenes, tmp_path, store)
 
     async def fake_resolve_scene_project(

--- a/tests/test_api_novel_prerequisites.py
+++ b/tests/test_api_novel_prerequisites.py
@@ -1,0 +1,104 @@
+"""Novel-import prerequisites for project-level build tasks."""
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from novelvideo.api.schemas import EpisodePlanRequest
+from novelvideo.novel_source import (
+    NOVEL_IMPORT_REQUIRED_CODE,
+    NOVEL_IMPORT_REQUIRED_MESSAGE,
+    has_imported_novel,
+    require_imported_novel,
+)
+
+
+class RejectEnqueueBackend:
+    async def enqueue_project_task(self, *_args, **_kwargs):
+        raise AssertionError("task must not be enqueued without an imported novel")
+
+
+def test_imported_novel_requires_non_whitespace_content(tmp_path: Path):
+    assert has_imported_novel(tmp_path) is False
+
+    (tmp_path / "novel.txt").write_text("  \n\t", encoding="utf-8")
+    assert has_imported_novel(tmp_path) is False
+    with pytest.raises(ValueError, match=f"^{NOVEL_IMPORT_REQUIRED_MESSAGE}$"):
+        require_imported_novel(tmp_path)
+
+    (tmp_path / "novel.txt").write_text("小说正文", encoding="utf-8")
+    assert has_imported_novel(tmp_path) is True
+    assert require_imported_novel(tmp_path) == "小说正文"
+
+
+@pytest.mark.asyncio
+async def test_build_characters_rejects_missing_novel_before_enqueue(tmp_path, monkeypatch):
+    from novelvideo.api.routes import characters
+
+    ctx = SimpleNamespace(project_id="project-1")
+
+    async def resolve_scope(project, user, *, required_role="viewer"):
+        return SimpleNamespace(ctx=ctx, project_dir=tmp_path, output_dir=str(tmp_path))
+
+    monkeypatch.setattr(characters, "resolve_project_scope", resolve_scope)
+    monkeypatch.setattr(characters, "get_task_backend", RejectEnqueueBackend)
+
+    response = await characters.build_characters("project-1", user={"username": "alice"})
+
+    assert response == {
+        "ok": False,
+        "code": NOVEL_IMPORT_REQUIRED_CODE,
+        "error": NOVEL_IMPORT_REQUIRED_MESSAGE,
+    }
+
+
+@pytest.mark.asyncio
+async def test_build_scenes_rejects_missing_novel_before_enqueue(tmp_path, monkeypatch):
+    from novelvideo.api.routes import scenes
+
+    ctx = SimpleNamespace(project_id="project-1")
+
+    async def resolve_scene(project, user, *, required_role="editor"):
+        return ctx, "alice", "demo", tmp_path, str(tmp_path), object()
+
+    monkeypatch.setattr(scenes, "_resolve_scene_project", resolve_scene)
+    monkeypatch.setattr(scenes, "get_task_backend", RejectEnqueueBackend)
+
+    response = await scenes.build_scenes("project-1", user={"username": "alice"})
+
+    assert response == {
+        "ok": False,
+        "code": NOVEL_IMPORT_REQUIRED_CODE,
+        "error": NOVEL_IMPORT_REQUIRED_MESSAGE,
+    }
+
+
+@pytest.mark.asyncio
+async def test_plan_episodes_rejects_missing_novel_before_enqueue(tmp_path, monkeypatch):
+    from novelvideo.api.routes import episodes
+
+    ctx = SimpleNamespace(project_id="project-1")
+
+    async def resolve_scope(project, user, *, required_role="viewer"):
+        return SimpleNamespace(
+            ctx=ctx,
+            project_dir=tmp_path,
+            output_dir=str(tmp_path),
+            state_dir=str(tmp_path / "state"),
+        )
+
+    monkeypatch.setattr(episodes, "resolve_project_scope", resolve_scope)
+    monkeypatch.setattr(episodes, "get_task_backend", RejectEnqueueBackend)
+
+    response = await episodes.plan_episodes(
+        "project-1",
+        EpisodePlanRequest(),
+        user={"username": "alice"},
+    )
+
+    assert response == {
+        "ok": False,
+        "code": NOVEL_IMPORT_REQUIRED_CODE,
+        "error": NOVEL_IMPORT_REQUIRED_MESSAGE,
+    }

--- a/tests/test_sqlite_store.py
+++ b/tests/test_sqlite_store.py
@@ -99,7 +99,7 @@ async def test_build_characters_from_graph_only_adds_missing_characters(tmp_proj
         "extract_characters_from_graph",
         fake_extract_characters_from_graph,
     )
-    monkeypatch.setattr(tmp_project, "load_novel_content", lambda: "剧本文本")
+    tmp_project.save_novel_content("剧本文本")
 
     added = await tmp_project.build_characters_from_graph()
 
@@ -195,7 +195,7 @@ async def test_build_scenes_from_graph_only_adds_missing_base_scenes(tmp_project
         ]
 
     monkeypatch.setattr(pipeline, "extract_scenes_from_script", fake_extract_scenes_from_script)
-    monkeypatch.setattr(tmp_project, "load_novel_content", lambda: "剧本文本")
+    tmp_project.save_novel_content("剧本文本")
 
     added = await tmp_project.build_scenes_from_graph()
 
@@ -208,6 +208,15 @@ async def test_build_scenes_from_graph_only_adds_missing_base_scenes(tmp_project
     assert derived.base_scene_id == "城市街道"
     assert derived.variant_prompt == "用户修过的雨夜增量"
     assert await tmp_project.sqlite_store.get_scene("新场景") is not None
+
+
+@pytest.mark.asyncio
+async def test_graph_build_steps_reject_missing_novel(tmp_project):
+    with pytest.raises(ValueError, match="^请先导入小说$"):
+        await tmp_project.build_characters_from_graph()
+
+    with pytest.raises(ValueError, match="^请先导入小说$"):
+        await tmp_project.build_scenes_from_graph()
 
 
 @pytest.mark.asyncio

--- a/tests/test_task_credit_errors.py
+++ b/tests/test_task_credit_errors.py
@@ -3,6 +3,11 @@ import sys
 
 import pytest
 
+from novelvideo.novel_source import (
+    NOVEL_IMPORT_REQUIRED_CODE,
+    NOVEL_IMPORT_REQUIRED_MESSAGE,
+    NovelImportRequiredError,
+)
 from novelvideo.shared.billing_errors import (
     INSUFFICIENT_CREDITS_CODE,
     INSUFFICIENT_CREDITS_MESSAGE,
@@ -53,6 +58,18 @@ def test_celery_task_failure_maps_insufficient_credits_stop(monkeypatch) -> None
     assert metadata["error_code"] == INSUFFICIENT_CREDITS_CODE
     assert metadata["required"] == 2
     assert metadata["balance"] == 1
+
+
+def test_task_failure_maps_novel_import_prerequisite(monkeypatch) -> None:
+    celery_tasks = _import_celery_tasks(monkeypatch)
+
+    error, metadata, handled = celery_tasks._project_task_failure_for_exception(
+        NovelImportRequiredError()
+    )
+
+    assert handled is True
+    assert error == NOVEL_IMPORT_REQUIRED_MESSAGE
+    assert metadata == {"error_code": NOVEL_IMPORT_REQUIRED_CODE}
 
 
 def test_celery_task_failure_maps_output_moderation(monkeypatch) -> None:


### PR DESCRIPTION
## Summary

- reject character, scene, and episode planning requests before task enqueue when the project has no non-empty imported novel
- return a stable `NOVEL_IMPORT_REQUIRED` error code and localize the message using the frontend's current language
- add task-runner fallback validation for race conditions such as the source being removed after enqueue
- show the prerequisite message without starting a missing task stream
- preserve normal CE behavior and the existing EE billing path for valid tasks

## Root cause

Character and scene build actions could be dispatched without source text. The character page also treated an HTTP 200 response with `ok: false` as a successful task dispatch, enabled SSE tracking, and replaced the useful prerequisite error with `Task not found`.

## User impact

Users now see `请先导入小说` in Chinese or `Please import a novel first` in English when source text is missing. No task is created, so EE does not reserve or charge credits for rejected requests. Valid imported-novel tasks continue through the existing enqueue and billing flow.

## Verification

- `uv run pytest -q` — 1695 passed, 16 skipped, 2 deselected
- `uv run ruff check ...` — passed for changed Python files
- `bun run test` — 1762 passed
- `bun run build:ce` — passed
- `git diff --check` — passed

## Impact notes

- no migration
- no configuration change
- no model-provider change
- license inventory updated for new source and test files
