### PR TITLE
chore: prepare v1.1.4 release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "supertale-ce"
-version = "1.1.3"
+version = "1.1.4"
 description = "SuperTale Community Edition API and video pipeline"
 readme = "README.md"
 requires-python = ">=3.11,<3.13"

--- a/src/novelvideo/release-notes.md
+++ b/src/novelvideo/release-notes.md
@@ -1,31 +1,34 @@
 ---
-version: 1.1.3
+version: 1.1.4
 attention: low
 ---
-# v1.1.3
+# v1.1.4
 
 ## User-facing Highlights (zh)
 
-- **Piko 一下小游戏库**: 新增记忆翻牌、打砖块、滚动小球、飞行的 Piko、Piko 接物和 Piko 跃迁,支持键盘与鼠标操作、音效、计分和重新挑战。
-- **自定义风格预览可持久保存**: 用户上传的风格参考图会随项目保存,刷新后仍可在风格列表和详情中查看。
-- **生成失败提示更清楚**: 图片和视频生成失败时优先展示简洁的上游错误原因,同时保留完整诊断信息供复制排查。
+- **知识图谱可视化**: 小说导入完成后可直接查看知识图谱,支持缩放、拖动、展开节点并检查关系和属性。
+- **图片与视频构图更准确**: Seedance 首帧、Beat 渲染和视频裁剪会遵循实际素材或所选输出比例,蒙版编辑也能更准确识别指定区域。
+- **知识图谱构建更稳定**: 项目会固定使用对应的嵌入模型与网关,并限制并发请求,减少配置变化、并行任务和上游限流造成的失败。
+- **操作前置校验更清楚**: 未导入小说时规划角色、场景或剧集会直接提示先导入内容,不会创建无效任务或产生扣费。
 
 ## User-facing Highlights (en)
 
-- **Piko mini game library**: Adds memory match, breakout, rolling ball, Flying Piko, Piko catch, and Piko leap with keyboard and pointer controls, sound, scoring, and replay.
-- **Persistent custom style previews**: User-uploaded style references are saved with the project and remain visible in style lists and details after refresh.
-- **Clearer generation failures**: Image and video failures now show concise provider messages while preserving complete diagnostics for troubleshooting.
+- **Knowledge graph visualization**: Explore the imported novel's knowledge graph with pan, zoom, node expansion, relationships, and property details.
+- **More accurate image and video framing**: Seedance first frames, Beat renders, and video crops now follow the actual source or selected output ratio, while mask edits identify the intended region more reliably.
+- **More reliable knowledge graph builds**: Projects retain their assigned embedding model and gateway, with bounded concurrency to reduce failures from configuration changes, parallel work, and upstream rate limits.
+- **Clearer prerequisite checks**: Character, scene, and episode planning now asks for an imported novel before creating a task or reserving credits.
 
 ## New Features
 
-- 扩展「Piko 一下」为可滚动的小游戏库,新增六款轻量小游戏及统一音效控制 (#155, #156).
+- 新增导入小说知识图谱的交互式可视化,支持查看节点、关系和属性 (#161).
 
 ## Bug Fixes
 
-- 修复自定义风格参考图刷新后丢失、预览地址错误及异常响应仍继续分析的问题 (#153, Fixes #152).
-- 优化图片和视频生成失败提示,保留完整错误与请求 ID 供复制排查 (#154).
-- 修复任务中心「图片反推提示词」显示为内部英文任务名的问题 (#146).
+- 未导入小说时阻止角色、场景和剧集规划,避免无效任务及扣费 (#162).
+- 修复 Seedance 首帧方向、Beat 渲染比例和视频输入裁剪与目标比例不一致的问题 (#166, #167, #168).
+- 修复不同项目的知识图谱嵌入模型和网关配置相互影响的问题 (#170).
+- 修复蒙版编辑区域仅存在于透明通道、视觉模型无法准确定位的问题 (#174).
 
 ## Improvements
 
-- 按运营计划下线猎魈人推广入口与相关展示,保留独立的社区作品内容 (#145).
+- 限制单次知识图谱流水线的模型与嵌入并发请求,降低上游限流导致的导入失败 (#171).

--- a/tests/test_release_feed.py
+++ b/tests/test_release_feed.py
@@ -114,7 +114,7 @@ def test_built_wheel_contains_parseable_release_notes_artifact(tmp_path: Path) -
 def test_project_version_is_single_source_of_truth() -> None:
     pyproject = tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))
 
-    assert pyproject["project"]["version"] == "1.1.3"
+    assert pyproject["project"]["version"] == "1.1.4"
     assert importlib.metadata.version("supertale-ce") == pyproject["project"]["version"]
     assert "__version__" not in Path("src/novelvideo/__init__.py").read_text(encoding="utf-8")
 

--- a/uv.lock
+++ b/uv.lock
@@ -3419,7 +3419,7 @@ wheels = [
 
 [[package]]
 name = "supertale-ce"
-version = "1.1.3"
+version = "1.1.4"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## PR 类型 / Type of PR
- [ ] 🐞 Bug 修复 / Bug fix
- [ ] ✨ 新功能 / Feature
- [x] 📝 文档 / Documentation
- [ ] 🧹 重构 / 清理 / Refactor or cleanup
- [x] ⚙️ 构建 / CI / Build or CI
- [ ] ⚠️ 破坏性变更 / Breaking change

## 改动说明 / What this PR does and why

- 将 `supertale-ce` 版本从 `1.1.3` 更新为 `1.1.4`，并同步锁文件和版本单一真源测试。
- 按发布规范更新包内中英文 release notes，整理 v1.1.3 之后合入的知识图谱、视频比例和蒙版编辑相关改进。
- 为合入后创建 `v1.1.4` tag、GitHub Release 和发布镜像做好准备。

## 关联 issue / Linked issues

N/A

## 给 reviewer 的说明 / Notes for the reviewer

- 分支直接基于创建时最新的 `origin/main` (`3303045`)。
- 本 PR 仅准备版本元数据和包内发布说明；审核合入前不会创建 tag 或 GitHub Release。
- 请重点核对中英文 Highlights 和分类条目是否准确覆盖 #161、#162、#166、#167、#168、#170、#171、#174。

## 面向用户的变更 / User-facing change

```release-note
v1.1.4 新增知识图谱可视化，并改进图片视频构图、知识图谱构建稳定性和导入前置校验。
```

## 自检 / Checklist
- [x] 已自测，`uv run pytest` 通过 / Self-tested, `uv run pytest` passes
- [x] 必要的文档已更新 / Docs updated where needed
- [x] 提交信息清晰（建议 Conventional Commits）/ Clear commits (Conventional Commits suggested)
- [x] 每个 commit 都已 `git commit -s` 附 DCO 签署 / Every commit signed off with `git commit -s` (DCO)
- [x] 我已阅读并同意[贡献者协议](../CONTRIBUTING.md#贡献者协议) / I've read and agree to the [contributor terms](../CONTRIBUTING.md#贡献者协议)

## 验证 / Verification

- `UV_CACHE_DIR=/claymorelab/.uv-cache uv lock`
- `UV_CACHE_DIR=/claymorelab/.uv-cache uv sync`
- `UV_CACHE_DIR=/claymorelab/.uv-cache uv run pytest tests/test_release_feed.py -q` (12 passed)
- `git diff --check`
