### PR TITLE
feat(mcp): let external agents (Claude Code) drive DramaClaw CE without a token

### DIFF
--- a/.hermes/plugins/dramaclaw/__init__.py
+++ b/.hermes/plugins/dramaclaw/__init__.py
@@ -157,11 +157,23 @@ def _with_chat_error_hints(value: Any) -> Any:
     return result
 
 
+def _ce_owner_mode() -> bool:
+    """CE single-user mode: authenticate as the local owner without a token.
+
+    A DramaClaw CE instance trusts local requests as the owner (no
+    ``Authorization`` header required), so an external MCP client such as
+    Claude Code can call the API on the same machine without minting an
+    agent-session token. This is opt-in via ``DRAMACLAW_CE_OWNER`` so it can
+    never silently drop auth against an EE deployment.
+    """
+    raw = os.environ.get("DRAMACLAW_CE_OWNER", "").strip().lower()
+    return raw in {"1", "true", "yes", "on"}
+
+
 def _available() -> bool:
-    return bool(
-        os.environ.get("DRAMACLAW_API_URL")
-        and os.environ.get("DRAMACLAW_AGENT_TOKEN")
-    )
+    if not os.environ.get("DRAMACLAW_API_URL"):
+        return False
+    return bool(os.environ.get("DRAMACLAW_AGENT_TOKEN")) or _ce_owner_mode()
 
 
 def _base_url() -> str:
@@ -258,10 +270,14 @@ def _request(method: str, path: str, *, query: Any = None, body: Any = None) -> 
     url = f"{_base_url()}{api_path}{_query_string(query)}"
     payload = None
     headers = {
-        "Authorization": f"Bearer {_token()}",
         "Accept": "application/json",
         "User-Agent": "dramaclaw-plugin/0.1.0",
     }
+    token = os.environ.get("DRAMACLAW_AGENT_TOKEN", "").strip()
+    if not token and not _ce_owner_mode():
+        _token()  # raise the standard "DRAMACLAW_AGENT_TOKEN is not set" error
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
     if body is not None:
         payload = json.dumps(body, ensure_ascii=False).encode("utf-8")
         headers["Content-Type"] = "application/json"

--- a/.hermes/plugins/dramaclaw/__init__.py
+++ b/.hermes/plugins/dramaclaw/__init__.py
@@ -12,7 +12,7 @@ import os
 from pathlib import Path
 from typing import Any
 from urllib.error import HTTPError, URLError
-from urllib.parse import quote, urlencode
+from urllib.parse import quote, urlencode, urlparse
 from urllib.request import Request, urlopen
 
 from tools.registry import tool_error, tool_result
@@ -170,6 +170,48 @@ def _ce_owner_mode() -> bool:
     return raw in {"1", "true", "yes", "on"}
 
 
+# Hosts trusted as the local CE owner in tokenless owner mode. ``urlparse``
+# lowercases the hostname and strips the brackets from ``[::1]``, so the bare
+# forms below cover the bracketed IPv6 literal too.
+_LOOPBACK_HOSTS = frozenset({"localhost", "127.0.0.1", "::1"})
+
+
+def _ce_owner_allow_remote() -> bool:
+    """Explicit, separately-named unsafe override for CE-owner mode.
+
+    Tokenless CE-owner mode drops the ``Authorization`` header entirely, so it
+    must only target a local CE the caller controls. Pointing it at a remote
+    host would send owner-level, unauthenticated requests across the network;
+    that is refused unless the operator opts in via
+    ``DRAMACLAW_CE_OWNER_ALLOW_REMOTE`` (deliberately a different variable from
+    ``DRAMACLAW_CE_OWNER`` so it cannot be enabled by accident).
+    """
+    raw = os.environ.get("DRAMACLAW_CE_OWNER_ALLOW_REMOTE", "").strip().lower()
+    return raw in {"1", "true", "yes", "on"}
+
+
+def _enforce_ce_owner_target(url: str) -> None:
+    """Require a loopback ``DRAMACLAW_API_URL`` in tokenless CE-owner mode.
+
+    Called only when owner mode is active and no bearer token is present. The
+    host must be a loopback address (``localhost``/``127.0.0.1``/``::1``/
+    ``[::1]``) unless the operator has set the explicit unsafe override
+    ``DRAMACLAW_CE_OWNER_ALLOW_REMOTE=1``.
+    """
+    if _ce_owner_allow_remote():
+        return
+    host = (urlparse(url).hostname or "").strip().lower()
+    if host in _LOOPBACK_HOSTS:
+        return
+    raise ValueError(
+        "DRAMACLAW_CE_OWNER=1 refuses non-loopback DRAMACLAW_API_URL "
+        f"(host {host!r}): tokenless owner mode sends unauthenticated, "
+        "owner-level requests and must point at a local CE "
+        "(localhost, 127.0.0.1, ::1). Set DRAMACLAW_CE_OWNER_ALLOW_REMOTE=1 "
+        "to override (unsafe), or provide DRAMACLAW_AGENT_TOKEN."
+    )
+
+
 def _available() -> bool:
     if not os.environ.get("DRAMACLAW_API_URL"):
         return False
