### PR TITLE
fix: align video input crop with output ratio

### DIFF
--- a/frontend/src/__tests__/components/episode/beat-workbench/video-pane.test.tsx
+++ b/frontend/src/__tests__/components/episode/beat-workbench/video-pane.test.tsx
@@ -1228,7 +1228,7 @@ describe("VideoPane Seedance2 inspector", () => {
     });
   });
 
-  it("maps 2:3 first-frame Seedance2 crops to 9:16 video input", async () => {
+  it("uses the configured output ratio for first-frame Seedance2 crops", async () => {
     const user = userEvent.setup();
     renderPane(
       makeBeat({
@@ -1243,8 +1243,7 @@ describe("VideoPane Seedance2 inspector", () => {
     expandSeedance2References();
 
     await user.click(screen.getAllByRole("button", { name: "裁剪" })[0]);
-    expect(await screen.findByText("裁剪 9:16")).toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: "16:9" })).not.toBeInTheDocument();
+    expect(await screen.findByText("裁剪 16:9")).toBeInTheDocument();
 
     const image = screen
       .getAllByAltText("当前 render · Beat 1")
@@ -1262,10 +1261,10 @@ describe("VideoPane Seedance2 inspector", () => {
 
     await waitFor(() => {
       expect(screen.getByLabelText("移动裁剪区域")).toHaveStyle({
-        left: "8.611599297012302%",
-        top: "0%",
-        width: "82.95254833040421%",
-        height: "100%",
+        left: "0%",
+        top: "30.870083432657925%",
+        width: "100%",
+        height: "38.14064362336114%",
       });
     });
 
@@ -1276,7 +1275,7 @@ describe("VideoPane Seedance2 inspector", () => {
       assetKey: "first_frame",
       sourcePath: "frames/ep001/beat_01.png",
       target: "first_frame",
-      crop: { x: 49, y: 0, width: 472, height: 839 },
+      crop: { x: 0, y: 259, width: 569, height: 320 },
     });
   });
 
@@ -1331,7 +1330,7 @@ describe("VideoPane Seedance2 inspector", () => {
     );
   });
 
-  it("keeps 16:9 first-frame Seedance2 crops at 16:9 video input", async () => {
+  it("does not override the configured first-frame crop ratio with the project aspect", async () => {
     const user = userEvent.setup();
     useAspectRatioStore.getState().setOrientation("demo", "landscape");
     renderPane(
@@ -1347,8 +1346,7 @@ describe("VideoPane Seedance2 inspector", () => {
     expandSeedance2References();
 
     await user.click(screen.getAllByRole("button", { name: "裁剪" })[0]);
-    expect(await screen.findByText("裁剪 16:9")).toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: "9:16" })).not.toBeInTheDocument();
+    expect(await screen.findByText("裁剪 9:16")).toBeInTheDocument();
   });
 
   it("allows trimming Seedance2 audio reference assets", async () => {

--- a/frontend/src/components/episode/beat-workbench/video-pane.tsx
+++ b/frontend/src/components/episode/beat-workbench/video-pane.tsx
@@ -228,7 +228,7 @@ interface Seedance2ConfigDraft {
 }
 
 type Seedance2ReferenceField = "prompt_guidance" | "final_prompt";
-type Seedance2CropAspect = "2:3" | "9:16" | "16:9";
+type Seedance2CropAspect = Seedance2ConfigDraft["ratio"];
 
 const SEEDANCE2_AUTOSAVE_DELAY_MS = 800;
 
@@ -2549,12 +2549,8 @@ export function VideoPane({
       <Seedance2AssetCropDialog
         intent={seedance2CropIntent}
         targetCropAspect={
-          showSeedance2Config
-            ? seedance2CropAspectForMode(
-                seedance2Draft.mode,
-                seedance2Draft.ratio,
-                spec.renderAspect,
-              )
+          showSeedance2Config || showHappyHorseConfig || showGrokVideoConfig
+            ? seedance2Draft.ratio
             : videoInputCropAspectForProjectAspect(spec.renderAspect)
         }
         pending={cropSeedance2Asset.isPending}
@@ -3105,17 +3101,6 @@ function seedance2DefaultRatioForProjectAspect(
   return aspect === "16:9" ? "16:9" : "9:16";
 }
 
-function seedance2CropAspectForMode(
-  mode: Seedance2ConfigDraft["mode"],
-  ratio: Seedance2ConfigDraft["ratio"],
-  firstFrameAspect: "2:3" | "16:9",
-): Seedance2CropAspect {
-  if (mode === "first_frame" || mode === "first_last_frame") {
-    return videoInputCropAspectForProjectAspect(firstFrameAspect);
-  }
-  return ratio === "16:9" ? "16:9" : "9:16";
-}
-
 function seedance2CropTargetForAsset(
   mode: Seedance2ConfigDraft["mode"],
   asset: Seedance2AssetItem,
@@ -3134,9 +3119,8 @@ function videoInputCropAspectForProjectAspect(
 }
 
 function cropAspectRatioValue(aspect: Seedance2CropAspect): number {
-  if (aspect === "16:9") return 16 / 9;
-  if (aspect === "2:3") return 2 / 3;
-  return 9 / 16;
+  const [width, height] = aspect.split(":").map(Number);
+  return width > 0 && height > 0 ? width / height : 9 / 16;
 }
 
 function defaultSeedance2Config(


### PR DESCRIPTION
## What changed

- make Seedance 2.0, HappyHorse, and Grok image crop frames follow the currently selected output ratio
- support every ratio already exposed by those model selectors in the crop geometry
- keep Seedance 1.0/1.5 on their existing project-derived crop fallback and adaptive generation behavior
- update crop regressions to cover output ratios that differ from the project aspect

## Why

The crop dialog previously used the project aspect even after a user selected a different video output ratio. That could produce, for example, a 9:16 first-frame crop while requesting a 16:9 video.

## Impact

The crop preview now matches the configured output framing. Model requests, billing, and backend persistence are unchanged.

## Verification

- `cd frontend && npm test -- --run src/__tests__/components/episode/beat-workbench/video-pane.test.tsx` (61 passed)
- `git diff --check`

The full frontend build remains blocked by pre-existing missing local modules: `lenis`, `mediabunny`, `@ffmpeg/ffmpeg`, and `@ffmpeg/util`.
