### PR TITLE
fix(freezone): 修自动保存并发竞态导致的假冲突 409

### DIFF
--- a/frontend/src/__tests__/features/freezone/canvasSaveCoordinator.test.ts
+++ b/frontend/src/__tests__/features/freezone/canvasSaveCoordinator.test.ts
@@ -1,0 +1,225 @@
+// SPDX-License-Identifier: Elastic-2.0
+// Copyright (c) 2026 ClaymoreLab
+import { describe, expect, it } from "vitest";
+
+import {
+  createCanvasSaveSession,
+  type CanvasSaveSession,
+} from "@/features/freezone/canvasSaveCoordinator";
+
+/** A `runSave` whose completions the test drives by hand. */
+function controllable() {
+  const calls: number[] = [];
+  const releases: Array<(persisted: boolean) => void> = [];
+  let active = 0;
+  let maxActive = 0;
+  const runSave = (version: number) => {
+    calls.push(version);
+    active += 1;
+    maxActive = Math.max(maxActive, active);
+    return new Promise<boolean>((resolve) => {
+      releases.push((persisted: boolean) => {
+        active -= 1;
+        resolve(persisted);
+      });
+    });
+  };
+  return {
+    runSave,
+    calls,
+    releases,
+    maxActive: () => maxActive,
+  };
+}
+
+function session(runSave: CanvasSaveSessionOptionsRunSave): CanvasSaveSession {
+  return createCanvasSaveSession({
+    canvasKey: "project-a:canvas-a",
+    generation: 1,
+    runSave,
+  });
+}
+
+type CanvasSaveSessionOptionsRunSave = (
+  version: number,
+  self: CanvasSaveSession,
+) => Promise<boolean>;
+
+/** Let queued microtasks drain. */
+const tick = async (times = 6) => {
+  for (let i = 0; i < times; i += 1) await Promise.resolve();
+};
+
+describe("createCanvasSaveSession", () => {
+  it("keeps at most one request on the wire", async () => {
+    const gate = controllable();
+    const s = session(gate.runSave);
+
+    void s.requestSave();
+    void s.requestSave();
+    void s.requestSave();
+    await tick();
+
+    expect(gate.calls).toHaveLength(1);
+    expect(gate.maxActive()).toBe(1);
+
+    gate.releases[0](true);
+    await tick();
+
+    // Three requests collapse into two sends: the one on the wire, plus a
+    // single follow-up carrying whatever the store holds by then.
+    expect(gate.calls).toHaveLength(2);
+    expect(gate.maxActive()).toBe(1);
+  });
+
+  it("coalesces every edit made during a request into one follow-up", async () => {
+    const gate = controllable();
+    const s = session(gate.runSave);
+
+    void s.requestSave(); // version 1 -> sent
+    await tick();
+    void s.requestSave(); // version 2 -> queued
+    void s.requestSave(); // version 3 -> supersedes 2
+    void s.requestSave(); // version 4 -> supersedes 3
+    gate.releases[0](true);
+    await tick();
+
+    expect(gate.calls).toEqual([1, 4]);
+  });
+
+  it("releases a waiter only once a request covering its version lands", async () => {
+    const gate = controllable();
+    const s = session(gate.runSave);
+
+    const first = s.requestSave();
+    await tick();
+    const second = s.requestSave();
+
+    let firstDone = false;
+    let secondDone = false;
+    void first.then(() => {
+      firstDone = true;
+    });
+    void second.then(() => {
+      secondDone = true;
+    });
+
+    gate.releases[0](true);
+    await tick();
+    // The first save landed; the second's content is only now being sent.
+    expect(firstDone).toBe(true);
+    expect(secondDone).toBe(false);
+
+    gate.releases[1](true);
+    await tick();
+    expect(secondDone).toBe(true);
+    expect(await second).toBe(true);
+    expect(s.savedVersion()).toBe(2);
+  });
+
+  it("reports failure to every waiter and stops the pump", async () => {
+    const gate = controllable();
+    const s = session(gate.runSave);
+
+    const first = s.requestSave();
+    await tick();
+    const second = s.requestSave();
+
+    gate.releases[0](false);
+    await tick();
+
+    expect(await first).toBe(false);
+    expect(await second).toBe(false);
+    // No retry storm: a terminal failure parks the pump until a real edit.
+    expect(gate.calls).toEqual([1]);
+    expect(s.isSaving()).toBe(false);
+
+    // A fresh edit restarts it.
+    void s.requestSave();
+    await tick();
+    expect(gate.calls).toEqual([1, 3]);
+  });
+
+  it("reports newer unsaved content so the draft is not dropped early", async () => {
+    const gate = controllable();
+    const s = session(gate.runSave);
+
+    void s.requestSave();
+    await tick();
+    // Nothing newer yet — the save on the wire covers everything.
+    expect(s.hasUnsavedContentBeyond(1)).toBe(false);
+
+    void s.requestSave();
+    // Now version 2 is queued and exists only in the draft.
+    expect(s.hasUnsavedContentBeyond(1)).toBe(true);
+
+    gate.releases[0](true);
+    await tick();
+    // Version 2 is the one on the wire now; nothing newer behind it.
+    expect(s.hasUnsavedContentBeyond(2)).toBe(false);
+  });
+
+  it("releases waiters and drops queued work when disposed", async () => {
+    const gate = controllable();
+    const s = session(gate.runSave);
+
+    void s.requestSave();
+    await tick();
+    const queued = s.requestSave();
+
+    s.dispose();
+    expect(await queued).toBe(false);
+    expect(s.isDisposed()).toBe(true);
+
+    // The request already on the wire is left to finish server-side, but its
+    // completion must not drain the queue of a session nobody is watching.
+    gate.releases[0](true);
+    await tick();
+    expect(gate.calls).toEqual([1]);
+
+    // And a disposed session accepts no further work.
+    expect(await s.requestSave()).toBe(false);
+    expect(gate.calls).toEqual([1]);
+  });
+
+  it("keeps two canvases' save lifecycles independent", async () => {
+    const a = controllable();
+    const b = controllable();
+    const sessionA = createCanvasSaveSession({
+      canvasKey: "project-a:canvas-a",
+      generation: 1,
+      runSave: a.runSave,
+    });
+    const sessionB = createCanvasSaveSession({
+      canvasKey: "project-a:canvas-b",
+      generation: 2,
+      runSave: b.runSave,
+    });
+
+    void sessionA.requestSave();
+    await tick();
+    expect(a.calls).toHaveLength(1);
+
+    // Canvas A is still on the wire; canvas B must not queue behind it.
+    const bSaved = sessionB.requestSave();
+    await tick();
+    expect(b.calls).toHaveLength(1);
+
+    b.releases[0](true);
+    await tick();
+    expect(await bSaved).toBe(true);
+    // Canvas B landing says nothing about canvas A.
+    expect(sessionA.savedVersion()).toBe(0);
+    expect(sessionB.savedVersion()).toBe(1);
+  });
+
+  it("does not let a rejected runSave escape as an unhandled rejection", async () => {
+    const s = createCanvasSaveSession({
+      canvasKey: "project-a:canvas-a",
+      generation: 1,
+      runSave: () => Promise.reject(new Error("network down")),
+    });
+
+    expect(await s.requestSave()).toBe(false);
+  });
+});

--- a/frontend/src/__tests__/features/freezone/canvasSaveCoordinator.test.ts
+++ b/frontend/src/__tests__/features/freezone/canvasSaveCoordinator.test.ts
@@ -213,6 +213,34 @@ describe("createCanvasSaveSession", () => {
     expect(sessionB.savedVersion()).toBe(1);
   });
 