@@ -274,8 +316,12 @@ def _request(method: str, path: str, *, query: Any = None, body: Any = None) -> 
         "User-Agent": "dramaclaw-plugin/0.1.0",
     }
     token = os.environ.get("DRAMACLAW_AGENT_TOKEN", "").strip()
-    if not token and not _ce_owner_mode():
-        _token()  # raise the standard "DRAMACLAW_AGENT_TOKEN is not set" error
+    if not token:
+        if not _ce_owner_mode():
+            _token()  # raise the standard "DRAMACLAW_AGENT_TOKEN is not set" error
+        # Tokenless owner mode drops Authorization entirely, so it must only
+        # ever target a loopback CE unless explicitly overridden.
+        _enforce_ce_owner_target(_base_url())
     if token:
         headers["Authorization"] = f"Bearer {token}"
     if body is not None:

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,12 @@
+{
+  "mcpServers": {
+    "dramaclaw": {
+      "command": "uv",
+      "args": ["run", "python", "-m", "novelvideo.chat.dramaclaw_mcp"],
+      "env": {
+        "DRAMACLAW_API_URL": "http://localhost:8780",
+        "DRAMACLAW_CE_OWNER": "1"
+      }
+    }
+  }
+}

--- a/docs/en/guides/mcp-claude-code.md
+++ b/docs/en/guides/mcp-claude-code.md
@@ -1,6 +1,3 @@
-<!-- lang-switch -->
-**English** · [简体中文](../../zh/guides/mcp-claude-code.md)
-
 # Driving DramaClaw from an AI agent (MCP)
 
 DramaClaw ships an [MCP](https://modelcontextprotocol.io) server that exposes the
@@ -27,13 +24,24 @@ The server authenticates to the API with two environment variables:
 | Variable | Purpose |
 |---|---|
 | `DRAMACLAW_API_URL` | Base URL of your instance, e.g. `http://localhost:8780` |
-| `DRAMACLAW_CE_OWNER` | Set to `1` for **CE** (self-host): calls are made as the local owner, no token needed |
+| `DRAMACLAW_CE_OWNER` | Set to `1` for **CE** (self-host): calls are made as the local owner, no token needed. The target **must be loopback** (`localhost`, `127.0.0.1`, `::1`, `[::1]`) |
+| `DRAMACLAW_CE_OWNER_ALLOW_REMOTE` | Unsafe override: set to `1` to allow tokenless CE-owner mode against a **non-loopback** `DRAMACLAW_API_URL` (see the warning below) |
 | `DRAMACLAW_AGENT_TOKEN` | **EE / multi-user** only: a scoped agent-session bearer token |
 | `DRAMACLAW_PROJECT_ID` | Optional: default project so tools can omit `project_id` |
 
 **Community Edition** trusts local requests as the owner, so `DRAMACLAW_CE_OWNER=1`
 is all you need — no token to mint. On EE, set `DRAMACLAW_AGENT_TOKEN` instead;
-CE-owner mode is ignored when a token is present.
+CE-owner mode is ignored when a token is present (the token always takes
+precedence and its `Authorization` header is sent).
+
+**Loopback is enforced.** Because tokenless owner mode sends *unauthenticated,
+owner-level* requests, the bridge refuses any `DRAMACLAW_API_URL` whose host is
+not a loopback address (`localhost`, `127.0.0.1`, `::1`, `[::1]`) with a clear
+error. If you genuinely must reach a remote CE without a token — e.g. an SSH
+tunnel you fully control — opt in explicitly with
+`DRAMACLAW_CE_OWNER_ALLOW_REMOTE=1`. This is deliberately a separate variable so
+it can never be enabled by accident; prefer a scoped `DRAMACLAW_AGENT_TOKEN` for
+any non-local target.
 
 ## Connect Claude Code
 
@@ -86,5 +94,8 @@ are an escape hatch for any endpoint not covered by a curated verb.
 
 - CE-owner mode grants **full owner access** to the instance it points at — only
   use it against a **local** CE you control. Never point it at a shared instance.
+- The bridge enforces this: tokenless CE-owner mode only accepts a **loopback**
+  `DRAMACLAW_API_URL` and errors out on any remote host unless you set the
+  explicit `DRAMACLAW_CE_OWNER_ALLOW_REMOTE=1` override.
 - On EE, use a scoped `DRAMACLAW_AGENT_TOKEN`; the server enforces the token's
   project boundary and write scopes.

--- a/docs/en/guides/mcp-claude-code.md
+++ b/docs/en/guides/mcp-claude-code.md
@@ -1,0 +1,90 @@
+<!-- lang-switch -->
+**English** · [简体中文](../../zh/guides/mcp-claude-code.md)
+
+# Driving DramaClaw from an AI agent (MCP)
+
+DramaClaw ships an [MCP](https://modelcontextprotocol.io) server that exposes the
+whole drama pipeline — ingest, characters, script, storyboards, first frames,
+video, audio, compose, export — as ~34 tools. Any MCP-speaking agent
+(**Claude Code**, Codex, etc.) can use it to build a drama end to end.
+
+The server (`src/novelvideo/chat/dramaclaw_mcp.py`) is a thin stdio bridge over
+the DramaClaw REST API: each tool is an HTTP call to your running instance, so it
+inherits the same auth, project guards, and task queue as the web UI.
+
+## Prerequisites
+
+- A running DramaClaw instance (`docker compose up -d`, REST API on `:8780`).
+- A configured, funded model gateway (Settings → Model Config) — the agent can
+  plan/script without it, but image/video/audio generation needs working models.
+- Local checkout with [`uv`](https://docs.astral.sh/uv/) synced (`uv sync`) so the
+  `novelvideo` package is importable.
+
+## Auth: two modes
+
+The server authenticates to the API with two environment variables:
+
+| Variable | Purpose |
+|---|---|
+| `DRAMACLAW_API_URL` | Base URL of your instance, e.g. `http://localhost:8780` |
+| `DRAMACLAW_CE_OWNER` | Set to `1` for **CE** (self-host): calls are made as the local owner, no token needed |
+| `DRAMACLAW_AGENT_TOKEN` | **EE / multi-user** only: a scoped agent-session bearer token |
+| `DRAMACLAW_PROJECT_ID` | Optional: default project so tools can omit `project_id` |
+
+**Community Edition** trusts local requests as the owner, so `DRAMACLAW_CE_OWNER=1`
+is all you need — no token to mint. On EE, set `DRAMACLAW_AGENT_TOKEN` instead;
+CE-owner mode is ignored when a token is present.
+
+## Connect Claude Code
+
+This repo ships a project [`.mcp.json`](../../../.mcp.json). Open the repo in
+Claude Code and approve the `dramaclaw` server when prompted — that's it.
+
+Or add it explicitly:
+
+```bash
+claude mcp add dramaclaw \
+  --env DRAMACLAW_API_URL=http://localhost:8780 \
+  --env DRAMACLAW_CE_OWNER=1 \
+  -- uv run python -m novelvideo.chat.dramaclaw_mcp
+```
+
+Verify the tools are live:
+
+```bash
+claude mcp list        # dramaclaw → ✓ connected
+```
+
+> **Running via Docker only?** Launch the bridge inside the container instead:
+> set the `.mcp.json` command to
+> `docker compose exec -T -e DRAMACLAW_API_URL=http://localhost:8780 -e DRAMACLAW_CE_OWNER=1 api python -m novelvideo.chat.dramaclaw_mcp`.
+
+## What the agent can do
+
+The tools cover the full pipeline. A typical end-to-end run:
+
+1. `dramaclaw_post` → `/projects/{p}/ingest/upload` + `/ingest/start` — ingest a manuscript
+2. `dramaclaw_build_characters` → extract the cast
+3. `dramaclaw_plan_episodes` → segment into episodes
+4. `dramaclaw_plan_identities` → per-episode identities
+5. `dramaclaw_generate_script` → episode script
+6. `dramaclaw_generate_portrait` / `dramaclaw_generate_scene_master` → key art
+7. `dramaclaw_generate_sketches` → storyboards
+8. `dramaclaw_render_first_frames` → first frames
+9. `dramaclaw_start_single_video` → shot video
+10. `dramaclaw_generate_audio` → voice-over
+11. `dramaclaw_compose_episode` → assemble
+12. `dramaclaw_get_final_video` → the finished episode (returns a servable URL)
+
+Generation is **asynchronous**: a tool call starts a task, then the agent polls
+`dramaclaw_pipeline_status` / `dramaclaw_list_tasks` / `dramaclaw_get_task` until
+it completes. Each tool's description names the exact task to poll. The generic
+`dramaclaw_get` / `dramaclaw_post` / `dramaclaw_patch` / `dramaclaw_delete` tools
+are an escape hatch for any endpoint not covered by a curated verb.
+
+## Security notes
+
+- CE-owner mode grants **full owner access** to the instance it points at — only
+  use it against a **local** CE you control. Never point it at a shared instance.
+- On EE, use a scoped `DRAMACLAW_AGENT_TOKEN`; the server enforces the token's
+  project boundary and write scopes.

--- a/license-inventory.csv
+++ b/license-inventory.csv
@@ -34,6 +34,7 @@ path,license_expression,copyright,evidence
 .hermes/skills/dramaclaw/references/read-behavior.md,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 .hermes/skills/dramaclaw/references/run-modes.md,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 .hermes/skills/dramaclaw/references/update-behavior.md,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
+.mcp.json,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 .pre-commit-config.yaml,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 AGENTS.md,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 CODE_OF_CONDUCT.md,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
@@ -77,6 +78,7 @@ docs/en/getting-started/configuring-models.md,Elastic-2.0,2026 SuperTale contrib
 docs/en/getting-started/installation.md,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 docs/en/getting-started/quickstart.md,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 docs/en/guides/ffmpeg.md,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
+docs/en/guides/mcp-claude-code.md,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 docs/en/guides/self-hosting.md,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 docs/en/guides/telemetry.md,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 docs/en/guides/troubleshooting.md,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
@@ -1761,6 +1763,7 @@ tests/test_indextts2_fal_smoke.py,Elastic-2.0,2026 SuperTale contributors,REUSE.
 tests/test_literal_script_writing_audio_type.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_m10_final_gate.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_manual_shots.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
+tests/test_mcp_ce_owner.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_media_model_request_schema.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_media_relay.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_model_gateway_settings.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation

--- a/tests/test_mcp_ce_owner.py
+++ b/tests/test_mcp_ce_owner.py
@@ -1,0 +1,208 @@
+"""CE-owner-mode safety boundary for the DramaClaw Hermes plugin.
+
+Tokenless CE-owner mode (``DRAMACLAW_CE_OWNER=1`` with no bearer token) drops
+the ``Authorization`` header entirely, so it must only ever target a loopback
+CE the caller controls. These tests cover loopback acceptance, remote-host
+rejection, the explicit unsafe override, bearer-token precedence, the
+outside-owner-mode missing-token failure, and that ``Authorization`` is never
+silently dropped when a token is present.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+_ENV_VARS = (
+    "DRAMACLAW_API_URL",
+    "DRAMACLAW_AGENT_TOKEN",
+    "DRAMACLAW_CE_OWNER",
+    "DRAMACLAW_CE_OWNER_ALLOW_REMOTE",
+)
+
+
+def _load_plugin_module():
+    tools_module = types.ModuleType("tools")
+    registry_module = types.ModuleType("tools.registry")
+    registry_module.tool_error = lambda value: value
+    registry_module.tool_result = lambda value: value
+    sys.modules.setdefault("tools", tools_module)
+    sys.modules.setdefault("tools.registry", registry_module)
+
+    path = Path(__file__).resolve().parents[1] / ".hermes" / "plugins" / "dramaclaw" / "__init__.py"
+    spec = importlib.util.spec_from_file_location("test_dramaclaw_ce_owner_plugin", path)
+    assert spec is not None
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+class _FakeResponse:
+    status = 200
+
+    def read(self) -> bytes:
+        return b'{"ok": true}'
+
+    def __enter__(self) -> "_FakeResponse":
+        return self
+
+    def __exit__(self, *_exc) -> bool:
+        return False
+
+
+def _capture_requests(module, monkeypatch) -> list:
+    """Patch the module's ``urlopen`` and record every outgoing Request."""
+    captured: list = []
+
+    def fake_urlopen(req, timeout=None):  # noqa: ARG001 - signature parity
+        captured.append(req)
+        return _FakeResponse()
+
+    monkeypatch.setattr(module, "urlopen", fake_urlopen)
+    return captured
+
+
+def _clear_env(monkeypatch) -> None:
+    for var in _ENV_VARS:
+        monkeypatch.delenv(var, raising=False)
+
+
+# --- loopback acceptance -------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "api_url",
+    [
+        "http://localhost:8780",
+        "http://127.0.0.1:8780",
+        "http://[::1]:8780",
+    ],
+)
+def test_owner_mode_loopback_accepted(monkeypatch, api_url):
+    module = _load_plugin_module()
+    _clear_env(monkeypatch)
+    monkeypatch.setenv("DRAMACLAW_API_URL", api_url)
+    monkeypatch.setenv("DRAMACLAW_CE_OWNER", "1")
+    captured = _capture_requests(module, monkeypatch)
+
+    assert module._available() is True
+    result = module._request("GET", "/api/v1/health")
+
+    assert result["ok"] is True
+    assert len(captured) == 1
+    # Tokenless owner mode: no Authorization header is sent.
+    assert captured[0].get_header("Authorization") is None
+
+
+def test_enforce_target_accepts_bracketed_ipv6_loopback():
+    module = _load_plugin_module()
+    # Should not raise for any loopback literal, including bracketed IPv6.
+    module._enforce_ce_owner_target("http://[::1]:8780")
+    module._enforce_ce_owner_target("http://localhost")
+    module._enforce_ce_owner_target("http://127.0.0.1:9000")
+
+
+# --- remote rejection ----------------------------------------------------
+
+
+def test_owner_mode_remote_rejected_without_override(monkeypatch):
+    module = _load_plugin_module()
+    _clear_env(monkeypatch)
+    monkeypatch.setenv("DRAMACLAW_API_URL", "http://drama.example.com:8780")
+    monkeypatch.setenv("DRAMACLAW_CE_OWNER", "1")
+    captured = _capture_requests(module, monkeypatch)
+
+    with pytest.raises(ValueError) as exc:
+        module._request("GET", "/api/v1/health")
+
+    assert "loopback" in str(exc.value).lower()
+    # The request must never have gone out.
+    assert captured == []
+
+
+def test_owner_mode_remote_lan_ip_rejected(monkeypatch):
+    module = _load_plugin_module()
+    _clear_env(monkeypatch)
+    monkeypatch.setenv("DRAMACLAW_API_URL", "http://192.168.1.50:8780")
+    monkeypatch.setenv("DRAMACLAW_CE_OWNER", "1")
+
+    with pytest.raises(ValueError):
+        module._enforce_ce_owner_target(module._base_url())
+
+
+# --- explicit unsafe override --------------------------------------------
+
+
+def test_owner_mode_remote_allowed_with_override(monkeypatch):
+    module = _load_plugin_module()
+    _clear_env(monkeypatch)
+    monkeypatch.setenv("DRAMACLAW_API_URL", "http://drama.example.com:8780")
+    monkeypatch.setenv("DRAMACLAW_CE_OWNER", "1")
+    monkeypatch.setenv("DRAMACLAW_CE_OWNER_ALLOW_REMOTE", "1")
+    captured = _capture_requests(module, monkeypatch)
+
+    result = module._request("GET", "/api/v1/health")
+
+    assert result["ok"] is True
+    assert len(captured) == 1
+    # Still tokenless: override permits the target but adds no auth.
+    assert captured[0].get_header("Authorization") is None
+
+
+# --- bearer-token precedence ---------------------------------------------
+
+
+def test_token_precedence_over_owner_mode(monkeypatch):
+    module = _load_plugin_module()
+    _clear_env(monkeypatch)
+    # Token present AND owner mode set AND a remote host: the token wins, the
+    # loopback restriction does not apply, and Authorization is sent.
+    monkeypatch.setenv("DRAMACLAW_API_URL", "http://drama.example.com:8780")
+    monkeypatch.setenv("DRAMACLAW_CE_OWNER", "1")
+    monkeypatch.setenv("DRAMACLAW_AGENT_TOKEN", "secret-token")
+    captured = _capture_requests(module, monkeypatch)
+
+    result = module._request("GET", "/api/v1/health")
+
+    assert result["ok"] is True
+    assert len(captured) == 1
+    assert captured[0].get_header("Authorization") == "Bearer secret-token"
+
+
+# --- missing token outside owner mode ------------------------------------
+
+
+def test_missing_token_outside_owner_mode_fails(monkeypatch):
+    module = _load_plugin_module()
+    _clear_env(monkeypatch)
+    monkeypatch.setenv("DRAMACLAW_API_URL", "http://localhost:8780")
+    captured = _capture_requests(module, monkeypatch)
+
+    assert module._available() is False
+    with pytest.raises(ValueError) as exc:
+        module._request("GET", "/api/v1/health")
+
+    assert "DRAMACLAW_AGENT_TOKEN is not set" in str(exc.value)
+    assert captured == []
+
+
+# --- Authorization is never silently dropped -----------------------------
+
+
+def test_authorization_present_when_token_provided(monkeypatch):
+    module = _load_plugin_module()
+    _clear_env(monkeypatch)
+    monkeypatch.setenv("DRAMACLAW_API_URL", "http://localhost:8780")
+    monkeypatch.setenv("DRAMACLAW_AGENT_TOKEN", "abc123")
+    captured = _capture_requests(module, monkeypatch)
+
+    result = module._request("POST", "/api/v1/health", body={"x": 1})
+
+    assert result["ok"] is True
+    assert len(captured) == 1
+    assert captured[0].get_header("Authorization") == "Bearer abc123"


### PR DESCRIPTION
## What

Let external MCP agents — **Claude Code**, Codex, etc. — drive a DramaClaw **CE** instance end to end (ingest → characters → script → storyboards → video → audio → compose → export) with a URL and no token.

## Why

DramaClaw already ships an MCP server (`src/novelvideo/chat/dramaclaw_mcp.py`) that re-exports the Hermes plugin's ~34 tools over stdio. But the plugin always sent `Authorization: Bearer <agent-session token>`, and in CE those tokens are minted **only in-process** (in-memory store, no REST route). So an external client had no way to obtain a valid token and every call 401'd.

Meanwhile CE already trusts a request with **no** `Authorization` header as the local owner (`FileAuthPort`), with no project-scope guard. The fix is to let the plugin use that path.

## Changes

- `.hermes/plugins/dramaclaw/__init__.py`
  - add opt-in **CE owner mode** (`DRAMACLAW_CE_OWNER=1`): the plugin omits the bearer header so CE authenticates it as the owner.
  - `_available()` no longer requires `DRAMACLAW_AGENT_TOKEN` when owner mode is on.
  - `_request()` sends `Authorization` only when a token is set.
- `.mcp.json` — project config so Claude Code auto-discovers the `dramaclaw` server.
- `docs/en/guides/mcp-claude-code.md` — setup, auth modes, the end-to-end tool flow, and security notes.

**Unchanged behavior:** Hermes and EE always set a token, so they still send the bearer exactly as before. Owner mode is opt-in, so auth is never silently dropped against EE.

## Verification

Against a live CE instance:

- `dramaclaw_get /api/v1/projects` in owner mode (no token) → **HTTP 200** with the project list.
- A bogus bearer → **HTTP 401** (agent-session verification still enforced).
- Plugin imports and indexes all **34** tools; `py_compile` clean; `.mcp.json` valid.

## Security notes

CE owner mode grants full owner access to the instance it targets — intended for a **local** CE you control, not a shared deployment. EE should use a scoped `DRAMACLAW_AGENT_TOKEN`, whose project boundary and write scopes remain enforced.
