### PR TITLE
fix(canvas): Seedance 1.x 提交前拦不可消费素材,避免静默丢/400

### DIFF
--- a/frontend/src/__tests__/features/canvas/video-model-capabilities.test.ts
+++ b/frontend/src/__tests__/features/canvas/video-model-capabilities.test.ts
@@ -11,6 +11,7 @@ import {
   isVideoModeSupportedByModel,
   videoEmptyStateCtaModes,
   videoModeRequiresPrompt,
+  videoSubmitMediaRejectionReason,
   videoUpstreamImageDefaultMode,
 } from "@/features/canvas/nodes/shared/videoModelCapabilities";
 
@@ -124,6 +125,61 @@ describe("videoUpstreamImageDefaultMode — auto-derived default on first image"
   it("Seedance 1.x 接图默认「首帧」而非全能参考 (否则提交必 400)", () => {
     expect(videoUpstreamImageDefaultMode(SEEDANCE10_PRO_FAST)).toBe("imageToVideo");
     expect(videoUpstreamImageDefaultMode(SEEDANCE15_PRO)).toBe("imageToVideo");
+  });
+});
+
+describe("videoSubmitMediaRejectionReason — 提交前素材守卫 (P1/P2)", () => {
+  const none = { images: 0, videos: 0, audios: 0 };
+
+  it("Seedance 1.x：接入视频 → 拦 (P1 静默丢视频)", () => {
+    expect(
+      videoSubmitMediaRejectionReason("imageToVideo", SEEDANCE10_PRO_FAST, { ...none, videos: 1 }),
+    ).toBeTruthy();
+    expect(
+      videoSubmitMediaRejectionReason("textToVideo", SEEDANCE10_PRO_FAST, { ...none, videos: 1 }),
+    ).toBeTruthy();
+  });
+
+  it("Seedance 1.x：接入音频 → 拦 (P1 静默丢音频)", () => {
+    expect(
+      videoSubmitMediaRejectionReason("imageToVideo", SEEDANCE10_PRO_FAST, { ...none, audios: 1 }),
+    ).toBeTruthy();
+  });
+
+  it("Seedance 1.x：>1 图 → 拦 (P2 多图 400)，无论 imageReference 还是 imageToVideo", () => {
+    for (const mode of ["imageReference", "imageToVideo"] as VideoGenMode[]) {
+      expect(
+        videoSubmitMediaRejectionReason(mode, SEEDANCE10_PRO_FAST, { images: 2, videos: 0, audios: 0 }),
+      ).toBeTruthy();
+      expect(
+        videoSubmitMediaRejectionReason(mode, SEEDANCE15_PRO, { images: 9, videos: 0, audios: 0 }),
+      ).toBeTruthy();
+    }
+  });
+
+  it("Seedance 1.x：单图 / 纯文本 → 放行", () => {
+    expect(
+      videoSubmitMediaRejectionReason("imageToVideo", SEEDANCE10_PRO_FAST, { ...none, images: 1 }),
+    ).toBeNull();
+    expect(
+      videoSubmitMediaRejectionReason("imageReference", SEEDANCE10_PRO_FAST, { ...none, images: 1 }),
+    ).toBeNull();
+    expect(videoSubmitMediaRejectionReason("textToVideo", SEEDANCE10_PRO_FAST, none)).toBeNull();
+  });
+
+  it("Seedance 2.0：全能参考消费视频/音频/多图 → 放行", () => {
+    expect(
+      videoSubmitMediaRejectionReason("allReference", SEEDANCE2_FAST, { images: 9, videos: 1, audios: 1 }),
+    ).toBeNull();
+  });
+
+  it("HappyHorse：视频编辑消费视频、图片参考消费多图 → 放行", () => {
+    expect(
+      videoSubmitMediaRejectionReason("videoEdit", HAPPYHORSE, { ...none, videos: 1 }),
+    ).toBeNull();
+    expect(
+      videoSubmitMediaRejectionReason("imageReference", HAPPYHORSE, { images: 5, videos: 0, audios: 0 }),
+    ).toBeNull();
   });
 });
 

--- a/frontend/src/features/canvas/nodes/VideoNode.tsx
+++ b/frontend/src/features/canvas/nodes/VideoNode.tsx
@@ -71,6 +71,7 @@ import {
   isVideoModeSupportedByModel,
   videoEmptyStateCtaModes,
   videoModeRequiresPrompt,
+  videoSubmitMediaRejectionReason,
   videoUpstreamImageDefaultMode,
   type VideoEmptyStateCtaMode,
 } from "@/features/canvas/nodes/shared/videoModelCapabilities";