+  it("restarts the pump when a waiter schedules another save as it resolves", async () => {
+    const gate = controllable();
+    const s = session(gate.runSave);
+
+    // The hook does exactly this shape: code resumes from `await requestSave()`
+    // and immediately saves again. That resumption happens in a microtask *after*
+    // the pump has seen an empty queue but *before* it has cleared its running
+    // flag, so the new request lands in the blind spot between the two.
+    const followUps: Array<Promise<boolean>> = [];
+    void s.requestSave().then(() => {
+      followUps.push(s.requestSave());
+    });
+    await tick();
+    expect(gate.calls).toEqual([1]);
+
+    gate.releases[0](true);
+    await tick();
+
+    // Without a re-check on the way out, version 2 would sit in the queue
+    // forever and its promise would never settle.
+    expect(gate.calls).toEqual([1, 2]);
+
+    gate.releases[1](true);
+    await tick();
+    expect(await followUps[0]).toBe(true);
+    expect(s.savedVersion()).toBe(2);
+  });
+
   it("does not let a rejected runSave escape as an unhandled rejection", async () => {
     const s = createCanvasSaveSession({
       canvasKey: "project-a:canvas-a",

--- a/frontend/src/__tests__/features/freezone/canvasSyncCore.test.ts
+++ b/frontend/src/__tests__/features/freezone/canvasSyncCore.test.ts
@@ -392,6 +392,34 @@ describe("classifySaveError", () => {
   it("maps 409 to conflict with the canonical message", () => {
     expect(classifySaveError(409, {}, "fallback")).toMatchObject({
       kind: "conflict",
+      message: "画布已被其他窗口或用户修改",
+    });
+  });
+
+  it("gives 409 canvas_idempotency_conflict its own wording", () => {
+    // Same client replaying one client_save_id with a different body — no
+    // other window is involved, so the canonical message would misdirect.
+    const outcome = classifySaveError(
+      409,
+      { detail: { code: "canvas_idempotency_conflict" } },
+      "fallback",
+    );
+    expect(outcome).toMatchObject({ kind: "conflict" });
+    expect((outcome as { message: string }).message).not.toBe(
+      "画布已被其他窗口或用户修改",
+    );
+  });
+
+  it("keeps the canonical message for a real revision conflict", () => {
+    expect(
+      classifySaveError(
+        409,
+        { detail: { code: "canvas_revision_conflict" } },
+        "fallback",
+      ),
+    ).toMatchObject({
+      kind: "conflict",
+      message: "画布已被其他窗口或用户修改",
     });
   });
 

--- a/frontend/src/__tests__/features/freezone/use-canvas-sync.test.tsx
+++ b/frontend/src/__tests__/features/freezone/use-canvas-sync.test.tsx
@@ -756,10 +756,10 @@ describe("useCanvasSync hydrate lifecycle", () => {
 
   // Same shape as above, except the user *edits* the canvas they switched to
   // while the old canvas's PUT is still hanging. Dropping the stale queued save
-  // must not drop the new canvas's edit with it: a save that arrives after the
-  // switch cannot ride on a queue slot belonging to the canvas we just left,
-  // because that slot is going to bail out on its generation check.
-  it("still dispatches the new canvas's save queued behind the old canvas's PUT", async () => {
+  // must not drop the new canvas's edit with it. Save sessions are per-canvas,
+  // so canvas B does not queue behind canvas A at all — the backend lock is
+  // per-canvas, and making B wait out A's slow request buys nothing.
+  it("dispatches the new canvas's save without waiting for the old canvas's PUT", async () => {
     vi.useFakeTimers();
     vi.mocked(getFreezoneCanvas).mockImplementation(
       async (_project: string, canvasId: string) => ({
@@ -839,24 +839,22 @@ describe("useCanvasSync hydrate lifecycle", () => {
       vi.advanceTimersByTime(800);
       await Promise.resolve();
     });
-    // Saves still never overlap: nothing new goes out while A is on the wire.
-    expect(putCanvasIds).toHaveLength(1);
-
-    // Release canvas A's PUT. Its own queued follow-up is dropped (it belongs
-    // to a canvas we left), but canvas B's edit must go out on its own.
-    await act(async () => {
-      releases[0]();
-      for (let i = 0; i < 12; i += 1) await Promise.resolve();
-    });
-
+    // Canvas B's edit goes out on its own session, immediately.
     expect(putCanvasIds).toEqual([
       "cross_source_user_eric",
       "cross_target_user_eric",
     ]);
     expect(putNodeXs).toEqual([[10], [0, 99]]);
-    // And it must carry canvas B's revision — not the one canvas A's response
-    // just returned, which would 409 straight back.
+    // And it carries canvas B's own revision, not canvas A's.
     expect(putBaseRevisions).toEqual([7, 3]);
+
+    // Canvas A's PUT finally lands. Its queued follow-up belongs to a canvas we
+    // left, so it must not produce a third request against canvas B.
+    await act(async () => {
+      releases[0]();
+      for (let i = 0; i < 12; i += 1) await Promise.resolve();
+    });
+    expect(putCanvasIds).toHaveLength(2);
 
     hook.unmount();
   });
@@ -936,6 +934,73 @@ describe("useCanvasSync hydrate lifecycle", () => {
       for (let i = 0; i < 12; i += 1) await Promise.resolve();
     });
     expect(putBaseRevisions).toEqual([7, 100]);
+
+    hook.unmount();
+  });
+
+  // The draft is the only copy of edits that have not reached the server. A
+  // save landing clears it — but only if nothing newer is still queued behind
+  // that save, otherwise the newest edit exists nowhere at all.
+  it("keeps the draft when newer content is still queued behind a save", async () => {
+    vi.useFakeTimers();
+    vi.mocked(getFreezoneCanvas).mockResolvedValue({
+      nodes: [],
+      edges: [],
+      revision: 7,
+    });
+
+    const releases: Array<() => void> = [];
+    let revision = 7;
+    vi.mocked(putFreezoneCanvas).mockImplementation(() => {
+      return new Promise((resolve) => {
+        releases.push(() => {
+          revision += 1;
+          resolve({ saved: true, revision });
+        });
+      });
+    });
+
+    const hook = renderHook(() =>
+      useCanvasSync("project-a", "draft_race_user_eric"),
+    );
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    // First edit: draft written, PUT on the wire.
+    useCanvasStore
+      .getState()
+      .addNode(CANVAS_NODE_TYPES.upload, { x: 10, y: 10 }, {});
+    await act(async () => {
+      vi.advanceTimersByTime(800);
+      await Promise.resolve();
+    });
+    expect(readCanvasDraft("project-a", "draft_race_user_eric")).not.toBeNull();
+
+    // Second edit while the first is still hanging: queued, draft-only.
+    useCanvasStore
+      .getState()
+      .addNode(CANVAS_NODE_TYPES.upload, { x: 20, y: 20 }, {});
+    await act(async () => {
+      vi.advanceTimersByTime(800);
+      await Promise.resolve();
+    });
+
+    // First PUT succeeds. The draft must survive: it is the only copy of the
+    // second node until the queued save lands.
+    await act(async () => {
+      releases[0]();
+      for (let i = 0; i < 12; i += 1) await Promise.resolve();
+    });
+    const midFlight = readCanvasDraft("project-a", "draft_race_user_eric");
+    expect(midFlight?.nodes).toHaveLength(2);
+
+    // Once the queued save lands too, nothing is unsaved and the draft goes.
+    await act(async () => {
+      releases[1]();
+      for (let i = 0; i < 12; i += 1) await Promise.resolve();
+    });
+    expect(readCanvasDraft("project-a", "draft_race_user_eric")).toBeNull();
 
     hook.unmount();
   });

--- a/frontend/src/__tests__/features/freezone/use-canvas-sync.test.tsx
+++ b/frontend/src/__tests__/features/freezone/use-canvas-sync.test.tsx
@@ -580,6 +580,179 @@ describe("useCanvasSync hydrate lifecycle", () => {
     hook.unmount();
   });
 
+  // Regression: on a slow link a PUT outlives the 800ms debounce, so two more
+  // debounced saves stack on the same in-flight promise. They used to resume in
+  // one microtask batch and both fire with the base_revision the first save had
+  // just published — the second earned a 409 and the UI blamed "another window"
+  // for a race the client created. Reproducible in the browser by throttling to
+  // 3G and dragging nodes.
+  it("serializes saves that stack behind a slow in-flight PUT", async () => {
+    vi.useFakeTimers();
+    vi.mocked(getFreezoneCanvas).mockResolvedValue({
+      nodes: [],
+      edges: [],
+      revision: 7,
+    });
+
+    const baseRevisions: Array<number | null> = [];
+    const nodeCounts: number[] = [];
+    const releases: Array<() => void> = [];
+    let inFlight = 0;
+    let maxInFlight = 0;
+    let revision = 7;
+    vi.mocked(putFreezoneCanvas).mockImplementation(
+      (_project: string, _canvasId: string, payload: unknown) => {
+        const body = payload as {
+          base_revision?: number | null;
+          nodes?: unknown[];
+        };
+        baseRevisions.push(body.base_revision ?? null);
+        nodeCounts.push((body.nodes ?? []).length);
+        inFlight += 1;
+        maxInFlight = Math.max(maxInFlight, inFlight);
+        return new Promise((resolve) => {
+          releases.push(() => {
+            inFlight -= 1;
+            revision += 1;
+            resolve({ saved: true, revision });
+          });
+        });
+      },
+    );
+
+    const hook = renderHook(() =>
+      useCanvasSync("project-a", "slow_link_user_eric"),
+    );
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(hook.result.current.status).toBe("ready");
+
+    // Three edits, each debounced out while the previous PUT is still hanging.
+    for (const x of [100, 200, 300]) {
+      useCanvasStore
+        .getState()
+        .addNode(CANVAS_NODE_TYPES.upload, { x, y: x }, {});
+      await act(async () => {
+        vi.advanceTimersByTime(800);
+        await Promise.resolve();
+      });
+    }
+
+    // Only the first save is on the wire; the other two collapse into one
+    // queued follow-up rather than stacking.
+    expect(putFreezoneCanvas).toHaveBeenCalledTimes(1);
+    expect(releases).toHaveLength(1);
+
+    // Release the in-flight save; the queued follow-up then goes out.
+    await act(async () => {
+      releases[0]();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(putFreezoneCanvas).toHaveBeenCalledTimes(2);
+    expect(releases).toHaveLength(2);
+    await act(async () => {
+      releases[1]();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    // Three edits produce two PUTs, never concurrent, never sharing a
+    // base_revision — and the queued one carries the newest node set rather
+    // than the snapshot captured before it waited.
+    expect(putFreezoneCanvas).toHaveBeenCalledTimes(2);
+    expect(maxInFlight).toBe(1);
+    expect(baseRevisions).toEqual([7, 8]);
+    expect(nodeCounts).toEqual([1, 3]);
+    expect(useCanvasStore.getState().nodes).toHaveLength(3);
+    expect(hook.result.current.status).toBe("ready");
+
+    hook.unmount();
+  });
+
+  // A queued save wakes up holding refs that now describe a *different* canvas:
+  // FreezoneShell is mounted without a key, so switching canvases re-runs the
+  // hydrate effect against the same ref set. Re-reading the store at that point
+  // would PUT the new canvas's content under the old canvas's id.
+  it("drops a save queued across a canvas switch", async () => {
+    vi.useFakeTimers();
+    vi.mocked(getFreezoneCanvas).mockImplementation(
+      async (_project: string, canvasId: string) => ({
+        nodes:
+          canvasId === "switch_target_user_eric"
+            ? [
+                {
+                  id: "b-node",
+                  type: CANVAS_NODE_TYPES.upload,
+                  position: { x: 0, y: 0 },
+                  data: { imageUrl: "/static/b.png" },
+                },
+              ]
+            : [],
+        edges: [],
+        revision: 7,
+      }),
+    );
+
+    const putCanvasIds: string[] = [];
+    const releases: Array<() => void> = [];
+    vi.mocked(putFreezoneCanvas).mockImplementation(
+      (_project: string, canvasId: string) => {
+        putCanvasIds.push(canvasId);
+        return new Promise((resolve) => {
+          releases.push(() => resolve({ saved: true, revision: 8 }));
+        });
+      },
+    );
+
+    const hook = renderHook(
+      ({ canvasId }: { canvasId: string }) =>
+        useCanvasSync("project-a", canvasId),
+      { initialProps: { canvasId: "switch_source_user_eric" } },
+    );
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    // Edit canvas A and let its save reach the wire.
+    useCanvasStore
+      .getState()
+      .addNode(CANVAS_NODE_TYPES.upload, { x: 10, y: 10 }, {});
+    await act(async () => {
+      vi.advanceTimersByTime(800);
+      await Promise.resolve();
+    });
+    expect(putCanvasIds).toEqual(["switch_source_user_eric"]);
+
+    // A second edit queues behind it, then the user switches canvases.
+    useCanvasStore
+      .getState()
+      .addNode(CANVAS_NODE_TYPES.upload, { x: 20, y: 20 }, {});
+    await act(async () => {
+      vi.advanceTimersByTime(800);
+      await Promise.resolve();
+    });
+
+    hook.rerender({ canvasId: "switch_target_user_eric" });
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    // Canvas A's PUT finally lands; the queued save must not resume against
+    // canvas B's content.
+    await act(async () => {
+      releases[0]();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(putCanvasIds).toEqual(["switch_source_user_eric"]);
+
+    hook.unmount();
+  });
+
   it("writes a draft and keepalive PUT on beforeunload when an edit is pending", async () => {
     vi.useFakeTimers();
     const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 204 }));

--- a/frontend/src/__tests__/features/freezone/use-canvas-sync.test.tsx
+++ b/frontend/src/__tests__/features/freezone/use-canvas-sync.test.tsx
@@ -753,6 +753,113 @@ describe("useCanvasSync hydrate lifecycle", () => {
     hook.unmount();
   });
 
+  // Same shape as above, except the user *edits* the canvas they switched to
+  // while the old canvas's PUT is still hanging. Dropping the stale queued save
+  // must not drop the new canvas's edit with it: a save that arrives after the
+  // switch cannot ride on a queue slot belonging to the canvas we just left,
+  // because that slot is going to bail out on its generation check.
+  it("still dispatches the new canvas's save queued behind the old canvas's PUT", async () => {
+    vi.useFakeTimers();
+    vi.mocked(getFreezoneCanvas).mockImplementation(
+      async (_project: string, canvasId: string) => ({
+        nodes:
+          canvasId === "cross_target_user_eric"
+            ? [
+                {
+                  id: "b-node",
+                  type: CANVAS_NODE_TYPES.upload,
+                  position: { x: 0, y: 0 },
+                  data: { imageUrl: "/static/b.png" },
+                },
+              ]
+            : [],
+        edges: [],
+        revision: canvasId === "cross_target_user_eric" ? 3 : 7,
+      }),
+    );
+
+    const putCanvasIds: string[] = [];
+    const putBaseRevisions: Array<number | null> = [];
+    const putNodeXs: number[][] = [];
+    const releases: Array<() => void> = [];
+    vi.mocked(putFreezoneCanvas).mockImplementation(
+      (_project: string, canvasId: string, payload: unknown) => {
+        const body = payload as {
+          base_revision?: number | null;
+          nodes?: Array<{ position?: { x?: number } }>;
+        };
+        putCanvasIds.push(canvasId);
+        putBaseRevisions.push(body.base_revision ?? null);
+        putNodeXs.push((body.nodes ?? []).map((node) => node.position?.x ?? -1));
+        return new Promise((resolve) => {
+          releases.push(() => resolve({ saved: true, revision: 42 }));
+        });
+      },
+    );
+
+    const hook = renderHook(
+      ({ canvasId }: { canvasId: string }) =>
+        useCanvasSync("project-a", canvasId),
+      { initialProps: { canvasId: "cross_source_user_eric" } },
+    );
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    // Canvas A: first edit reaches the wire and hangs there.
+    useCanvasStore
+      .getState()
+      .addNode(CANVAS_NODE_TYPES.upload, { x: 10, y: 10 }, {});
+    await act(async () => {
+      vi.advanceTimersByTime(800);
+      await Promise.resolve();
+    });
+    expect(putCanvasIds).toEqual(["cross_source_user_eric"]);
+
+    // Canvas A: a second edit takes the single queue slot behind it.
+    useCanvasStore
+      .getState()
+      .addNode(CANVAS_NODE_TYPES.upload, { x: 20, y: 20 }, {});
+    await act(async () => {
+      vi.advanceTimersByTime(800);
+      await Promise.resolve();
+    });
+    expect(putCanvasIds).toHaveLength(1);
+
+    // Switch to canvas B, then edit it while canvas A's PUT is still hanging.
+    hook.rerender({ canvasId: "cross_target_user_eric" });
+    await act(async () => {
+      for (let i = 0; i < 8; i += 1) await Promise.resolve();
+    });
+    useCanvasStore
+      .getState()
+      .addNode(CANVAS_NODE_TYPES.upload, { x: 99, y: 99 }, {});
+    await act(async () => {
+      vi.advanceTimersByTime(800);
+      await Promise.resolve();
+    });
+    // Saves still never overlap: nothing new goes out while A is on the wire.
+    expect(putCanvasIds).toHaveLength(1);
+
+    // Release canvas A's PUT. Its own queued follow-up is dropped (it belongs
+    // to a canvas we left), but canvas B's edit must go out on its own.
+    await act(async () => {
+      releases[0]();
+      for (let i = 0; i < 12; i += 1) await Promise.resolve();
+    });
+
+    expect(putCanvasIds).toEqual([
+      "cross_source_user_eric",
+      "cross_target_user_eric",
+    ]);
+    expect(putNodeXs).toEqual([[10], [0, 99]]);
+    // And it must carry canvas B's revision — not the one canvas A's response
+    // just returned, which would 409 straight back.
+    expect(putBaseRevisions).toEqual([7, 3]);
+
+    hook.unmount();
+  });
+
   it("writes a draft and keepalive PUT on beforeunload when an edit is pending", async () => {
     vi.useFakeTimers();
     const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 204 }));

--- a/frontend/src/__tests__/features/freezone/use-canvas-sync.test.tsx
+++ b/frontend/src/__tests__/features/freezone/use-canvas-sync.test.tsx
@@ -17,6 +17,7 @@ import {
   writeCanvasDraft,
 } from "@/features/freezone/canvasDraftStorage";
 import {
+  applyRemoteFreezoneCanvas,
   consumeQueuedLocalFreezoneProjections,
   queueLocalFreezoneProjection,
   removeLocalFreezoneProjection,
@@ -856,6 +857,85 @@ describe("useCanvasSync hydrate lifecycle", () => {
     // And it must carry canvas B's revision — not the one canvas A's response
     // just returned, which would 409 straight back.
     expect(putBaseRevisions).toEqual([7, 3]);
+
+    hook.unmount();
+  });
+
+  // A remote refresh rewrites revisionRef from the server. A PUT dispatched
+  // before that refresh comes back carrying an *older* revision; letting it
+  // land would roll the ref backwards and 409 the very next save.
+  it("ignores a save response that lands after a remote refresh", async () => {
+    vi.useFakeTimers();
+    vi.mocked(getFreezoneCanvas).mockResolvedValue({
+      nodes: [],
+      edges: [],
+      revision: 7,
+    });
+
+    const putBaseRevisions: Array<number | null> = [];
+    const releases: Array<(revision: number) => void> = [];
+    vi.mocked(putFreezoneCanvas).mockImplementation(
+      (_project: string, _canvasId: string, payload: unknown) => {
+        const body = payload as { base_revision?: number | null };
+        putBaseRevisions.push(body.base_revision ?? null);
+        return new Promise((resolve) => {
+          releases.push((revision: number) =>
+            resolve({ saved: true, revision }),
+          );
+        });
+      },
+    );
+
+    const hook = renderHook(() =>
+      useCanvasSync("project-a", "fence_user_eric"),
+    );
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    // An edit goes out against revision 7 and hangs on the wire.
+    useCanvasStore
+      .getState()
+      .addNode(CANVAS_NODE_TYPES.upload, { x: 10, y: 10 }, {});
+    await act(async () => {
+      vi.advanceTimersByTime(800);
+      await Promise.resolve();
+    });
+    expect(putBaseRevisions).toEqual([7]);
+
+    // Meanwhile the runtime pushes a much newer server state.
+    act(() => {
+      applyRemoteFreezoneCanvas("project-a", "fence_user_eric", {
+        nodes: [
+          {
+            id: "remote-node",
+            type: CANVAS_NODE_TYPES.upload,
+            position: { x: 0, y: 0 },
+            data: { imageUrl: "/static/remote.png" },
+          },
+        ],
+        edges: [],
+        revision: 100,
+      });
+    });
+    expect(hook.result.current.revision).toBe(100);
+
+    // The stale PUT finally answers with revision 8. It must not win.
+    await act(async () => {
+      releases[0](8);
+      for (let i = 0; i < 12; i += 1) await Promise.resolve();
+    });
+    expect(hook.result.current.revision).toBe(100);
+
+    // And the next save must build on 100, not on the rolled-back 8.
+    useCanvasStore
+      .getState()
+      .addNode(CANVAS_NODE_TYPES.upload, { x: 30, y: 30 }, {});
+    await act(async () => {
+      vi.advanceTimersByTime(800);
+      for (let i = 0; i < 12; i += 1) await Promise.resolve();
+    });
+    expect(putBaseRevisions).toEqual([7, 100]);
 
     hook.unmount();
   });

--- a/frontend/src/__tests__/features/freezone/use-canvas-sync.test.tsx
+++ b/frontend/src/__tests__/features/freezone/use-canvas-sync.test.tsx
@@ -859,6 +859,85 @@ describe("useCanvasSync hydrate lifecycle", () => {
     hook.unmount();
   });
 
+  // Unmount is the third way a session can be orphaned (after a canvas switch
+  // and a remote refresh). The store is global, so whatever mounts next owns it;
+  // a queued save from the unmounted hook would read *that* content and PUT it
+  // to the canvas it left.
+  it("drops a queued save when the hook unmounts", async () => {
+    vi.useFakeTimers();
+    vi.mocked(getFreezoneCanvas).mockImplementation(
+      async (_project: string, canvasId: string) => ({
+        nodes:
+          canvasId === "unmount_target_user_eric"
+            ? [
+                {
+                  id: "b-node",
+                  type: CANVAS_NODE_TYPES.upload,
+                  position: { x: 0, y: 0 },
+                  data: { imageUrl: "/static/b.png" },
+                },
+              ]
+            : [],
+        edges: [],
+        revision: canvasId === "unmount_target_user_eric" ? 3 : 7,
+      }),
+    );
+
+    const putCanvasIds: string[] = [];
+    const releases: Array<() => void> = [];
+    vi.mocked(putFreezoneCanvas).mockImplementation(
+      (_project: string, canvasId: string) => {
+        putCanvasIds.push(canvasId);
+        return new Promise((resolve) => {
+          releases.push(() => resolve({ saved: true, revision: 42 }));
+        });
+      },
+    );
+
+    const hookA = renderHook(() =>
+      useCanvasSync("project-a", "unmount_source_user_eric"),
+    );
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    // Canvas A: one PUT on the wire, one save queued behind it.
+    useCanvasStore
+      .getState()
+      .addNode(CANVAS_NODE_TYPES.upload, { x: 10, y: 10 }, {});
+    await act(async () => {
+      vi.advanceTimersByTime(800);
+      await Promise.resolve();
+    });
+    useCanvasStore
+      .getState()
+      .addNode(CANVAS_NODE_TYPES.upload, { x: 20, y: 20 }, {});
+    await act(async () => {
+      vi.advanceTimersByTime(800);
+      await Promise.resolve();
+    });
+    expect(putCanvasIds).toEqual(["unmount_source_user_eric"]);
+
+    // Canvas A goes away and canvas B takes over the global store.
+    hookA.unmount();
+    const hookB = renderHook(() =>
+      useCanvasSync("project-a", "unmount_target_user_eric"),
+    );
+    await act(async () => {
+      for (let i = 0; i < 8; i += 1) await Promise.resolve();
+    });
+
+    // Canvas A's PUT finally answers. Draining its queue now would send canvas
+    // B's nodes to canvas A's id.
+    await act(async () => {
+      releases[0]();
+      for (let i = 0; i < 12; i += 1) await Promise.resolve();
+    });
+    expect(putCanvasIds).toEqual(["unmount_source_user_eric"]);
+
+    hookB.unmount();
+  });
+
   // A remote refresh rewrites revisionRef from the server. A PUT dispatched
   // before that refresh comes back carrying an *older* revision; letting it
   // land would roll the ref backwards and 409 the very next save.
@@ -1001,6 +1080,83 @@ describe("useCanvasSync hydrate lifecycle", () => {
       for (let i = 0; i < 12; i += 1) await Promise.resolve();
     });
     expect(readCanvasDraft("project-a", "draft_race_user_eric")).toBeNull();
+
+    hook.unmount();
+  });
+
+  // The session only learns about content that has reached `requestSave`. An
+  // edit still inside the autosave debounce has already been written to the
+  // draft but has no version yet, so "nothing newer is queued" is not enough to
+  // conclude the draft is redundant.
+  it("keeps the draft for an edit still inside the autosave debounce window", async () => {
+    vi.useFakeTimers();
+    vi.mocked(getFreezoneCanvas).mockResolvedValue({
+      nodes: [],
+      edges: [],
+      revision: 7,
+    });
+
+    const releases: Array<() => void> = [];
+    let revision = 7;
+    vi.mocked(putFreezoneCanvas).mockImplementation(() => {
+      return new Promise((resolve) => {
+        releases.push(() => {
+          revision += 1;
+          resolve({ saved: true, revision });
+        });
+      });
+    });
+
+    const hook = renderHook(() =>
+      useCanvasSync("project-a", "draft_debounce_user_eric"),
+    );
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    // First edit: draft written, PUT on the wire.
+    useCanvasStore
+      .getState()
+      .addNode(CANVAS_NODE_TYPES.upload, { x: 10, y: 10 }, {});
+    await act(async () => {
+      vi.advanceTimersByTime(800);
+      await Promise.resolve();
+    });
+    expect(releases).toHaveLength(1);
+
+    // Second edit: past the 300ms draft debounce, still short of the 800ms
+    // autosave debounce. The session has never heard of this content.
+    useCanvasStore
+      .getState()
+      .addNode(CANVAS_NODE_TYPES.upload, { x: 20, y: 20 }, {});
+    await act(async () => {
+      vi.advanceTimersByTime(300);
+      await Promise.resolve();
+    });
+    expect(
+      readCanvasDraft("project-a", "draft_debounce_user_eric")?.nodes,
+    ).toHaveLength(2);
+
+    // The first save lands. It only ever carried one node, so the draft is
+    // still the sole copy of the second one.
+    await act(async () => {
+      releases[0]();
+      for (let i = 0; i < 12; i += 1) await Promise.resolve();
+    });
+    expect(
+      readCanvasDraft("project-a", "draft_debounce_user_eric")?.nodes,
+    ).toHaveLength(2);
+
+    // Once the debounce elapses and that save lands too, the draft is redundant.
+    await act(async () => {
+      vi.advanceTimersByTime(500);
+      for (let i = 0; i < 12; i += 1) await Promise.resolve();
+    });
+    await act(async () => {
+      releases[1]();
+      for (let i = 0; i < 12; i += 1) await Promise.resolve();
+    });
+    expect(readCanvasDraft("project-a", "draft_debounce_user_eric")).toBeNull();
 
     hook.unmount();
   });

--- a/frontend/src/features/freezone/canvasSaveCoordinator.ts
+++ b/frontend/src/features/freezone/canvasSaveCoordinator.ts
@@ -182,6 +182,16 @@ export function createCanvasSaveSession(
         await pump();
       } finally {
         pumping = false;
+        // Re-check before parking. `settle()` only *resolves* the waiters — their
+        // `.then` callbacks run in a later microtask, after the loop has already
+        // seen an empty queue and returned. So a caller that saves again the
+        // moment its save lands (`await requestSave(); …; requestSave()`) enqueues
+        // while `pumping` is still true, and its `startPump()` bails out. Without
+        // this re-check that work would sit in `pendingVersion` forever and its
+        // promise would never settle.
+        if (!disposed && pendingVersion !== null) {
+          startPump();
+        }
       }
     })();
   }

--- a/frontend/src/features/freezone/canvasSaveCoordinator.ts
+++ b/frontend/src/features/freezone/canvasSaveCoordinator.ts
@@ -1,0 +1,190 @@
+// SPDX-License-Identifier: Elastic-2.0
+// Copyright (c) 2026 ClaymoreLab
+
+/**
+ * Save scheduling for one loaded canvas, isolated from the React hook.
+ *
+ * `useCanvasSync` used to schedule saves out of a shared bag of refs living on
+ * the hook. That bag is the problem: `FreezoneShell` is mounted without a key,
+ * so switching canvases re-runs the hydrate effect against the *same* refs. A
+ * save scheduled for canvas A would wake up holding refs that now describe
+ * canvas B, and there was no way to tell from inside the scheduler which canvas
+ * any given piece of state belonged to.
+ *
+ * A session fixes that by construction: everything that can go stale across a
+ * canvas load lives on a session object, and a canvas load creates a new one.
+ * The old session is disposed, its queued work is dropped, and its in-flight
+ * request — which we deliberately do *not* cancel, the server should still
+ * commit it — can no longer write to anything the new canvas reads.
+ *
+ * The invariants the session guarantees:
+ *
+ *  1. At most one save request in flight per session.
+ *  2. N edits during one request collapse into a single follow-up request,
+ *     which reads the store at *send* time so it carries the newest content.
+ *  3. Sessions never share a promise. A save for the canvas you just switched
+ *     to is never satisfied by a save belonging to the canvas you left.
+ *  4. A caller waiting on `requestSave()` is released only once a request that
+ *     covers *its* content version has actually landed.
+ *  5. Disposal releases every waiter (as "not persisted") rather than hanging.
+ *  6. `hasUnsavedContentBeyond` lets the caller avoid dropping the local draft
+ *     while newer content is still queued.
+ */
+
+export interface CanvasSaveSession {
+  /** `${project}:${canvasId}` — which canvas this session saves. */
+  readonly canvasKey: string;
+  /**
+   * The canvas-load counter this session was created under. `useCanvasSync`
+   * stamps outgoing requests with it and refuses to apply a response whose
+   * stamp no longer matches, which is what keeps a late reply from canvas A
+   * out of canvas B's revision/status.
+   */
+  readonly generation: number;
+  isDisposed(): boolean;
+  /** True while a request is on the wire or a follow-up is queued. */
+  isSaving(): boolean;
+  /** Monotonic counter of save requests made against this session. */
+  contentVersion(): number;
+  /** The highest content version known to have reached the server. */
+  savedVersion(): number;
+  /**
+   * Whether content newer than `version` is still waiting to be sent. Callers
+   * use this to decide whether dropping the local draft is safe: a draft is the
+   * only copy of edits that have not been persisted yet.
+   */
+  hasUnsavedContentBeyond(version: number): boolean;
+  /**
+   * Ask for the current store content to be persisted. Resolves true once a
+   * request covering this call's content has landed, false if that content was
+   * never persisted (conflict, error, the decision gate declined, or the
+   * session was disposed first).
+   */
+  requestSave(): Promise<boolean>;
+  /**
+   * Retire this session. Queued work is dropped and waiters are released;
+   * anything already on the wire is left alone to finish server-side.
+   */
+  dispose(): void;
+}
+
+export interface CanvasSaveSessionOptions {
+  canvasKey: string;
+  generation: number;
+  /**
+   * Put the canvas on the wire. Called only by the pump, never concurrently
+   * with itself, and always immediately before the request goes out — so it
+   * must read the live stores rather than close over a snapshot. Resolves true
+   * when the content was persisted.
+   */
+  runSave: (version: number, session: CanvasSaveSession) => Promise<boolean>;
+}
+
+interface Waiter {
+  version: number;
+  resolve: (persisted: boolean) => void;
+}
+
+export function createCanvasSaveSession(
+  options: CanvasSaveSessionOptions,
+): CanvasSaveSession {
+  let contentVersion = 0;
+  let savedVersion = 0;
+  // The single queued follow-up, as a content version rather than a promise.
+  // Holding a version instead of a promise is what makes coalescing free: a
+  // second edit during a request just overwrites it.
+  let pendingVersion: number | null = null;
+  let pumping = false;
+  let disposed = false;
+  const waiters: Waiter[] = [];
+
+  /** Release every waiter at or below `upTo`. */
+  const settle = (upTo: number, persisted: boolean): void => {
+    for (let i = waiters.length - 1; i >= 0; i -= 1) {
+      if (waiters[i].version <= upTo) {
+        const [waiter] = waiters.splice(i, 1);
+        waiter.resolve(persisted);
+      }
+    }
+  };
+
+  const session: CanvasSaveSession = {
+    canvasKey: options.canvasKey,
+    generation: options.generation,
+    isDisposed: () => disposed,
+    isSaving: () => pumping,
+    contentVersion: () => contentVersion,
+    savedVersion: () => savedVersion,
+    hasUnsavedContentBeyond: (version: number) =>
+      pendingVersion !== null || contentVersion > version,
+    requestSave: () => {
+      if (disposed) return Promise.resolve(false);
+      const version = (contentVersion += 1);
+      // Latest wins: an earlier queued version is simply superseded, because
+      // the request that eventually goes out re-reads the store anyway and
+      // will therefore carry that earlier content too.
+      pendingVersion = version;
+      const landed = new Promise<boolean>((resolve) => {
+        waiters.push({ version, resolve });
+      });
+      startPump();
+      return landed;
+    },
+    dispose: () => {
+      if (disposed) return;
+      disposed = true;
+      pendingVersion = null;
+      // Nothing queued will ever run now. Waiters must learn that rather than
+      // hang — `flush()` on the way out of a canvas depends on it.
+      settle(Number.POSITIVE_INFINITY, false);
+    },
+  };
+
+  async function pump(): Promise<void> {
+    while (!disposed && pendingVersion !== null) {
+      const version = pendingVersion;
+      pendingVersion = null;
+
+      let persisted = false;
+      try {
+        persisted = await options.runSave(version, session);
+      } catch {
+        // `runSave` reports its own failures through the hook's error handling;
+        // a rejection here only means "not persisted".
+        persisted = false;
+      }
+
+      if (disposed) return;
+
+      if (persisted) {
+        savedVersion = Math.max(savedVersion, version);
+        settle(savedVersion, true);
+        continue;
+      }
+
+      // The request did not stick — a conflict, a hard error, or the decision
+      // gate declining to send. Draining the queue would re-send immediately
+      // into the same wall (the hook stops autosaving once status is
+      // conflict/error, so every retry would decline again, spinning). Stop the
+      // pump instead; the next genuine edit calls `requestSave` and restarts
+      // it. Everything still waiting is told its content did not land.
+      pendingVersion = null;
+      settle(Number.POSITIVE_INFINITY, false);
+      return;
+    }
+  }
+
+  function startPump(): void {
+    if (pumping) return;
+    pumping = true;
+    void (async () => {
+      try {
+        await pump();
+      } finally {
+        pumping = false;
+      }
+    })();
+  }
+
+  return session;
+}

--- a/frontend/src/features/freezone/canvasSyncCore.ts
+++ b/frontend/src/features/freezone/canvasSyncCore.ts
@@ -374,6 +374,20 @@ export function classifySaveError(
   const code = typeof body?.detail?.code === "string" ? body.detail.code : null;
 
   if (status === 409) {
+    // Three backend conditions land on 409, but only two are distinguishable
+    // here: `canvas_revision_conflict` and `canvas_idempotency_conflict` carry
+    // a `detail.code`, while `CanvasBaseRevisionRequired` raises a bare string
+    // detail and therefore still falls through to the canonical message.
+    // `canvas_idempotency_conflict` is one client replaying a client_save_id
+    // with a different body — telling that user "another window" sends them
+    // hunting for a tab that does not exist. Only the plain revision conflict
+    // really means someone else wrote to the canvas.
+    if (code === "canvas_idempotency_conflict") {
+      return {
+        kind: "conflict",
+        message: "同一次保存被重复提交且内容不一致，请刷新后重试",
+      };
+    }
     return {
       kind: "conflict",
       message: "画布已被其他窗口或用户修改",

--- a/frontend/src/features/freezone/useCanvasSync.ts
+++ b/frontend/src/features/freezone/useCanvasSync.ts
@@ -670,6 +670,12 @@ export function useCanvasSync(
   // measure/select pass after load doesn't fire a redundant save.
   const lastSignatureRef = useRef<string | null>(null);
   const inFlightRef = useRef<Promise<boolean> | null>(null);
+  // At most one save waits behind the one on the wire; further callers ride on
+  // it instead of stacking. See `scheduleSave`.
+  const queuedSaveRef = useRef<Promise<boolean> | null>(null);
+  // Incremented whenever the hydrate effect points this ref set at a different
+  // canvas, so a save that was queued across the switch can bail out.
+  const canvasGenerationRef = useRef(0);
   const debounceTimerRef = useRef<number | null>(null);
   const draftTimerRef = useRef<number | null>(null);
   const suppressNextCanvasAutosaveRef = useRef(false);
@@ -752,6 +758,22 @@ export function useCanvasSync(
       buildPersistMetadata(shot),
     );
   };
+  // Everything a save payload is built from, read fresh. Handed to
+  // `scheduleSave` so a save that had to queue behind an in-flight PUT can
+  // refresh its stale snapshot instead of overwriting newer content. Pure on
+  // purpose: it runs before the decision gate, so a save that ends up skipped
+  // or blocked must not leave persistence state behind (notably
+  // `lastSavedViewportRef`, which suppresses the localStorage viewport mirror).
+  const currentSaveSnapshot = () => {
+    const canvasState = useCanvasStore.getState();
+    const shot = useShotMetadataStore.getState().shot;
+    return {
+      nodes: canvasState.nodes as unknown[],
+      edges: canvasState.edges as unknown[],
+      viewport: canvasState.currentViewport,
+      metadata: buildPersistMetadata(shot),
+    };
+  };
 
   const scheduleDraftWrite = () => {
     if (draftTimerRef.current != null) {
@@ -812,7 +834,11 @@ export function useCanvasSync(
           edges: canvasState.edges,
           viewport: canvasState.currentViewport,
           metadata: buildPersistMetadata(shot),
+          resnapshot: currentSaveSnapshot,
           revisionRef,
+          statusRef,
+          canvasGenerationRef,
+          queuedSaveRef,
           canvasEnvelopeRef,
           pendingClientSaveIdRef,
           pendingClientSaveIdSignatureRef,
@@ -890,7 +916,11 @@ export function useCanvasSync(
             edges: canvasState.edges,
             viewport: canvasState.currentViewport,
             metadata: buildPersistMetadata(shot),
+            resnapshot: currentSaveSnapshot,
             revisionRef,
+            statusRef,
+            canvasGenerationRef,
+            queuedSaveRef,
             canvasEnvelopeRef,
             pendingClientSaveIdRef,
             pendingClientSaveIdSignatureRef,
@@ -972,6 +1002,10 @@ export function useCanvasSync(
     lastPersistedDraftSignatureRef.current = null;
     hydratedRef.current = false;
     switchingRef.current = true;
+    // These refs are about to describe a different canvas. Any save still
+    // queued for the previous one must not wake up and PUT this canvas's
+    // content under the old canvas id.
+    canvasGenerationRef.current += 1;
     lastRemoteNodeCountRef.current = 0;
     pendingClientSaveIdRef.current = null;
     pendingClientSaveIdSignatureRef.current = null;
@@ -1216,7 +1250,11 @@ export function useCanvasSync(
           edges: canvasState.edges,
           viewport: canvasState.currentViewport,
           metadata: buildPersistMetadata(shot),
+          resnapshot: currentSaveSnapshot,
           revisionRef,
+          statusRef,
+          canvasGenerationRef,
+          queuedSaveRef,
           canvasEnvelopeRef,
           pendingClientSaveIdRef,
           pendingClientSaveIdSignatureRef,
@@ -1321,7 +1359,11 @@ export function useCanvasSync(
       edges,
       viewport: currentViewport,
       metadata: buildPersistMetadata(shot),
+      resnapshot: currentSaveSnapshot,
       revisionRef,
+      statusRef,
+      canvasGenerationRef,
+      queuedSaveRef,
       canvasEnvelopeRef,
       pendingClientSaveIdRef,
       pendingClientSaveIdSignatureRef,
@@ -1580,7 +1622,31 @@ interface SaveArgs {
    * that already know what they are.
    */
   forcedDecision?: Extract<SaveDecision, { kind: "send" }>;
+  /**
+   * Re-read the live snapshot a save payload is built from. `scheduleSave`
+   * calls this only when it had to queue behind an in-flight save, where the
+   * caller's captured `nodes`/`edges`/`viewport`/`metadata` have gone stale.
+   * Every autosave site reads the same two stores, so re-reading is exactly
+   * what the caller would have captured had it run at that moment. A caller
+   * that omits it (to send one fixed payload) is simply never queued: rather
+   * than PUT a snapshot from before the wait, `scheduleSave` drops the save.
+   */
+  resnapshot?: () => Pick<
+    SaveArgs,
+    "nodes" | "edges" | "viewport" | "metadata"
+  >;
   revisionRef: { current: number | null };
+  statusRef: { current: CanvasSyncStatus };
+  /**
+   * Bumped by the hydrate effect every time a different canvas is loaded into
+   * these refs. A queued save compares it before and after its wait so it can
+   * never PUT the newly-loaded canvas's content to the canvas it was scheduled
+   * for — `FreezoneShell` is mounted without a key, so a canvas switch reuses
+   * the whole ref set.
+   */
+  canvasGenerationRef: { current: number };
+  /** The single follow-up save queued behind the one on the wire, if any. */
+  queuedSaveRef: { current: Promise<boolean> | null };
   canvasEnvelopeRef: { current: Partial<FreezoneCanvasPayload> };
   pendingClientSaveIdRef: { current: string | null };
   pendingClientSaveIdSignatureRef: { current: string | null };
@@ -1607,10 +1673,83 @@ interface SaveArgs {
   markDraftPersisted?: (signature: string) => void;
 }
 
-async function scheduleSave(args: SaveArgs): Promise<boolean> {
+async function scheduleSave(
+  args: SaveArgs,
+  requeued = false,
+): Promise<boolean> {
   // Coalesce overlapping saves.
-  if (args.inFlightRef.current) {
-    await args.inFlightRef.current;
+  //
+  // The old code did this with a single `await` on the in-flight promise, which
+  // is not enough: several callers park on the *same* promise, and when it
+  // settles they all resume inside one microtask batch — each then walks
+  // straight through to its own PUT carrying the base_revision the first save
+  // just published. The backend's optimistic lock 409s the loser, and the UI
+  // blames "another window" for a race we caused ourselves. (Reproducible by
+  // throttling to 3G and dragging nodes: a PUT slower than DEBOUNCE_MS is all
+  // it takes for two debounced saves to stack, and the projection-sync / flush
+  // paths skip the debounce entirely.)
+  //
+  // So: exactly one follow-up save is ever queued behind the one on the wire.
+  // Because a queued save re-reads the store before it builds its payload, a
+  // second waiter would put byte-identical content on the wire one round-trip
+  // later; extra callers ride on the queued save instead. That also keeps
+  // `flush()` honest — the save it rides on carries the content flush wanted
+  // persisted, and flush waits one round-trip rather than N.
+  const inFlight = args.inFlightRef.current;
+  if (inFlight) {
+    const alreadyQueued = args.queuedSaveRef.current;
+    if (alreadyQueued) {
+      return await alreadyQueued;
+    }
+    // Which canvas this save belongs to. `FreezoneShell` is mounted without a
+    // key, so switching canvases re-runs the hydrate effect against these very
+    // refs: by the time we wake, the store can be holding a different canvas
+    // entirely, and re-reading it would PUT that canvas's content to our
+    // (stale) args.canvasId.
+    const generation = args.canvasGenerationRef.current;
+    const follow = (async () => {
+      try {
+        await inFlight;
+      } catch {
+        // The save we queued behind reported its own failure through
+        // handleSaveError; its rejection must not become ours.
+      }
+      args.queuedSaveRef.current = null;
+      if (args.canvasGenerationRef.current !== generation) {
+        return false;
+      }
+      return await scheduleSave(args, true);
+    })();
+    args.queuedSaveRef.current = follow;
+    return await follow;
+  }
+
+  if (requeued) {
+    // We skipped the guards our callers apply before scheduling, and the world
+    // moved while we sat in the queue. Re-apply them now.
+    if (
+      args.statusRef.current === "conflict" ||
+      args.statusRef.current === "error"
+    ) {
+      // The save ahead of us failed terminally. Callers stop autosaving in this
+      // state; a queued save must not sneak a doomed PUT past that, nor
+      // overwrite the conflict snapshot the overlay offers for download.
+      return false;
+    }
+    if (!args.resnapshot) {
+      // Without a fresh read we would PUT the payload captured before the wait,
+      // rolling the canvas back over whatever just landed. Skipping is strictly
+      // better; the content is still in the store and the next edit re-triggers.
+      return false;
+    }
+    // The save we queued behind persisted part of our payload, and the user
+    // kept editing meanwhile. Re-read the live stores so we carry the newest
+    // content rather than overwriting it with a stale snapshot.
+    const fresh = args.resnapshot();
+    args.nodes = fresh.nodes;
+    args.edges = fresh.edges;
+    args.viewport = fresh.viewport;
+    args.metadata = fresh.metadata;
   }
 
   // ---- Decision gate ---- //

--- a/frontend/src/features/freezone/useCanvasSync.ts
+++ b/frontend/src/features/freezone/useCanvasSync.ts
@@ -670,9 +670,12 @@ export function useCanvasSync(
   // measure/select pass after load doesn't fire a redundant save.
   const lastSignatureRef = useRef<string | null>(null);
   const inFlightRef = useRef<Promise<boolean> | null>(null);
-  // At most one save waits behind the one on the wire; further callers ride on
-  // it instead of stacking. See `scheduleSave`.
-  const queuedSaveRef = useRef<Promise<boolean> | null>(null);
+  // At most one save waits behind the one on the wire; further callers for the
+  // same canvas generation ride on it instead of stacking. See `scheduleSave`.
+  const queuedSaveRef = useRef<{
+    generation: number;
+    promise: Promise<boolean>;
+  } | null>(null);
   // Incremented whenever the hydrate effect points this ref set at a different
   // canvas, so a save that was queued across the switch can bail out.
   const canvasGenerationRef = useRef(0);
@@ -1645,8 +1648,16 @@ interface SaveArgs {
    * the whole ref set.
    */
   canvasGenerationRef: { current: number };
-  /** The single follow-up save queued behind the one on the wire, if any. */
-  queuedSaveRef: { current: Promise<boolean> | null };
+  /**
+   * The single follow-up save queued behind the one on the wire, if any, tagged
+   * with the canvas generation it belongs to. The tag is what stops a save for
+   * a freshly-switched-to canvas from riding on a queued save for the previous
+   * one — that one bails on its generation check, and the rider would be
+   * swallowed with it.
+   */
+  queuedSaveRef: {
+    current: { generation: number; promise: Promise<boolean> } | null;
+  };
   canvasEnvelopeRef: { current: Partial<FreezoneCanvasPayload> };
   pendingClientSaveIdRef: { current: string | null };
   pendingClientSaveIdSignatureRef: { current: string | null };
@@ -1697,30 +1708,45 @@ async function scheduleSave(
   // persisted, and flush waits one round-trip rather than N.
   const inFlight = args.inFlightRef.current;
   if (inFlight) {
-    const alreadyQueued = args.queuedSaveRef.current;
-    if (alreadyQueued) {
-      return await alreadyQueued;
-    }
     // Which canvas this save belongs to. `FreezoneShell` is mounted without a
     // key, so switching canvases re-runs the hydrate effect against these very
     // refs: by the time we wake, the store can be holding a different canvas
     // entirely, and re-reading it would PUT that canvas's content to our
     // (stale) args.canvasId.
     const generation = args.canvasGenerationRef.current;
+    const alreadyQueued = args.queuedSaveRef.current;
+    if (alreadyQueued && alreadyQueued.generation === generation) {
+      // Same canvas: ride along. The queued save re-reads the store, so it will
+      // carry our content too.
+      return await alreadyQueued.promise;
+    }
+    // Either nothing is queued, or what is queued belongs to the canvas we just
+    // left — that one will bail out on its own generation check, and riding on
+    // it would silently swallow this canvas's save. Chain behind it instead so
+    // the two still never overlap.
+    const waitFor = alreadyQueued?.promise ?? inFlight;
+    // Assigned on the line after the IIFE is created. The closure only reads it
+    // past an `await`, so it is always populated by the time it is dereferenced.
+    let entry!: { generation: number; promise: Promise<boolean> };
     const follow = (async () => {
       try {
-        await inFlight;
+        await waitFor;
       } catch {
         // The save we queued behind reported its own failure through
         // handleSaveError; its rejection must not become ours.
       }
-      args.queuedSaveRef.current = null;
+      // Only clear the slot if it is still ours — a newer generation may have
+      // chained behind us and taken it over.
+      if (args.queuedSaveRef.current === entry) {
+        args.queuedSaveRef.current = null;
+      }
       if (args.canvasGenerationRef.current !== generation) {
         return false;
       }
       return await scheduleSave(args, true);
     })();
-    args.queuedSaveRef.current = follow;
+    entry = { generation, promise: follow };
+    args.queuedSaveRef.current = entry;
     return await follow;
   }
 
@@ -1804,9 +1830,16 @@ async function scheduleSave(
   const clientSaveId = args.pendingClientSaveIdRef.current;
 
   args.setStatus("saving");
+  const dispatchGeneration = args.canvasGenerationRef.current;
   const job = (async () => {
     try {
-      return await performSave(args, decision, clientSaveId, 0);
+      return await performSave(
+        args,
+        decision,
+        clientSaveId,
+        0,
+        dispatchGeneration,
+      );
     } finally {
       args.inFlightRef.current = null;
     }
@@ -1820,6 +1853,13 @@ async function performSave(
   decision: Extract<SaveDecision, { kind: "send" }>,
   clientSaveId: string,
   attempt: number,
+  /**
+   * The canvas generation this PUT was dispatched under. If the user switches
+   * canvases while it is on the wire, the shared refs no longer describe the
+   * canvas we saved, and publishing the response into them would corrupt the
+   * new canvas's state.
+   */
+  dispatchGeneration: number,
 ): Promise<boolean> {
   const payload = buildSavePayload({
     canvasId: args.canvasId,
@@ -1873,12 +1913,32 @@ async function performSave(
 
   try {
     const response = await putFreezoneCanvas(args.project, args.canvasId, payload);
+    if (args.canvasGenerationRef.current !== dispatchGeneration) {
+      // The user switched canvases while this PUT was on the wire. The save
+      // itself succeeded server-side, but every ref the response would update
+      // (revision, envelope, remote node count, draft signature) now belongs to
+      // a different canvas — writing this canvas's revision into them would
+      // make the new canvas's next save PUT a stale base_revision and 409.
+      return true;
+    }
     consumeSaveResponse(args, response, decision);
     args.setStatus("ready");
     args.setError(null);
     return true;
   } catch (err) {
-    return await handleSaveError(args, err, decision, clientSaveId, attempt);
+    if (args.canvasGenerationRef.current !== dispatchGeneration) {
+      // Same reasoning: a failure that belongs to the canvas we left must not
+      // flip the new canvas into a conflict/error state or hijack its retry.
+      return false;
+    }
+    return await handleSaveError(
+      args,
+      err,
+      decision,
+      clientSaveId,
+      attempt,
+      dispatchGeneration,
+    );
   }
 }
 
@@ -1941,6 +2001,7 @@ async function handleSaveError(
   decision: Extract<SaveDecision, { kind: "send" }>,
   clientSaveId: string,
   attempt: number,
+  dispatchGeneration: number,
 ): Promise<boolean> {
   const { status, body } = saveErrorStatusAndBody(err);
   const fallback = err instanceof Error ? err.message : String(err);
@@ -1979,7 +2040,18 @@ async function handleSaveError(
         await new Promise((resolve) =>
           setTimeout(resolve, outcome.afterMs),
         );
-        return await performSave(args, decision, clientSaveId, attempt + 1);
+        if (args.canvasGenerationRef.current !== dispatchGeneration) {
+          // Switched canvases during the backoff; the retry would PUT the new
+          // canvas's content under the old canvas's id.
+          return false;
+        }
+        return await performSave(
+          args,
+          decision,
+          clientSaveId,
+          attempt + 1,
+          dispatchGeneration,
+        );
       }
       // Retry budget exhausted — surface as a generic error so the user
       // knows the save did not stick.

--- a/frontend/src/features/freezone/useCanvasSync.ts
+++ b/frontend/src/features/freezone/useCanvasSync.ts
@@ -47,6 +47,10 @@ import {
   removeProjectionMetadata,
 } from "./projections";
 import {
+  createCanvasSaveSession,
+  type CanvasSaveSession,
+} from "./canvasSaveCoordinator";
+import {
   canvasDraftSignature,
   clearCanvasDraft,
   pruneOldCanvasDrafts,
@@ -669,16 +673,14 @@ export function useCanvasSync(
   // is how we ignore pure view-state churn. Seeded on hydrate so the initial
   // measure/select pass after load doesn't fire a redundant save.
   const lastSignatureRef = useRef<string | null>(null);
-  const inFlightRef = useRef<Promise<boolean> | null>(null);
-  // At most one save waits behind the one on the wire; further callers for the
-  // same canvas generation ride on it instead of stacking. See `scheduleSave`.
-  const queuedSaveRef = useRef<{
-    canvasKey: string;
-    generation: number;
-    promise: Promise<boolean>;
-  } | null>(null);
-  // Incremented whenever the hydrate effect points this ref set at a different
-  // canvas, so a save that was queued across the switch can bail out.
+  // All save scheduling for the currently-loaded canvas. Replaced (and the old
+  // one disposed) on every hydrate and every remote refresh, so queued work can
+  // never survive into a canvas it was not written for. See
+  // `canvasSaveCoordinator`.
+  const sessionRef = useRef<CanvasSaveSession | null>(null);
+  // Incremented alongside every new session. Outgoing requests are stamped with
+  // it so a late response can be recognised as belonging to a canvas load we
+  // have already moved past.
   const canvasGenerationRef = useRef(0);
   const debounceTimerRef = useRef<number | null>(null);
   const draftTimerRef = useRef<number | null>(null);
@@ -762,23 +764,6 @@ export function useCanvasSync(
       buildPersistMetadata(shot),
     );
   };
-  // Everything a save payload is built from, read fresh. Handed to
-  // `scheduleSave` so a save that had to queue behind an in-flight PUT can
-  // refresh its stale snapshot instead of overwriting newer content. Pure on
-  // purpose: it runs before the decision gate, so a save that ends up skipped
-  // or blocked must not leave persistence state behind (notably
-  // `lastSavedViewportRef`, which suppresses the localStorage viewport mirror).
-  const currentSaveSnapshot = () => {
-    const canvasState = useCanvasStore.getState();
-    const shot = useShotMetadataStore.getState().shot;
-    return {
-      nodes: canvasState.nodes as unknown[],
-      edges: canvasState.edges as unknown[],
-      viewport: canvasState.currentViewport,
-      metadata: buildPersistMetadata(shot),
-    };
-  };
-
   const scheduleDraftWrite = () => {
     if (draftTimerRef.current != null) {
       window.clearTimeout(draftTimerRef.current);
@@ -814,6 +799,67 @@ export function useCanvasSync(
     setBackupStatus(next);
   };
 
+  // One place that describes a save. The session pump calls it immediately
+  // before the request goes out, which is what makes a coalesced save carry the
+  // newest content instead of the snapshot whichever caller scheduled it held.
+  const buildSaveArgs = (
+    session: CanvasSaveSession,
+    version: number,
+  ): SaveArgs => {
+    const canvasState = useCanvasStore.getState();
+    const shot = useShotMetadataStore.getState().shot;
+    return {
+      project,
+      canvasId,
+      nodes: canvasState.nodes,
+      edges: canvasState.edges,
+      viewport: canvasState.currentViewport,
+      metadata: buildPersistMetadata(shot),
+      revisionRef,
+      statusRef,
+      canvasGenerationRef,
+      canvasEnvelopeRef,
+      pendingClientSaveIdRef,
+      pendingClientSaveIdSignatureRef,
+      hydratedRef,
+      switchingRef,
+      lastRemoteNodeCountRef,
+      setStatus: setSyncStatus,
+      setError,
+      snapshotConflict,
+      publishBackupStatus,
+      publishRevision: setRevision,
+      clearDraftAfterSave: () => {
+        // This save landing does not make the draft redundant. The user may
+        // have kept editing while it was on the wire, and that newer content
+        // exists nowhere but localStorage until the queued save lands too.
+        if (session.hasUnsavedContentBeyond(version)) return;
+        clearDraftTimerAndDraft();
+      },
+      markDraftPersisted: (signature) => {
+        lastPersistedDraftSignatureRef.current = signature;
+      },
+    };
+  };
+
+  // Retire the session for the canvas we are leaving and open one for the
+  // canvas we are entering. Bumping the generation in lock-step is what lets a
+  // response arriving after this point be recognised as stale.
+  const startSaveSession = (): CanvasSaveSession => {
+    sessionRef.current?.dispose();
+    canvasGenerationRef.current += 1;
+    const session = createCanvasSaveSession({
+      canvasKey: `${project}:${canvasId}`,
+      generation: canvasGenerationRef.current,
+      runSave: (version, self) => scheduleSave(buildSaveArgs(self, version)),
+    });
+    sessionRef.current = session;
+    return session;
+  };
+
+  const requestSave = (): Promise<boolean> =>
+    sessionRef.current?.requestSave() ?? Promise.resolve(false);
+
   // ---- 0. External-trigger remote canvas refresh ---- //
   // canvasSyncRuntime lets other features (beat-context preset refresh,
   // mainline rebuild) hand us a fresh server payload to apply in place.
@@ -828,38 +874,9 @@ export function useCanvasSync(
         if (statusRef.current === "conflict" || statusRef.current === "error") {
           return;
         }
-        const canvasState = useCanvasStore.getState();
-        const shot = useShotMetadataStore.getState().shot;
-        lastSavedViewportRef.current = canvasState.currentViewport;
-        void scheduleSave({
-          project,
-          canvasId,
-          nodes: canvasState.nodes,
-          edges: canvasState.edges,
-          viewport: canvasState.currentViewport,
-          metadata: buildPersistMetadata(shot),
-          resnapshot: currentSaveSnapshot,
-          revisionRef,
-          statusRef,
-          canvasGenerationRef,
-          queuedSaveRef,
-          canvasEnvelopeRef,
-          pendingClientSaveIdRef,
-          pendingClientSaveIdSignatureRef,
-          hydratedRef,
-          switchingRef,
-          lastRemoteNodeCountRef,
-          setStatus: setSyncStatus,
-          setError,
-          inFlightRef,
-          snapshotConflict,
-          publishBackupStatus,
-          publishRevision: setRevision,
-          clearDraftAfterSave: clearDraftTimerAndDraft,
-          markDraftPersisted: (signature) => {
-            lastPersistedDraftSignatureRef.current = signature;
-          },
-        });
+        lastSavedViewportRef.current =
+          useCanvasStore.getState().currentViewport;
+        void requestSave();
       }, 0);
     };
 
@@ -876,9 +893,9 @@ export function useCanvasSync(
       // overwrite revisionRef with the remote revision; a PUT already on the
       // wire would otherwise come back with an older revision and roll it
       // backwards, and the next save would 409 against it. A save still queued
-      // behind that PUT is stale for the same reason — the merged content is
-      // rescheduled explicitly below when there is local work to keep.
-      canvasGenerationRef.current += 1;
+      // Queued work is stale for the same reason — the merged content is
+      // rescheduled explicitly below when there is local work worth keeping.
+      startSaveSession();
       const local = useCanvasStore.getState();
       const remoteNodes = (remote.nodes ?? []) as CanvasNode[];
       const remoteEdges = (remote.edges ?? []) as CanvasEdge[];
@@ -917,38 +934,9 @@ export function useCanvasSync(
       if (mergedLocalWork) {
         window.setTimeout(() => {
           if (!hydratedRef.current || switchingRef.current) return;
-          const canvasState = useCanvasStore.getState();
-          const shot = useShotMetadataStore.getState().shot;
-          lastSavedViewportRef.current = canvasState.currentViewport;
-          void scheduleSave({
-            project,
-            canvasId,
-            nodes: canvasState.nodes,
-            edges: canvasState.edges,
-            viewport: canvasState.currentViewport,
-            metadata: buildPersistMetadata(shot),
-            resnapshot: currentSaveSnapshot,
-            revisionRef,
-            statusRef,
-            canvasGenerationRef,
-            queuedSaveRef,
-            canvasEnvelopeRef,
-            pendingClientSaveIdRef,
-            pendingClientSaveIdSignatureRef,
-            hydratedRef,
-            switchingRef,
-            lastRemoteNodeCountRef,
-            setStatus: setSyncStatus,
-            setError,
-            inFlightRef,
-            snapshotConflict,
-            publishBackupStatus,
-            publishRevision: setRevision,
-            clearDraftAfterSave: clearDraftTimerAndDraft,
-            markDraftPersisted: (signature) => {
-              lastPersistedDraftSignatureRef.current = signature;
-            },
-          });
+          lastSavedViewportRef.current =
+            useCanvasStore.getState().currentViewport;
+          void requestSave();
         }, 0);
       }
     }, flush, (projection) => {
@@ -1013,10 +1001,10 @@ export function useCanvasSync(
     lastPersistedDraftSignatureRef.current = null;
     hydratedRef.current = false;
     switchingRef.current = true;
-    // These refs are about to describe a different canvas. Any save still
-    // queued for the previous one must not wake up and PUT this canvas's
-    // content under the old canvas id.
-    canvasGenerationRef.current += 1;
+    // Everything queued for the previous canvas is dropped here: the new
+    // session owns save scheduling from now on, and the old one can no longer
+    // write to anything this canvas reads.
+    startSaveSession();
     lastRemoteNodeCountRef.current = 0;
     pendingClientSaveIdRef.current = null;
     pendingClientSaveIdSignatureRef.current = null;
@@ -1251,38 +1239,9 @@ export function useCanvasSync(
         window.clearTimeout(debounceTimerRef.current);
       }
       debounceTimerRef.current = window.setTimeout(() => {
-        const canvasState = useCanvasStore.getState();
-        const shot = useShotMetadataStore.getState().shot;
-        lastSavedViewportRef.current = canvasState.currentViewport;
-        void scheduleSave({
-          project,
-          canvasId,
-          nodes: canvasState.nodes,
-          edges: canvasState.edges,
-          viewport: canvasState.currentViewport,
-          metadata: buildPersistMetadata(shot),
-          resnapshot: currentSaveSnapshot,
-          revisionRef,
-          statusRef,
-          canvasGenerationRef,
-          queuedSaveRef,
-          canvasEnvelopeRef,
-          pendingClientSaveIdRef,
-          pendingClientSaveIdSignatureRef,
-          hydratedRef,
-          switchingRef,
-          lastRemoteNodeCountRef,
-          setStatus: setSyncStatus,
-          setError,
-          inFlightRef,
-          snapshotConflict,
-          publishBackupStatus,
-          publishRevision: setRevision,
-          clearDraftAfterSave: clearDraftTimerAndDraft,
-          markDraftPersisted: (signature) => {
-            lastPersistedDraftSignatureRef.current = signature;
-          },
-        });
+        lastSavedViewportRef.current =
+          useCanvasStore.getState().currentViewport;
+        void requestSave();
       }, DEBOUNCE_MS);
     };
     // Only react to changes that alter the persisted nodes/edges shape. View
@@ -1360,38 +1319,8 @@ export function useCanvasSync(
       window.clearTimeout(debounceTimerRef.current);
       debounceTimerRef.current = null;
     }
-    const { nodes, edges, currentViewport } = useCanvasStore.getState();
-    const shot = useShotMetadataStore.getState().shot;
-    lastSavedViewportRef.current = currentViewport;
-    return await scheduleSave({
-      project,
-      canvasId,
-      nodes,
-      edges,
-      viewport: currentViewport,
-      metadata: buildPersistMetadata(shot),
-      resnapshot: currentSaveSnapshot,
-      revisionRef,
-      statusRef,
-      canvasGenerationRef,
-      queuedSaveRef,
-      canvasEnvelopeRef,
-      pendingClientSaveIdRef,
-      pendingClientSaveIdSignatureRef,
-      hydratedRef,
-      switchingRef,
-      lastRemoteNodeCountRef,
-      setStatus: setSyncStatus,
-      setError,
-      inFlightRef,
-      snapshotConflict,
-      publishBackupStatus,
-      publishRevision: setRevision,
-      clearDraftAfterSave: clearDraftTimerAndDraft,
-      markDraftPersisted: (signature) => {
-        lastPersistedDraftSignatureRef.current = signature;
-      },
-    });
+    lastSavedViewportRef.current = useCanvasStore.getState().currentViewport;
+    return await requestSave();
   };
 
   // Save once more on tab close — best effort, fire-and-forget. Fires when a
@@ -1412,7 +1341,7 @@ export function useCanvasSync(
       const hasUnsettledContentSave =
         draftTimerRef.current != null ||
         debounceTimerRef.current != null ||
-        inFlightRef.current != null ||
+        sessionRef.current?.isSaving() === true ||
         statusRef.current === "saving";
       if (
         !hasUnsettledContentSave ||
@@ -1633,43 +1562,15 @@ interface SaveArgs {
    * that already know what they are.
    */
   forcedDecision?: Extract<SaveDecision, { kind: "send" }>;
-  /**
-   * Re-read the live snapshot a save payload is built from. `scheduleSave`
-   * calls this only when it had to queue behind an in-flight save, where the
-   * caller's captured `nodes`/`edges`/`viewport`/`metadata` have gone stale.
-   * Every autosave site reads the same two stores, so re-reading is exactly
-   * what the caller would have captured had it run at that moment. A caller
-   * that omits it (to send one fixed payload) is simply never queued: rather
-   * than PUT a snapshot from before the wait, `scheduleSave` drops the save.
-   */
-  resnapshot?: () => Pick<
-    SaveArgs,
-    "nodes" | "edges" | "viewport" | "metadata"
-  >;
   revisionRef: { current: number | null };
   statusRef: { current: CanvasSyncStatus };
   /**
-   * Bumped by the hydrate effect every time a different canvas is loaded into
-   * these refs. A queued save compares it before and after its wait so it can
-   * never PUT the newly-loaded canvas's content to the canvas it was scheduled
-   * for — `FreezoneShell` is mounted without a key, so a canvas switch reuses
-   * the whole ref set.
+   * Bumped every time a canvas is loaded into these refs (hydrate or remote
+   * refresh). A request stamps itself with the value it saw and refuses to
+   * apply its response if the stamp has moved on — `FreezoneShell` is mounted
+   * without a key, so a canvas switch reuses the whole ref set.
    */
   canvasGenerationRef: { current: number };
-  /**
-   * The single follow-up save queued behind the one on the wire, if any, tagged
-   * with the canvas generation it belongs to. The tag is what stops a save for
-   * a freshly-switched-to canvas from riding on a queued save for the previous
-   * one — that one bails on its generation check, and the rider would be
-   * swallowed with it.
-   */
-  queuedSaveRef: {
-    current: {
-      canvasKey: string;
-      generation: number;
-      promise: Promise<boolean>;
-    } | null;
-  };
   canvasEnvelopeRef: { current: Partial<FreezoneCanvasPayload> };
   pendingClientSaveIdRef: { current: string | null };
   pendingClientSaveIdSignatureRef: { current: string | null };
@@ -1678,7 +1579,6 @@ interface SaveArgs {
   lastRemoteNodeCountRef: { current: number };
   setStatus: (s: CanvasSyncStatus) => void;
   setError: (e: string | null) => void;
-  inFlightRef: { current: Promise<boolean> | null };
   /**
    * Persist a snapshot of the local edits to `localStorage` so the user can
    * recover them after a 409. Implementation lives in the hook so the keys
@@ -1696,112 +1596,20 @@ interface SaveArgs {
   markDraftPersisted?: (signature: string) => void;
 }
 
-async function scheduleSave(
-  args: SaveArgs,
-  requeued = false,
-): Promise<boolean> {
-  // Coalesce overlapping saves.
-  //
-  // The old code did this with a single `await` on the in-flight promise, which
-  // is not enough: several callers park on the *same* promise, and when it
-  // settles they all resume inside one microtask batch — each then walks
-  // straight through to its own PUT carrying the base_revision the first save
-  // just published. The backend's optimistic lock 409s the loser, and the UI
-  // blames "another window" for a race we caused ourselves. (Reproducible by
-  // throttling to 3G and dragging nodes: a PUT slower than DEBOUNCE_MS is all
-  // it takes for two debounced saves to stack, and the projection-sync / flush
-  // paths skip the debounce entirely.)
-  //
-  // So: exactly one follow-up save is ever queued behind the one on the wire.
-  // Because a queued save re-reads the store before it builds its payload, a
-  // second waiter would put byte-identical content on the wire one round-trip
-  // later; extra callers ride on the queued save instead. That also keeps
-  // `flush()` honest — the save it rides on carries the content flush wanted
-  // persisted, and flush waits one round-trip rather than N.
-  const inFlight = args.inFlightRef.current;
-  if (inFlight) {
-    // Which canvas this save belongs to. `FreezoneShell` is mounted without a
-    // key, so switching canvases re-runs the hydrate effect against these very
-    // refs: by the time we wake, the store can be holding a different canvas
-    // entirely, and re-reading it would PUT that canvas's content to our
-    // (stale) args.canvasId.
-    const generation = args.canvasGenerationRef.current;
-    // Belt and braces: the generation counter already moves on every hydrate
-    // and every remote refresh, so it covers a canvas switch. Comparing the
-    // canvas key too means a queue slot can never be shared across canvases
-    // even if some future caller reaches `scheduleSave` between a canvasId
-    // change and the hydrate effect that bumps the counter.
-    const canvasKey = `${args.project}:${args.canvasId}`;
-    const alreadyQueued = args.queuedSaveRef.current;
-    if (
-      alreadyQueued &&
-      alreadyQueued.generation === generation &&
-      alreadyQueued.canvasKey === canvasKey
-    ) {
-      // Same canvas: ride along. The queued save re-reads the store, so it will
-      // carry our content too.
-      return await alreadyQueued.promise;
-    }
-    // Either nothing is queued, or what is queued belongs to the canvas we just
-    // left — that one will bail out on its own generation check, and riding on
-    // it would silently swallow this canvas's save. Chain behind it instead so
-    // the two still never overlap.
-    const waitFor = alreadyQueued?.promise ?? inFlight;
-    // Assigned on the line after the IIFE is created. The closure only reads it
-    // past an `await`, so it is always populated by the time it is dereferenced.
-    let entry!: {
-      canvasKey: string;
-      generation: number;
-      promise: Promise<boolean>;
-    };
-    const follow = (async () => {
-      try {
-        await waitFor;
-      } catch {
-        // The save we queued behind reported its own failure through
-        // handleSaveError; its rejection must not become ours.
-      }
-      // Only clear the slot if it is still ours — a newer generation may have
-      // chained behind us and taken it over.
-      if (args.queuedSaveRef.current === entry) {
-        args.queuedSaveRef.current = null;
-      }
-      if (args.canvasGenerationRef.current !== generation) {
-        return false;
-      }
-      return await scheduleSave(args, true);
-    })();
-    entry = { canvasKey, generation, promise: follow };
-    args.queuedSaveRef.current = entry;
-    return await follow;
-  }
-
-  if (requeued) {
-    // We skipped the guards our callers apply before scheduling, and the world
-    // moved while we sat in the queue. Re-apply them now.
-    if (
-      args.statusRef.current === "conflict" ||
-      args.statusRef.current === "error"
-    ) {
-      // The save ahead of us failed terminally. Callers stop autosaving in this
-      // state; a queued save must not sneak a doomed PUT past that, nor
-      // overwrite the conflict snapshot the overlay offers for download.
-      return false;
-    }
-    if (!args.resnapshot) {
-      // Without a fresh read we would PUT the payload captured before the wait,
-      // rolling the canvas back over whatever just landed. Skipping is strictly
-      // better; the content is still in the store and the next edit re-triggers.
-      return false;
-    }
-    // The save we queued behind persisted part of our payload, and the user
-    // kept editing meanwhile. Re-read the live stores so we carry the newest
-    // content rather than overwriting it with a stale snapshot.
-    const fresh = args.resnapshot();
-    args.nodes = fresh.nodes;
-    args.edges = fresh.edges;
-    args.viewport = fresh.viewport;
-    args.metadata = fresh.metadata;
+async function scheduleSave(args: SaveArgs): Promise<boolean> {
+  // Serialisation and coalescing live in `canvasSaveCoordinator` now. This
+  // function is only ever entered from a session's pump, one call at a time,
+  // with `args` read from the live stores a moment earlier. What is left here
+  // is the per-attempt work: re-check the guards, run the decision gate, put
+  // the payload on the wire.
+  if (
+    args.statusRef.current === "conflict" ||
+    args.statusRef.current === "error"
+  ) {
+    // A previous save failed terminally. Callers stop autosaving in this state;
+    // a save already queued when that happened must not sneak a doomed PUT
+    // past it, nor overwrite the conflict snapshot the overlay offers.
+    return false;
   }
 
   // ---- Decision gate ---- //
@@ -1856,22 +1664,13 @@ async function scheduleSave(
   const clientSaveId = args.pendingClientSaveIdRef.current;
 
   args.setStatus("saving");
-  const dispatchGeneration = args.canvasGenerationRef.current;
-  const job = (async () => {
-    try {
-      return await performSave(
-        args,
-        decision,
-        clientSaveId,
-        0,
-        dispatchGeneration,
-      );
-    } finally {
-      args.inFlightRef.current = null;
-    }
-  })();
-  args.inFlightRef.current = job;
-  return await job;
+  return await performSave(
+    args,
+    decision,
+    clientSaveId,
+    0,
+    args.canvasGenerationRef.current,
+  );
 }
 
 async function performSave(

--- a/frontend/src/features/freezone/useCanvasSync.ts
+++ b/frontend/src/features/freezone/useCanvasSync.ts
@@ -673,6 +673,7 @@ export function useCanvasSync(
   // At most one save waits behind the one on the wire; further callers for the
   // same canvas generation ride on it instead of stacking. See `scheduleSave`.
   const queuedSaveRef = useRef<{
+    canvasKey: string;
     generation: number;
     promise: Promise<boolean>;
   } | null>(null);
@@ -871,6 +872,13 @@ export function useCanvasSync(
       // path uses to suppress in-flight save callbacks from clobbering the
       // freshly-applied remote content.
       switchingRef.current = true;
+      // Fence off every save dispatched before this refresh. We are about to
+      // overwrite revisionRef with the remote revision; a PUT already on the
+      // wire would otherwise come back with an older revision and roll it
+      // backwards, and the next save would 409 against it. A save still queued
+      // behind that PUT is stale for the same reason — the merged content is
+      // rescheduled explicitly below when there is local work to keep.
+      canvasGenerationRef.current += 1;
       const local = useCanvasStore.getState();
       const remoteNodes = (remote.nodes ?? []) as CanvasNode[];
       const remoteEdges = (remote.edges ?? []) as CanvasEdge[];
@@ -1656,7 +1664,11 @@ interface SaveArgs {
    * swallowed with it.
    */
   queuedSaveRef: {
-    current: { generation: number; promise: Promise<boolean> } | null;
+    current: {
+      canvasKey: string;
+      generation: number;
+      promise: Promise<boolean>;
+    } | null;
   };
   canvasEnvelopeRef: { current: Partial<FreezoneCanvasPayload> };
   pendingClientSaveIdRef: { current: string | null };
@@ -1714,8 +1726,18 @@ async function scheduleSave(
     // entirely, and re-reading it would PUT that canvas's content to our
     // (stale) args.canvasId.
     const generation = args.canvasGenerationRef.current;
+    // Belt and braces: the generation counter already moves on every hydrate
+    // and every remote refresh, so it covers a canvas switch. Comparing the
+    // canvas key too means a queue slot can never be shared across canvases
+    // even if some future caller reaches `scheduleSave` between a canvasId
+    // change and the hydrate effect that bumps the counter.
+    const canvasKey = `${args.project}:${args.canvasId}`;
     const alreadyQueued = args.queuedSaveRef.current;
-    if (alreadyQueued && alreadyQueued.generation === generation) {
+    if (
+      alreadyQueued &&
+      alreadyQueued.generation === generation &&
+      alreadyQueued.canvasKey === canvasKey
+    ) {
       // Same canvas: ride along. The queued save re-reads the store, so it will
       // carry our content too.
       return await alreadyQueued.promise;
@@ -1727,7 +1749,11 @@ async function scheduleSave(
     const waitFor = alreadyQueued?.promise ?? inFlight;
     // Assigned on the line after the IIFE is created. The closure only reads it
     // past an `await`, so it is always populated by the time it is dereferenced.
-    let entry!: { generation: number; promise: Promise<boolean> };
+    let entry!: {
+      canvasKey: string;
+      generation: number;
+      promise: Promise<boolean>;
+    };
     const follow = (async () => {
       try {
         await waitFor;
@@ -1745,7 +1771,7 @@ async function scheduleSave(
       }
       return await scheduleSave(args, true);
     })();
-    entry = { generation, promise: follow };
+    entry = { canvasKey, generation, promise: follow };
     args.queuedSaveRef.current = entry;
     return await follow;
   }

--- a/frontend/src/features/freezone/useCanvasSync.ts
+++ b/frontend/src/features/freezone/useCanvasSync.ts
@@ -808,13 +808,21 @@ export function useCanvasSync(
   ): SaveArgs => {
     const canvasState = useCanvasStore.getState();
     const shot = useShotMetadataStore.getState().shot;
+    const metadata = buildPersistMetadata(shot);
+    // What this request actually carries. Compared against the live store when
+    // the response comes back, to decide whether the draft is now redundant.
+    const sentSignature = canvasDraftSignature(
+      canvasState.nodes,
+      canvasState.edges,
+      metadata,
+    );
     return {
       project,
       canvasId,
       nodes: canvasState.nodes,
       edges: canvasState.edges,
       viewport: canvasState.currentViewport,
-      metadata: buildPersistMetadata(shot),
+      metadata,
       revisionRef,
       statusRef,
       canvasGenerationRef,
@@ -834,6 +842,12 @@ export function useCanvasSync(
         // have kept editing while it was on the wire, and that newer content
         // exists nowhere but localStorage until the queued save lands too.
         if (session.hasUnsavedContentBeyond(version)) return;
+        // The autosave debounce is a second blind spot the session can't see:
+        // an edit made in the last DEBOUNCE_MS has already been written to the
+        // draft, but has not called `requestSave` yet, so no version exists for
+        // it. Compare what we sent against what the store holds now — if they
+        // differ, the draft is still the only copy of the difference.
+        if (sentSignature !== currentDraftSignature()) return;
         clearDraftTimerAndDraft();
       },
       markDraftPersisted: (signature) => {
@@ -859,6 +873,25 @@ export function useCanvasSync(
 
   const requestSave = (): Promise<boolean> =>
     sessionRef.current?.requestSave() ?? Promise.resolve(false);
+
+  // ---- 0a. Retire the last session on unmount ---- //
+  // `startSaveSession` only ever disposes its *predecessor*, so without this the
+  // final session outlives the hook: its queued follow-up would still fire, and
+  // (because it reads the live stores at send time) would PUT the *next*
+  // canvas's nodes to the unmounted canvas's id. Bumping the generation matters
+  // just as much as disposing — a request already on the wire must also be
+  // barred from writing back into revision/status/draft state that now belongs
+  // to whoever mounted next.
+  useEffect(() => {
+    return () => {
+      canvasGenerationRef.current += 1;
+      const session = sessionRef.current;
+      sessionRef.current = null;
+      session?.dispose();
+    };
+    // Mount-scoped on purpose: canvas switches are handled by startSaveSession.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   // ---- 0. External-trigger remote canvas refresh ---- //
   // canvasSyncRuntime lets other features (beat-context preset refresh,

--- a/license-inventory.csv
+++ b/license-inventory.csv
@@ -373,6 +373,7 @@ frontend/src/__tests__/features/companion/petdex-pets.test.ts,Elastic-2.0,2026 S
 frontend/src/__tests__/features/freezone/asset-library-panel-beat-context.test.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/__tests__/features/freezone/beat-context-projection.test.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/__tests__/features/freezone/canvas-draft-storage.test.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
+frontend/src/__tests__/features/freezone/canvasSaveCoordinator.test.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/__tests__/features/freezone/canvasSyncCore.test.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/__tests__/features/freezone/canvases-tab-query.test.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/__tests__/features/freezone/canvases-tab.test.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
@@ -951,6 +952,7 @@ frontend/src/features/freezone/CanvasesTab.tsx,Elastic-2.0,2026 SuperTale contri
 frontend/src/features/freezone/FreezoneShell.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/features/freezone/canvasDraftStorage.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/features/freezone/canvasMetadataContext.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
+frontend/src/features/freezone/canvasSaveCoordinator.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/features/freezone/canvasSyncCore.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/features/freezone/canvasSyncRuntime.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/features/freezone/capabilities/candidate_capabilities.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation


### PR DESCRIPTION
## 问题

线上用户反复看到「画布已被其他窗口或用户修改」的冲突遮罩，但并没有第二个窗口在编辑。Grafana 上能看到同一画布相隔 **3.45ms** 的一对 200 / 409 —— 是客户端自己撞自己。

`scheduleSave` 只用一个 `await` 等待在飞的保存：

```js
if (args.inFlightRef.current) {
  await args.inFlightRef.current;   // 醒来后不复查
}
...                                  // 到 PUT 之间全是同步代码
const job = (async () => { ... })(); // PUT 已在此发出
args.inFlightRef.current = job;      // 才登记
```

多个调用方挂在同一个 promise 上，settle 后在**同一个微任务批次**里依次醒来，各自带着前一次保存刚发布的 `base_revision` 发出自己的 PUT。后端乐观锁（`canvas_store.py:554`）把后到的那个 409 掉，前端 `classifySaveError` 再把它显示成跨窗口冲突，并冻结后续所有自动保存 —— 用户只能刷新或另存副本。

## 复现

网络限速到 3G，快速拖动画布节点即可稳定复现。单次 PUT 超过 800ms 防抖间隔，两次防抖保存就能叠在一起；投影同步（`setTimeout 0`）与 `flush()` 路径更是完全绕过防抖，不需要慢请求就能凑齐两个等待者。

## 改动

- **`scheduleSave` 改为单槽排队**。在飞的保存之后最多再排一个后继保存，其余调用方直接搭车。只做串行不做合并会产生写放大 —— N 个调用方排队就是 N 个整画布 PUT，后面几个内容完全相同，在本来就慢的链路上帮倒忙。
- **排队的保存在发车前重读 store**。只加排队不重读会把 409 换成**静默数据回退**：排队者手里的快照已经旧于刚落库的内容。
- **新增 `canvasGenerationRef` 守卫跨画布切换**。`FreezoneShell` 挂载时没有 `key`，切画布只重跑 hydrate effect，`inFlightRef`/`revisionRef` 是同一批 ref；没有这道守卫，排队者醒来会把**新画布**的内容 PUT 到旧的 canvas id。
- **排队者醒来后重新校验 `statusRef`**。四个调用点都在调度前检查 conflict/error，排队者跳过了这道门：前一次保存终态失败后，它不该再发一个必然失败的 PUT，也不该覆盖冲突遮罩「下载本地 JSON」要读的快照。
- **409 按 `detail.code` 分流**，`canvas_idempotency_conflict` 不再误报「其他窗口」。`CanvasBaseRevisionRequired` 抛的是裸字符串 detail、无 `code`，确实无法区分，注释已如实说明。

## 测试

两个新用例都验证过「去掉修复就失败」，不是空过：

- 并发用例断言确切的 PUT 次数与 `base_revision` 序列。改回单次 `await` 后 `maxInFlight` 为 2，用例失败。
- 跨画布切换用例：注掉 generation 守卫后立刻多出一个发往旧画布的 PUT，用例失败。

`tsc -b` 干净，277 个测试文件 1770 个用例全过，`pnpm build` 成功。

## 已知遗留（本 PR 不处理）

以下都是既有问题，不是本次引入的，混进来会让这条分支说不清，建议单开：

- 客户端 `contentSignature` 与后端 `request_hash` 口径不一致，503 重试期间 revision 被远端回调改写时仍可能触发 `canvas_idempotency_conflict`。
- `canvas_idempotency_conflict` 目前是终态冲突，其实一次换新 id 的重试就能恢复。
- 保存成功即清 localStorage 草稿，而队列里可能还有更新的内容未发出。

🤖 Generated with [Claude Code](https://claude.com/claude-code)