### PR TITLE
fix: inherit beat Render aspect from sketch

### DIFF
--- a/frontend/src/__tests__/components/episode/beat-workbench/render-section.test.tsx
+++ b/frontend/src/__tests__/components/episode/beat-workbench/render-section.test.tsx
@@ -537,6 +537,54 @@ describe("RenderSection", () => {
     });
   });
 
+  it("prefers the source sketch aspect over the project aspect", async () => {
+    const user = userEvent.setup();
+    useAspectRatioStore.getState().setOrientation("demo", "landscape");
+    regenerateMock.mockResolvedValue({ ok: true, scope: "render-scope" });
+    class MockImage {
+      naturalWidth = 1200;
+      naturalHeight = 1800;
+      onload: (() => void) | null = null;
+
+      set src(_value: string) {
+        queueMicrotask(() => this.onload?.());
+      }
+    }
+    vi.stubGlobal("Image", MockImage);
+
+    try {
+      render(
+        <I18nextProvider i18n={i18n}>
+          <RenderSection
+            beat={{ ...beat, sketch_url: "/static/current-sketch.png" }}
+            project="demo"
+            episode={1}
+            images={[renderImage, sketchImage]}
+            assignments={{ "5": "render-5" }}
+          />
+        </I18nextProvider>,
+      );
+
+      await waitFor(() =>
+        expect(generationCreditCostMock).toHaveBeenLastCalledWith(
+          "image_selection",
+          "doubao_seedream-3.0-t2i",
+          { surface: "supertale", imageRole: "render", modeKey: "1x1_2-3" },
+        ),
+      );
+
+      await user.click(screen.getByRole("button", { name: /重新生成/ }));
+      await user.click(screen.getByRole("button", { name: "确认" }));
+
+      expect(regenerateMock).toHaveBeenCalledWith({
+        beatIndices: [5],
+        modeKey: "1x1_2-3",
+      });
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
   it("shows render background reference controls and renders current sketch", async () => {
     const user = userEvent.setup();
     regenerateMock.mockResolvedValue({ ok: true, scope: "render-scope" });

--- a/frontend/src/__tests__/components/episode/beat-workbench/render-section.test.tsx
+++ b/frontend/src/__tests__/components/episode/beat-workbench/render-section.test.tsx
@@ -84,6 +84,7 @@ const cropBackgroundAnchorMock: Mock = vi.fn();
 const uploadBackgroundAnchorMock: Mock = vi.fn();
 const taskStartMock: Mock = vi.fn();
 const invalidateQueriesMock: Mock = vi.fn();
+const generationCreditCostMock: Mock = vi.fn();
 
 vi.mock("@tanstack/react-query", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@tanstack/react-query")>();
@@ -170,12 +171,7 @@ vi.mock("@/lib/queries/scenes", () => ({
 }));
 
 vi.mock("@/lib/queries/generation-credit-cost", () => ({
-  useGenerationCreditCost: () => ({
-    data: {
-      ok: true,
-      data: { cost: 1, display: "1 credit" },
-    },
-  }),
+  useGenerationCreditCost: (...args: unknown[]) => generationCreditCostMock(...args),
 }));
 
 vi.mock("@/hooks/use-task-controller", () => ({
@@ -353,6 +349,13 @@ beforeEach(() => {
   uploadBackgroundAnchorMock.mockResolvedValue({ ok: true });
   taskStartMock.mockReset();
   invalidateQueriesMock.mockReset();
+  generationCreditCostMock.mockReset();
+  generationCreditCostMock.mockReturnValue({
+    data: {
+      ok: true,
+      data: { cost: 1, display: "1 credit" },
+    },
+  });
   scenePlatePreviewState.data = null;
 });
 
@@ -500,6 +503,38 @@ describe("RenderSection", () => {
     expect(
       updateBackgroundAnchorMock.mock.invocationCallOrder[0],
     ).toBeLessThan(regenerateMock.mock.invocationCallOrder[0]);
+  });
+
+  it("uses the landscape project aspect for single render regeneration and credit cost", async () => {
+    const user = userEvent.setup();
+    useAspectRatioStore.getState().setOrientation("demo", "landscape");
+    regenerateMock.mockResolvedValue({ ok: true, scope: "render-scope" });
+
+    render(
+      <I18nextProvider i18n={i18n}>
+        <RenderSection
+          beat={beat}
+          project="demo"
+          episode={1}
+          images={[renderImage, sketchImage]}
+          assignments={{ "5": "render-5" }}
+        />
+      </I18nextProvider>,
+    );
+
+    expect(generationCreditCostMock).toHaveBeenCalledWith(
+      "image_selection",
+      "doubao_seedream-3.0-t2i",
+      { surface: "supertale", imageRole: "render", modeKey: "1x1_16-9" },
+    );
+
+    await user.click(screen.getByRole("button", { name: /重新生成/ }));
+    await user.click(screen.getByRole("button", { name: "确认" }));
+
+    expect(regenerateMock).toHaveBeenCalledWith({
+      beatIndices: [5],
+      modeKey: "1x1_16-9",
+    });
   });
 
   it("shows render background reference controls and renders current sketch", async () => {

--- a/frontend/src/components/episode/beat-workbench/render-section.tsx
+++ b/frontend/src/components/episode/beat-workbench/render-section.tsx
@@ -134,8 +134,29 @@ export function RenderSection({
   const { t } = useTranslation();
   const queryClient = useQueryClient();
   const { spec: aspectSpec } = useProjectAspectRatio(project);
+  const currentAssignment = assignments[String(beat.beat_number)] ?? null;
+  const currentSketch = currentAssignment
+    ? images.find((image) => isSketchAssignmentMatch(image, currentAssignment)) ?? null
+    : null;
+  const latestSketch = images
+    .filter(
+      (image) =>
+        image.type === "sketch" &&
+        image.original_beat === beat.beat_number &&
+        image.cell_url,
+    )
+    .sort((a, b) => {
+      const ta = a.generated_at ? Date.parse(a.generated_at) : 0;
+      const tb = b.generated_at ? Date.parse(b.generated_at) : 0;
+      return tb - ta;
+    })[0] ?? null;
+  const sourceSketchAspect = useImageAspectRatio(
+    beat.sketch_url || currentSketch?.cell_url || latestSketch?.cell_url || null,
+  );
   const singleRenderModeKey =
-    aspectSpec.renderAspect === "16:9" ? "1x1_16-9" : "1x1_2-3";
+    (sourceSketchAspect ?? aspectSpec.renderAspect) === "16:9"
+      ? "1x1_16-9"
+      : "1x1_2-3";
   const poolSelect = usePoolSelect(project, episode);
   const regenerate = useRegenerateRenderBeats(project, episode);
   const renderSettings = useRenderSettings(project);
@@ -200,7 +221,6 @@ export function RenderSection({
       return tb - ta;
     });
 
-  const currentAssignment = assignments[String(beat.beat_number)] ?? null;
   const assignedRender = currentAssignment
     ? images.find((i) => isRenderAssignmentMatch(i, currentAssignment)) ?? null
     : null;
@@ -1109,4 +1129,41 @@ function isRenderAssignmentMatch(img: PoolImage, assignment: string) {
       img.cell_path === assignment ||
       img.grid_path === assignment)
   );
+}
+
+function isSketchAssignmentMatch(img: PoolImage, assignment: string) {
+  return (
+    img.type === "sketch" &&
+    (img.id === assignment ||
+      img.cell_path === assignment ||
+      img.grid_path === assignment)
+  );
+}
+
+function useImageAspectRatio(url: string | null): "2:3" | "16:9" | null {
+  const [aspect, setAspect] = useState<"2:3" | "16:9" | null>(null);
+
+  useEffect(() => {
+    setAspect(null);
+    const resolvedUrl = url ? resolveMediaUrl(url) : null;
+    if (!resolvedUrl) return;
+
+    let active = true;
+    const image = new Image();
+    image.onload = () => {
+      if (!active || image.naturalWidth <= 0 || image.naturalHeight <= 0) return;
+      const ratio = image.naturalWidth / image.naturalHeight;
+      setAspect(
+        Math.abs(ratio - 16 / 9) < Math.abs(ratio - 2 / 3) ? "16:9" : "2:3",
+      );
+    };
+    image.src = resolvedUrl;
+
+    return () => {
+      active = false;
+      image.onload = null;
+    };
+  }, [url]);
+
+  return aspect;
 }

--- a/frontend/src/components/episode/beat-workbench/render-section.tsx
+++ b/frontend/src/components/episode/beat-workbench/render-section.tsx
@@ -134,6 +134,8 @@ export function RenderSection({
   const { t } = useTranslation();
   const queryClient = useQueryClient();
   const { spec: aspectSpec } = useProjectAspectRatio(project);
+  const singleRenderModeKey =
+    aspectSpec.renderAspect === "16:9" ? "1x1_16-9" : "1x1_2-3";
   const poolSelect = usePoolSelect(project, episode);
   const regenerate = useRegenerateRenderBeats(project, episode);
   const renderSettings = useRenderSettings(project);
@@ -151,7 +153,7 @@ export function RenderSection({
   const renderRegenCost = useGenerationCreditCost(
     "image_selection",
     renderSettings.data?.data.render_image_selection,
-    { surface: "supertale", imageRole: "render", modeKey: "1x1_2-3" },
+    { surface: "supertale", imageRole: "render", modeKey: singleRenderModeKey },
   );
   const uploadRender = useUploadBeatImage(project, episode, "render");
   const backgroundAnchors = useBeatBackgroundAnchors(project, episode, beat.beat_number);
@@ -259,7 +261,10 @@ export function RenderSection({
         toast.error(backgroundRes.error || t("episode.workbench.render.backgroundSaveFailed"));
         return;
       }
-      const res = await regenerate.mutateAsync({ beatIndices: [beat.beat_number], modeKey: "1x1_2-3" });
+      const res = await regenerate.mutateAsync({
+        beatIndices: [beat.beat_number],
+        modeKey: singleRenderModeKey,
+      });
       if (res.ok === false) {
         toast.error(res.error || t("episode.workbench.render.regenFailed"));
         return;

--- a/src/novelvideo/api/routes/generation.py
+++ b/src/novelvideo/api/routes/generation.py
@@ -80,7 +80,7 @@ from novelvideo.services.background_anchor_service import (
     save_uploaded_background_anchor_image,
     select_background_anchor,
 )
-from novelvideo.utils.path_resolver import compute_identity_path, compute_portrait_path
+from novelvideo.utils.path_resolver import PathResolver, compute_identity_path, compute_portrait_path
 
 router = APIRouter()
 
@@ -88,6 +88,30 @@ logger = logging.getLogger(__name__)
 
 AI_IDENTITY_DETECTION_FEATURE_KEY = "ai_identity_detection"
 MODEL_CALL_CREDIT_POLICY_FEATURE_INCLUDED = "feature_included"
+
+
+def _single_render_mode_from_sketch(
+    output_dir: str,
+    episode: int,
+    beat_indices: list[int],
+) -> str | None:
+    """Choose a single-render mode from the canonical upstream sketch."""
+    if len(beat_indices) != 1:
+        return None
+
+    from PIL import Image
+
+    sketch_path = PathResolver(output_dir, episode).sketch(int(beat_indices[0]))
+    try:
+        with Image.open(sketch_path) as image:
+            width, height = image.size
+    except Exception:
+        return None
+    if width <= 0 or height <= 0:
+        return None
+
+    ratio = width / height
+    return "1x1_16-9" if abs(ratio - 16 / 9) < abs(ratio - 2 / 3) else "1x1_2-3"
 
 
 async def _resolve_generation_project(project: str, user: dict, required_role: str = "editor"):
@@ -2785,7 +2809,12 @@ async def regenerate_beats(
         use_detected_identities=True,
     )
 
-    mode_key = body.mode_key
+    # The selected sketch is the source of truth for a single Render. The
+    # client mode remains a compatibility fallback for missing legacy assets.
+    mode_key = (
+        _single_render_mode_from_sketch(output_dir, episode_num, body.beat_indices)
+        or body.mode_key
+    )
     episode_obj = _episode_from_store_or_none(store, episode_num)
     prop_menu = await _runtime_prop_menu_with_global_props(store, episode_obj, beats)
     config = {

--- a/tests/test_api_render_regenerate.py
+++ b/tests/test_api_render_regenerate.py
@@ -198,6 +198,39 @@ def test_render_selected_regen_returns_scope_and_passes_render_settings(
     assert "force_half_k" not in calls[0]["payload"]["config"]
 
 
+@pytest.mark.parametrize(
+    ("sketch_size", "requested_mode", "expected_mode"),
+    [
+        ((1200, 1800), "1x1_16-9", "1x1_2-3"),
+        ((1920, 1080), "1x1_2-3", "1x1_16-9"),
+    ],
+)
+def test_single_render_inherits_canonical_sketch_aspect(
+    monkeypatch,
+    tmp_path,
+    sketch_size,
+    requested_mode,
+    expected_mode,
+):
+    from PIL import Image
+    from novelvideo.task_identity import selection_scope
+
+    sketch_path = tmp_path / "sketches" / "ep002" / "beat_01.png"
+    sketch_path.parent.mkdir(parents=True)
+    Image.new("RGB", sketch_size).save(sketch_path)
+    client, calls = _client(monkeypatch, tmp_path)
+
+    response = client.post(
+        "/api/v1/projects/demo/episodes/2/beats/regenerate",
+        json={"beat_indices": [1], "mode_key": requested_mode},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["scope"] == selection_scope(expected_mode, [1])
+    assert calls[0]["payload"]["mode_key"] == expected_mode
+    assert calls[0]["payload"]["config"]["mode_key"] == expected_mode
+
+
 def test_render_selected_regen_checks_only_selected_beat_detection(monkeypatch, tmp_path):
     client, calls, seen_character_map_beats = _client_with_real_detection_guard(
         monkeypatch,


### PR DESCRIPTION
## What changed

- derive single-Beat Render mode from the current upstream sketch's real dimensions
- use the same inherited mode for credit estimation and the regeneration request
- validate the canonical sketch again in the backend before enqueueing, protecting old clients and direct API calls
- retain the project aspect only as a fallback when no readable sketch exists
- add frontend and backend regressions for both portrait and landscape inheritance

## Why

Single-Beat Render hardcoded the portrait `1x1_2-3` mode. Using only the project setting as a replacement would still be wrong after a project aspect change because an existing sketch keeps its original dimensions. The upstream sketch must remain the source of truth.

## Impact

Render regeneration now follows the actual sketch: 2:3 sketch → 2:3 Render, 16:9 sketch → 16:9 Render. No migration is required.

## Verification

- `cd frontend && npm test -- --run src/__tests__/components/episode/beat-workbench/render-section.test.tsx`
- `uv run pytest tests/test_api_render_regenerate.py -q`
- `uv run ruff check src/novelvideo/api/routes/generation.py tests/test_api_render_regenerate.py`
- `git diff --check`

Closes #164