@@ -2085,8 +2086,16 @@ export const VideoNode = memo(
       genMode === "videoEdit"
         ? upstreamCounts.videos > 0
         : upstreamCounts.images > 0;
+    // 提交前守卫：当前模型/模式无法消费已接入素材（视频/音频被静默丢、非 2.0 非
+    // HappyHorse 多图会被后端 400）时给出理由并禁用提交，替代静默丢素材 / 提交 400。
+    const mediaRejectionReason = videoSubmitMediaRejectionReason(
+      genMode,
+      selectedVideoModelId,
+      upstreamCounts,
+    );
     const submitDisabled =
       isGenerating ||
+      mediaRejectionReason != null ||
       (videoModeRequiresPrompt(genMode)
         ? !hasPromptText
         : !hasRequiredMediaForMode);
@@ -3395,7 +3404,7 @@ export const VideoNode = memo(
                     title={
                       isGenerating
                         ? t("node.videoNode.submitBusy")
-                        : t("node.videoNode.submit")
+                        : (mediaRejectionReason ?? t("node.videoNode.submit"))
                     }
                     onClick={(event) => {
                       event.stopPropagation();

--- a/frontend/src/features/canvas/nodes/shared/videoModelCapabilities.ts
+++ b/frontend/src/features/canvas/nodes/shared/videoModelCapabilities.ts
@@ -117,3 +117,39 @@ export function videoUpstreamImageDefaultMode(
 export function videoModeRequiresPrompt(mode: VideoGenMode): boolean {
   return mode === "textToVideo" || mode === "allReference";
 }
+
+/**
+ * 提交前守卫：当前 (模型, 模式) 是否会**丢弃或被后端直接拒绝**已接入的上游素材。
+ * 返回非空理由则应禁用提交、并把理由显示到按钮 tooltip 上，替代「静默丢素材 / 提交 400」。
+ *
+ * 规则对齐后端 freezone i2v / omni-gen 端点（src/novelvideo/api/routes/freezone.py）：
+ * - 视频素材：仅「全能参考」(omni，Seedance 2.0) 与「视频编辑」(HappyHorse) 消费，
+ *   其余模式静默丢弃 → 拦；
+ * - 音频素材：仅「全能参考」(omni，Seedance 2.0) 消费，其余模式静默丢弃 → 拦；
+ * - 多图(>1)：i2v 端点仅 Seedance 2.0 / HappyHorse 放行，非 2.0 非 HappyHorse
+ *   （Seedance 1.x）传 >1 图后端直接 400 → 拦。
+ *
+ * 非 2.0 / 非 HappyHorse 一接入视频/音频就无模式可消费（allReference / videoEdit 均
+ * 不受支持），因此这三条只会在真正会丢素材 / 400 的场景触发；2.0 / HappyHorse 的自动
+ * 推导 effect 会先把模式导到能消费素材的模式，不会误伤。
+ */
+export function videoSubmitMediaRejectionReason(
+  mode: VideoGenMode,
+  modelId: string | null | undefined,
+  counts: { images: number; videos: number; audios: number },
+): string | null {
+  if (counts.videos > 0 && mode !== "allReference" && mode !== "videoEdit") {
+    return "该模型不支持视频素材";
+  }
+  if (counts.audios > 0 && mode !== "allReference") {
+    return "该模型不支持音频素材";
+  }
+  if (
+    counts.images > 1 &&
+    !isSeedance2VideoModel(modelId) &&
+    !isHappyHorseVideoModel(modelId)
+  ) {
+    return "该模型单次仅支持 1 张图片";
+  }
+  return null;
+}


### PR DESCRIPTION
## 背景

复审 PR #185 时发现两条 Seedance 1.x 缺陷:此前 `videoModelReferenceDisabledReason` 只接在**模型选择器**上,只能拦「已连素材、想切换到 1.x」;挡不住反向的「已经在 1.x、再连视频/音频/多图」。#185 已 merge,故另开分支从 main 修。

- **[P1] 静默丢视频/音频**:非 2.0 非 HappyHorse 无模式消费视频(仅 `allReference`/`videoEdit`)与音频(仅 `allReference`);自动推导 effect 对非 2.0 全部 bail,节点停在 `textToVideo`,提交只校验提示词,素材被**静默丢弃**。
- **[P2] 多图必 400**:后端 `i2v` 端点对非 2.0 非 HappyHorse 的 `>1` 图**直接 400**(`freezone.py`),而前端 `submitDisabled` 只要 `images>0` 就放行。且此路径与 `imageReference`/`imageToVideo` 无关——两种模式都走同一 i2v 端点,藏 tab 不足以修,必须按图数拦。

## 改动

新增 `videoSubmitMediaRejectionReason(mode, model, counts)`(`videoModelCapabilities.ts`,单一事实来源),规则严格对齐后端 `freezone` i2v/omni-gen 端点:

1. 有视频且模式非 `allReference`/`videoEdit` → 拦(P1 视频);
2. 有音频且模式非 `allReference` → 拦(P1 音频);
3. `images>1` 且模型非 Seedance 2.0 非 HappyHorse → 拦(P2 多图 400)。

接到 `VideoNode` 的 `submitDisabled` 与生成按钮 `title`:把「静默丢素材 / 提交 400」变成**明确禁用 + 理由提示**。2.0 / HappyHorse 的自动推导 effect 会先把模式导到能消费素材的模式,不受影响(单元测试覆盖)。

## 验证

- 新增 `videoSubmitMediaRejectionReason` 单测(1.x 视频/音频/多图拦、单图/纯文本放行、2.0 全能参考放行、HappyHorse 视频编辑/图片参考放行);`video-model-capabilities.test.ts` 21/21 通过。
- `tsc -b` 通过、`vite build` 通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)