### PR TITLE
fix(cognee): bind embedding models per project

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -80,7 +80,8 @@ COGNEE_SKIP_CONNECTION_TEST=true
 # project_config.json 的 cognee_embedding_model 决定：官方历史项目使用 v1，
 # 官方新项目使用 v2，CE 自定义 newAPI 项目使用无后缀兼容模型名。
 COGNEE_EMBEDDING_MODEL=DC-cognee-embedding
-# Cognee 本地向量引擎维度；当前 v1、v2 和 CE 自定义项目均固定为 1024 维。
+# Cognee 启动和无项目上下文旧路径的默认维度。项目实际维度由
+# project_config.json 的 cognee_embedding_dimension 决定。
 COGNEE_EMBEDDING_DIM=1024
 
 # 每次小说导入 pipeline 的上游在途请求上限。多个同时导入的 pipeline 会分别计算。
@@ -92,12 +93,6 @@ COGNEE_EMBEDDING_BATCH_CONCURRENCY=4
 # Cognee embedding 单次请求文本条数。官方默认使用 10，兼容 Qwen / 阿里等低 input 上限模型。
 # 如果上游 embedding 模型支持更大批量，可以按需调高。
 EMBEDDING_BATCH_SIZE=10
-
-# 仅作为 CE 自定义 newAPI 旧配置缺少 sendDimensions 时的兼容值。
-# 项目级 v1/v2 不读取该变量：v1 固定不发送 dimensions，v2 固定发送 dimensions=1024。
-# CE 自定义模型已保存 sendDimensions 时，以模型配置页保存的值为准。
-COGNEE_EMBEDDING_SEND_DIMENSIONS=false
-
 
 # =============================================================================
 # 4. newAPI 文本模型

--- a/.env.example
+++ b/.env.example
@@ -76,8 +76,11 @@ COGNEE_LLM_THINKING_LEVEL=high
 # 跳过 Cognee 启动连接预检，真实请求仍会走 newAPI。
 COGNEE_SKIP_CONNECTION_TEST=true
 
-# 导入小说 embedding 使用的模型。
+# Cognee 启动和旧路径使用的默认模型名。项目实际请求模型由各自
+# project_config.json 的 cognee_embedding_model 决定：官方历史项目使用 v1，
+# 官方新项目使用 v2，CE 自定义 newAPI 项目使用无后缀兼容模型名。
 COGNEE_EMBEDDING_MODEL=DC-cognee-embedding
+# Cognee 本地向量引擎维度；当前 v1、v2 和 CE 自定义项目均固定为 1024 维。
 COGNEE_EMBEDDING_DIM=1024
 
 # 每次小说导入 pipeline 的上游在途请求上限。多个同时导入的 pipeline 会分别计算。
@@ -90,8 +93,9 @@ COGNEE_EMBEDDING_BATCH_CONCURRENCY=4
 # 如果上游 embedding 模型支持更大批量，可以按需调高。
 EMBEDDING_BATCH_SIZE=10
 
-# COGNEE_EMBEDDING_MODEL 是 newAPI 内部模型名；需要在模型配置页映射到真实上游 embedding 模型。
-# false 表示 dimensions 只用于本地向量库 sizing，不传给上游。
+# 仅作为 CE 自定义 newAPI 旧配置缺少 sendDimensions 时的兼容值。
+# 项目级 v1/v2 不读取该变量：v1 固定不发送 dimensions，v2 固定发送 dimensions=1024。
+# CE 自定义模型已保存 sendDimensions 时，以模型配置页保存的值为准。
 COGNEE_EMBEDDING_SEND_DIMENSIONS=false
 
 

