### PR TITLE
feat(compose): add Artlist background music to episode composition

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -244,9 +244,11 @@ NEWAPI_VIDEO_GENERATE_AUDIO=auto
 NEWAPI_VIDEO_AUDIO_MODELS=seedance-1.5-pro,seedance-2.0,seedance-2.0-fast,seedance-2.0-value,seedance-2.0-fast-value
 
 # --- Artlist background music (BGM) for episode composition ---
-# When compose is run with add_bgm=true, DramaClaw fetches a royalty-free track
-# from Artlist's Business API and mixes it under the episode audio. Requires
-# Artlist Enterprise API credentials (OAuth2 client-credentials key pair).
+# BGM is provider-neutral: compose selects a source explicitly via
+# bgm_source (e.g. "artlist"). When compose is run with add_bgm=true and
+# bgm_source="artlist", DramaClaw fetches a royalty-free track from Artlist's
+# Business API and mixes it under the episode audio. Requires Artlist
+# Enterprise API credentials (OAuth2 client-credentials key pair).
 ARTLIST_CLIENT_ID=
 ARTLIST_CLIENT_SECRET=
 # Optional: default search term, mix volume (0-1), and API overrides.

--- a/.env.example
+++ b/.env.example
@@ -243,6 +243,18 @@ NEWAPI_VIDEO_GENERATE_AUDIO=auto
 # 支持 generate_audio 的视频模型。
 NEWAPI_VIDEO_AUDIO_MODELS=seedance-1.5-pro,seedance-2.0,seedance-2.0-fast,seedance-2.0-value,seedance-2.0-fast-value
 
+# --- Artlist background music (BGM) for episode composition ---
+# When compose is run with add_bgm=true, DramaClaw fetches a royalty-free track
+# from Artlist's Business API and mixes it under the episode audio. Requires
+# Artlist Enterprise API credentials (OAuth2 client-credentials key pair).
+ARTLIST_CLIENT_ID=
+ARTLIST_CLIENT_SECRET=
+# Optional: default search term, mix volume (0-1), and API overrides.
+# ARTLIST_BGM_QUERY=cinematic
+# ARTLIST_BGM_VOLUME=0.15
+# ARTLIST_API_BASE=https://business.artlist.io
+# ARTLIST_TOKEN_URL=https://artlist-business-api-prod-cognito.artlist.io/oauth2/token
+
 # 各视频模型允许的 duration 范围，单位秒。
 NEWAPI_VIDEO_DURATION_BOUNDS=seedance-1.0-pro-fast:2-12,seedance-1.5-pro:4-12,seedance-2.0:4-15,seedance-2.0-fast:4-15,seedance-2.0-value:4-15,seedance-2.0-fast-value:4-15,happyhorse-1.0:3-15
 

--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -1420,6 +1420,8 @@
     "globalOptimize": "Global Optimize",
     "videoGenerating": "Generating video...",
     "addSubtitles": "Add Subtitles",
+    "addBgm": "Background music",
+    "bgmQueryPlaceholder": "Mood or genre (optional)",
     "composeVideo": "Compose Video",
     "composing": "Composing...",
     "composeHint": "Configure options and click \"Compose Video\" to generate final video",

--- a/frontend/public/locales/zh/translation.json
+++ b/frontend/public/locales/zh/translation.json
@@ -1420,6 +1420,8 @@
     "globalOptimize": "全局优化",
     "videoGenerating": "视频生成中...",
     "addSubtitles": "添加字幕",
+    "addBgm": "背景音乐",
+    "bgmQueryPlaceholder": "情绪或风格（可选）",
     "composeVideo": "合成视频",
     "composing": "合成中...",
     "composeHint": "配置选项后点击「合成视频」生成最终视频",

--- a/frontend/src/__tests__/routes/compose-export-contract.test.ts
+++ b/frontend/src/__tests__/routes/compose-export-contract.test.ts
@@ -19,16 +19,19 @@ describe("compose export API alignment", () => {
     expect(compose).not.toContain("export/${suffix}");
   });
 
