### PR TITLE
fix(canvas): 蒙版编辑改用红色高亮标注,修复视觉模型区域定位失败

### DIFF
--- a/frontend/src/features/canvas/ui/EraseOverlay.tsx
+++ b/frontend/src/features/canvas/ui/EraseOverlay.tsx
@@ -117,6 +117,8 @@ export const EraseOverlay = memo(({ node, imageSource, onClose }: EraseOverlayPr
   const undoStackRef = useRef<ImageData[]>([]);
   const redoStackRef = useRef<ImageData[]>([]);
   const baseUrlRef = useRef(imageSource.split('?')[0]);
+  // 已加载的源图，导出蒙版时用作红色高亮的打底（后端把蒙版当视觉参考图）。
+  const sourceImgRef = useRef<HTMLImageElement | null>(null);
 
   const [tool, setTool] = useState<Tool>('brush');
   const [brushSize, setBrushSize] = useState(DEFAULT_BRUSH);
@@ -179,6 +181,7 @@ export const EraseOverlay = memo(({ node, imageSource, onClose }: EraseOverlayPr
         c.width = w;
         c.height = h;
       });
+      sourceImgRef.current = img;
       setImageDims({ w, h });
     };
     img.onerror = () => setError('无法加载源图');
@@ -410,19 +413,34 @@ export const EraseOverlay = memo(({ node, imageSource, onClose }: EraseOverlayPr
     [canvasToImageCoords, commitRect, recomputeHasMask, tool],
   );
 
-  // 蒙版导出：白底 + 透明的可编辑区域（与后端约定，透明像素 = 重绘/擦除区域）。
+  // 蒙版导出（供视觉模型识别）：源图 + 涂抹区半透明红色高亮。
+  // 后端把它当作 Image 2 的编辑参考——红色只是标注区域用，模型不会把红色画进结果。
+  // 旧做法是「白底 + 透明孔洞」，编辑区只存在于 alpha 通道，模型 RGB 里看是整张纯白 → 定位失败。
   const buildMaskBlob = useCallback(async (): Promise<Blob> => {
-    const src = maskCanvasRef.current;
-    if (!src) throw new Error('mask canvas not ready');
+    const mask = maskCanvasRef.current;
+    const baseImg = sourceImgRef.current;
+    if (!mask) throw new Error('mask canvas not ready');
+    if (!baseImg) throw new Error('source image not ready');
+    const w = mask.width;
+    const h = mask.height;
     const out = document.createElement('canvas');
-    out.width = src.width;
-    out.height = src.height;
+    out.width = w;
+    out.height = h;
     const ctx = out.getContext('2d');
     if (!ctx) throw new Error('ctx');
-    ctx.fillStyle = 'rgba(255,255,255,1)';
-    ctx.fillRect(0, 0, out.width, out.height);
-    ctx.globalCompositeOperation = 'destination-out';
-    ctx.drawImage(src, 0, 0);
+    // 1) 源图打底。
+    ctx.drawImage(baseImg, 0, 0, w, h);
+    // 2) 把涂抹区归一成均匀的半透明红（source-in 消除笔刷叠加深浅不均），再叠到源图上。
+    const overlay = document.createElement('canvas');
+    overlay.width = w;
+    overlay.height = h;
+    const octx = overlay.getContext('2d');
+    if (!octx) throw new Error('ctx');
+    octx.drawImage(mask, 0, 0);
+    octx.globalCompositeOperation = 'source-in';
+    octx.fillStyle = 'rgba(255, 0, 0, 0.6)';
+    octx.fillRect(0, 0, w, h);
+    ctx.drawImage(overlay, 0, 0);
     return await new Promise<Blob>((resolve, reject) => {
       out.toBlob(
         (blob) => (blob ? resolve(blob) : reject(new Error('toBlob returned null'))),

--- a/frontend/src/features/canvas/ui/EraseOverlay.tsx
+++ b/frontend/src/features/canvas/ui/EraseOverlay.tsx
@@ -37,6 +37,7 @@ import {
   type FreezoneRedrawAspectRatio,
 } from '@/api/ops';
 import { awaitTaskCompletion } from '@/api/tasks';
+import { buildRedHighlightMaskBlob } from '@/lib/mask-highlight';
 import { generationTaskDescriptor } from '@/features/canvas/application/resumeGeneration';
 import { readUrl } from '@/lib/url-params';
 import { NODE_TOOLBAR_CLASS } from './nodeToolbarConfig';
@@ -413,40 +414,13 @@ export const EraseOverlay = memo(({ node, imageSource, onClose }: EraseOverlayPr
     [canvasToImageCoords, commitRect, recomputeHasMask, tool],
   );
 
-  // 蒙版导出（供视觉模型识别）：源图 + 涂抹区半透明红色高亮。
-  // 后端把它当作 Image 2 的编辑参考——红色只是标注区域用，模型不会把红色画进结果。
-  // 旧做法是「白底 + 透明孔洞」，编辑区只存在于 alpha 通道，模型 RGB 里看是整张纯白 → 定位失败。
+  // 蒙版导出（供视觉模型识别）：源图 + 涂抹区二值化后的均匀半透明红高亮，见 mask-highlight.ts。
   const buildMaskBlob = useCallback(async (): Promise<Blob> => {
     const mask = maskCanvasRef.current;
     const baseImg = sourceImgRef.current;
     if (!mask) throw new Error('mask canvas not ready');
     if (!baseImg) throw new Error('source image not ready');
-    const w = mask.width;
-    const h = mask.height;
-    const out = document.createElement('canvas');
-    out.width = w;
-    out.height = h;
-    const ctx = out.getContext('2d');
-    if (!ctx) throw new Error('ctx');
-    // 1) 源图打底。
-    ctx.drawImage(baseImg, 0, 0, w, h);
-    // 2) 把涂抹区归一成均匀的半透明红（source-in 消除笔刷叠加深浅不均），再叠到源图上。
-    const overlay = document.createElement('canvas');
-    overlay.width = w;
-    overlay.height = h;
-    const octx = overlay.getContext('2d');
-    if (!octx) throw new Error('ctx');
-    octx.drawImage(mask, 0, 0);
-    octx.globalCompositeOperation = 'source-in';
-    octx.fillStyle = 'rgba(255, 0, 0, 0.6)';
-    octx.fillRect(0, 0, w, h);
-    ctx.drawImage(overlay, 0, 0);
-    return await new Promise<Blob>((resolve, reject) => {
-      out.toBlob(
-        (blob) => (blob ? resolve(blob) : reject(new Error('toBlob returned null'))),
-        'image/png',
-      );
-    });
+    return await buildRedHighlightMaskBlob(baseImg, mask);
   }, []);
 
   // 建一个 loading 结果节点并连边，立即返回节点 id（同步，不等待上传/生成）。

--- a/frontend/src/features/canvas/ui/RedrawOverlay.tsx
+++ b/frontend/src/features/canvas/ui/RedrawOverlay.tsx
@@ -375,18 +375,34 @@ export const RedrawOverlay = memo(({ node, imageSource, onClose }: RedrawOverlay
     [canvasToImageCoords, commitRect, recomputeHasMask, tool],
   );
 
+  // 蒙版导出（供视觉模型识别）：源图 + 涂抹区半透明红色高亮。
+  // 后端把它当作 Image 2 的编辑参考——红色只是标注区域用，模型不会把红色画进结果。
+  // 旧做法是「白底 + 透明孔洞」，编辑区只存在于 alpha 通道，模型 RGB 里看是整张纯白 → 定位失败。
   const buildMaskBlob = useCallback(async (): Promise<Blob> => {
-    const src = maskCanvasRef.current;
-    if (!src) throw new Error('mask canvas not ready');
+    const mask = maskCanvasRef.current;
+    const baseCanvas = baseCanvasRef.current;
+    if (!mask) throw new Error('mask canvas not ready');
+    if (!baseCanvas) throw new Error('source image not ready');
+    const w = mask.width;
+    const h = mask.height;
     const out = document.createElement('canvas');
-    out.width = src.width;
-    out.height = src.height;
+    out.width = w;
+    out.height = h;
     const ctx = out.getContext('2d');
     if (!ctx) throw new Error('ctx');
-    ctx.fillStyle = 'rgba(255,255,255,1)';
-    ctx.fillRect(0, 0, out.width, out.height);
-    ctx.globalCompositeOperation = 'destination-out';
-    ctx.drawImage(src, 0, 0);
+    // 1) 源图打底（baseCanvas 在加载源图时已绘制）。
+    ctx.drawImage(baseCanvas, 0, 0, w, h);
+    // 2) 把涂抹区归一成均匀的半透明红（source-in 消除笔刷叠加深浅不均），再叠到源图上。
+    const overlay = document.createElement('canvas');
+    overlay.width = w;
+    overlay.height = h;
+    const octx = overlay.getContext('2d');
+    if (!octx) throw new Error('ctx');
+    octx.drawImage(mask, 0, 0);
+    octx.globalCompositeOperation = 'source-in';
+    octx.fillStyle = 'rgba(255, 0, 0, 0.6)';
+    octx.fillRect(0, 0, w, h);
+    ctx.drawImage(overlay, 0, 0);
     return await new Promise<Blob>((resolve, reject) => {
       out.toBlob(
         (blob) => (blob ? resolve(blob) : reject(new Error('toBlob returned null'))),

--- a/frontend/src/features/canvas/ui/RedrawOverlay.tsx
+++ b/frontend/src/features/canvas/ui/RedrawOverlay.tsx
@@ -36,6 +36,7 @@ import {
   type FreezoneRedrawAspectRatio,
 } from '@/api/ops';
 import { awaitTaskCompletion } from '@/api/tasks';
+import { buildRedHighlightMaskBlob } from '@/lib/mask-highlight';
 import { generationTaskDescriptor } from '@/features/canvas/application/resumeGeneration';
 import { readUrl } from '@/lib/url-params';
 import {
@@ -375,40 +376,14 @@ export const RedrawOverlay = memo(({ node, imageSource, onClose }: RedrawOverlay
     [canvasToImageCoords, commitRect, recomputeHasMask, tool],
   );
 
-  // 蒙版导出（供视觉模型识别）：源图 + 涂抹区半透明红色高亮。
-  // 后端把它当作 Image 2 的编辑参考——红色只是标注区域用，模型不会把红色画进结果。
-  // 旧做法是「白底 + 透明孔洞」，编辑区只存在于 alpha 通道，模型 RGB 里看是整张纯白 → 定位失败。
+  // 蒙版导出（供视觉模型识别）：源图 + 涂抹区二值化后的均匀半透明红高亮，见 mask-highlight.ts。
+  // baseCanvas 在加载源图时已绘制。
   const buildMaskBlob = useCallback(async (): Promise<Blob> => {
     const mask = maskCanvasRef.current;
     const baseCanvas = baseCanvasRef.current;
     if (!mask) throw new Error('mask canvas not ready');
     if (!baseCanvas) throw new Error('source image not ready');
-    const w = mask.width;
-    const h = mask.height;
-    const out = document.createElement('canvas');
-    out.width = w;
-    out.height = h;
-    const ctx = out.getContext('2d');
-    if (!ctx) throw new Error('ctx');
-    // 1) 源图打底（baseCanvas 在加载源图时已绘制）。
-    ctx.drawImage(baseCanvas, 0, 0, w, h);
-    // 2) 把涂抹区归一成均匀的半透明红（source-in 消除笔刷叠加深浅不均），再叠到源图上。
-    const overlay = document.createElement('canvas');
-    overlay.width = w;
-    overlay.height = h;
-    const octx = overlay.getContext('2d');
-    if (!octx) throw new Error('ctx');
-    octx.drawImage(mask, 0, 0);
-    octx.globalCompositeOperation = 'source-in';
-    octx.fillStyle = 'rgba(255, 0, 0, 0.6)';
-    octx.fillRect(0, 0, w, h);
-    ctx.drawImage(overlay, 0, 0);
-    return await new Promise<Blob>((resolve, reject) => {
-      out.toBlob(
-        (blob) => (blob ? resolve(blob) : reject(new Error('toBlob returned null'))),
-        'image/png',
-      );
-    });
+    return await buildRedHighlightMaskBlob(baseCanvas, mask);
   }, []);
 
   // 建一个 loading 结果节点并连边，立即返回节点 id（同步，不等待上传/生成）。

--- a/frontend/src/lib/mask-highlight.test.ts
+++ b/frontend/src/lib/mask-highlight.test.ts
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: Elastic-2.0
+// Copyright (c) 2026 ClaymoreLab
+import { describe, expect, it } from 'vitest';
+import {
+  MASK_ALPHA_THRESHOLD,
+  MASK_HIGHLIGHT_RGBA,
+  binarizeMaskToRed,
+} from './mask-highlight';
+
+/** 构造一个只含单像素的 RGBA 缓冲。 */
+function pixel(r: number, g: number, b: number, a: number): Uint8ClampedArray {
+  return new Uint8ClampedArray([r, g, b, a]);
+}
+
+describe('binarizeMaskToRed', () => {
+  const { r, g, b, a } = MASK_HIGHLIGHT_RGBA;
+
+  it('单笔涂抹区（alpha 140）→ 均匀半透明红', () => {
+    const d = pixel(239, 68, 68, 140); // 0.55 笔刷
+    binarizeMaskToRed(d);
+    expect([...d]).toEqual([r, g, b, a]);
+  });
+
+  it('叠加区（alpha 203）输出与单笔完全相同——证明消除了深浅不均', () => {
+    const single = pixel(239, 68, 68, 140);
+    const overlap = pixel(239, 68, 68, 203); // ~0.80 段接头叠加
+    binarizeMaskToRed(single);
+    binarizeMaskToRed(overlap);
+    expect([...overlap]).toEqual([...single]);
+    expect([...overlap]).toEqual([r, g, b, a]);
+  });
+
+  it('未涂抹像素（alpha 0）→ 全透明', () => {
+    const d = pixel(0, 0, 0, 0);
+    binarizeMaskToRed(d);
+    expect(d[3]).toBe(0);
+  });
+
+  it('低于阈值的抗锯齿边缘 → 全透明', () => {
+    const d = pixel(239, 68, 68, MASK_ALPHA_THRESHOLD - 1);
+    binarizeMaskToRed(d);
+    expect(d[3]).toBe(0);
+  });
+
+  it('无论原始颜色，涂抹区一律改写为红', () => {
+    const d = pixel(12, 200, 99, 60);
+    binarizeMaskToRed(d);
+    expect([...d]).toEqual([r, g, b, a]);
+  });
+
+  it('多像素混合缓冲：涂抹区统一红、其余透明', () => {
+    const d = new Uint8ClampedArray([
+      239, 68, 68, 140, // 涂抹
+      239, 68, 68, 203, // 叠加
+      0, 0, 0, 0, // 空
+      1, 2, 3, 4, // 低于阈值
+    ]);
+    binarizeMaskToRed(d);
+    expect([...d]).toEqual([
+      r, g, b, a,
+      r, g, b, a,
+      0, 0, 0, 0,
+      1, 2, 3, 0,
+    ]);
+  });
+});

--- a/frontend/src/lib/mask-highlight.ts
+++ b/frontend/src/lib/mask-highlight.ts
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: Elastic-2.0
+// Copyright (c) 2026 ClaymoreLab
+//
+// 蒙版导出（供视觉模型识别）：源图 + 涂抹区半透明红色高亮。
+// 后端把它当作 Image 2 的编辑参考——红色只是标注区域用，模型不会把红色画进结果。
+// 旧做法是「白底 + 透明孔洞」，编辑区只存在于 alpha 通道，模型 RGB 里看是整张纯白 → 定位失败。
+//
+// EraseOverlay / RedrawOverlay / MaskEditor 三个蒙版生产者共用这里，保证导出格式一致，
+// 后端只需维护单一契约（红色高亮）。
+
+/** 涂抹区归一后的固定颜色：均匀半透明红 rgba(255,0,0,0.6)。0.6 × 255 ≈ 153。 */
+export const MASK_HIGHLIGHT_RGBA = { r: 255, g: 0, b: 0, a: 153 } as const;
+
+/**
+ * 低于此 alpha 的像素视为「未涂抹」。与 hasMask 检测保持一致（> 8 = 涂过）。
+ * 笔刷本身以 alpha≈140（0.55）绘制，抗锯齿边缘从 0 爬升，这里把整个笔迹足印算作涂抹区。
+ */
+export const MASK_ALPHA_THRESHOLD = 8;
+
+/**
+ * 就地二值化一段 straight-alpha RGBA 缓冲：涂抹区 → 均匀半透明红，其余 → 全透明。
+ *
+ * 为什么必须二值化：笔刷以 alpha 0.55 叠加绘制，段接头/重叠处 alpha 爬到 ~0.80，
+ * mask 通道本身深浅不均。若直接 `source-in` 一个 rgba(255,0,0,0.6)，Porter-Duff
+ * "in" 会让输出 alpha = 0.6 × mask_alpha（单笔 0.33 / 叠加 0.48），不均匀原样保留。
+ * 先把 mask alpha 拍平成 0/1，再写固定红，才能得到真正均匀的高亮。
+ *
+ * 纯函数（不碰 canvas），便于单测。
+ */
+export function binarizeMaskToRed(
+  data: Uint8ClampedArray,
+  alphaThreshold: number = MASK_ALPHA_THRESHOLD,
+): void {
+  const { r, g, b, a } = MASK_HIGHLIGHT_RGBA;
+  for (let i = 0; i < data.length; i += 4) {
+    if (data[i + 3] > alphaThreshold) {
+      data[i] = r;
+      data[i + 1] = g;
+      data[i + 2] = b;
+      data[i + 3] = a;
+    } else {
+      data[i + 3] = 0;
+    }
+  }
+}
+
+/**
+ * 由源图 + 蒙版画布合成红色高亮蒙版 PNG。
+ *
+ * @param baseImage 已加载的源图（HTMLImageElement 或已绘制源图的 canvas）
+ * @param maskCanvas 用户涂抹的蒙版画布（涂抹区为半透明红，尺寸即输出尺寸）
+ */
+export async function buildRedHighlightMaskBlob(
+  baseImage: CanvasImageSource,
+  maskCanvas: HTMLCanvasElement,
+): Promise<Blob> {
+  const w = maskCanvas.width;
+  const h = maskCanvas.height;
+  const out = document.createElement('canvas');
+  out.width = w;
+  out.height = h;
+  const ctx = out.getContext('2d');
+  if (!ctx) throw new Error('ctx');
+  // 1) 源图打底 —— 给视觉模型真实 RGB 内容。
+  ctx.drawImage(baseImage, 0, 0, w, h);
+  // 2) 把涂抹区二值化成均匀半透明红，叠到源图上。
+  //    只对 mask 画布做 getImageData（本地绘制、不会 taint），源图仍走 drawImage/toBlob，
+  //    CORS 行为与旧代码一致。
+  const overlay = document.createElement('canvas');
+  overlay.width = w;
+  overlay.height = h;
+  const octx = overlay.getContext('2d');
+  if (!octx) throw new Error('ctx');
+  octx.drawImage(maskCanvas, 0, 0);
+  const img = octx.getImageData(0, 0, w, h);
+  binarizeMaskToRed(img.data);
+  octx.putImageData(img, 0, 0);
+  ctx.drawImage(overlay, 0, 0);
+  return await new Promise<Blob>((resolve, reject) => {
+    out.toBlob(
+      (blob) => (blob ? resolve(blob) : reject(new Error('toBlob returned null'))),
+      'image/png',
+    );
+  });
+}

--- a/frontend/src/pipeline-import/MaskEditor.tsx
+++ b/frontend/src/pipeline-import/MaskEditor.tsx
@@ -7,6 +7,7 @@ import {
   fetchFreezoneJobResult,
 } from "@/api/ops";
 import { awaitTaskCompletion } from "@/api/tasks";
+import { buildRedHighlightMaskBlob } from "@/lib/mask-highlight";
 
 interface MaskEditorProps {
   project: string;
@@ -28,9 +29,9 @@ const DEFAULT_BRUSH = 50;
  * Mask edit UI:
  *   - Canvas A renders the base image (read-only).
  *   - Canvas B floats above as a translucent red mask layer the user paints on.
- *   - On submit, we composite Canvas B into a "transparent-on-white" PNG
- *     (transparent = paint = editable region per OpenAI's mask convention),
- *     upload it to /freezone/upload, then POST /freezone/redraw with mask_url.
+ *   - On submit, we composite the base image + a uniform translucent-red highlight
+ *     over the painted region (see mask-highlight.ts), upload it to /freezone/upload,
+ *     then POST /freezone/redraw with mask_url.
  */
 export function MaskEditor({
   project,
@@ -157,35 +158,17 @@ export function MaskEditor({
   };
 
   /**
-   * Build the OpenAI-shaped mask PNG:
-   *   transparent pixels = painted region (editable),
-   *   opaque pixels (white) = preserve.
-   * Our mask canvas already has paint at non-transparent pixels — we invert
-   * by drawing a white background under "everywhere except where we painted":
-   * a destination-out using current alpha then fill white in-place.
+   * 蒙版导出（供视觉模型识别）：源图 + 涂抹区二值化后的均匀半透明红高亮，见 mask-highlight.ts。
+   * 后端 /freezone/redraw 对所有 mask_url 一律套用「红色高亮」prompt，EraseOverlay /
+   * RedrawOverlay / MaskEditor 三个生产者必须导出同一格式；旧的「白底 + 透明孔洞」会让模型
+   * 去找一个 RGB 里根本不存在的红色区域 → 定位失败。
    */
   const buildMaskBlob = async (): Promise<Blob> => {
-    const src = maskCanvasRef.current;
-    if (!src) throw new Error("mask canvas not ready");
-    const w = src.width;
-    const h = src.height;
-    const out = document.createElement("canvas");
-    out.width = w;
-    out.height = h;
-    const ctx = out.getContext("2d");
-    if (!ctx) throw new Error("ctx");
-    // 1. Fill the whole output canvas opaque white = "preserve everywhere".
-    ctx.fillStyle = "rgba(255,255,255,1)";
-    ctx.fillRect(0, 0, w, h);
-    // 2. Punch holes wherever the painted mask has non-transparent pixels.
-    ctx.globalCompositeOperation = "destination-out";
-    ctx.drawImage(src, 0, 0);
-    return await new Promise<Blob>((resolve, reject) => {
-      out.toBlob((blob) => {
-        if (!blob) reject(new Error("toBlob returned null"));
-        else resolve(blob);
-      }, "image/png");
-    });
+    const mask = maskCanvasRef.current;
+    const baseImg = baseImgRef.current;
+    if (!mask) throw new Error("mask canvas not ready");
+    if (!baseImg) throw new Error("source image not ready");
+    return await buildRedHighlightMaskBlob(baseImg, mask);
   };
 
   const hasPaint = (): boolean => {

--- a/license-inventory.csv
+++ b/license-inventory.csv
@@ -1074,6 +1074,8 @@ frontend/src/lib/literal-source-text.ts,Elastic-2.0,2026 SuperTale contributors,
 frontend/src/lib/localStorageQuota.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/lib/login-community.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/lib/login-posters.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
+frontend/src/lib/mask-highlight.test.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
+frontend/src/lib/mask-highlight.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/lib/media-url.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/lib/mention-markers.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/lib/nav-lock.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation

--- a/src/novelvideo/api/schemas.py
+++ b/src/novelvideo/api/schemas.py
@@ -883,13 +883,17 @@ class FreezoneRedrawRequest(BaseModel):
 
     统一承接整体重绘和局部擦除：
     - 不传 mask_url：整体/局部自由重绘
-    - 传 mask_url：仅在 mask 透明区域内按 prompt 执行局部编辑
+    - 传 mask_url：仅在标注的编辑区内按 prompt 执行局部编辑。mask 约定为
+      「源图 + 涂抹区半透明红色高亮」（红色仅作区域标注，不进入结果）
     """
 
     source_url: str = Field(description="待重绘的源图静态地址，作为图生图的 base 图")
     mask_url: Optional[str] = Field(
         default=None,
-        description="可选的遮罩图静态地址。传入后表示走局部擦除/局部重绘模式",
+        description=(
+            "可选的遮罩图静态地址。传入后走局部擦除/局部重绘模式；约定为"
+            "「源图 + 涂抹区半透明红色高亮」，仅编辑红色区域"
+        ),
     )
     aspect_ratio: Literal["original", "1:1", "4:3", "3:4", "16:9", "9:16"] = Field(
         default="original",

--- a/src/novelvideo/freezone/jobs.py
+++ b/src/novelvideo/freezone/jobs.py
@@ -136,9 +136,11 @@ async def run_freezone_mask_edit(
     provider_name = str(cfg.get("provider") or provider or "newapi").strip().lower()
     mask_prompt = (
         f"{prompt}\n\n"
-        "Use Image 1 as the source image. Use Image 2 as the edit mask reference. "
-        "Only modify the masked/transparent marked region; preserve all unmasked source pixels, "
-        "composition, identity, lighting, and texture as much as possible."
+        "Use Image 1 as the source image. Image 2 is the same image with a translucent RED "
+        "highlight painted over the region to edit. Edit ONLY the red-highlighted region; the "
+        "red highlight is just an annotation marking where to work and must NOT appear in the "
+        "output. Preserve all pixels outside the highlighted region — composition, identity, "
+        "lighting, and texture — as much as possible."
     ).strip()
     try:
         await generate_reference_edit_image(

--- a/tests/test_freezone_image_backend.py
+++ b/tests/test_freezone_image_backend.py
@@ -2172,7 +2172,9 @@ async def test_mask_edit_job_uses_reference_edit_provider_routing(
     assert captured["reference_images"] == [str(base), str(mask)]
     assert captured["config"]["provider"] == "newapi"
     assert captured["config"]["model"] == NEWAPI_IMAGE_MODEL
-    assert "Use Image 2 as the edit mask reference" in captured["prompt"]
+    # Image 2 = 源图 + 红色高亮标注；模型只改红色区域，且红色不进入结果。
+    assert "red-highlighted region" in captured["prompt"]
+    assert "must NOT appear in the output" in captured["prompt"]
 
 
 def test_camera_prompt_contains_camera_body_lens_focal_and_aperture() -> None:


### PR DESCRIPTION
Closes #173

## 背景

Erase/Redraw 蒙版旧做法导出「白底 + 透明孔洞」,待编辑区域只存在于 alpha 通道,视觉模型在 RGB 里看到的是整张纯白图,无法定位编辑区(详见 #173)。

## 改动

**前端** `EraseOverlay.tsx` / `RedrawOverlay.tsx` 的 `buildMaskBlob`:
- 蒙版改为导出「源图 + 涂抹区半透明红色高亮」
- 源图打底 → 涂抹区经 `source-in` 归一为均匀的 `rgba(255,0,0,0.6)`(消除笔刷叠加深浅不均)→ 叠到源图上
- EraseOverlay 新增 `sourceImgRef` 缓存已加载源图作为打底

**后端** `src/novelvideo/freezone/jobs.py` 的 `run_freezone_mask_edit`:
- prompt 同步说明:Image 2 是涂了半透明红色高亮的源图,只编辑红色区域,**红色高亮为标注、不得出现在结果中**,红色区域外的像素(构图/身份/光照/纹理)尽量保留

**测试** `tests/test_freezone_image_backend.py`:
- 更新 `test_mask_edit_job_uses_reference_edit_provider_routing` 断言,匹配新 prompt(`red-highlighted region` / `must NOT appear in the output`)

## 验证

- 前端 `pnpm build`(`tsc -b && vite build`)✓
- 后端 `pytest tests/test_freezone_image_backend.py -k mask_edit` ✓ 1 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)