--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -3923,7 +3923,7 @@
       },
       "embeddingModel": {
         "title": "② Vectorization & Semantic Search (Embedding)",
-        "description": "Vectorizes text for semantic knowledge-base search. Choose a channel and upstream Embedding model; the dimension must match the actual upstream output.",
+        "description": "Vectorizes text for semantic knowledge-base search. Custom Cognee embeddings use a fixed 1024-dimensional vector space.",
         "colProvider": "Configured Channel",
         "colUpstreamModel": "Upstream Model",
         "colDimension": "Dimension",
@@ -3931,7 +3931,7 @@
         "defaultProvider": "Choose Channel",
         "upstreamModelPlaceholder": "Enter upstream embedding model, e.g. text-embedding-3-large",
         "batchSizePlaceholder": "Default 10",
-        "dimensionWarning": "The dimension must match the upstream embedding output. Empty batch size uses the EMBEDDING_BATCH_SIZE env var or the official default 10; models that support larger batches can be tuned upward.",
+        "dimensionWarning": "Changing the upstream model changes the shared CE vector space. Rebuild the graph for every project bound to the custom embedding model. Empty batch size uses the official default 10.",
         "saveHint": "Saving writes the NewAPI mapping and stores the dimension and optional batch size in the CE local config.",
         "noChannelsHint": "Add provider channels above before configuring the embedding model.",
         "save": "Save Embedding Config",
@@ -3939,7 +3939,7 @@
         "noChannels": "Add a provider channel first.",
         "missingProvider": "Choose the provider channel for embedding.",
         "missingModel": "Enter the upstream embedding model name.",
-        "invalidDimension": "Enter a valid embedding dimension.",
+        "invalidDimension": "Embedding dimension must be 1024.",
         "invalidBatchSize": "Enter a valid embedding batch size."
       },
       "mediaModels": {

--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -3923,7 +3923,7 @@
       },
       "embeddingModel": {
         "title": "② Vectorization & Semantic Search (Embedding)",
-        "description": "Vectorizes text for semantic knowledge-base search. Custom Cognee embeddings use a fixed 1024-dimensional vector space.",
+        "description": "Vectorizes text for semantic knowledge-base search. A custom model's dimension is bound when each project is created.",
         "colProvider": "Configured Channel",
         "colUpstreamModel": "Upstream Model",
         "colDimension": "Dimension",
@@ -3931,7 +3931,7 @@
         "defaultProvider": "Choose Channel",
         "upstreamModelPlaceholder": "Enter upstream embedding model, e.g. text-embedding-3-large",
         "batchSizePlaceholder": "Default 10",
-        "dimensionWarning": "Changing the upstream model changes the shared CE vector space. Rebuild the graph for every project bound to the custom embedding model. Empty batch size uses the official default 10.",
+        "dimensionWarning": "The dimension is bound to the custom embedding model when a project is created; later changes here affect only new projects. Clear and rebuild the graph before changing an existing project's model or dimension. Empty batch size uses the official default 10.",
         "saveHint": "Saving writes the NewAPI mapping and stores the dimension and optional batch size in the CE local config.",
         "noChannelsHint": "Add provider channels above before configuring the embedding model.",
         "save": "Save Embedding Config",
@@ -3939,7 +3939,7 @@
         "noChannels": "Add a provider channel first.",
         "missingProvider": "Choose the provider channel for embedding.",
         "missingModel": "Enter the upstream embedding model name.",
-        "invalidDimension": "Embedding dimension must be 1024.",
+        "invalidDimension": "Embedding dimension must be a positive integer.",
         "invalidBatchSize": "Enter a valid embedding batch size."
       },
       "mediaModels": {

--- a/frontend/public/locales/zh/translation.json
+++ b/frontend/public/locales/zh/translation.json
@@ -3923,7 +3923,7 @@
       },
       "embeddingModel": {
         "title": "② 向量化与语义检索（Embedding）",
-        "description": "负责文本向量化和知识库语义检索。请选择渠道和上游 Embedding 模型，维度必须与实际上游输出一致。",
+        "description": "负责文本向量化和知识库语义检索。Cognee 自定义 Embedding 固定使用 1024 维向量空间。",
         "colProvider": "已配置渠道",
         "colUpstreamModel": "上游模型名",
         "colDimension": "维度",
@@ -3931,7 +3931,7 @@
         "defaultProvider": "选择渠道",
         "upstreamModelPlaceholder": "填写上游 embedding 模型名，如 text-embedding-3-large",
         "batchSizePlaceholder": "默认 10",
-        "dimensionWarning": "维度必须与上游 embedding 输出一致。批量大小为空时使用 EMBEDDING_BATCH_SIZE 环境变量或官方默认 10；如果上游支持更大批量，可以按需调高。",
+        "dimensionWarning": "更换上游模型会改变CE共享向量空间，所有绑定自定义Embedding的项目都必须清空图谱并重建。批量大小为空时使用官方默认10。",
         "saveHint": "保存后会写入 NewAPI 映射，并把维度和可选批量大小保存到 CE 本地配置。",
         "noChannelsHint": "请先在上方添加供应商渠道，再配置 embedding 模型。",
         "save": "保存 Embedding 配置",
@@ -3939,7 +3939,7 @@
         "noChannels": "请先添加供应商渠道。",
         "missingProvider": "请选择 embedding 使用的供应商渠道。",
         "missingModel": "请填写上游 embedding 模型名。",
-        "invalidDimension": "请填写有效的 embedding 维度。",
+        "invalidDimension": "Embedding 维度必须为 1024。",
         "invalidBatchSize": "请填写有效的 embedding 批量大小。"
       },
       "mediaModels": {

--- a/frontend/public/locales/zh/translation.json
+++ b/frontend/public/locales/zh/translation.json
@@ -3923,7 +3923,7 @@
       },
       "embeddingModel": {
         "title": "② 向量化与语义检索（Embedding）",
-        "description": "负责文本向量化和知识库语义检索。Cognee 自定义 Embedding 固定使用 1024 维向量空间。",
+        "description": "负责文本向量化和知识库语义检索。自定义模型的维度会在项目创建时绑定。",
         "colProvider": "已配置渠道",
         "colUpstreamModel": "上游模型名",
         "colDimension": "维度",
@@ -3931,7 +3931,7 @@
         "defaultProvider": "选择渠道",
         "upstreamModelPlaceholder": "填写上游 embedding 模型名，如 text-embedding-3-large",
         "batchSizePlaceholder": "默认 10",
-        "dimensionWarning": "更换上游模型会改变CE共享向量空间，所有绑定自定义Embedding的项目都必须清空图谱并重建。批量大小为空时使用官方默认10。",
+        "dimensionWarning": "维度会在创建项目时与自定义Embedding模型一起绑定；之后修改这里只影响新项目。更换已有项目的模型或维度前必须清空图谱并重建。批量大小为空时使用官方默认10。",
         "saveHint": "保存后会写入 NewAPI 映射，并把维度和可选批量大小保存到 CE 本地配置。",
         "noChannelsHint": "请先在上方添加供应商渠道，再配置 embedding 模型。",
         "save": "保存 Embedding 配置",
@@ -3939,7 +3939,7 @@
         "noChannels": "请先添加供应商渠道。",
         "missingProvider": "请选择 embedding 使用的供应商渠道。",
         "missingModel": "请填写上游 embedding 模型名。",
-        "invalidDimension": "Embedding 维度必须为 1024。",
+        "invalidDimension": "Embedding 维度必须为正整数。",
         "invalidBatchSize": "请填写有效的 embedding 批量大小。"
       },
       "mediaModels": {

--- a/frontend/src/components/settings/settings-dialog.tsx
+++ b/frontend/src/components/settings/settings-dialog.tsx
@@ -1081,7 +1081,7 @@ function EmbeddingModelBlock({
 
   const selectedProvider = localModel?.provider ?? "";
   const upstreamModel = localModel?.upstreamModel ?? "";
-  const dimension = localModel?.dimension ?? DEFAULT_EMBEDDING_DIMENSION;
+  const dimension = DEFAULT_EMBEDDING_DIMENSION;
   const batchSize =
     localModel === undefined ? DEFAULT_EMBEDDING_BATCH_SIZE : localModel.batchSize;
 
@@ -1122,7 +1122,7 @@ function EmbeddingModelBlock({
       return;
     }
     const normalizedDimension = Math.round(Number(dimension));
-    if (!Number.isFinite(normalizedDimension) || normalizedDimension <= 0) {
+    if (normalizedDimension !== DEFAULT_EMBEDDING_DIMENSION) {
       toast.error(t("settings.modelConfig.embeddingModel.invalidDimension"));
       return;
     }
@@ -1214,13 +1214,12 @@ function EmbeddingModelBlock({
           />
           <Input
             value={String(dimension)}
-            onChange={(event) => updateLocal({ dimension: Number(event.target.value) })}
             inputMode="numeric"
             min={1}
             step={1}
             type="number"
             className="h-8 rounded-md border-input/80 focus-visible:border-ring/70 focus-visible:ring-1 focus-visible:ring-ring/30"
-            disabled={configuredProviders.length === 0}
+            readOnly
           />
           <Input
             value={batchSize == null ? "" : String(batchSize)}

--- a/frontend/src/components/settings/settings-dialog.tsx
+++ b/frontend/src/components/settings/settings-dialog.tsx
@@ -1081,7 +1081,8 @@ function EmbeddingModelBlock({
 
   const selectedProvider = localModel?.provider ?? "";
   const upstreamModel = localModel?.upstreamModel ?? "";
-  const dimension = DEFAULT_EMBEDDING_DIMENSION;
+  const dimension =
+    localModel === undefined ? DEFAULT_EMBEDDING_DIMENSION : localModel.dimension;
   const batchSize =
     localModel === undefined ? DEFAULT_EMBEDDING_BATCH_SIZE : localModel.batchSize;
 
@@ -1121,8 +1122,8 @@ function EmbeddingModelBlock({
       toast.error(t("settings.modelConfig.embeddingModel.missingModel"));
       return;
     }
-    const normalizedDimension = Math.round(Number(dimension));
-    if (normalizedDimension !== DEFAULT_EMBEDDING_DIMENSION) {
+    const normalizedDimension = Number(dimension);
+    if (!Number.isInteger(normalizedDimension) || normalizedDimension <= 0) {
       toast.error(t("settings.modelConfig.embeddingModel.invalidDimension"));
       return;
     }
@@ -1214,12 +1215,19 @@ function EmbeddingModelBlock({
           />
           <Input
             value={String(dimension)}
+            onChange={(event) => {
+              if (event.target.value.trim()) {
+                updateLocal({
+                  dimension: Number(event.target.value),
+                });
+              }
+            }}
             inputMode="numeric"
             min={1}
             step={1}
             type="number"
             className="h-8 rounded-md border-input/80 focus-visible:border-ring/70 focus-visible:ring-1 focus-visible:ring-ring/30"
-            readOnly
+            disabled={configuredProviders.length === 0}
           />
           <Input
             value={batchSize == null ? "" : String(batchSize)}

--- a/frontend/src/lib/queries/model-gateway.ts
+++ b/frontend/src/lib/queries/model-gateway.ts
@@ -60,6 +60,7 @@ export interface SavedEmbeddingModelConfig {
   upstreamModel: string;
   dimension: number;
   batchSize?: number;
+  sendDimensions?: boolean;
   internalModel?: string;
 }
 

--- a/license-inventory.csv
+++ b/license-inventory.csv
@@ -1335,6 +1335,7 @@ src/novelvideo/director_world/store.py,Elastic-2.0,2026 SuperTale contributors,R
 src/novelvideo/director_world/supertale_lanzhou_demo.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 src/novelvideo/director_world/supertale_voxel_palette.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 src/novelvideo/director_world/sync_global_props.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
+src/novelvideo/embedding_models.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 src/novelvideo/env.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 src/novelvideo/export/__init__.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 src/novelvideo/export/episode_export.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
@@ -1724,6 +1725,7 @@ tests/test_pool_index_state_storage.py,Elastic-2.0,2026 SuperTale contributors,R
 tests/test_project_config_narration.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_project_context.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_project_dependencies.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
+tests/test_project_embedding_models.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_project_id_route_paths.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_project_spine_template.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_project_static_media.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation

--- a/src/novelvideo/agents/identity_planner.py
+++ b/src/novelvideo/agents/identity_planner.py
@@ -558,13 +558,14 @@ class IdentityPlanner:
 
             # 获取与本集相关的图谱上下文（人物关系、别名、背景信息）
             try:
-                graph_results = await cognee.search(
-                    query_text=f"第{episode.number}集出场的人物角色，以及他们的别名、称谓和关系",
-                    query_type=SearchType.GRAPH_COMPLETION,
-                    datasets=[self.cognee_store.dataset_name],
-                    only_context=True,
-                    top_k=20,
-                )
+                with self.cognee_store.embedding_model_scope():
+                    graph_results = await cognee.search(
+                        query_text=f"第{episode.number}集出场的人物角色，以及他们的别名、称谓和关系",
+                        query_type=SearchType.GRAPH_COMPLETION,
+                        datasets=[self.cognee_store.dataset_name],
+                        only_context=True,
+                        top_k=20,
+                    )
                 if graph_results:
                     parts = []
                     for item in graph_results:

--- a/src/novelvideo/api/routes/model_gateway.py
+++ b/src/novelvideo/api/routes/model_gateway.py
@@ -283,15 +283,18 @@ def _build_embedding_model_channel_spec(
         raise ValueError("provider is required for embedding model")
     if not upstream_model:
         raise ValueError("upstreamModel is required for embedding model")
-    if dimension != 1024:
-        raise ValueError("dimension must be 1024 for project-bound Cognee embeddings")
+    if dimension <= 0:
+        raise ValueError("dimension must be positive")
     if body.batch_size is not None and batch_size <= 0:
         raise ValueError("batchSize must be positive")
     normalized = {
         "provider": provider,
         "upstreamModel": upstream_model,
         "dimension": dimension,
-        "sendDimensions": body.send_dimensions,
+        # Kept in the response/config schema for compatibility with older
+        # clients. Runtime request behavior is controlled by the internal
+        # EmbeddingModelSpec, not by this user-supplied field.
+        "sendDimensions": True,
         "internalModel": "DC-cognee-embedding",
     }
     if batch_size > 0:

--- a/src/novelvideo/api/routes/model_gateway.py
+++ b/src/novelvideo/api/routes/model_gateway.py
@@ -176,6 +176,7 @@ class SaveEmbeddingModelBody(BaseModel):
     upstream_model: str = Field(alias="upstreamModel")
     dimension: int
     batch_size: int | None = Field(default=None, alias="batchSize")
+    send_dimensions: bool = Field(default=True, alias="sendDimensions")
 
 
 def _permission_error(exc: PermissionError) -> HTTPException:
@@ -282,14 +283,15 @@ def _build_embedding_model_channel_spec(
         raise ValueError("provider is required for embedding model")
     if not upstream_model:
         raise ValueError("upstreamModel is required for embedding model")
-    if dimension <= 0:
-        raise ValueError("dimension must be positive")
+    if dimension != 1024:
+        raise ValueError("dimension must be 1024 for project-bound Cognee embeddings")
     if body.batch_size is not None and batch_size <= 0:
         raise ValueError("batchSize must be positive")
     normalized = {
         "provider": provider,
         "upstreamModel": upstream_model,
         "dimension": dimension,
+        "sendDimensions": body.send_dimensions,
         "internalModel": "DC-cognee-embedding",
     }
     if batch_size > 0:
@@ -768,6 +770,7 @@ async def save_custom_newapi_embedding_model(
         upstream_model=normalized_model["upstreamModel"],
         dimension=normalized_model["dimension"],
         batch_size=normalized_model.get("batchSize"),
+        send_dimensions=normalized_model["sendDimensions"],
     )
     return {
         "ok": True,

--- a/src/novelvideo/api/routes/projects.py
+++ b/src/novelvideo/api/routes/projects.py
@@ -29,6 +29,10 @@ from novelvideo.api.schemas import (
     ProjectUpdate,
 )
 from novelvideo.config import ensure_project_dirs_at_paths
+from novelvideo.embedding_models import (
+    PROJECT_EMBEDDING_MODEL_KEY,
+    embedding_model_for_new_project,
+)
 from novelvideo.ports import get_project_access, get_project_registry
 from novelvideo.ports.project import ProjectRecord
 from novelvideo.project_config import (
@@ -462,7 +466,13 @@ async def create_project(
             state_dir=record.state_dir,
             runtime_dir=record.runtime_dir,
         )
-        save_project_config_in_state_dir(record.state_dir, config={"user": user["username"]})
+        save_project_config_in_state_dir(
+            record.state_dir,
+            config={
+                "user": user["username"],
+                PROJECT_EMBEDDING_MODEL_KEY: embedding_model_for_new_project(),
+            },
+        )
     except Exception:
         try:
             await registry.delete_uncommitted_project(record.id)

--- a/src/novelvideo/api/routes/projects.py
+++ b/src/novelvideo/api/routes/projects.py
@@ -30,8 +30,9 @@ from novelvideo.api.schemas import (
 )
 from novelvideo.config import ensure_project_dirs_at_paths
 from novelvideo.embedding_models import (
+    PROJECT_EMBEDDING_DIMENSION_KEY,
     PROJECT_EMBEDDING_MODEL_KEY,
-    embedding_model_for_new_project,
+    embedding_model_binding_for_new_project,
 )
 from novelvideo.ports import get_project_access, get_project_registry
 from novelvideo.ports.project import ProjectRecord
@@ -466,11 +467,13 @@ async def create_project(
             state_dir=record.state_dir,
             runtime_dir=record.runtime_dir,
         )
+        embedding_binding = embedding_model_binding_for_new_project()
         save_project_config_in_state_dir(
             record.state_dir,
             config={
                 "user": user["username"],
-                PROJECT_EMBEDDING_MODEL_KEY: embedding_model_for_new_project(),
+                PROJECT_EMBEDDING_MODEL_KEY: embedding_binding.internal_model,
+                PROJECT_EMBEDDING_DIMENSION_KEY: embedding_binding.dimensions,
             },
         )
     except Exception:

--- a/src/novelvideo/cognee/config.py
+++ b/src/novelvideo/cognee/config.py
@@ -14,13 +14,17 @@ import os
 import sys
 import warnings
 from pathlib import Path
-from typing import Optional
+from typing import Awaitable, Callable, Optional
 
 from dotenv import load_dotenv
 
 from novelvideo.cognee.concurrency import (
     get_cognee_concurrency_config,
     install_cognee_pipeline_concurrency,
+)
+from novelvideo.embedding_models import (
+    embedding_gateway_credentials,
+    require_current_embedding_model_spec,
 )
 from novelvideo.llm_instrumentation import (
     reset_model_call_reservation_active,
@@ -492,8 +496,148 @@ def _embedding_response_trace(
     return request_id, response_id
 
 
+def _project_embedding_request_kwargs(kwargs: dict) -> dict:
+    """Apply the current project's immutable model and gateway to LiteLLM kwargs."""
+
+    spec = require_current_embedding_model_spec()
+    api_key, base_url = embedding_gateway_credentials(spec)
+    if not api_key or not base_url:
+        raise RuntimeError(f"Embedding gateway is not configured for {spec.gateway}")
+
+    routed = dict(kwargs)
+    routed["custom_llm_provider"] = "openai"
+    routed["model"] = _normalize_embedding_model("newapi", spec.internal_model)
+    routed["api_key"] = api_key
+    routed["api_base"] = base_url
+    if spec.send_dimensions:
+        routed["dimensions"] = spec.dimensions
+        allowed_openai_params = list(routed.get("allowed_openai_params") or [])
+        if "dimensions" not in allowed_openai_params:
+            allowed_openai_params.append("dimensions")
+        routed["allowed_openai_params"] = allowed_openai_params
+    else:
+        routed.pop("dimensions", None)
+        allowed_openai_params = [
+            param
+            for param in (routed.get("allowed_openai_params") or [])
+            if param != "dimensions"
+        ]
+        if allowed_openai_params:
+            routed["allowed_openai_params"] = allowed_openai_params
+        else:
+            routed.pop("allowed_openai_params", None)
+    return routed
+
+
+def _validate_embedding_vectors(
+    vectors: object,
+    *,
+    expected_dimensions: int,
+    expected_count: int,
+) -> list[list[float]]:
+    if not isinstance(vectors, list) or len(vectors) != expected_count:
+        received_count = len(vectors) if isinstance(vectors, list) else 0
+        raise RuntimeError(
+            "Embedding response count mismatch: "
+            f"expected {expected_count}, received {received_count}"
+        )
+    for index, vector in enumerate(vectors):
+        received = len(vector) if isinstance(vector, list) else 0
+        if received != expected_dimensions:
+            raise RuntimeError(
+                "Embedding dimension mismatch: "
+                f"expected {expected_dimensions}, received {received} "
+                f"at index {index}"
+            )
+    return vectors
+
+
+async def _run_project_embedding_with_billing(
+    operation: Callable[[], Awaitable[list[list[float]]]],
+    *,
+    expected_count: int,
+) -> list[list[float]]:
+    spec = require_current_embedding_model_spec()
+    captured_headers: dict[str, str] = {}
+    token = _embedding_headers_capture.set(captured_headers)
+    reservation_id = ""
+    active_token = None
+    metadata = {
+        "source": "cognee_embedding_gateway",
+        "embedding_gateway": spec.gateway,
+    }
+    try:
+        try:
+            reservation_id = (
+                await get_usage_meter().reserve_current_model_call_credit(
+                    model=spec.internal_model,
+                    billing_kind="embedding",
+                    metadata=metadata,
+                )
+            )
+        except Exception as exc:
+            insufficient = find_insufficient_credits_error(exc)
+            if insufficient is not None:
+                raise InsufficientCreditsStop(
+                    user_id=insufficient.user_id,
+                    cost=insufficient.cost,
+                    balance=insufficient.balance,
+                ) from None
+            raise
+        active_token = set_model_call_reservation_active(bool(reservation_id))
+        result = _validate_embedding_vectors(
+            await operation(),
+            expected_dimensions=spec.dimensions,
+            expected_count=expected_count,
+        )
+    except BaseException:
+        if reservation_id:
+            try:
+                await get_usage_meter().refund_model_call_credit_reservation(
+                    reservation_id,
+                    metadata={
+                        "source": "cognee_embedding_gateway_exception",
+                        "embedding_gateway": spec.gateway,
+                    },
+                )
+            except Exception:
+                pass
+        raise
+    finally:
+        if active_token is not None:
+            try:
+                reset_model_call_reservation_active(active_token)
+            except Exception:
+                pass
+        _embedding_headers_capture.reset(token)
+
+    if reservation_id:
+        try:
+            request_id = (
+                captured_headers.get("x-novelvideo-request-id")
+                or captured_headers.get("x-request-id")
+                or captured_headers.get("x-newapi-request-id")
+                or captured_headers.get("x-oneapi-request-id")
+                or ""
+            )
+            bump_metadata = dict(metadata)
+            response_id = captured_headers.get("x-novelvideo-response-id", "")
+            if response_id:
+                bump_metadata["response_id"] = response_id
+            await get_usage_meter().bump_model_call(
+                user_id=None,
+                model=spec.internal_model,
+                credit_reservation_id=reservation_id,
+                provider_request_id=request_id,
+                metadata=bump_metadata,
+            )
+        except Exception:
+            pass
+    return result
+
+
 def _patch_cognee_embedding_gateway() -> None:
-    """Force Cognee LiteLLM embeddings through the newAPI OpenAI-compatible gateway."""
+    """Install one concurrency-safe project-aware newAPI embedding gateway."""
     global _embedding_gateway_patch_installed
     if _embedding_gateway_patch_installed:
         return
@@ -511,121 +655,41 @@ def _patch_cognee_embedding_gateway() -> None:
         return
 
     original_embed_text = engine_cls.embed_text
+    litellm = _mod.litellm
+    original_aembedding = litellm.aembedding
 
-    async def patched_embed_text(self, text):
-        provider = str(getattr(self, "provider", "") or "").strip().lower()
-        endpoint = str(getattr(self, "endpoint", "") or "").strip()
-        if provider not in {"custom", "openai"} or not endpoint:
-            return await original_embed_text(self, text)
-
-        litellm = _mod.litellm
-        original_aembedding = litellm.aembedding
-
-        async def gateway_aembedding(*args, **kwargs):
-            kwargs.setdefault("custom_llm_provider", "openai")
-            raw_model = str(kwargs.get("model") or "").strip()
-            if raw_model:
-                kwargs["model"] = _normalize_embedding_model("newapi", raw_model)
-            if os.getenv("COGNEE_EMBEDDING_SEND_DIMENSIONS", "false").lower() not in (
-                "1",
-                "true",
-                "yes",
-                "on",
-            ):
-                # dimensions 仍用于本地向量库 sizing；默认不传给 newAPI 上游。
-                kwargs.pop("dimensions", None)
-            response = await original_aembedding(*args, **kwargs)
+    async def gateway_aembedding(*args, **kwargs):
+        response = await original_aembedding(
+            *args, **_project_embedding_request_kwargs(kwargs)
+        )
+        captured_headers = _embedding_headers_capture.get()
+        if captured_headers is not None:
             _attach_embedding_response_headers(response, captured_headers)
-            nonlocal captured_request_id, captured_response_id
             request_id, response_id = _embedding_response_trace(
                 response, captured_headers
             )
-            captured_request_id = captured_request_id or request_id
-            captured_response_id = captured_response_id or response_id
-            return response
+            if request_id:
+                captured_headers.setdefault("x-novelvideo-request-id", request_id)
+            if response_id:
+                captured_headers.setdefault("x-novelvideo-response-id", response_id)
+        return response
 
-        litellm.aembedding = gateway_aembedding
-        _install_litellm_embedding_header_capture()
-        captured_headers: dict[str, str] = {}
-        captured_request_id = ""
-        captured_response_id = ""
-        token = _embedding_headers_capture.set(captured_headers)
-        raw_model = str(
-            getattr(self, "model", "") or os.getenv("EMBEDDING_MODEL", "")
-        ).strip()
-        model = _normalize_embedding_model("newapi", raw_model)
-        billing_model = _billing_model_name(raw_model or model)
-        original_model = getattr(self, "model", None)
-        reservation_id = ""
-        active_token = None
-        try:
-            if model:
-                self.model = model
+    litellm.aembedding = gateway_aembedding
+    _install_litellm_embedding_header_capture()
 
-            try:
-                reservation_id = (
-                    await get_usage_meter().reserve_current_model_call_credit(
-                        model=billing_model,
-                        billing_kind="embedding",
-                        metadata={"source": "cognee_embedding_gateway"},
-                    )
-                )
-            except Exception as exc:
-                insufficient = find_insufficient_credits_error(exc)
-                if insufficient is not None:
-                    raise InsufficientCreditsStop(
-                        user_id=insufficient.user_id,
-                        cost=insufficient.cost,
-                        balance=insufficient.balance,
-                    ) from None
-                raise
-            active_token = set_model_call_reservation_active(bool(reservation_id))
-            result = await original_embed_text(self, text)
-        except BaseException:
-            if reservation_id:
-                try:
-                    await get_usage_meter().refund_model_call_credit_reservation(
-                        reservation_id,
-                        metadata={"source": "cognee_embedding_gateway_exception"},
-                    )
-                except Exception:
-                    pass
-            raise
-        finally:
-            if active_token is not None:
-                try:
-                    reset_model_call_reservation_active(active_token)
-                except Exception:
-                    pass
-            if original_model is not None:
-                self.model = original_model
-            _embedding_headers_capture.reset(token)
-            litellm.aembedding = original_aembedding
-        if reservation_id:
-            try:
-                request_id = (
-                    captured_request_id
-                    or captured_headers.get("x-request-id")
-                    or captured_headers.get("x-newapi-request-id")
-                    or captured_headers.get("x-oneapi-request-id")
-                    or ""
-                )
-                metadata = {"source": "cognee_embedding_gateway"}
-                if captured_response_id:
-                    metadata["response_id"] = captured_response_id
-                await get_usage_meter().bump_model_call(
-                    user_id=None,
-                    model=billing_model,
-                    credit_reservation_id=reservation_id,
-                    provider_request_id=request_id,
-                    metadata=metadata,
-                )
-            except Exception:
-                pass
-        return result
+    async def patched_embed_text(self, text):
+        provider = str(getattr(self, "provider", "") or "").strip().lower()
+        if provider not in {"custom", "openai"}:
+            return await original_embed_text(self, text)
+        expected_count = len(text) if isinstance(text, list) else 1
+        return await _run_project_embedding_with_billing(
+            lambda: original_embed_text(self, text),
+            expected_count=expected_count,
+        )
 
     engine_cls.embed_text = patched_embed_text
     engine_cls._novelvideo_original_embed_text = original_embed_text
+    engine_cls._novelvideo_original_aembedding = original_aembedding
     engine_cls._novelvideo_gateway_patch = True
     _embedding_gateway_patch_installed = True
 

--- a/src/novelvideo/cognee/config.py
+++ b/src/novelvideo/cognee/config.py
@@ -23,6 +23,7 @@ from novelvideo.cognee.concurrency import (
     install_cognee_pipeline_concurrency,
 )
 from novelvideo.embedding_models import (
+    current_embedding_model_spec,
     embedding_gateway_credentials,
     require_current_embedding_model_spec,
 )
@@ -655,6 +656,8 @@ def _patch_cognee_embedding_gateway() -> None:
         return
 
     original_embed_text = engine_cls.embed_text
+    original_get_vector_size = engine_cls.get_vector_size
+    original_handle_embedding_response = _mod.handle_embedding_response
     litellm = _mod.litellm
     original_aembedding = litellm.aembedding
 
@@ -677,18 +680,46 @@ def _patch_cognee_embedding_gateway() -> None:
     litellm.aembedding = gateway_aembedding
     _install_litellm_embedding_header_capture()
 
+    def project_handle_embedding_response(original_texts, embeddings, dimensions):
+        spec = current_embedding_model_spec()
+        return original_handle_embedding_response(
+            original_texts,
+            embeddings,
+            spec.dimensions if spec is not None else dimensions,
+        )
+
+    _mod.handle_embedding_response = project_handle_embedding_response
+
     async def patched_embed_text(self, text):
         provider = str(getattr(self, "provider", "") or "").strip().lower()
         if provider not in {"custom", "openai"}:
             return await original_embed_text(self, text)
         expected_count = len(text) if isinstance(text, list) else 1
+
+        async def project_embed():
+            if getattr(self, "mock", False):
+                dimensions = require_current_embedding_model_spec().dimensions
+                return [[0.0] * dimensions for _ in range(expected_count)]
+            return await original_embed_text(self, text)
+
         return await _run_project_embedding_with_billing(
-            lambda: original_embed_text(self, text),
+            project_embed,
             expected_count=expected_count,
         )
 
+    def patched_get_vector_size(self):
+        spec = current_embedding_model_spec()
+        if spec is not None:
+            return spec.dimensions
+        return original_get_vector_size(self)
+
     engine_cls.embed_text = patched_embed_text
+    engine_cls.get_vector_size = patched_get_vector_size
     engine_cls._novelvideo_original_embed_text = original_embed_text
+    engine_cls._novelvideo_original_get_vector_size = original_get_vector_size
+    engine_cls._novelvideo_original_handle_embedding_response = (
+        original_handle_embedding_response
+    )
     engine_cls._novelvideo_original_aembedding = original_aembedding
     engine_cls._novelvideo_gateway_patch = True
     _embedding_gateway_patch_installed = True

--- a/src/novelvideo/cognee/store.py
+++ b/src/novelvideo/cognee/store.py
@@ -33,7 +33,7 @@ from novelvideo.embedding_models import (
 )
 from novelvideo.official_defaults import DEFAULT_COGNEE_LLM_MODEL
 from novelvideo.novel_source import require_imported_novel
-from novelvideo.project_config import ensure_cognee_embedding_model_in_state_dir
+from novelvideo.project_config import ensure_cognee_embedding_binding_in_state_dir
 from novelvideo.sqlite_store import SQLiteStore
 from novelvideo.utils.document_parsers import load_novel_text
 
@@ -161,6 +161,7 @@ class CogneeStore:
         )
         self._share_sqlite_caches()
         self.cognee_embedding_model: str | None = None
+        self.cognee_embedding_dimensions: int | None = None
 
         # 立即设置 Cognee 上下文
         self._set_cognee_context()
@@ -294,15 +295,18 @@ class CogneeStore:
 
     def embedding_model_scope(self):
         model = getattr(self, "cognee_embedding_model", None)
-        if not model:
+        dimensions = getattr(self, "cognee_embedding_dimensions", None)
+        if not model or dimensions is None:
             state_dir = getattr(self, "state_dir", None)
-            model = (
-                ensure_cognee_embedding_model_in_state_dir(state_dir)
-                if state_dir
-                else embedding_model_for_legacy_project()
-            )
+            if state_dir:
+                binding = ensure_cognee_embedding_binding_in_state_dir(state_dir)
+                model = binding.internal_model
+                dimensions = binding.dimensions
+            else:
+                model = embedding_model_for_legacy_project()
             self.cognee_embedding_model = model
-        return project_embedding_model_scope(model)
+            self.cognee_embedding_dimensions = dimensions
+        return project_embedding_model_scope(model, dimensions=dimensions)
 
     @staticmethod
     def _ensure_pipeline_run_succeeded(result, stage_name: str) -> None:
@@ -405,9 +409,9 @@ class CogneeStore:
 
     async def initialize(self):
         """初始化 SQLite 数据库和 Cognee 配置。"""
-        self.cognee_embedding_model = ensure_cognee_embedding_model_in_state_dir(
-            self.state_dir
-        )
+        embedding_binding = ensure_cognee_embedding_binding_in_state_dir(self.state_dir)
+        self.cognee_embedding_model = embedding_binding.internal_model
+        self.cognee_embedding_dimensions = embedding_binding.dimensions
         init_cognee()
 
         # 初始化项目 SQLite；Cognee 图谱上下文独立设置。

--- a/src/novelvideo/cognee/store.py
+++ b/src/novelvideo/cognee/store.py
@@ -27,8 +27,13 @@ with preserve_st_env():
     from cognee.modules.engine.operations.setup import setup
 from rich.console import Console
 from novelvideo.config import get_newapi_reasoning_kwargs
+from novelvideo.embedding_models import (
+    embedding_model_for_legacy_project,
+    embedding_model_scope as project_embedding_model_scope,
+)
 from novelvideo.official_defaults import DEFAULT_COGNEE_LLM_MODEL
 from novelvideo.novel_source import require_imported_novel
+from novelvideo.project_config import ensure_cognee_embedding_model_in_state_dir
 from novelvideo.sqlite_store import SQLiteStore
 from novelvideo.utils.document_parsers import load_novel_text
 
@@ -155,6 +160,7 @@ class CogneeStore:
             state_dir=self.state_dir,
         )
         self._share_sqlite_caches()
+        self.cognee_embedding_model: str | None = None
 
         # 立即设置 Cognee 上下文
         self._set_cognee_context()
@@ -286,6 +292,18 @@ class CogneeStore:
                 flush=True,
             )
 
+    def embedding_model_scope(self):
+        model = getattr(self, "cognee_embedding_model", None)
+        if not model:
+            state_dir = getattr(self, "state_dir", None)
+            model = (
+                ensure_cognee_embedding_model_in_state_dir(state_dir)
+                if state_dir
+                else embedding_model_for_legacy_project()
+            )
+            self.cognee_embedding_model = model
+        return project_embedding_model_scope(model)
+
     @staticmethod
     def _ensure_pipeline_run_succeeded(result, stage_name: str) -> None:
         """Treat Cognee pipeline Errored/Failed results as task failures."""
@@ -360,7 +378,8 @@ class CogneeStore:
             self._set_cognee_context()
             try:
                 async with cognee_pipeline_concurrency():
-                    result = await operation()
+                    with self.embedding_model_scope():
+                        result = await operation()
                 self._ensure_pipeline_run_succeeded(result, stage_name)
                 return result
             except Exception as exc:
@@ -386,6 +405,9 @@ class CogneeStore:
 
     async def initialize(self):
         """初始化 SQLite 数据库和 Cognee 配置。"""
+        self.cognee_embedding_model = ensure_cognee_embedding_model_in_state_dir(
+            self.state_dir
+        )
         init_cognee()
 
         # 初始化项目 SQLite；Cognee 图谱上下文独立设置。
@@ -395,7 +417,8 @@ class CogneeStore:
         self._set_cognee_context(verbose=True)
 
         try:
-            await setup()
+            with self.embedding_model_scope():
+                await setup()
         except Exception as e:
             # cognee 0.5.3 bug: 重复初始化时 CREATE TABLE data 报 already exists
             if "already exists" in str(e):
@@ -410,7 +433,8 @@ class CogneeStore:
             )
 
         try:
-            await resolve_authorized_user_datasets(datasets=self.dataset_name)
+            with self.embedding_model_scope():
+                await resolve_authorized_user_datasets(datasets=self.dataset_name)
         except Exception as e:
             if "UNIQUE constraint failed: datasets.id" in str(e):
                 pass
@@ -566,7 +590,8 @@ class CogneeStore:
         report(0.1, "解析原文...")
         log("Step 1/2: 导入原文到 Cognee...")
         self._set_cognee_context()
-        await cognee.add(content, dataset_name=self.dataset_name)
+        with self.embedding_model_scope():
+            await cognee.add(content, dataset_name=self.dataset_name)
         log("原文导入完成")
         await asyncio.sleep(0)
 
@@ -757,13 +782,14 @@ class CogneeStore:
         report(0.1, "从图谱提取人物节点...")
         log("从图谱提取角色候选...")
         self._set_cognee_context()
-        characters = await extract_characters_from_graph(
-            dataset_name=self.dataset_name,
-            project_name=self.project_name,
-            project_dir=str(self.project_dir),
-            novel_text=novel_text,
-            on_progress=lambda p, t: report(0.1 + p * 0.6, t),
-        )
+        with self.embedding_model_scope():
+            characters = await extract_characters_from_graph(
+                dataset_name=self.dataset_name,
+                project_name=self.project_name,
+                project_dir=str(self.project_dir),
+                novel_text=novel_text,
+                on_progress=lambda p, t: report(0.1 + p * 0.6, t),
+            )
 
         if not characters:
             log("⚠️ 图谱提取无结果，保留现有角色数据")
@@ -1416,11 +1442,12 @@ class CogneeStore:
         search_type = mode_map.get(mode, SearchType.GRAPH_COMPLETION)
 
         try:
-            result = await cognee.search(
-                query_type=search_type,
-                query_text=query,
-                top_k=top_k,
-            )
+            with self.embedding_model_scope():
+                result = await cognee.search(
+                    query_type=search_type,
+                    query_text=query,
+                    top_k=top_k,
+                )
         except DatasetNotFoundError:
             return "暂无相关数据，请先运行 cognee-ingest 导入小说"
         except Exception as e:
@@ -1924,13 +1951,14 @@ class CogneeStore:
         novel_text = self.load_novel_content()
         if novel_text:
             log(f"已加载原文全文用于辅助道具提取: {len(novel_text)} 字符")
-        props = await extract_props_from_graph(
-            dataset_name=self.dataset_name,
-            project_name=self.project_name,
-            project_dir=self.project_dir,
-            novel_text=novel_text,
-            on_progress=lambda p, t: report(0.1 + p * 0.6, t),
-        )
+        with self.embedding_model_scope():
+            props = await extract_props_from_graph(
+                dataset_name=self.dataset_name,
+                project_name=self.project_name,
+                project_dir=self.project_dir,
+                novel_text=novel_text,
+                on_progress=lambda p, t: report(0.1 + p * 0.6, t),
+            )
 
         if not props:
             log("⚠️ 图谱提取无结果，保留现有道具数据")

--- a/src/novelvideo/embedding_models.py
+++ b/src/novelvideo/embedding_models.py
@@ -1,0 +1,149 @@
+"""Project-bound Cognee embedding model selection and request scoping."""
+
+from __future__ import annotations
+
+import os
+from contextlib import contextmanager
+from contextvars import ContextVar
+from dataclasses import dataclass
+from typing import Iterator
+
+from novelvideo.model_gateway_settings import (
+    MODE_CUSTOM,
+    MODE_OFFICIAL,
+    get_ce_newapi_config_for_mode,
+    get_effective_newapi_config,
+    get_newapi_embedding_model_config,
+)
+from novelvideo.official_defaults import OFFICIAL_NEWAPI_BASE_URL
+from novelvideo.shared.runtime_env import is_ce_effective
+
+PROJECT_EMBEDDING_MODEL_KEY = "cognee_embedding_model"
+COGNEE_EMBEDDING_MODEL_LEGACY = "DC-cognee-embedding"
+COGNEE_EMBEDDING_MODEL_V1 = "DC-cognee-embedding-v1"
+COGNEE_EMBEDDING_MODEL_V2 = "DC-cognee-embedding-v2"
+COGNEE_EMBEDDING_DIMENSIONS = 1024
+
+
+@dataclass(frozen=True)
+class EmbeddingModelSpec:
+    internal_model: str
+    dimensions: int
+    send_dimensions: bool
+    gateway: str
+
+
+_CURRENT_COGNEE_EMBEDDING_SPEC: ContextVar[EmbeddingModelSpec | None] = ContextVar(
+    "current_cognee_embedding_spec",
+    default=None,
+)
+
+
+def _environment_flag(name: str, default: bool) -> bool:
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    return raw.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def active_gateway_uses_custom_embedding() -> bool:
+    """Return whether new projects should bind to the CE custom model alias."""
+
+    if not is_ce_effective():
+        return False
+    return get_effective_newapi_config().mode == MODE_CUSTOM
+
+
+def embedding_model_for_new_project() -> str:
+    """Choose the permanent model binding for a project created now."""
+
+    if active_gateway_uses_custom_embedding():
+        return COGNEE_EMBEDDING_MODEL_LEGACY
+    return COGNEE_EMBEDDING_MODEL_V2
+
+
+def embedding_model_for_legacy_project() -> str:
+    """Choose the compatibility binding for a pre-versioning project."""
+
+    if active_gateway_uses_custom_embedding():
+        return COGNEE_EMBEDDING_MODEL_LEGACY
+    return COGNEE_EMBEDDING_MODEL_V1
+
+
+def embedding_model_spec(model: str) -> EmbeddingModelSpec:
+    """Resolve and strictly validate one persisted internal model name."""
+
+    clean_model = str(model or "").strip()
+    if clean_model == COGNEE_EMBEDDING_MODEL_V1:
+        return EmbeddingModelSpec(
+            internal_model=clean_model,
+            dimensions=COGNEE_EMBEDDING_DIMENSIONS,
+            send_dimensions=False,
+            gateway=MODE_OFFICIAL,
+        )
+    if clean_model == COGNEE_EMBEDDING_MODEL_V2:
+        return EmbeddingModelSpec(
+            internal_model=clean_model,
+            dimensions=COGNEE_EMBEDDING_DIMENSIONS,
+            send_dimensions=True,
+            gateway=MODE_OFFICIAL,
+        )
+    if clean_model == COGNEE_EMBEDDING_MODEL_LEGACY:
+        if not is_ce_effective():
+            raise RuntimeError(
+                "DC-cognee-embedding is reserved for CE custom NewAPI projects"
+            )
+        saved = get_newapi_embedding_model_config()
+        dimensions = int(saved.get("dimension") or COGNEE_EMBEDDING_DIMENSIONS)
+        if dimensions != COGNEE_EMBEDDING_DIMENSIONS:
+            raise RuntimeError(
+                "Unsupported CE custom embedding dimension: "
+                f"expected {COGNEE_EMBEDDING_DIMENSIONS}, configured {dimensions}"
+            )
+        return EmbeddingModelSpec(
+            internal_model=clean_model,
+            dimensions=dimensions,
+            send_dimensions=bool(
+                saved.get(
+                    "sendDimensions",
+                    _environment_flag("COGNEE_EMBEDDING_SEND_DIMENSIONS", True),
+                )
+            ),
+            gateway=MODE_CUSTOM,
+        )
+    raise RuntimeError(f"Unsupported embedding model: {clean_model or '<empty>'}")
+
+
+def embedding_gateway_credentials(spec: EmbeddingModelSpec) -> tuple[str, str]:
+    """Resolve credentials for the gateway permanently implied by a model spec."""
+
+    if is_ce_effective():
+        gateway = get_ce_newapi_config_for_mode(spec.gateway)
+        return gateway.api_key, gateway.base_url
+    if spec.gateway != MODE_OFFICIAL:
+        raise RuntimeError("Custom embedding gateway is only available in CE")
+    gateway = get_effective_newapi_config(official_base_url=OFFICIAL_NEWAPI_BASE_URL)
+    return gateway.api_key, gateway.base_url
+
+
+def current_embedding_model_spec() -> EmbeddingModelSpec | None:
+    return _CURRENT_COGNEE_EMBEDDING_SPEC.get()
+
+
+def require_current_embedding_model_spec() -> EmbeddingModelSpec:
+    spec = current_embedding_model_spec()
+    if spec is None:
+        raise RuntimeError("Cognee embedding request has no project model context")
+    return spec
+
+
+@contextmanager
+def embedding_model_scope(model: str) -> Iterator[EmbeddingModelSpec]:
+    """Bind one project's embedding model to all calls in the current async context."""
+
+    spec = embedding_model_spec(model)
+    token = _CURRENT_COGNEE_EMBEDDING_SPEC.set(spec)
+    try:
+        yield spec
+    finally:
+        _CURRENT_COGNEE_EMBEDDING_SPEC.reset(token)

--- a/src/novelvideo/embedding_models.py
+++ b/src/novelvideo/embedding_models.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import os
 from contextlib import contextmanager
 from contextvars import ContextVar
 from dataclasses import dataclass
@@ -19,6 +18,7 @@ from novelvideo.official_defaults import OFFICIAL_NEWAPI_BASE_URL
 from novelvideo.shared.runtime_env import is_ce_effective
 
 PROJECT_EMBEDDING_MODEL_KEY = "cognee_embedding_model"
+PROJECT_EMBEDDING_DIMENSION_KEY = "cognee_embedding_dimension"
 COGNEE_EMBEDDING_MODEL_LEGACY = "DC-cognee-embedding"
 COGNEE_EMBEDDING_MODEL_V1 = "DC-cognee-embedding-v1"
 COGNEE_EMBEDDING_MODEL_V2 = "DC-cognee-embedding-v2"
@@ -39,13 +39,6 @@ _CURRENT_COGNEE_EMBEDDING_SPEC: ContextVar[EmbeddingModelSpec | None] = ContextV
 )
 
 
-def _environment_flag(name: str, default: bool) -> bool:
-    raw = os.environ.get(name)
-    if raw is None:
-        return default
-    return raw.strip().lower() in {"1", "true", "yes", "on"}
-
-
 def active_gateway_uses_custom_embedding() -> bool:
     """Return whether new projects should bind to the CE custom model alias."""
 
@@ -57,9 +50,20 @@ def active_gateway_uses_custom_embedding() -> bool:
 def embedding_model_for_new_project() -> str:
     """Choose the permanent model binding for a project created now."""
 
+    return embedding_model_binding_for_new_project().internal_model
+
+
+def embedding_model_binding_for_new_project() -> EmbeddingModelSpec:
+    """Snapshot the embedding model contract for a project created now."""
+
     if active_gateway_uses_custom_embedding():
-        return COGNEE_EMBEDDING_MODEL_LEGACY
-    return COGNEE_EMBEDDING_MODEL_V2
+        saved = get_newapi_embedding_model_config()
+        dimensions = int(saved.get("dimension") or COGNEE_EMBEDDING_DIMENSIONS)
+        return embedding_model_spec(
+            COGNEE_EMBEDDING_MODEL_LEGACY,
+            dimensions=dimensions,
+        )
+    return embedding_model_spec(COGNEE_EMBEDDING_MODEL_V2)
 
 
 def embedding_model_for_legacy_project() -> str:
@@ -70,18 +74,39 @@ def embedding_model_for_legacy_project() -> str:
     return COGNEE_EMBEDDING_MODEL_V1
 
 
-def embedding_model_spec(model: str) -> EmbeddingModelSpec:
+def embedding_model_spec(
+    model: str,
+    *,
+    dimensions: int | None = None,
+) -> EmbeddingModelSpec:
     """Resolve and strictly validate one persisted internal model name."""
 
     clean_model = str(model or "").strip()
+    project_dimensions = int(dimensions) if dimensions is not None else None
+    if project_dimensions is not None and project_dimensions <= 0:
+        raise RuntimeError(
+            f"Unsupported embedding dimensions: {project_dimensions}"
+        )
     if clean_model == COGNEE_EMBEDDING_MODEL_V1:
+        if project_dimensions not in {None, COGNEE_EMBEDDING_DIMENSIONS}:
+            raise RuntimeError(
+                "Embedding dimension does not match DC-cognee-embedding-v1: "
+                f"expected {COGNEE_EMBEDDING_DIMENSIONS}, "
+                f"configured {project_dimensions}"
+            )
         return EmbeddingModelSpec(
             internal_model=clean_model,
             dimensions=COGNEE_EMBEDDING_DIMENSIONS,
-            send_dimensions=False,
+            send_dimensions=True,
             gateway=MODE_OFFICIAL,
         )
     if clean_model == COGNEE_EMBEDDING_MODEL_V2:
+        if project_dimensions not in {None, COGNEE_EMBEDDING_DIMENSIONS}:
+            raise RuntimeError(
+                "Embedding dimension does not match DC-cognee-embedding-v2: "
+                f"expected {COGNEE_EMBEDDING_DIMENSIONS}, "
+                f"configured {project_dimensions}"
+            )
         return EmbeddingModelSpec(
             internal_model=clean_model,
             dimensions=COGNEE_EMBEDDING_DIMENSIONS,
@@ -93,22 +118,15 @@ def embedding_model_spec(model: str) -> EmbeddingModelSpec:
             raise RuntimeError(
                 "DC-cognee-embedding is reserved for CE custom NewAPI projects"
             )
-        saved = get_newapi_embedding_model_config()
-        dimensions = int(saved.get("dimension") or COGNEE_EMBEDDING_DIMENSIONS)
-        if dimensions != COGNEE_EMBEDDING_DIMENSIONS:
-            raise RuntimeError(
-                "Unsupported CE custom embedding dimension: "
-                f"expected {COGNEE_EMBEDDING_DIMENSIONS}, configured {dimensions}"
+        if project_dimensions is None:
+            saved = get_newapi_embedding_model_config()
+            project_dimensions = int(
+                saved.get("dimension") or COGNEE_EMBEDDING_DIMENSIONS
             )
         return EmbeddingModelSpec(
             internal_model=clean_model,
-            dimensions=dimensions,
-            send_dimensions=bool(
-                saved.get(
-                    "sendDimensions",
-                    _environment_flag("COGNEE_EMBEDDING_SEND_DIMENSIONS", True),
-                )
-            ),
+            dimensions=project_dimensions,
+            send_dimensions=True,
             gateway=MODE_CUSTOM,
         )
     raise RuntimeError(f"Unsupported embedding model: {clean_model or '<empty>'}")
@@ -138,10 +156,14 @@ def require_current_embedding_model_spec() -> EmbeddingModelSpec:
 
 
 @contextmanager
-def embedding_model_scope(model: str) -> Iterator[EmbeddingModelSpec]:
+def embedding_model_scope(
+    model: str,
+    *,
+    dimensions: int | None = None,
+) -> Iterator[EmbeddingModelSpec]:
     """Bind one project's embedding model to all calls in the current async context."""
 
-    spec = embedding_model_spec(model)
+    spec = embedding_model_spec(model, dimensions=dimensions)
     token = _CURRENT_COGNEE_EMBEDDING_SPEC.set(spec)
     try:
         yield spec

--- a/src/novelvideo/model_gateway_settings.py
+++ b/src/novelvideo/model_gateway_settings.py
@@ -301,7 +301,9 @@ def _decode_embedding_model_config(value: str | None) -> dict[str, Any]:
         "provider": provider,
         "upstreamModel": upstream_model,
         "dimension": dimensions,
-        "sendDimensions": _bool_setting(raw.get("sendDimensions"), True),
+        # Retain the field for API compatibility, but request behavior is an
+        # internal model contract and cannot be disabled by saved CE settings.
+        "sendDimensions": True,
         "internalModel": "DC-cognee-embedding",
     }
     if batch_size > 0:
@@ -431,7 +433,7 @@ def save_newapi_embedding_model_config(
         "provider": normalized_provider,
         "upstreamModel": normalized_upstream_model,
         "dimension": normalized_dimension,
-        "sendDimensions": bool(send_dimensions),
+        "sendDimensions": True,
         "internalModel": "DC-cognee-embedding",
     }
     if normalized_batch_size > 0:

--- a/src/novelvideo/model_gateway_settings.py
+++ b/src/novelvideo/model_gateway_settings.py
@@ -301,6 +301,7 @@ def _decode_embedding_model_config(value: str | None) -> dict[str, Any]:
         "provider": provider,
         "upstreamModel": upstream_model,
         "dimension": dimensions,
+        "sendDimensions": _bool_setting(raw.get("sendDimensions"), True),
         "internalModel": "DC-cognee-embedding",
     }
     if batch_size > 0:
@@ -412,6 +413,7 @@ def save_newapi_embedding_model_config(
     upstream_model: str,
     dimension: int | str,
     batch_size: int | str | None = None,
+    send_dimensions: bool = True,
 ) -> dict[str, Any]:
     normalized_provider = str(provider or "").strip().lower()
     normalized_upstream_model = str(upstream_model or "").strip()
@@ -429,6 +431,7 @@ def save_newapi_embedding_model_config(
         "provider": normalized_provider,
         "upstreamModel": normalized_upstream_model,
         "dimension": normalized_dimension,
+        "sendDimensions": bool(send_dimensions),
         "internalModel": "DC-cognee-embedding",
     }
     if normalized_batch_size > 0:
@@ -519,6 +522,21 @@ def get_effective_newapi_config(
 
     settings = get_model_gateway_settings()
     mode = normalize_gateway_mode(settings.get("model_gateway_mode"))
+    return get_ce_newapi_config_for_mode(mode)
+
+
+def get_ce_newapi_config_for_mode(mode: str) -> EffectiveNewApiConfig:
+    """Return CE credentials for one gateway without changing the active mode.
+
+    Embedding projects can remain bound to the gateway that created their vector
+    space even when the installation's general model gateway is switched later.
+    """
+
+    if not _uses_ce_gateway_settings():
+        raise RuntimeError("CE model gateway settings are not available in EE")
+
+    settings = get_model_gateway_settings()
+    mode = normalize_gateway_mode(mode)
     if mode == MODE_CUSTOM:
         return EffectiveNewApiConfig(
             mode=MODE_CUSTOM,
@@ -540,6 +558,14 @@ def _int_setting(value: str | None, default: int) -> int:
         return int(str(value or "").strip())
     except ValueError:
         return default
+
+
+def _bool_setting(value: Any, default: bool) -> bool:
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    return str(value).strip().lower() in {"1", "true", "yes", "on"}
 
 
 def get_effective_media_relay_config(
@@ -646,7 +672,11 @@ def get_effective_cognee_embedding_config(
     env_dimensions: str | int | None = None,
     llm_provider: str | None = None,
 ) -> EffectiveCogneeEmbeddingConfig:
-    saved = get_newapi_embedding_model_config() if _uses_ce_gateway_settings() else {}
+    saved: dict[str, Any] = {}
+    if _uses_ce_gateway_settings():
+        gateway = get_effective_newapi_config()
+        if gateway.mode == MODE_CUSTOM:
+            saved = get_newapi_embedding_model_config()
     if saved:
         saved_batch_size = str(
             saved.get("batchSize")

--- a/src/novelvideo/project_config.py
+++ b/src/novelvideo/project_config.py
@@ -10,11 +10,14 @@ import uuid
 from contextlib import contextmanager
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Callable, Iterable
+from typing import TYPE_CHECKING, Callable, Iterable
 
 from novelvideo.config import STATE_DIR
 
 _log = logging.getLogger(__name__)
+
+if TYPE_CHECKING:
+    from novelvideo.embedding_models import EmbeddingModelSpec
 
 # Backward-compatible monkeypatch alias: source-branch tests
 # (e.g. test_indextts2_beat_audio_task) redirect config root by setting
@@ -83,15 +86,19 @@ def load_project_config_file_from_state_dir(state_dir: str | Path) -> dict:
     return load_project_config_file_from_path(get_project_config_path_from_state_dir(state_dir))
 
 
-def ensure_cognee_embedding_model_in_state_dir(state_dir: str | Path) -> str:
-    """Return the project's permanent embedding binding, backfilling legacy projects.
+def ensure_cognee_embedding_binding_in_state_dir(
+    state_dir: str | Path,
+) -> EmbeddingModelSpec:
+    """Return the permanent embedding contract, backfilling legacy projects.
 
     Unlike the general compatibility loader, this path is intentionally strict:
     corrupt project configuration must not be mistaken for a missing historical
-    field because choosing the wrong 1024-dimensional vector space is silent.
+    field because choosing the wrong vector space is silent.
     """
 
     from novelvideo.embedding_models import (
+        COGNEE_EMBEDDING_DIMENSIONS,
+        PROJECT_EMBEDDING_DIMENSION_KEY,
         PROJECT_EMBEDDING_MODEL_KEY,
         embedding_model_for_legacy_project,
         embedding_model_spec,
@@ -112,14 +119,38 @@ def ensure_cognee_embedding_model_in_state_dir(state_dir: str | Path) -> str:
         else:
             config = {}
 
+        changed = False
         model = str(config.get(PROJECT_EMBEDDING_MODEL_KEY) or "").strip()
         if not model:
             model = embedding_model_for_legacy_project()
             config[PROJECT_EMBEDDING_MODEL_KEY] = model
-            _write_project_config_atomic(config_path, config)
+            changed = True
 
-        embedding_model_spec(model)
-        return model
+        raw_dimensions = config.get(PROJECT_EMBEDDING_DIMENSION_KEY)
+        if raw_dimensions is None:
+            # Every project created before dimension binding used the historical
+            # 1024-dimensional Cognee vector store, including CE custom projects.
+            dimensions = COGNEE_EMBEDDING_DIMENSIONS
+            config[PROJECT_EMBEDDING_DIMENSION_KEY] = dimensions
+            changed = True
+        else:
+            try:
+                dimensions = int(raw_dimensions)
+            except (TypeError, ValueError) as exc:
+                raise RuntimeError(
+                    f"Invalid project embedding dimensions: {raw_dimensions!r}"
+                ) from exc
+
+        spec = embedding_model_spec(model, dimensions=dimensions)
+        if changed:
+            _write_project_config_atomic(config_path, config)
+        return spec
+
+
+def ensure_cognee_embedding_model_in_state_dir(state_dir: str | Path) -> str:
+    """Compatibility wrapper returning only the project's bound model name."""
+
+    return ensure_cognee_embedding_binding_in_state_dir(state_dir).internal_model
 
 
 def _default_project_config() -> dict:

--- a/src/novelvideo/project_config.py
+++ b/src/novelvideo/project_config.py
@@ -83,6 +83,45 @@ def load_project_config_file_from_state_dir(state_dir: str | Path) -> dict:
     return load_project_config_file_from_path(get_project_config_path_from_state_dir(state_dir))
 
 
+def ensure_cognee_embedding_model_in_state_dir(state_dir: str | Path) -> str:
+    """Return the project's permanent embedding binding, backfilling legacy projects.
+
+    Unlike the general compatibility loader, this path is intentionally strict:
+    corrupt project configuration must not be mistaken for a missing historical
+    field because choosing the wrong 1024-dimensional vector space is silent.
+    """
+
+    from novelvideo.embedding_models import (
+        PROJECT_EMBEDDING_MODEL_KEY,
+        embedding_model_for_legacy_project,
+        embedding_model_spec,
+    )
+
+    config_path = get_project_config_path_from_state_dir(state_dir)
+    with _project_config_lock(config_path):
+        if config_path.exists():
+            try:
+                raw = json.loads(config_path.read_text(encoding="utf-8"))
+            except Exception as exc:
+                raise RuntimeError(
+                    f"Invalid project configuration: {config_path}"
+                ) from exc
+            if not isinstance(raw, dict):
+                raise RuntimeError(f"Invalid project configuration object: {config_path}")
+            config = normalize_project_config(raw)
+        else:
+            config = {}
+
+        model = str(config.get(PROJECT_EMBEDDING_MODEL_KEY) or "").strip()
+        if not model:
+            model = embedding_model_for_legacy_project()
+            config[PROJECT_EMBEDDING_MODEL_KEY] = model
+            _write_project_config_atomic(config_path, config)
+
+        embedding_model_spec(model)
+        return model
+
+
 def _default_project_config() -> dict:
     from novelvideo.config import (
         DEFAULT_RENDER_IMAGE_SELECTION,

--- a/tests/contract/test_m01_auth.py
+++ b/tests/contract/test_m01_auth.py
@@ -127,6 +127,7 @@ def test_ce_auth_me_logout_and_project_crud_contract(
             detail.json()["data"]["cognee_embedding_model"]
             == "DC-cognee-embedding-v2"
         )
+        assert detail.json()["data"]["cognee_embedding_dimension"] == 1024
 
 
 @pytest.mark.ee

--- a/tests/contract/test_m01_auth.py
+++ b/tests/contract/test_m01_auth.py
@@ -123,6 +123,10 @@ def test_ce_auth_me_logout_and_project_crud_contract(
         detail = client.get(f"/api/v1/projects/{project_id}")
         assert detail.status_code == 200
         assert detail.json()["data"]["project_id"] == project_id
+        assert (
+            detail.json()["data"]["cognee_embedding_model"]
+            == "DC-cognee-embedding-v2"
+        )
 
 
 @pytest.mark.ee

--- a/tests/test_model_gateway_settings.py
+++ b/tests/test_model_gateway_settings.py
@@ -2170,26 +2170,20 @@ def test_custom_newapi_embedding_model_writes_mapping_and_persists_dimension(
     }
 
 
-def test_custom_newapi_embedding_model_rejects_non_project_dimension(
-    monkeypatch,
-    tmp_path,
+def test_custom_newapi_embedding_model_accepts_positive_project_dimension(
 ):
-    _isolate_settings_db(monkeypatch, tmp_path)
-    monkeypatch.setenv("NEWAPI_PROVISIONER_ENABLED", "true")
-
-    app = FastAPI()
-    app.include_router(model_gateway.router)
-    response = TestClient(app).post(
-        "/model-gateway/custom/newapi/embedding-model",
-        json={
+    body = model_gateway.SaveEmbeddingModelBody.model_validate(
+        {
             "provider": "openai",
             "upstreamModel": "text-embedding-3-large",
             "dimension": 3072,
-        },
+        }
     )
 
-    assert response.status_code == 400
-    assert "dimension must be 1024" in response.text
+    _, normalized = model_gateway._build_embedding_model_channel_spec(body)
+
+    assert normalized["dimension"] == 3072
+    assert normalized["sendDimensions"] is True
 
 
 def test_effective_cognee_embedding_prefers_saved_custom_config(monkeypatch, tmp_path):

--- a/tests/test_model_gateway_settings.py
+++ b/tests/test_model_gateway_settings.py
@@ -2141,7 +2141,7 @@ def test_custom_newapi_embedding_model_writes_mapping_and_persists_dimension(
             "newApiBaseUrl": "http://new-api:3000",
             "provider": "openai",
             "upstreamModel": "text-embedding-3-large",
-            "dimension": 3072,
+            "dimension": 1024,
             "batchSize": 36,
         },
     )
@@ -2155,7 +2155,7 @@ def test_custom_newapi_embedding_model_writes_mapping_and_persists_dimension(
         "DC-cognee-embedding": "text-embedding-3-large",
     }
     assert "dimension" not in payloads[0]["channel"]
-    assert "3072" not in payloads[0]["channel"]["model_mapping"]
+    assert "1024" not in payloads[0]["channel"]["model_mapping"]
     assert "sk-openai-upstream-secret" not in response.text
 
     config_response = client.get("/model-gateway/config")
@@ -2163,14 +2163,38 @@ def test_custom_newapi_embedding_model_writes_mapping_and_persists_dimension(
     assert embedding == {
         "provider": "openai",
         "upstreamModel": "text-embedding-3-large",
-        "dimension": 3072,
+        "dimension": 1024,
         "batchSize": 36,
+        "sendDimensions": True,
         "internalModel": "DC-cognee-embedding",
     }
 
 
+def test_custom_newapi_embedding_model_rejects_non_project_dimension(
+    monkeypatch,
+    tmp_path,
+):
+    _isolate_settings_db(monkeypatch, tmp_path)
+    monkeypatch.setenv("NEWAPI_PROVISIONER_ENABLED", "true")
+
+    app = FastAPI()
+    app.include_router(model_gateway.router)
+    response = TestClient(app).post(
+        "/model-gateway/custom/newapi/embedding-model",
+        json={
+            "provider": "openai",
+            "upstreamModel": "text-embedding-3-large",
+            "dimension": 3072,
+        },
+    )
+
+    assert response.status_code == 400
+    assert "dimension must be 1024" in response.text
+
+
 def test_effective_cognee_embedding_prefers_saved_custom_config(monkeypatch, tmp_path):
     _isolate_settings_db(monkeypatch, tmp_path)
+    set_model_gateway_mode(MODE_CUSTOM)
     monkeypatch.setenv("COGNEE_EMBEDDING_PROVIDER", "gemini")
     monkeypatch.setenv("COGNEE_EMBEDDING_MODEL", "gemini-embedding-001")
     monkeypatch.setenv("COGNEE_EMBEDDING_DIM", "768")
@@ -2193,6 +2217,7 @@ def test_effective_cognee_embedding_prefers_saved_custom_config(monkeypatch, tmp
 
 def test_effective_cognee_embedding_keeps_saved_batch_size(monkeypatch, tmp_path):
     _isolate_settings_db(monkeypatch, tmp_path)
+    set_model_gateway_mode(MODE_CUSTOM)
 
     save_newapi_embedding_model_config(
         provider="ali",
@@ -2208,6 +2233,25 @@ def test_effective_cognee_embedding_keeps_saved_batch_size(monkeypatch, tmp_path
     assert effective.model == "DC-cognee-embedding"
     assert effective.dimensions == "1024"
     assert effective.batch_size == "10"
+
+
+def test_ce_official_embedding_ignores_saved_custom_model(monkeypatch, tmp_path):
+    _isolate_settings_db(monkeypatch, tmp_path)
+    save_newapi_embedding_model_config(
+        provider="openai",
+        upstream_model="stale-custom-model",
+        dimension=1024,
+    )
+    set_model_gateway_mode(MODE_OFFICIAL)
+    monkeypatch.setenv("COGNEE_EMBEDDING_MODEL", "DC-cognee-embedding")
+    monkeypatch.setenv("COGNEE_EMBEDDING_DIM", "1024")
+
+    effective = get_effective_cognee_embedding_config()
+
+    assert effective.source == "environment"
+    assert effective.model == "DC-cognee-embedding"
+    assert effective.dimensions == "1024"
+    assert effective.upstream_model == ""
 
 
 def test_cognee_apply_embedding_env_sets_saved_batch_size(monkeypatch, tmp_path):

--- a/tests/test_project_embedding_models.py
+++ b/tests/test_project_embedding_models.py
@@ -10,6 +10,8 @@ from novelvideo.embedding_models import (
     COGNEE_EMBEDDING_MODEL_LEGACY,
     COGNEE_EMBEDDING_MODEL_V1,
     COGNEE_EMBEDDING_MODEL_V2,
+    PROJECT_EMBEDDING_DIMENSION_KEY,
+    embedding_model_binding_for_new_project,
     embedding_model_for_legacy_project,
     embedding_model_for_new_project,
     embedding_gateway_credentials,
@@ -25,7 +27,10 @@ from novelvideo.model_gateway_settings import (
     save_official_newapi_key,
     set_model_gateway_mode,
 )
-from novelvideo.project_config import ensure_cognee_embedding_model_in_state_dir
+from novelvideo.project_config import (
+    ensure_cognee_embedding_binding_in_state_dir,
+    ensure_cognee_embedding_model_in_state_dir,
+)
 
 
 def _isolate_ce(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
@@ -52,6 +57,27 @@ def test_ce_custom_projects_bind_unversioned_model(monkeypatch, tmp_path):
 
     assert embedding_model_for_new_project() == COGNEE_EMBEDDING_MODEL_LEGACY
     assert embedding_model_for_legacy_project() == COGNEE_EMBEDDING_MODEL_LEGACY
+
+
+def test_ce_custom_new_project_snapshots_configured_dimensions(monkeypatch, tmp_path):
+    _isolate_ce(monkeypatch, tmp_path)
+    save_custom_newapi_gateway(
+        base_url="http://new-api:3000",
+        api_key="sk-custom",
+        activate=True,
+    )
+    save_newapi_embedding_model_config(
+        provider="ali",
+        upstream_model="Qwen3-Embedding-8B",
+        dimension=3072,
+        send_dimensions=False,
+    )
+
+    binding = embedding_model_binding_for_new_project()
+
+    assert binding.internal_model == COGNEE_EMBEDDING_MODEL_LEGACY
+    assert binding.dimensions == 3072
+    assert binding.send_dimensions is True
 
 
 def test_project_model_keeps_its_gateway_after_active_mode_switch(monkeypatch, tmp_path):
@@ -90,6 +116,7 @@ def test_legacy_project_binding_is_backfilled_once(monkeypatch, tmp_path):
     assert persisted == {
         "visual_style": "cinematic",
         "cognee_embedding_model": COGNEE_EMBEDDING_MODEL_V1,
+        PROJECT_EMBEDDING_DIMENSION_KEY: 1024,
     }
 
     set_model_gateway_mode(MODE_CUSTOM)
@@ -125,7 +152,7 @@ def test_fixed_official_model_specs():
     assert (v1.gateway, v1.dimensions, v1.send_dimensions) == (
         MODE_OFFICIAL,
         1024,
-        False,
+        True,
     )
     assert (v2.gateway, v2.dimensions, v2.send_dimensions) == (
         MODE_OFFICIAL,
@@ -134,7 +161,18 @@ def test_fixed_official_model_specs():
     )
 
 
-def test_ce_custom_spec_uses_saved_send_dimensions(monkeypatch, tmp_path):
+def test_official_project_dimension_mismatch_fails_closed():
+    with pytest.raises(RuntimeError, match="does not match"):
+        embedding_model_spec(
+            COGNEE_EMBEDDING_MODEL_V2,
+            dimensions=3072,
+        )
+
+
+def test_ce_custom_spec_uses_project_dimensions_and_internal_send_policy(
+    monkeypatch,
+    tmp_path,
+):
     _isolate_ce(monkeypatch, tmp_path)
     save_newapi_embedding_model_config(
         provider="ali",
@@ -143,11 +181,45 @@ def test_ce_custom_spec_uses_saved_send_dimensions(monkeypatch, tmp_path):
         send_dimensions=False,
     )
 
-    spec = embedding_model_spec(COGNEE_EMBEDDING_MODEL_LEGACY)
+    spec = embedding_model_spec(
+        COGNEE_EMBEDDING_MODEL_LEGACY,
+        dimensions=3072,
+    )
 
     assert spec.gateway == MODE_CUSTOM
-    assert spec.dimensions == 1024
-    assert spec.send_dimensions is False
+    assert spec.dimensions == 3072
+    assert spec.send_dimensions is True
+
+
+def test_existing_custom_project_keeps_backfilled_1024_dimensions(
+    monkeypatch,
+    tmp_path,
+):
+    _isolate_ce(monkeypatch, tmp_path)
+    save_custom_newapi_gateway(
+        base_url="http://new-api:3000",
+        api_key="sk-custom",
+        activate=True,
+    )
+    save_newapi_embedding_model_config(
+        provider="ali",
+        upstream_model="Qwen3-Embedding-8B",
+        dimension=3072,
+    )
+    state_dir = tmp_path / "project-state"
+    state_dir.mkdir()
+    config_path = state_dir / "project_config.json"
+    config_path.write_text(
+        json.dumps({"cognee_embedding_model": COGNEE_EMBEDDING_MODEL_LEGACY}),
+        encoding="utf-8",
+    )
+
+    binding = ensure_cognee_embedding_binding_in_state_dir(state_dir)
+
+    assert binding.dimensions == 1024
+    assert json.loads(config_path.read_text(encoding="utf-8"))[
+        PROJECT_EMBEDDING_DIMENSION_KEY
+    ] == 1024
 
 
 @pytest.mark.asyncio
@@ -177,6 +249,50 @@ async def test_embedding_model_scope_is_isolated_between_concurrent_tasks():
         require_current_embedding_model_spec()
 
 
+@pytest.mark.asyncio
+async def test_custom_project_dimensions_are_isolated_between_concurrent_tasks(
+    monkeypatch,
+    tmp_path,
+):
+    _isolate_ce(monkeypatch, tmp_path)
+
+    async def read_scoped(dimensions: int) -> int:
+        with embedding_model_scope(
+            COGNEE_EMBEDDING_MODEL_LEGACY,
+            dimensions=dimensions,
+        ):
+            await asyncio.sleep(0)
+            return require_current_embedding_model_spec().dimensions
+
+    first, second = await asyncio.gather(
+        read_scoped(768),
+        read_scoped(3072),
+    )
+
+    assert (first, second) == (768, 3072)
+
+
+def test_cognee_vector_size_follows_project_scope(monkeypatch, tmp_path):
+    _isolate_ce(monkeypatch, tmp_path)
+    from cognee.infrastructure.databases.vector.embeddings.LiteLLMEmbeddingEngine import (
+        LiteLLMEmbeddingEngine,
+    )
+
+    from novelvideo.cognee import config as cognee_config
+
+    cognee_config._patch_cognee_embedding_gateway()
+    engine = LiteLLMEmbeddingEngine.__new__(LiteLLMEmbeddingEngine)
+    engine.dimensions = 1024
+
+    with embedding_model_scope(
+        COGNEE_EMBEDDING_MODEL_LEGACY,
+        dimensions=3072,
+    ):
+        assert engine.get_vector_size() == 3072
+
+    assert engine.get_vector_size() == 1024
+
+
 def test_litellm_kwargs_follow_project_model(monkeypatch):
     from novelvideo.cognee import config as cognee_config
 
@@ -198,8 +314,8 @@ def test_litellm_kwargs_follow_project_model(monkeypatch):
         v2 = cognee_config._project_embedding_request_kwargs({"model": "wrong"})
 
     assert v1["model"] == "openai/DC-cognee-embedding-v1"
-    assert "dimensions" not in v1
-    assert "allowed_openai_params" not in v1
+    assert v1["dimensions"] == 1024
+    assert v1["allowed_openai_params"] == ["dimensions"]
     assert v1["api_base"] == "https://official.example/v1"
     assert v2["model"] == "openai/DC-cognee-embedding-v2"
     assert v2["dimensions"] == 1024
@@ -240,7 +356,8 @@ async def test_concurrent_embedding_requests_do_not_cross_models(monkeypatch):
     )
 
     assert v1["model"] == "openai/DC-cognee-embedding-v1"
-    assert "dimensions" not in v1
+    assert v1["dimensions"] == 1024
+    assert v1["allowed_openai_params"] == ["dimensions"]
     assert v2["model"] == "openai/DC-cognee-embedding-v2"
     assert v2["dimensions"] == 1024
     assert v2["allowed_openai_params"] == ["dimensions"]

--- a/tests/test_project_embedding_models.py
+++ b/tests/test_project_embedding_models.py
@@ -1,0 +1,327 @@
+from __future__ import annotations
+
+import asyncio
+import json
+
+import pytest
+
+from novelvideo import config
+from novelvideo.embedding_models import (
+    COGNEE_EMBEDDING_MODEL_LEGACY,
+    COGNEE_EMBEDDING_MODEL_V1,
+    COGNEE_EMBEDDING_MODEL_V2,
+    embedding_model_for_legacy_project,
+    embedding_model_for_new_project,
+    embedding_gateway_credentials,
+    embedding_model_scope,
+    embedding_model_spec,
+    require_current_embedding_model_spec,
+)
+from novelvideo.model_gateway_settings import (
+    MODE_CUSTOM,
+    MODE_OFFICIAL,
+    save_custom_newapi_gateway,
+    save_newapi_embedding_model_config,
+    save_official_newapi_key,
+    set_model_gateway_mode,
+)
+from novelvideo.project_config import ensure_cognee_embedding_model_in_state_dir
+
+
+def _isolate_ce(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    monkeypatch.setattr(config, "STATE_DIR", str(tmp_path / "state-root"))
+    monkeypatch.setenv("ST_EDITION", "ce")
+    monkeypatch.delenv("ST_CONTROL_PLANE_DSN", raising=False)
+
+
+def test_new_and_legacy_official_projects_bind_v2_and_v1(monkeypatch, tmp_path):
+    _isolate_ce(monkeypatch, tmp_path)
+    set_model_gateway_mode(MODE_OFFICIAL)
+
+    assert embedding_model_for_new_project() == COGNEE_EMBEDDING_MODEL_V2
+    assert embedding_model_for_legacy_project() == COGNEE_EMBEDDING_MODEL_V1
+
+
+def test_ce_custom_projects_bind_unversioned_model(monkeypatch, tmp_path):
+    _isolate_ce(monkeypatch, tmp_path)
+    save_custom_newapi_gateway(
+        base_url="http://new-api:3000",
+        api_key="sk-custom",
+        activate=True,
+    )
+
+    assert embedding_model_for_new_project() == COGNEE_EMBEDDING_MODEL_LEGACY
+    assert embedding_model_for_legacy_project() == COGNEE_EMBEDDING_MODEL_LEGACY
+
+
+def test_project_model_keeps_its_gateway_after_active_mode_switch(monkeypatch, tmp_path):
+    _isolate_ce(monkeypatch, tmp_path)
+    save_official_newapi_key(api_key="sk-official", activate=True)
+    save_custom_newapi_gateway(
+        base_url="http://new-api:3000",
+        api_key="sk-custom",
+        activate=True,
+    )
+
+    official = embedding_gateway_credentials(
+        embedding_model_spec(COGNEE_EMBEDDING_MODEL_V1)
+    )
+    custom = embedding_gateway_credentials(
+        embedding_model_spec(COGNEE_EMBEDDING_MODEL_LEGACY)
+    )
+
+    assert official == ("sk-official", "https://relayclaw.cdnfg.com/v1")
+    assert custom == ("sk-custom", "http://new-api:3000/v1")
+
+
+def test_legacy_project_binding_is_backfilled_once(monkeypatch, tmp_path):
+    _isolate_ce(monkeypatch, tmp_path)
+    set_model_gateway_mode(MODE_OFFICIAL)
+    state_dir = tmp_path / "project-state"
+    state_dir.mkdir()
+    config_path = state_dir / "project_config.json"
+    config_path.write_text('{"visual_style":"cinematic"}', encoding="utf-8")
+
+    assert (
+        ensure_cognee_embedding_model_in_state_dir(state_dir)
+        == COGNEE_EMBEDDING_MODEL_V1
+    )
+    persisted = json.loads(config_path.read_text(encoding="utf-8"))
+    assert persisted == {
+        "visual_style": "cinematic",
+        "cognee_embedding_model": COGNEE_EMBEDDING_MODEL_V1,
+    }
+
+    set_model_gateway_mode(MODE_CUSTOM)
+    assert (
+        ensure_cognee_embedding_model_in_state_dir(state_dir)
+        == COGNEE_EMBEDDING_MODEL_V1
+    )
+
+
+@pytest.mark.parametrize(
+    "payload",
+    ["not-json", "[]", '{"cognee_embedding_model":"unknown"}'],
+)
+def test_invalid_project_embedding_config_fails_closed(
+    monkeypatch,
+    tmp_path,
+    payload,
+):
+    _isolate_ce(monkeypatch, tmp_path)
+    set_model_gateway_mode(MODE_OFFICIAL)
+    state_dir = tmp_path / "project-state"
+    state_dir.mkdir()
+    (state_dir / "project_config.json").write_text(payload, encoding="utf-8")
+
+    with pytest.raises(RuntimeError):
+        ensure_cognee_embedding_model_in_state_dir(state_dir)
+
+
+def test_fixed_official_model_specs():
+    v1 = embedding_model_spec(COGNEE_EMBEDDING_MODEL_V1)
+    v2 = embedding_model_spec(COGNEE_EMBEDDING_MODEL_V2)
+
+    assert (v1.gateway, v1.dimensions, v1.send_dimensions) == (
+        MODE_OFFICIAL,
+        1024,
+        False,
+    )
+    assert (v2.gateway, v2.dimensions, v2.send_dimensions) == (
+        MODE_OFFICIAL,
+        1024,
+        True,
+    )
+
+
+def test_ce_custom_spec_uses_saved_send_dimensions(monkeypatch, tmp_path):
+    _isolate_ce(monkeypatch, tmp_path)
+    save_newapi_embedding_model_config(
+        provider="ali",
+        upstream_model="Qwen3-Embedding-8B",
+        dimension=1024,
+        send_dimensions=False,
+    )
+
+    spec = embedding_model_spec(COGNEE_EMBEDDING_MODEL_LEGACY)
+
+    assert spec.gateway == MODE_CUSTOM
+    assert spec.dimensions == 1024
+    assert spec.send_dimensions is False
+
+
+@pytest.mark.asyncio
+async def test_embedding_model_scope_is_isolated_between_concurrent_tasks():
+    ready = asyncio.Event()
+    seen: list[tuple[str, str]] = []
+
+    async def read_scoped(model: str) -> None:
+        with embedding_model_scope(model):
+            before = require_current_embedding_model_spec().internal_model
+            ready.set()
+            await asyncio.sleep(0)
+            after = require_current_embedding_model_spec().internal_model
+            seen.append((before, after))
+
+    await asyncio.gather(
+        read_scoped(COGNEE_EMBEDDING_MODEL_V1),
+        read_scoped(COGNEE_EMBEDDING_MODEL_V2),
+    )
+    await ready.wait()
+
+    assert sorted(seen) == [
+        (COGNEE_EMBEDDING_MODEL_V1, COGNEE_EMBEDDING_MODEL_V1),
+        (COGNEE_EMBEDDING_MODEL_V2, COGNEE_EMBEDDING_MODEL_V2),
+    ]
+    with pytest.raises(RuntimeError, match="no project model context"):
+        require_current_embedding_model_spec()
+
+
+def test_litellm_kwargs_follow_project_model(monkeypatch):
+    from novelvideo.cognee import config as cognee_config
+
+    monkeypatch.setattr(
+        cognee_config,
+        "embedding_gateway_credentials",
+        lambda spec: (f"key-{spec.gateway}", f"https://{spec.gateway}.example/v1"),
+    )
+
+    with embedding_model_scope(COGNEE_EMBEDDING_MODEL_V1):
+        v1 = cognee_config._project_embedding_request_kwargs(
+            {
+                "model": "wrong",
+                "dimensions": 999,
+                "allowed_openai_params": ["dimensions"],
+            }
+        )
+    with embedding_model_scope(COGNEE_EMBEDDING_MODEL_V2):
+        v2 = cognee_config._project_embedding_request_kwargs({"model": "wrong"})
+
+    assert v1["model"] == "openai/DC-cognee-embedding-v1"
+    assert "dimensions" not in v1
+    assert "allowed_openai_params" not in v1
+    assert v1["api_base"] == "https://official.example/v1"
+    assert v2["model"] == "openai/DC-cognee-embedding-v2"
+    assert v2["dimensions"] == 1024
+    assert v2["allowed_openai_params"] == ["dimensions"]
+    assert v2["api_key"] == "key-official"
+
+    from litellm.utils import get_optional_params_embeddings
+
+    optional_params = get_optional_params_embeddings(
+        model=v2["model"],
+        dimensions=v2["dimensions"],
+        custom_llm_provider=v2["custom_llm_provider"],
+        allowed_openai_params=v2["allowed_openai_params"],
+    )
+    assert optional_params["dimensions"] == 1024
+
+
+@pytest.mark.asyncio
+async def test_concurrent_embedding_requests_do_not_cross_models(monkeypatch):
+    from novelvideo.cognee import config as cognee_config
+
+    monkeypatch.setattr(
+        cognee_config,
+        "embedding_gateway_credentials",
+        lambda spec: ("key", f"https://{spec.internal_model}.example/v1"),
+    )
+
+    async def route(model: str) -> dict:
+        with embedding_model_scope(model):
+            await asyncio.sleep(0)
+            return cognee_config._project_embedding_request_kwargs(
+                {"model": "global-default", "dimensions": 999}
+            )
+
+    v1, v2 = await asyncio.gather(
+        route(COGNEE_EMBEDDING_MODEL_V1),
+        route(COGNEE_EMBEDDING_MODEL_V2),
+    )
+
+    assert v1["model"] == "openai/DC-cognee-embedding-v1"
+    assert "dimensions" not in v1
+    assert v2["model"] == "openai/DC-cognee-embedding-v2"
+    assert v2["dimensions"] == 1024
+    assert v2["allowed_openai_params"] == ["dimensions"]
+
+
+@pytest.mark.asyncio
+async def test_dimension_mismatch_refunds_reserved_embedding_credit(monkeypatch):
+    from novelvideo.cognee import config as cognee_config
+
+    class UsageMeter:
+        def __init__(self):
+            self.reserve: list[dict] = []
+            self.refunds: list[str] = []
+            self.bumps: list[dict] = []
+
+        async def reserve_current_model_call_credit(self, **kwargs):
+            self.reserve.append(kwargs)
+            return "embedding-reservation"
+
+        async def refund_model_call_credit_reservation(
+            self,
+            reservation_id,
+            *,
+            metadata=None,
+        ):
+            self.refunds.append(reservation_id)
+
+        async def bump_model_call(self, **kwargs):
+            self.bumps.append(kwargs)
+
+    meter = UsageMeter()
+    monkeypatch.setattr(cognee_config, "get_usage_meter", lambda: meter)
+
+    async def wrong_dimensions():
+        return [[0.0] * 4096]
+
+    with embedding_model_scope(COGNEE_EMBEDDING_MODEL_V2):
+        with pytest.raises(
+            RuntimeError,
+            match="Embedding dimension mismatch: expected 1024, received 4096",
+        ):
+            await cognee_config._run_project_embedding_with_billing(
+                wrong_dimensions,
+                expected_count=1,
+            )
+
+    assert meter.reserve[0]["model"] == COGNEE_EMBEDDING_MODEL_V2
+    assert meter.refunds == ["embedding-reservation"]
+    assert meter.bumps == []
+
+
+@pytest.mark.asyncio
+async def test_successful_embedding_bills_the_project_model(monkeypatch):
+    from novelvideo.cognee import config as cognee_config
+
+    class UsageMeter:
+        def __init__(self):
+            self.bump: dict | None = None
+
+        async def reserve_current_model_call_credit(self, **_kwargs):
+            return "embedding-reservation"
+
+        async def refund_model_call_credit_reservation(self, *_args, **_kwargs):
+            raise AssertionError("successful embedding must not be refunded")
+
+        async def bump_model_call(self, **kwargs):
+            self.bump = kwargs
+
+    meter = UsageMeter()
+    monkeypatch.setattr(cognee_config, "get_usage_meter", lambda: meter)
+
+    async def valid_embedding():
+        return [[0.0] * 1024]
+
+    with embedding_model_scope(COGNEE_EMBEDDING_MODEL_V1):
+        result = await cognee_config._run_project_embedding_with_billing(
+            valid_embedding,
+            expected_count=1,
+        )
+
+    assert len(result[0]) == 1024
+    assert meter.bump is not None
+    assert meter.bump["model"] == COGNEE_EMBEDDING_MODEL_V1
+    assert meter.bump["credit_reservation_id"] == "embedding-reservation"


### PR DESCRIPTION
## Summary

- Permanently bind each project to its Cognee embedding model and gateway.
- Keep historical official projects on v1, create new official projects on v2, and preserve the CE custom NewAPI alias.
- Route concurrent Cognee embedding operations through project-scoped context with persisted dimensions and response validation.
- Always send each project's persisted embedding dimensions while preserving billing, refunds, credentials, and request diagnostics.
- Add CE custom embedding configuration constraints, localized guidance, and regression coverage.

## Root cause

Cognee previously relied on mutable process-wide embedding defaults and temporarily replaced LiteLLM's global embedding function. Projects using different semantic vector spaces could therefore route through the wrong model under configuration changes or concurrent work. Internal model aliases also require explicit LiteLLM permission to pass the project's embedding dimensions.

## Behavior

- Official historical projects without a binding are atomically backfilled to `DC-cognee-embedding-v1`.
- New official CE/EE projects use `DC-cognee-embedding-v2`.
- CE custom NewAPI projects use `DC-cognee-embedding` and their saved custom gateway configuration.
- v1 and v2 always send `dimensions=1024`.
- CE custom projects always send their persisted project-specific `dimensions`.
- Unknown bindings and dimension-mismatched responses fail explicitly; failed reserved calls are refunded.

## Validation

- `uv run pytest -q` — 1718 passed, 16 skipped, 2 deselected
- `bun run test` — 277 files / 1766 tests passed
- `bun run build:ce`
- Ruff on all changed Python files
- `uvx pre-commit run --all-files` — gitleaks and banned-words passed
- Post-rebase integration — 113 focused Cognee/model-gateway tests passed; Ruff passed on all affected Python files

## Operational impact

- Official NewAPI must retain stable v1/v2 mappings and pricing.
- Existing workers must be drained before creating v2 projects during rollout.
- Changing the CE custom upstream embedding model requires rebuilding every project bound to the custom alias.

Closes #172