-  it("drops the BGM toggle but still sends add_bgm:false to /videos/compose", () => {
+  it("wires the BGM toggle into the /videos/compose payload", () => {
     const compose = read(
       "src/routes/_app/projects.$project/episodes.$episode/compose.lazy.tsx",
     );
 
-    // The 添加背景音乐 toggle was removed from the UI; the compose payload keeps
-    // the flag explicitly off so the backend default never re-enables it.
-    expect(compose).toContain("add_bgm: false");
-    expect(compose).not.toContain("setAddBgm");
-    expect(compose).not.toContain("video.addBgm");
+    // The 背景音乐 toggle is the supported caller: when on it names an explicit
+    // provider so the provider-neutral backend contract is reachable; when off
+    // the payload keeps add_bgm driven by state (default false).
+    expect(compose).toContain("add_bgm: addBgm");
+    expect(compose).toContain("setAddBgm");
+    expect(compose).toContain('bgm_source: "artlist"');
+    expect(compose).toContain("bgm_query:");
+    expect(compose).toContain('t("video.addBgm")');
   });
 
   it("hydrates and persists NiceGUI compose preferences from project config", () => {

--- a/frontend/src/lib/queries/video.ts
+++ b/frontend/src/lib/queries/video.ts
@@ -181,6 +181,11 @@ export function useComposeEpisode(project: string, episode: number) {
     mutationFn: (params: {
       add_subtitles?: boolean;
       add_bgm?: boolean;
+      // Provider-neutral BGM selection. When add_bgm is true the backend
+      // requires an explicit source (e.g. "artlist"); bgm_query narrows
+      // mood/genre. Both omitted when the toggle is off.
+      bgm_source?: string;
+      bgm_query?: string;
       resolution?: string;
     }) =>
       api

--- a/frontend/src/routes/_app/projects.$project/episodes.$episode/compose.lazy.tsx
+++ b/frontend/src/routes/_app/projects.$project/episodes.$episode/compose.lazy.tsx
@@ -10,6 +10,7 @@ import {
   FileText,
   Film,
   Loader2,
+  Music,
   Subtitles,
 } from "lucide-react";
 
@@ -29,6 +30,7 @@ import {
 import { EpisodeEmptyState } from "@/components/episode/episode-empty-state";
 import { StageProgressPanel } from "@/components/stage-progress-panel";
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -135,6 +137,10 @@ function ComposeTabContent() {
   const orientation = orientationForAspectRatio(projectConfig?.aspect_ratio) ?? "portrait";
 
   const [addSubtitles, setAddSubtitles] = useState(true);
+  // Background music is opt-in. When on, compose sends the only implemented
+  // provider (`bgm_source: "artlist"`); the optional query narrows mood/genre.
+  const [addBgm, setAddBgm] = useState(false);
+  const [bgmQuery, setBgmQuery] = useState("");
   const [resolution, setResolution] = useState<Resolution>("720x1280");
   const [resultUrl, setResultUrl] = useState<string | null>(null);
   const [composeConfirm, setComposeConfirm] = useState(false);
@@ -238,9 +244,14 @@ function ComposeTabContent() {
   const handleCompose = async () => {
     try {
       setResultUrl(null);
+      const trimmedBgmQuery = bgmQuery.trim();
       await composeEpisode.mutateAsync({
         add_subtitles: addSubtitles,
-        add_bgm: false,
+        add_bgm: addBgm,
+        // Provider-neutral contract: add_bgm alone never picks a vendor, so name
+        // the only implemented source when the toggle is on.
+        ...(addBgm ? { bgm_source: "artlist" } : {}),
+        ...(addBgm && trimmedBgmQuery ? { bgm_query: trimmedBgmQuery } : {}),
         resolution,
       });
       task.start();
@@ -499,6 +510,24 @@ function ComposeTabContent() {
                   icon={Subtitles}
                   label={t("video.addSubtitles")}
                 />
+
+                {/* Background music: opt-in, with optional mood/genre query */}
+                <div className="flex items-center gap-2">
+                  <InlineSwitch
+                    checked={addBgm}
+                    onChange={() => setAddBgm((v) => !v)}
+                    icon={Music}
+                    label={t("video.addBgm")}
+                  />
+                  {addBgm && (
+                    <Input
+                      value={bgmQuery}
+                      onChange={(e) => setBgmQuery(e.target.value)}
+                      placeholder={t("video.bgmQueryPlaceholder")}
+                      className="!h-7 w-44 rounded-[6px] border-white/10 text-[12px]"
+                    />
+                  )}
+                </div>
               </div>
             </div>
           )}

--- a/license-inventory.csv
+++ b/license-inventory.csv
@@ -1402,6 +1402,8 @@ src/novelvideo/manual_shots.py,Elastic-2.0,2026 SuperTale contributors,REUSE.tom
 src/novelvideo/model_gateway_runtime.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 src/novelvideo/model_gateway_settings.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 src/novelvideo/models.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
+src/novelvideo/music/__init__.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
+src/novelvideo/music/artlist_provider.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 src/novelvideo/newapi_provisioner.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 src/novelvideo/novel_source.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 src/novelvideo/official_defaults.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
@@ -1641,6 +1643,7 @@ tests/test_api_sketch_ai_detection.py,Elastic-2.0,2026 SuperTale contributors,RE
 tests/test_api_sketch_pose_editor.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_api_sketch_regenerate.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_api_styles.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
+tests/test_artlist_bgm.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_asset_compiler_prop_planning.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_asset_compiler_scene_enrichment.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_asset_resolver.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation

--- a/src/novelvideo/api/routes/generation.py
+++ b/src/novelvideo/api/routes/generation.py
@@ -1847,6 +1847,10 @@ async def compose_video(
         "beats": beats,
         "add_subtitles": body.add_subtitles,
         "add_bgm": body.add_bgm,
+        # Provider-neutral: pass the explicit BGM source/query through so the
+        # runner never has to assume a vendor from add_bgm alone.
+        "bgm_source": body.bgm_source,
+        "bgm_query": body.bgm_query,
     }
 
     if ctx is not None:

--- a/src/novelvideo/api/schemas.py
+++ b/src/novelvideo/api/schemas.py
@@ -248,6 +248,11 @@ class VideoBackendOption(BaseModel):
 class VideoComposeRequest(BaseModel):
     add_subtitles: bool = True
     add_bgm: bool = False
+    # Provider-neutral BGM selection. When add_bgm is true, the caller must name
+    # an explicit source (e.g. "artlist"); "none" is an explicit opt-out. Left
+    # unset, add_bgm=true is rejected rather than defaulting to a vendor.
+    bgm_source: Optional[str] = None
+    bgm_query: Optional[str] = None
     resolution: str = "720x1280"
 
 

--- a/src/novelvideo/music/__init__.py
+++ b/src/novelvideo/music/__init__.py
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: Elastic-2.0
+# Copyright (c) 2026 ClaymoreLab
+"""Background-music providers (royalty-free licensed catalogs)."""
+
+from novelvideo.music.artlist_provider import (
+    ArtlistError,
+    ArtlistMusicProvider,
+    ArtlistTrack,
+)
+
+__all__ = ["ArtlistError", "ArtlistMusicProvider", "ArtlistTrack"]

--- a/src/novelvideo/music/artlist_provider.py
+++ b/src/novelvideo/music/artlist_provider.py
@@ -1,0 +1,243 @@
+# SPDX-License-Identifier: Elastic-2.0
+# Copyright (c) 2026 ClaymoreLab
+"""Artlist Enterprise Music API provider.
+
+Search Artlist's royalty-free catalog and fetch a downloadable track for use as
+background music (BGM) in episode composition.
+
+Auth is OAuth2 client-credentials: set ``ARTLIST_CLIENT_ID`` /
+``ARTLIST_CLIENT_SECRET`` (the Enterprise API key pair). Access tokens live for
+one hour and are cached until shortly before expiry.
+
+API contract (Artlist Business API):
+  - token: POST {token_url}  (Basic base64(id:secret), grant_type=client_credentials)
+  - search: GET {base}/search/v1/song?page&query&categoryIds&durationMin/Max&bpmMin/Max
+      -> {"songs": [{"id", "duration", "genreCategories": [{"name"}], "url"}]}
+  - download: GET {base}/download/v1/downloadable/song/{id}/{mp3|wave}
+      -> {"url": "<downloadable file>"}
+"""
+
+from __future__ import annotations
+
+import base64
+import os
+import time
+from dataclasses import dataclass
+from typing import Any, Iterable, Optional
+
+import aiohttp
+
+DEFAULT_API_BASE = "https://business.artlist.io"
+DEFAULT_TOKEN_URL = (
+    "https://artlist-business-api-prod-cognito.artlist.io/oauth2/token"
+)
+# Artlist caps song duration filters at 420s (7 min).
+MAX_SONG_DURATION = 420
+
+
+class ArtlistError(RuntimeError):
+    """Raised when an Artlist API call fails."""
+
+
+@dataclass
+class ArtlistTrack:
+    """A song returned by Artlist search."""
+
+    id: str
+    duration: float  # seconds
+    url: str  # AAC preview URL from search results
+    name: str = ""
+    genres: tuple[str, ...] = ()
+
+
+class ArtlistMusicProvider:
+    """Thin async client for the Artlist Business music API."""
+
+    def __init__(
+        self,
+        client_id: Optional[str] = None,
+        client_secret: Optional[str] = None,
+        api_base: Optional[str] = None,
+        token_url: Optional[str] = None,
+    ):
+        self.client_id = client_id or os.environ.get("ARTLIST_CLIENT_ID")
+        self.client_secret = client_secret or os.environ.get("ARTLIST_CLIENT_SECRET")
+        self.api_base = (
+            api_base or os.environ.get("ARTLIST_API_BASE") or DEFAULT_API_BASE
+        ).rstrip("/")
+        self.token_url = (
+            token_url or os.environ.get("ARTLIST_TOKEN_URL") or DEFAULT_TOKEN_URL
+        )
+        self._token: Optional[str] = None
+        self._token_exp: float = 0.0
+
+        if not (self.client_id and self.client_secret):
+            raise ValueError(
+                "ARTLIST_CLIENT_ID and ARTLIST_CLIENT_SECRET must be set for Artlist"
+            )
+
+    async def _access_token(self) -> str:
+        # Reuse the cached token until 60s before it expires.
+        if self._token and time.time() < self._token_exp - 60:
+            return self._token
+
+        basic = base64.b64encode(
+            f"{self.client_id}:{self.client_secret}".encode()
+        ).decode()
+        headers = {
+            "Authorization": f"Basic {basic}",
+            "Content-Type": "application/x-www-form-urlencoded",
+        }
+        async with aiohttp.ClientSession() as session:
+            async with session.post(
+                self.token_url,
+                headers=headers,
+                data="grant_type=client_credentials",
+            ) as resp:
+                if resp.status != 200:
+                    text = await resp.text()
+                    raise ArtlistError(
+                        f"Token request failed: HTTP {resp.status} - {text[:200]}"
+                    )
+                data = await resp.json()
+
+        token = data.get("access_token")
+        if not token:
+            raise ArtlistError(f"No access_token in token response: {str(data)[:200]}")
+        self._token = token
+        self._token_exp = time.time() + float(data.get("expires_in") or 3600)
+        return token
+
+    async def _auth_headers(self) -> dict[str, str]:
+        return {
+            "Authorization": f"Bearer {await self._access_token()}",
+            "Accept": "application/json",
+        }
+
+    async def search_songs(
+        self,
+        *,
+        query: Optional[str] = None,
+        category_ids: Optional[Iterable[str]] = None,
+        duration_min: Optional[int] = None,
+        duration_max: Optional[int] = None,
+        bpm_min: Optional[int] = None,
+        bpm_max: Optional[int] = None,
+        vocal_type: Optional[str] = None,
+        page: int = 1,
+    ) -> list[ArtlistTrack]:
+        """Search the catalog. Filters map 1:1 to the Artlist query params."""
+        params: dict[str, Any] = {"page": max(1, int(page))}
+        if query:
+            params["query"] = query
+        if category_ids:
+            params["categoryIds"] = list(category_ids)
+        if duration_min is not None:
+            params["durationMin"] = int(duration_min)
+        if duration_max is not None:
+            params["durationMax"] = int(duration_max)
+        if bpm_min is not None:
+            params["bpmMin"] = int(bpm_min)
+        if bpm_max is not None:
+            params["bpmMax"] = int(bpm_max)
+        if vocal_type:
+            params["vocalType"] = vocal_type
+
+        async with aiohttp.ClientSession() as session:
+            async with session.get(
+                f"{self.api_base}/search/v1/song",
+                params=params,
+                headers=await self._auth_headers(),
+            ) as resp:
+                if resp.status != 200:
+                    text = await resp.text()
+                    raise ArtlistError(
+                        f"Song search failed: HTTP {resp.status} - {text[:200]}"
+                    )
+                data = await resp.json()
+
+        tracks: list[ArtlistTrack] = []
+        for song in data.get("songs") or []:
+            genres = tuple(
+                (g or {}).get("name", "")
+                for g in (song.get("genreCategories") or [])
+                if (g or {}).get("name")
+            )
+            tracks.append(
+                ArtlistTrack(
+                    id=str(song.get("id")),
+                    duration=float(song.get("duration") or 0),
+                    url=song.get("url") or "",
+                    name=song.get("name") or "",
+                    genres=genres,
+                )
+            )
+        return tracks
+
+    async def get_download_url(self, song_id: str, fmt: str = "mp3") -> str:
+        """Resolve a downloadable file URL for a song (fmt: 'mp3' or 'wave')."""
+        fmt = fmt if fmt in {"mp3", "wave"} else "mp3"
+        async with aiohttp.ClientSession() as session:
+            async with session.get(
+                f"{self.api_base}/download/v1/downloadable/song/{song_id}/{fmt}",
+                headers=await self._auth_headers(),
+            ) as resp:
+                if resp.status != 200:
+                    text = await resp.text()
+                    raise ArtlistError(
+                        f"Download URL request failed: HTTP {resp.status} - {text[:200]}"
+                    )
+                data = await resp.json()
+        url = data.get("url")
+        if not url:
+            raise ArtlistError(f"No url in downloadable response: {str(data)[:200]}")
+        return url
+
+    async def download_track(self, url: str, output_path: str) -> str:
+        """Download an audio file to ``output_path``."""
+        os.makedirs(os.path.dirname(os.path.abspath(output_path)), exist_ok=True)
+        async with aiohttp.ClientSession() as session:
+            async with session.get(url) as resp:
+                if resp.status != 200:
+                    raise ArtlistError(f"Track download failed: HTTP {resp.status}")
+                with open(output_path, "wb") as f:
+                    f.write(await resp.read())
+        return output_path
+
+    async def fetch_bgm(
+        self,
+        output_path: str,
+        *,
+        query: Optional[str] = None,
+        duration_target: Optional[float] = None,
+        fmt: str = "mp3",
+        tolerance: float = 30.0,
+    ) -> tuple[ArtlistTrack, str]:
+        """Search for a track, pick the best duration match, and download it.
+
+        Returns ``(track, local_path)``. Prefers a track near
+        ``duration_target`` seconds; the composer can still loop/trim to the
+        exact episode length.
+        """
+        dmin = dmax = None
+        if duration_target:
+            dmin = max(0, int(duration_target - tolerance))
+            dmax = min(MAX_SONG_DURATION, int(duration_target + tolerance))
+
+        tracks = await self.search_songs(
+            query=query, duration_min=dmin, duration_max=dmax
+        )
+        if not tracks and (dmin is not None or dmax is not None):
+            # Relax the duration window if nothing matched.
+            tracks = await self.search_songs(query=query)
+        if not tracks:
+            raise ArtlistError("No Artlist tracks matched the query")
+
+        if duration_target:
+            track = min(tracks, key=lambda t: abs(t.duration - duration_target))
+        else:
+            track = tracks[0]
+
+        download_url = await self.get_download_url(track.id, fmt=fmt)
+        await self.download_track(download_url, output_path)
+        return track, output_path

--- a/src/novelvideo/task_backend/runners/video.py
+++ b/src/novelvideo/task_backend/runners/video.py
@@ -8,6 +8,7 @@ from typing import Any
 
 from novelvideo.project_context import ProjectContext
 from novelvideo.task_backend.cancel import (
+    TaskCancelled,
     TaskTimedOut,
     await_envelope_with_cancel_watch,
     raise_if_envelope_cancel_requested,
@@ -848,6 +849,11 @@ def run_compose_episode(envelope: dict[str, Any], ctx: ProjectContext) -> dict[s
                 manager.update_progress_for_project(
                     ctx, "compose_episode", episode, logs=[status]
                 )
+            except (TaskCancelled, TaskTimedOut):
+                # Control-flow exceptions (user cancellation / cooperative
+                # timeout) must propagate — never mask them as a skipped BGM,
+                # or a cancelled/timed-out compose would report success.
+                raise
             except Exception as exc:
                 # BGM is best-effort: never fail delivery over it.
                 bgm_provenance = None

--- a/src/novelvideo/task_backend/runners/video.py
+++ b/src/novelvideo/task_backend/runners/video.py
@@ -439,6 +439,60 @@ def _probe_media_duration(path: str, *, timeout_seconds: int | None) -> float:
         return 0.0
 
 
+# --- Provider-neutral BGM source selection ------------------------------------
+# ``add_bgm=true`` alone is NOT enough to pick a vendor: the caller must name an
+# explicit source so the compose contract stays provider-neutral. Add future
+# providers here (e.g. an internal catalog) without touching the runner logic.
+_BGM_SOURCE_NONE = "none"
+_BGM_SOURCE_ARTLIST = "artlist"
+SUPPORTED_BGM_SOURCES = (_BGM_SOURCE_ARTLIST, _BGM_SOURCE_NONE)
+
+
+def _resolve_bgm_source(add_bgm: bool, raw_source: object) -> str | None:
+    """Resolve which BGM provider to apply, provider-neutrally.
+
+    Returns the provider key to use, or ``None`` for no BGM. ``add_bgm=true``
+    must be paired with an explicit ``bgm_source``; a missing or unknown source
+    raises ``ValueError`` so misconfiguration fails loudly instead of silently
+    defaulting to a specific vendor. ``"none"`` is an explicit opt-out.
+    """
+    source = str(raw_source or "").strip().lower()
+    if not add_bgm:
+        return None
+    if not source:
+        raise ValueError(
+            "add_bgm=true requires an explicit bgm_source "
+            f"(one of: {', '.join(SUPPORTED_BGM_SOURCES)}); "
+            "refusing to assume a background-music provider"
+        )
+    if source == _BGM_SOURCE_NONE:
+        return None
+    if source not in SUPPORTED_BGM_SOURCES:
+        raise ValueError(
+            f"Unknown bgm_source {source!r}; supported: {', '.join(SUPPORTED_BGM_SOURCES)}"
+        )
+    return source
+
+
+def _write_bgm_provenance(final_video_path: Path, provenance: dict[str, Any]) -> str | None:
+    """Persist a BGM provenance sidecar next to the exported media.
+
+    A log line is not sufficient provenance for exported commercial media, so we
+    record the track/license reference on disk beside the final video. Returns
+    the sidecar path, or ``None`` if it could not be written (best-effort).
+    """
+    import json
+
+    sidecar = final_video_path.with_suffix(".bgm.json")
+    try:
+        sidecar.write_text(
+            json.dumps(provenance, ensure_ascii=False, indent=2), encoding="utf-8"
+        )
+        return sidecar.as_posix()
+    except OSError:
+        return None
+
+
 def _apply_artlist_bgm(
     *,
     video_path: Path,
@@ -447,15 +501,21 @@ def _apply_artlist_bgm(
     volume: float,
     run_checked,
     subprocess_timeout,
-) -> str:
+    fmt: str = "mp3",
+) -> tuple[str, dict[str, Any]]:
     """Mix an Artlist background track under the episode audio, in place.
 
     Searches Artlist for a track near the episode length, loops/ducks it under
     the existing dialogue/narration, and overwrites ``video_path``. Raises on
     failure so the caller can log-and-skip — BGM never blocks delivery.
+
+    Returns ``(status_message, provenance)`` where ``provenance`` is a structured
+    record of the selected track, its source/provider, and the license/account
+    reference — sufficient to attribute the track in exported commercial media.
     """
     import asyncio
     import shutil
+    from datetime import datetime, timezone
 
     from novelvideo.music import ArtlistMusicProvider
 
@@ -469,6 +529,7 @@ def _apply_artlist_bgm(
             bgm_source,
             query=query or None,
             duration_target=duration or None,
+            fmt=fmt,
         )
     )
 
@@ -504,7 +565,26 @@ def _apply_artlist_bgm(
         raise RuntimeError(f"BGM mix failed: {result.stderr[:300]}")
 
     shutil.move(str(mixed_path), str(video_path))
-    return f"Artlist BGM applied: {track.name or track.id} ({track.duration:.0f}s)"
+
+    provenance: dict[str, Any] = {
+        "provider": _BGM_SOURCE_ARTLIST,
+        "source": _BGM_SOURCE_ARTLIST,
+        "track_id": track.id,
+        "track_name": track.name or track.id,
+        "genres": list(track.genres),
+        "duration_seconds": round(float(track.duration), 3),
+        "download_format": fmt,
+        "query": query or None,
+        "mix_volume": volume,
+        # License / account reference for the exported track. The Artlist
+        # Business (Enterprise) catalog is royalty-free under the account keyed
+        # by ARTLIST_CLIENT_ID (the client id, not the secret).
+        "license": "Artlist Business API royalty-free license",
+        "account_ref": provider.client_id,
+        "mixed_at": datetime.now(timezone.utc).isoformat(),
+    }
+    status = f"Artlist BGM applied: {track.name or track.id} ({track.duration:.0f}s)"
+    return status, provenance
 
 
 def run_compose_episode(envelope: dict[str, Any], ctx: ProjectContext) -> dict[str, Any]:
@@ -527,6 +607,12 @@ def run_compose_episode(envelope: dict[str, Any], ctx: ProjectContext) -> dict[s
     resolution = str(payload.get("resolution") or "720x1280")
     add_subtitles = bool(payload.get("add_subtitles"))
     add_bgm = bool(payload.get("add_bgm"))
+    # Provider-neutral: add_bgm alone does not select a vendor. Resolve (and
+    # validate) the explicit source up front so a bad selection fails fast,
+    # before any expensive ffmpeg work.
+    bgm_source = _resolve_bgm_source(
+        add_bgm, payload.get("bgm_source") or payload.get("bgm_provider")
+    )
     manager = get_task_manager()
     paths = PathResolver(output_dir, episode)
     final_dir = Path(output_dir) / "videos" / "episodes"
@@ -731,7 +817,8 @@ def run_compose_episode(envelope: dict[str, Any], ctx: ProjectContext) -> dict[s
             raise RuntimeError(f"拼接失败: {result.stderr[:500]}")
 
         bgm_applied = False
-        if add_bgm:
+        bgm_provenance: dict[str, Any] | None = None
+        if bgm_source == _BGM_SOURCE_ARTLIST:
             check_cancel()
             manager.update_progress_for_project(
                 ctx,
@@ -740,7 +827,7 @@ def run_compose_episode(envelope: dict[str, Any], ctx: ProjectContext) -> dict[s
                 current_task="Adding background music...",
             )
             try:
-                status = _apply_artlist_bgm(
+                status, bgm_provenance = _apply_artlist_bgm(
                     video_path=output_path,
                     tmp_dir=tmp_dir,
                     query=str(
@@ -753,11 +840,17 @@ def run_compose_episode(envelope: dict[str, Any], ctx: ProjectContext) -> dict[s
                     subprocess_timeout=subprocess_timeout,
                 )
                 bgm_applied = True
+                # Persist provenance beside the exported media (a log line alone
+                # is not sufficient provenance for commercial media).
+                sidecar = _write_bgm_provenance(output_path, bgm_provenance)
+                if sidecar:
+                    bgm_provenance["provenance_sidecar"] = sidecar
                 manager.update_progress_for_project(
                     ctx, "compose_episode", episode, logs=[status]
                 )
             except Exception as exc:
                 # BGM is best-effort: never fail delivery over it.
+                bgm_provenance = None
                 manager.update_progress_for_project(
                     ctx,
                     "compose_episode",
@@ -765,11 +858,18 @@ def run_compose_episode(envelope: dict[str, Any], ctx: ProjectContext) -> dict[s
                     logs=[f"Background music skipped: {exc}"],
                 )
 
-    return {
+    result: dict[str, Any] = {
         "video_path": output_path.as_posix(),
         "add_subtitles_requested": add_subtitles,
         "bgm_applied": bgm_applied,
+        # Provider-neutral record of what BGM (if any) was requested.
+        "bgm_source": bgm_source,
     }
+    if bgm_provenance is not None:
+        # Structured provenance attached to the composition result: track id,
+        # name, source/provider, and license/account reference.
+        result["bgm"] = bgm_provenance
+    return result
 
 
 register_project_task_runner("compose_episode", run_compose_episode)

--- a/src/novelvideo/task_backend/runners/video.py
+++ b/src/novelvideo/task_backend/runners/video.py
@@ -414,9 +414,109 @@ def run_video_generation(envelope: dict[str, Any], ctx: ProjectContext) -> dict[
     )
 
 
+def _probe_media_duration(path: str, *, timeout_seconds: int | None) -> float:
+    """Return a media file's duration in seconds via ffprobe (0.0 on failure)."""
+    import subprocess
+
+    try:
+        out = subprocess.run(
+            [
+                "ffprobe",
+                "-v",
+                "error",
+                "-show_entries",
+                "format=duration",
+                "-of",
+                "default=noprint_wrappers=1:nokey=1",
+                str(path),
+            ],
+            capture_output=True,
+            text=True,
+            timeout=timeout_seconds,
+        )
+        return float((out.stdout or "").strip() or 0)
+    except Exception:
+        return 0.0
+
+
+def _apply_artlist_bgm(
+    *,
+    video_path: Path,
+    tmp_dir: Path,
+    query: str,
+    volume: float,
+    run_checked,
+    subprocess_timeout,
+) -> str:
+    """Mix an Artlist background track under the episode audio, in place.
+
+    Searches Artlist for a track near the episode length, loops/ducks it under
+    the existing dialogue/narration, and overwrites ``video_path``. Raises on
+    failure so the caller can log-and-skip — BGM never blocks delivery.
+    """
+    import asyncio
+    import shutil
+
+    from novelvideo.music import ArtlistMusicProvider
+
+    duration = _probe_media_duration(
+        str(video_path), timeout_seconds=subprocess_timeout(30)
+    )
+    provider = ArtlistMusicProvider()
+    bgm_source = str(tmp_dir / "bgm_source.mp3")
+    track, _ = asyncio.run(
+        provider.fetch_bgm(
+            bgm_source,
+            query=query or None,
+            duration_target=duration or None,
+        )
+    )
+
+    mixed_path = tmp_dir / "episode_with_bgm.mp4"
+    cmd = [
+        "ffmpeg",
+        "-y",
+        "-i",
+        str(video_path),
+        "-stream_loop",
+        "-1",
+        "-i",
+        bgm_source,
+        "-filter_complex",
+        # Music at a low fixed level, mixed under the full-length dialogue track.
+        f"[1:a]volume={volume}[bg];"
+        f"[0:a][bg]amix=inputs=2:duration=first:dropout_transition=2[aout]",
+        "-map",
+        "0:v:0",
+        "-map",
+        "[aout]",
+        "-c:v",
+        "copy",
+        "-c:a",
+        "aac",
+        "-b:a",
+        "160k",
+        "-shortest",
+        str(mixed_path),
+    ]
+    result = run_checked(cmd, default_timeout_seconds=30 * 60)
+    if result.returncode != 0:
+        raise RuntimeError(f"BGM mix failed: {result.stderr[:300]}")
+
+    shutil.move(str(mixed_path), str(video_path))
+    return f"Artlist BGM applied: {track.name or track.id} ({track.duration:.0f}s)"
+
+
 def run_compose_episode(envelope: dict[str, Any], ctx: ProjectContext) -> dict[str, Any]:
+    import os
     import subprocess
     import tempfile
+
+    def _bgm_volume() -> float:
+        try:
+            return float(os.environ.get("ARTLIST_BGM_VOLUME") or 0.15)
+        except ValueError:
+            return 0.15
 
     from novelvideo.utils.path_resolver import PathResolver
 
@@ -426,6 +526,7 @@ def run_compose_episode(envelope: dict[str, Any], ctx: ProjectContext) -> dict[s
     beats = list(payload.get("beats") or [])
     resolution = str(payload.get("resolution") or "720x1280")
     add_subtitles = bool(payload.get("add_subtitles"))
+    add_bgm = bool(payload.get("add_bgm"))
     manager = get_task_manager()
     paths = PathResolver(output_dir, episode)
     final_dir = Path(output_dir) / "videos" / "episodes"
@@ -629,9 +730,45 @@ def run_compose_episode(envelope: dict[str, Any], ctx: ProjectContext) -> dict[s
         if result.returncode != 0:
             raise RuntimeError(f"拼接失败: {result.stderr[:500]}")
 
+        bgm_applied = False
+        if add_bgm:
+            check_cancel()
+            manager.update_progress_for_project(
+                ctx,
+                "compose_episode",
+                episode,
+                current_task="Adding background music...",
+            )
+            try:
+                status = _apply_artlist_bgm(
+                    video_path=output_path,
+                    tmp_dir=tmp_dir,
+                    query=str(
+                        payload.get("bgm_query")
+                        or os.environ.get("ARTLIST_BGM_QUERY")
+                        or "cinematic"
+                    ),
+                    volume=_bgm_volume(),
+                    run_checked=run_checked,
+                    subprocess_timeout=subprocess_timeout,
+                )
+                bgm_applied = True
+                manager.update_progress_for_project(
+                    ctx, "compose_episode", episode, logs=[status]
+                )
+            except Exception as exc:
+                # BGM is best-effort: never fail delivery over it.
+                manager.update_progress_for_project(
+                    ctx,
+                    "compose_episode",
+                    episode,
+                    logs=[f"Background music skipped: {exc}"],
+                )
+
     return {
         "video_path": output_path.as_posix(),
         "add_subtitles_requested": add_subtitles,
+        "bgm_applied": bgm_applied,
     }
 
 

--- a/tests/test_artlist_bgm.py
+++ b/tests/test_artlist_bgm.py
@@ -1,0 +1,322 @@
+"""Tests for the Artlist BGM provider and provider-neutral compose wiring.
+
+Covers OAuth token caching, search duration fallback, download failure,
+ffmpeg mix success/failure, compose cancellation, missing credentials, and the
+provider-neutral BGM source resolution + provenance persistence. All HTTP and
+ffmpeg subprocess calls are mocked — no network or ffmpeg binary required.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from novelvideo.music import ArtlistError, ArtlistMusicProvider
+
+
+# --- aiohttp fakes ------------------------------------------------------------
+
+
+class _FakeResp:
+    def __init__(self, *, status=200, json_data=None, text_data="", body=b""):
+        self.status = status
+        self._json = json_data
+        self._text = text_data
+        self._body = body
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    async def json(self):
+        return self._json
+
+    async def text(self):
+        return self._text
+
+    async def read(self):
+        return self._body
+
+
+class _FakeSession:
+    def __init__(self, handler):
+        self._handler = handler
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    def post(self, url, **kw):
+        return self._handler("POST", url, kw)
+
+    def get(self, url, **kw):
+        return self._handler("GET", url, kw)
+
+
+def _install_http(monkeypatch, handler):
+    from novelvideo.music import artlist_provider
+
+    monkeypatch.setattr(
+        artlist_provider.aiohttp,
+        "ClientSession",
+        lambda *a, **k: _FakeSession(handler),
+    )
+
+
+# --- provider: OAuth token caching -------------------------------------------
+
+
+async def test_oauth_token_cached_and_refreshed(monkeypatch):
+    counter = {"token": 0}
+
+    def handler(method, url, kw):
+        if "oauth2/token" in url:
+            counter["token"] += 1
+            return _FakeResp(
+                json_data={"access_token": f"tok{counter['token']}", "expires_in": 3600}
+            )
+        raise AssertionError(f"unexpected call: {method} {url}")
+
+    _install_http(monkeypatch, handler)
+    provider = ArtlistMusicProvider(client_id="id", client_secret="sec")
+
+    first = await provider._access_token()
+    second = await provider._access_token()
+    assert first == second == "tok1"
+    assert counter["token"] == 1  # reused within TTL, not re-fetched
+
+    # Force expiry -> next call must refresh.
+    provider._token_exp = time.time() - 1
+    third = await provider._access_token()
+    assert third == "tok2"
+    assert counter["token"] == 2
+
+
+# --- provider: search duration fallback --------------------------------------
+
+
+async def test_search_duration_fallback(monkeypatch, tmp_path):
+    calls = {"search": 0}
+
+    def handler(method, url, kw):
+        if "oauth2/token" in url:
+            return _FakeResp(json_data={"access_token": "tok", "expires_in": 3600})
+        if url.endswith("/search/v1/song"):
+            calls["search"] += 1
+            params = kw.get("params") or {}
+            if "durationMin" in params or "durationMax" in params:
+                # Nothing matches the tight duration window.
+                return _FakeResp(json_data={"songs": []})
+            # Relaxed search (no duration filter) returns a hit.
+            return _FakeResp(
+                json_data={
+                    "songs": [
+                        {
+                            "id": "7",
+                            "duration": 95,
+                            "name": "Relaxed",
+                            "url": "preview",
+                            "genreCategories": [{"name": "cinematic"}],
+                        }
+                    ]
+                }
+            )
+        if "/download/v1/downloadable/song/" in url:
+            return _FakeResp(json_data={"url": "https://dl.example/track.mp3"})
+        if url == "https://dl.example/track.mp3":
+            return _FakeResp(body=b"audio-bytes")
+        raise AssertionError(f"unexpected call: {method} {url}")
+
+    _install_http(monkeypatch, handler)
+    provider = ArtlistMusicProvider(client_id="id", client_secret="sec")
+
+    out = tmp_path / "bgm.mp3"
+    track, path = await provider.fetch_bgm(
+        str(out), query="calm", duration_target=100
+    )
+
+    assert calls["search"] == 2  # windowed search then relaxed fallback
+    assert track.id == "7"
+    assert track.name == "Relaxed"
+    assert Path(path).read_bytes() == b"audio-bytes"
+
+
+# --- provider: download failure ----------------------------------------------
+
+
+async def test_download_failure_raises(monkeypatch, tmp_path):
+    def handler(method, url, kw):
+        return _FakeResp(status=500, text_data="server error")
+
+    _install_http(monkeypatch, handler)
+    provider = ArtlistMusicProvider(client_id="id", client_secret="sec")
+
+    with pytest.raises(ArtlistError):
+        await provider.download_track(
+            "https://dl.example/x.mp3", str(tmp_path / "x.mp3")
+        )
+
+
+# --- provider: missing credentials -------------------------------------------
+
+
+def test_missing_credentials_raises(monkeypatch):
+    monkeypatch.delenv("ARTLIST_CLIENT_ID", raising=False)
+    monkeypatch.delenv("ARTLIST_CLIENT_SECRET", raising=False)
+    with pytest.raises(ValueError):
+        ArtlistMusicProvider()
+
+
+# --- runner: provider-neutral source resolution ------------------------------
+
+
+def test_resolve_bgm_source_is_provider_neutral():
+    from novelvideo.task_backend.runners.video import _resolve_bgm_source
+
+    # add_bgm off -> never any BGM regardless of source.
+    assert _resolve_bgm_source(False, None) is None
+    assert _resolve_bgm_source(False, "artlist") is None
+
+    # Explicit provider selection is required and case-insensitive.
+    assert _resolve_bgm_source(True, "artlist") == "artlist"
+    assert _resolve_bgm_source(True, "ARTLIST") == "artlist"
+
+    # "none" is an explicit opt-out.
+    assert _resolve_bgm_source(True, "none") is None
+
+    # add_bgm=true alone must NOT silently pick a vendor.
+    with pytest.raises(ValueError):
+        _resolve_bgm_source(True, None)
+
+    # Unknown providers error clearly.
+    with pytest.raises(ValueError):
+        _resolve_bgm_source(True, "spotify")
+
+
+# --- runner: ffmpeg mix success + provenance ---------------------------------
+
+
+def _install_fake_provider(monkeypatch, track):
+    import novelvideo.music as music_mod
+
+    class _FakeProvider:
+        def __init__(self, *a, **k):
+            self.client_id = "acct-xyz"
+
+        async def fetch_bgm(self, output_path, **kw):
+            Path(output_path).write_bytes(b"track")
+            return track, output_path
+
+    monkeypatch.setattr(music_mod, "ArtlistMusicProvider", _FakeProvider)
+
+
+def test_apply_artlist_bgm_success_persists_provenance(monkeypatch, tmp_path):
+    import shutil
+
+    from novelvideo.task_backend.runners import video
+
+    track = SimpleNamespace(
+        id="123", name="Night Drive", genres=("cinematic",), duration=120.0
+    )
+    _install_fake_provider(monkeypatch, track)
+    monkeypatch.setattr(video, "_probe_media_duration", lambda *a, **k: 120.0)
+    # No real ffmpeg output file exists; make the in-place move a no-op-ish copy.
+    monkeypatch.setattr(shutil, "move", lambda s, d: Path(d).write_bytes(b"mixed"))
+
+    seen = []
+
+    def run_checked(cmd, *, default_timeout_seconds):
+        seen.append(cmd)
+        return SimpleNamespace(returncode=0, stderr="")
+
+    video_path = tmp_path / "ep001_final.mp4"
+    video_path.write_bytes(b"video")
+
+    status, prov = video._apply_artlist_bgm(
+        video_path=video_path,
+        tmp_dir=tmp_path,
+        query="cinematic",
+        volume=0.15,
+        run_checked=run_checked,
+        subprocess_timeout=lambda n: n,
+    )
+
+    assert seen and seen[0][0] == "ffmpeg"
+    assert "Night Drive" in status
+    assert prov["provider"] == "artlist"
+    assert prov["source"] == "artlist"
+    assert prov["track_id"] == "123"
+    assert prov["track_name"] == "Night Drive"
+    assert prov["account_ref"] == "acct-xyz"
+    assert prov["license"]  # non-empty license reference
+    assert prov["download_format"] == "mp3"
+
+    # Sidecar persistence writes structured provenance next to the media.
+    sidecar = video._write_bgm_provenance(video_path, prov)
+    assert sidecar is not None
+    loaded = json.loads(Path(sidecar).read_text(encoding="utf-8"))
+    assert loaded["track_id"] == "123"
+    assert loaded["provider"] == "artlist"
+
+
+# --- runner: ffmpeg mix failure ----------------------------------------------
+
+
+def test_apply_artlist_bgm_ffmpeg_failure_raises(monkeypatch, tmp_path):
+    from novelvideo.task_backend.runners import video
+
+    track = SimpleNamespace(id="9", name="X", genres=(), duration=10.0)
+    _install_fake_provider(monkeypatch, track)
+    monkeypatch.setattr(video, "_probe_media_duration", lambda *a, **k: 10.0)
+
+    def run_checked(cmd, *, default_timeout_seconds):
+        return SimpleNamespace(returncode=1, stderr="ffmpeg boom")
+
+    video_path = tmp_path / "ep.mp4"
+    video_path.write_bytes(b"video")
+
+    with pytest.raises(RuntimeError, match="BGM mix failed"):
+        video._apply_artlist_bgm(
+            video_path=video_path,
+            tmp_dir=tmp_path,
+            query="q",
+            volume=0.15,
+            run_checked=run_checked,
+            subprocess_timeout=lambda n: n,
+        )
+
+
+# --- runner: cancellation propagates -----------------------------------------
+
+
+def test_compose_episode_cancellation(monkeypatch, tmp_path):
+    from novelvideo.task_backend.cancel import TaskCancelled
+    from novelvideo.task_backend.runners import video
+
+    monkeypatch.setattr(video, "get_task_manager", lambda: MagicMock())
+
+    def _raise(*a, **k):
+        raise TaskCancelled()
+
+    monkeypatch.setattr(video, "raise_if_envelope_cancel_requested", _raise)
+
+    envelope = {
+        "episode": 1,
+        "payload": {
+            "output_dir": str(tmp_path),
+            "beats": [{"beat_number": 1}],
+            "add_bgm": False,
+        },
+    }
+
+    with pytest.raises(TaskCancelled):
+        video.run_compose_episode(envelope, MagicMock())

--- a/tests/test_artlist_bgm.py
+++ b/tests/test_artlist_bgm.py
@@ -320,3 +320,61 @@ def test_compose_episode_cancellation(monkeypatch, tmp_path):
 
     with pytest.raises(TaskCancelled):
         video.run_compose_episode(envelope, MagicMock())
+
+
+# --- runner: cancel/timeout during the BGM step propagates -------------------
+
+
+@pytest.mark.parametrize("exc_factory", ["cancelled", "timed_out"])
+def test_compose_episode_bgm_control_flow_propagates(monkeypatch, tmp_path, exc_factory):
+    """A cancellation/timeout raised *inside* the BGM step must propagate.
+
+    Regression: the BGM block caught bare ``Exception`` and converted every
+    failure into a "Background music skipped" log line, so ``TaskCancelled`` /
+    ``TaskTimedOut`` (both subclasses of ``Exception``) raised during the
+    Artlist fetch or ffmpeg mix were silently swallowed and the compose was
+    reported as a success. The step must re-raise these control-flow signals.
+    """
+    from novelvideo.task_backend.cancel import TaskCancelled, TaskTimedOut
+    from novelvideo.task_backend.runners import video
+
+    if exc_factory == "cancelled":
+        control_exc: Exception = TaskCancelled()
+        expected = TaskCancelled
+    else:
+        control_exc = TaskTimedOut(timeout_seconds=30 * 60)
+        expected = TaskTimedOut
+
+    # A single beat with a real video file so composition reaches the BGM step.
+    video_dir = tmp_path / "videos" / "beats" / "ep001"
+    video_dir.mkdir(parents=True)
+    (video_dir / "beat_01.mp4").write_bytes(b"video")
+
+    def fake_run(cmd, **_kwargs):
+        # ffprobe (audio-stream detection) reports no audio; ffmpeg succeeds.
+        if cmd and cmd[0] == "ffprobe":
+            return SimpleNamespace(returncode=0, stdout="\n", stderr="")
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(video, "get_task_manager", lambda: MagicMock())
+    monkeypatch.setattr(video, "run_project_subprocess", fake_run)
+    monkeypatch.setattr(video, "raise_if_envelope_cancel_requested", lambda *a, **k: None)
+
+    def _raise_during_bgm(*_a, **_k):
+        raise control_exc
+
+    monkeypatch.setattr(video, "_apply_artlist_bgm", _raise_during_bgm)
+
+    envelope = {
+        "episode": 1,
+        "payload": {
+            "output_dir": str(tmp_path),
+            "beats": [{"beat_number": 1}],
+            "add_bgm": True,
+            "bgm_source": "artlist",
+        },
+    }
+
+    # Must propagate — NOT be converted into a successful compose / skip result.
+    with pytest.raises(expected):
+        video.run_compose_episode(envelope, MagicMock())


### PR DESCRIPTION
## What

Turn the previously-stubbed `add_bgm` compose flag into a working feature by adding **Artlist** as a background-music source. When an episode is composed with `add_bgm=true`, DramaClaw fetches a royalty-free track from Artlist's Business API and mixes it under the episode's dialogue/narration.

## Why

`add_bgm` was accepted and passed to the compose task but never applied — `run_compose_episode` had no music step. This wires it to a real, licensed catalog.

## Changes

- **`novelvideo.music.ArtlistMusicProvider`** (new module) — async client for the Artlist Business API:
  - OAuth2 **client-credentials** auth → cached bearer token (`ARTLIST_CLIENT_ID` / `ARTLIST_CLIENT_SECRET`)
  - `search_songs(...)` → `GET /search/v1/song` (query, `categoryIds` mood/genre, `durationMin/Max`, `bpmMin/Max`)
  - `get_download_url(id, fmt)` → `GET /download/v1/downloadable/song/{id}/{mp3|wave}`
  - `fetch_bgm(...)` convenience — search near a target duration, pick the closest, download
- **`run_compose_episode`** — after the final concat, ffmpeg-mixes a duration-matched Artlist track under the episode audio (stream-looped, low fixed volume). **Best-effort**: any failure logs "Background music skipped" and delivers the episode without BGM.
- **`.env.example`** — `ARTLIST_CLIENT_ID` / `ARTLIST_CLIENT_SECRET` (+ optional `ARTLIST_BGM_QUERY`, `ARTLIST_BGM_VOLUME`, API overrides).

## Verification

- `py_compile` clean on all touched files.
- Runtime: `ArtlistMusicProvider` instantiates with the correct base URL (`https://business.artlist.io`), token URL, and OAuth2 Basic-auth encoding.
- **End-to-end needs real Artlist Enterprise credentials + a rendered episode** (not exercised in CI).

## Scope note — video

Artlist's Enterprise API is **music-only**; its documented controllers are Song / Artist / Album / Downloadable, with **no footage or AI video-generation endpoint**. So this integration covers **BGM**, not video generation. If Artlist exposes a video-generation API (e.g. via a private/enterprise endpoint), point me at its docs and I'll add it as a `VideoGeneratorBase` provider alongside Higgsfield.

## Follow-ups

- Drive the BGM search `query` from the episode's mood/theme (currently a configurable default).
- Optional sidechain ducking (music dips under dialogue) instead of a fixed low volume.
- Surface `add_bgm` + a track picker in the compose UI.
