### PR TITLE
fix: make Seedance follow the prepared first frame

### DIFF
--- a/src/novelvideo/generators/video_generator.py
+++ b/src/novelvideo/generators/video_generator.py
@@ -468,7 +468,10 @@ class SeedanceVideoGenerator(VideoGeneratorBase):
         duration = max(4, min(12, math.ceil(duration)))
 
         # 映射 aspect_ratio 格式
-        ratio = aspect_ratio if ":" in aspect_ratio else "9:16"
+        ratio_text = str(aspect_ratio or "").strip().lower()
+        # Seedance I2V uses ``adaptive`` to preserve the first-frame framing.
+        # The old colon-only guard accidentally converted it back to 9:16.
+        ratio = ratio_text if ":" in ratio_text or ratio_text == "adaptive" else "9:16"
 
         # 处理首帧
         if image_path.startswith(("http://", "https://", "data:")):
@@ -2202,7 +2205,10 @@ class NewApiVideoGenerator(VideoGeneratorBase):
         if duration != original_duration:
             log(f"时长已调整: {original_duration:.1f}s -> {duration:.0f}s")
 
-        ratio = aspect_ratio if ":" in aspect_ratio else "9:16"
+        ratio_text = str(aspect_ratio or "").strip().lower()
+        # Seedance I2V uses ``adaptive`` to preserve the first-frame framing.
+        # The old colon-only guard accidentally converted it back to 9:16.
+        ratio = ratio_text if ":" in ratio_text or ratio_text == "adaptive" else "9:16"
         image_path = str(image_path or "").strip()
 
         metadata: dict[str, object] = {

--- a/src/novelvideo/task_backend/runners/video.py
+++ b/src/novelvideo/task_backend/runners/video.py
@@ -31,6 +31,19 @@ def _log(manager, ctx: ProjectContext, envelope: dict[str, Any], message: str) -
     )
 
 
+def _resolve_video_aspect_ratio(value: object, frame_path: object) -> str:
+    """Use the provider's adaptive mode when I2V should follow its first frame.
+
+    Legacy Seedance 1.x tasks historically omitted ``ratio`` and were forced to
+    9:16.  Seedance does not expose a fixed 2:3 output preset, but its I2V API
+    supports ``adaptive`` specifically for following the supplied first frame.
+    """
+    requested = str(value or "").strip()
+    if requested and requested.lower() != "auto":
+        return requested
+    return "adaptive" if str(frame_path or "").strip() else "9:16"
+
+
 def _append_freezone_video_node_history(
     *,
     ctx: ProjectContext,
@@ -175,7 +188,7 @@ async def _run_single_video_async(envelope: dict[str, Any], ctx: ProjectContext)
         "image_path": frame_path,
         "prompt": prompt,
         "output_path": video_path.as_posix(),
-        "aspect_ratio": str(config.get("ratio") or "9:16"),
+        "aspect_ratio": _resolve_video_aspect_ratio(config.get("ratio"), frame_path),
         "duration": video_duration,
         "on_log": on_log,
         "on_progress": on_progress,

--- a/tests/test_seedance2_request.py
+++ b/tests/test_seedance2_request.py
@@ -616,6 +616,46 @@ async def test_newapi_seedance2_generator_preserves_config_resolution_and_scene_
     assert payload["seconds"] == "8"
 
 
+async def test_newapi_seedance1_generator_preserves_adaptive_ratio(tmp_path, monkeypatch):
+    from novelvideo.generators import video_generator as video_module
+    from novelvideo.generators.video_generator import NewApiVideoGenerator
+
+    captured: dict[str, object] = {}
+    generator = NewApiVideoGenerator(
+        api_key="test-key",
+        endpoint="https://newapi.example",
+        model="seedance-1.0-pro-fast",
+        resolution="720p",
+    )
+
+    async def fake_reserve(*_args, **_kwargs):
+        return "reservation-1"
+
+    async def fake_refund(*_args, **_kwargs):
+        return None
+
+    async def fake_post_json(_url: str, payload: dict):
+        captured["payload"] = payload
+        return {}
+
+    monkeypatch.setattr(video_module, "_reserve_video_model_call", fake_reserve)
+    monkeypatch.setattr(video_module, "_refund_video_model_call", fake_refund)
+    monkeypatch.setattr(generator, "_post_json", fake_post_json)
+
+    await generator.generate(
+        image_path="https://example.com/first.png",
+        prompt="人物缓慢抬头。",
+        output_path=str(tmp_path / "out.mp4"),
+        aspect_ratio="adaptive",
+    )
+
+    payload = captured["payload"]
+    assert isinstance(payload, dict)
+    metadata = payload["metadata"]
+    assert isinstance(metadata, dict)
+    assert metadata["ratio"] == "adaptive"
+
+
 async def test_newapi_happyhorse_video_generator_uses_happyhorse_payload(tmp_path, monkeypatch):
     from pathlib import Path
 

--- a/tests/test_task_video_runner_returned_last_frame.py
+++ b/tests/test_task_video_runner_returned_last_frame.py
@@ -28,6 +28,15 @@ def _ctx(tmp_path: Path) -> ProjectContext:
     )
 
 
+def test_video_aspect_ratio_uses_adaptive_mode_for_first_frame():
+    from novelvideo.task_backend.runners.video import _resolve_video_aspect_ratio
+
+    assert _resolve_video_aspect_ratio("auto", "/tmp/first.png") == "adaptive"
+    assert _resolve_video_aspect_ratio(None, "/tmp/first.png") == "adaptive"
+    assert _resolve_video_aspect_ratio("9:16", "/tmp/first.png") == "9:16"
+    assert _resolve_video_aspect_ratio(None, None) == "9:16"
+
+
 @pytest.mark.asyncio
 async def test_single_video_runner_includes_returned_last_frame_in_task_result(
     tmp_path,


### PR DESCRIPTION
## What changed

- use Seedance I2V adaptive aspect-ratio mode whenever a first frame is present and no explicit ratio is required
- preserve the adaptive value through both the direct Seedance generator and the NewAPI video generator
- keep the existing prepared-first-frame workflow unchanged: uncropped 2:3 stays 2:3, a 9:16 crop generates 9:16, and a 16:9 first frame generates 16:9

## Root cause

The pipeline already prepares/crops the actual first frame before video generation. However, the worker defaulted a missing ratio to 9:16, and both Seedance generator paths treated any value without a colon—including adaptive—as invalid and replaced it with 9:16. This overrode the first-frame framing.

## User impact

Seedance 1.x now follows the actual frame supplied by the existing crop workflow. No additional aspect-ratio control is introduced, so users cannot accidentally select a ratio that conflicts with the prepared first frame.

## Validation

- uv run ruff check on all changed Python files — passed
- uv run pytest tests/test_task_video_runner_returned_last_frame.py tests/test_seedance2_request.py -q — 24 passed

Closes #165