### PR TITLE
feat(video): Artlist generative video provider (incl. Seedance via Artlist)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -247,10 +247,20 @@ NEWAPI_VIDEO_AUDIO_MODELS=seedance-1.5-pro,seedance-2.0,seedance-2.0-fast,seedan
 # Set VIDEO_BACKEND=artlist to route shot video through Artlist's generative
 # models. DramaClaw connects to Artlist's MCP server as a partner client,
 # uploads the first frame, generates, polls, and downloads.
-# NOTE: this needs a NON-INTERACTIVE partner token for mcp.artlist.io — the
-# per-user claude.ai connector cannot be used from a backend. Confirm the exact
-# partner auth scheme with Artlist; this client sends `Authorization: Bearer`.
+# WARNING — UNVERIFIED / NOT PRODUCTION-READY:
+#  * Auth is ASSUMED. The public Artlist MCP flow uses interactive per-account
+#    authorization; this backend assumes an undocumented NON-INTERACTIVE partner
+#    bearer token (`Authorization: Bearer <token>`) for mcp.artlist.io. That
+#    scheme has NOT been confirmed with Artlist. The per-user claude.ai
+#    connector cannot be used from a backend.
+#  * No end-to-end generation has yet succeeded against the live gateway with
+#    real partner credentials. Tool names, request fields, confirmation flow,
+#    polling payloads and downloads are pinned by mocked contract tests only
+#    (tests/test_artlist_video.py) and remain pending live verification.
+#  * Set ARTLIST_AUTO_CONFIRM=true only if you want paid generations that the
+#    gateway flags for cost confirmation to be auto-approved (default: refuse).
 ARTLIST_MCP_TOKEN=
+# ARTLIST_AUTO_CONFIRM=false
 # Pick a specific model group. Two ways:
 #  - alias:   VIDEO_BACKEND=artlist_seedance-2.0  (also: -1.0-pro-fast, -1.5,
 #             -2.0-fast, -2.0-mini; plus kling-2.1, veo-3.1, sora-2, happyhorse-1.1)

--- a/.env.example
+++ b/.env.example
@@ -243,6 +243,18 @@ NEWAPI_VIDEO_GENERATE_AUDIO=auto
 # 支持 generate_audio 的视频模型。
 NEWAPI_VIDEO_AUDIO_MODELS=seedance-1.5-pro,seedance-2.0,seedance-2.0-fast,seedance-2.0-value,seedance-2.0-fast-value
 
+# --- Native Artlist generative video (image-to-video via Artlist MCP gateway) ---
+# Set VIDEO_BACKEND=artlist to route shot video through Artlist's generative
+# models. DramaClaw connects to Artlist's MCP server as a partner client,
+# uploads the first frame, generates, polls, and downloads.
+# NOTE: this needs a NON-INTERACTIVE partner token for mcp.artlist.io — the
+# per-user claude.ai connector cannot be used from a backend. Confirm the exact
+# partner auth scheme with Artlist; this client sends `Authorization: Bearer`.
+ARTLIST_MCP_TOKEN=
+# Optional overrides:
+# ARTLIST_MCP_URL=https://mcp.artlist.io/mcp
+# ARTLIST_VIDEO_MODEL_GROUP_ID=   # auto-routes to an i2v-capable model group
+
 # 各视频模型允许的 duration 范围，单位秒。
 NEWAPI_VIDEO_DURATION_BOUNDS=seedance-1.0-pro-fast:2-12,seedance-1.5-pro:4-12,seedance-2.0:4-15,seedance-2.0-fast:4-15,seedance-2.0-value:4-15,seedance-2.0-fast-value:4-15,happyhorse-1.0:3-15
 

--- a/.env.example
+++ b/.env.example
@@ -251,9 +251,14 @@ NEWAPI_VIDEO_AUDIO_MODELS=seedance-1.5-pro,seedance-2.0,seedance-2.0-fast,seedan
 # per-user claude.ai connector cannot be used from a backend. Confirm the exact
 # partner auth scheme with Artlist; this client sends `Authorization: Bearer`.
 ARTLIST_MCP_TOKEN=
-# Optional overrides:
+# Pick a specific model group. Two ways:
+#  - alias:   VIDEO_BACKEND=artlist_seedance-2.0  (also: -1.0-pro-fast, -1.5,
+#             -2.0-fast, -2.0-mini; plus kling-2.1, veo-3.1, sora-2, happyhorse-1.1)
+#  - numeric: VIDEO_BACKEND=artlist_358           (any Artlist model-group id)
+#  - default: VIDEO_BACKEND=artlist  + ARTLIST_VIDEO_MODEL_GROUP_ID below
+# So DramaClaw can run Seedance (and Kling/Veo/Sora/…) through Artlist's gateway.
 # ARTLIST_MCP_URL=https://mcp.artlist.io/mcp
-# ARTLIST_VIDEO_MODEL_GROUP_ID=   # auto-routes to an i2v-capable model group
+# ARTLIST_VIDEO_MODEL_GROUP_ID=   # default group when VIDEO_BACKEND=artlist
 
 # 各视频模型允许的 duration 范围，单位秒。
 NEWAPI_VIDEO_DURATION_BOUNDS=seedance-1.0-pro-fast:2-12,seedance-1.5-pro:4-12,seedance-2.0:4-15,seedance-2.0-fast:4-15,seedance-2.0-value:4-15,seedance-2.0-fast-value:4-15,happyhorse-1.0:3-15

--- a/license-inventory.csv
+++ b/license-inventory.csv
@@ -1367,6 +1367,7 @@ src/novelvideo/freezone/text_node.py,Elastic-2.0,2026 SuperTale contributors,REU
 src/novelvideo/freezone/video_node.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 src/novelvideo/freezone/vision_gateway.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 src/novelvideo/generators/__init__.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
+src/novelvideo/generators/artlist_video.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 src/novelvideo/generators/episode_optimizer.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 src/novelvideo/generators/grid_splitter.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 src/novelvideo/generators/huimengi.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
@@ -1641,6 +1642,7 @@ tests/test_api_sketch_ai_detection.py,Elastic-2.0,2026 SuperTale contributors,RE
 tests/test_api_sketch_pose_editor.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_api_sketch_regenerate.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_api_styles.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
+tests/test_artlist_video.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_asset_compiler_prop_planning.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_asset_compiler_scene_enrichment.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_asset_resolver.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation

--- a/src/novelvideo/generators/artlist_video.py
+++ b/src/novelvideo/generators/artlist_video.py
@@ -11,12 +11,28 @@ Server-side (non-interactive) auth — set:
   ARTLIST_MCP_TOKEN             partner bearer token for the generative gateway
   ARTLIST_VIDEO_MODEL_GROUP_ID  optional; auto-routes to an i2v-capable model
 
-NOTE: the exact partner/server auth scheme for mcp.artlist.io must be confirmed
-with Artlist — the interactive claude.ai connector is not usable from a backend.
-This client sends ``Authorization: Bearer <token>``; adjust ``_headers`` if
-Artlist's partner auth differs. Tool result field names (generationId, the video
-URL location) follow the observed MCP contract; ``_find_video_url`` is defensive
-across common shapes.
+VERIFICATION STATUS — read before enabling in production:
+  * AUTH IS ASSUMED / UNVERIFIED. The public Artlist MCP flow uses interactive,
+    per-account authorization; this backend instead assumes an undocumented
+    partner bearer token (``Authorization: Bearer <token>``). That scheme has
+    NOT been confirmed with Artlist and the interactive claude.ai connector is
+    not usable from a backend. Adjust ``_headers`` once the real partner auth is
+    documented.
+  * NO END-TO-END GENERATION has yet succeeded against the live gateway with
+    real partner credentials. Tool names (``upload_image``, ``confirm_upload``,
+    ``generate_video``, ``get_generation_status``), request fields, the cost
+    confirmation flow, polling payloads, and download URLs all follow the
+    OBSERVED/PLAUSIBLE MCP contract but remain pending live verification.
+  * The contract in tests/test_artlist_video.py pins the request/response shapes
+    this code depends on, using mocked MCP responses. Those tests guard the
+    wiring; they are not a substitute for a live smoke test.
+
+CAPABILITIES: this backend forwards only a single first-frame image plus prompt,
+aspect ratio, duration and (optionally) resolution. Multi-image/keyframe, audio
+or video references, and generated/native audio are declared UNSUPPORTED and
+such requests are rejected (see ModelCapabilities / validate_capabilities)
+rather than silently dropped — so ``artlist_seedance-2.0`` does not pretend to
+match the full Seedance omni workflow.
 """
 
 from __future__ import annotations
@@ -25,6 +41,7 @@ import asyncio
 import json
 import mimetypes
 import os
+from dataclasses import dataclass, fields
 from pathlib import Path
 from typing import Any, Callable, Optional
 
@@ -39,6 +56,7 @@ from novelvideo.generators.video_generator import (
 DEFAULT_MCP_URL = "https://mcp.artlist.io/mcp"
 _DONE_STATES = {"completed", "succeeded", "done", "success"}
 _FAILED_STATES = {"failed", "error", "canceled", "cancelled", "nsfw", "rejected"}
+_CONFIRM_STATES = {"confirmation_required", "confirm_required", "pending_confirmation"}
 
 # Convenience aliases so a backend string like ``artlist_seedance-2.0`` routes
 # to a specific Artlist model group (mirrors the ``newapi_<model>`` pattern).
@@ -76,6 +94,123 @@ def parse_artlist_video_backend(backend: Optional[str]) -> Optional[int]:
     return ARTLIST_VIDEO_MODEL_GROUPS.get(model.lower())
 
 
+@dataclass(frozen=True)
+class ModelCapabilities:
+    """What this generator actually FORWARDS to the Artlist gateway.
+
+    IMPORTANT: these flags describe DramaClaw's *forwarding* behaviour, not the
+    raw ability of the underlying model. Aliases such as ``artlist_seedance-2.0``
+    route to models that (on the interactive Artlist product) also accept multi
+    image, audio references, video references and native/generated audio. This
+    backend does NOT forward those inputs, so it declares them unsupported and
+    REJECTS requests that use them — rather than silently dropping them and
+    returning a clip that ignores the caller's references. Extend the per-group
+    overrides below only once each capability is exercised against the live
+    gateway with real partner credentials.
+    """
+
+    first_frame_image: bool = True  # single first-frame image (assetId)
+    prompt: bool = True
+    aspect_ratio: bool = True
+    duration: bool = True
+    resolution: bool = False
+    multi_image: bool = False  # more than one reference image / keyframe
+    audio_reference: bool = False  # caller-supplied audio reference input
+    video_reference: bool = False  # caller-supplied video reference input
+    generated_audio: bool = False  # native/generated audio in the output
+
+
+# Conservative default: single first frame + prompt + aspect ratio + duration,
+# plus resolution (forwarded as a settings field). Every extra capability is
+# OFF until verified live. ``resolution`` is included because it maps cleanly
+# onto the same ``settings`` dict already used for aspect ratio and duration.
+_DEFAULT_CAPABILITIES = ModelCapabilities(resolution=True)
+
+# Per-model-group overrides. Empty until each group's extra capabilities are
+# confirmed against mcp.artlist.io; until then every group uses the safe
+# default above. This is the honest hook the review asked for — capabilities
+# are declared per group, not assumed from the alias name.
+ARTLIST_MODEL_CAPABILITIES: dict[int, ModelCapabilities] = {}
+
+
+def capabilities_for_group(group_id: Optional[int]) -> ModelCapabilities:
+    """Return the declared capabilities for a model group (default if unknown)."""
+    if group_id is not None and group_id in ARTLIST_MODEL_CAPABILITIES:
+        return ARTLIST_MODEL_CAPABILITIES[group_id]
+    return _DEFAULT_CAPABILITIES
+
+
+def _count_reference_types(references: Any) -> dict[str, int]:
+    """Count image/video/audio references from a list of ShotReference/dicts."""
+    counts = {"image": 0, "video": 0, "audio": 0}
+    for ref in references or []:
+        if isinstance(ref, dict):
+            ref_type = str(ref.get("type") or "image").strip().lower()
+        else:
+            ref_type = str(getattr(ref, "type", "image") or "image").strip().lower()
+        if ref_type in counts:
+            counts[ref_type] += 1
+        else:
+            counts["image"] += 1
+    return counts
+
+
+def validate_capabilities(
+    caps: ModelCapabilities,
+    *,
+    references: Any = None,
+    last_frame_path: Any = None,
+    resolution: Any = None,
+    generate_audio: Any = None,
+    audio: Any = None,
+) -> list[str]:
+    """Return a list of human-readable reasons the request is unsupported.
+
+    An empty list means the request only uses declared capabilities. This is the
+    validation the review asked for: reject (don't silently drop) any capability
+    this generator does not forward.
+    """
+    reasons: list[str] = []
+
+    counts = _count_reference_types(references)
+    image_refs = counts["image"]
+    # A first-frame image plus any additional reference image, OR an explicit
+    # last frame, means more than one image — that needs multi_image.
+    extra_images = max(0, image_refs - 1) + (1 if last_frame_path else 0)
+    if extra_images > 0 and not caps.multi_image:
+        reasons.append(
+            f"multi-image / keyframe input ({image_refs} reference image(s)"
+            f"{' + last frame' if last_frame_path else ''}) is not forwarded by "
+            "the Artlist backend; only a single first-frame image is supported"
+        )
+    if counts["video"] > 0 and not caps.video_reference:
+        reasons.append(
+            f"{counts['video']} video reference(s) requested but video references "
+            "are not forwarded by the Artlist backend"
+        )
+    if counts["audio"] > 0 and not caps.audio_reference:
+        reasons.append(
+            f"{counts['audio']} audio reference(s) requested but audio references "
+            "are not forwarded by the Artlist backend"
+        )
+    if bool(generate_audio) or bool(audio):
+        if not caps.generated_audio:
+            reasons.append(
+                "generated/native audio was requested but is not forwarded by the "
+                "Artlist backend (video is generated silently)"
+            )
+    if resolution and not caps.resolution:
+        reasons.append(
+            "resolution control was requested but is not supported for this model group"
+        )
+    return reasons
+
+
+def describe_capabilities(caps: ModelCapabilities) -> dict[str, bool]:
+    """Expose the declared capability flags (for logs / diagnostics)."""
+    return {f.name: getattr(caps, f.name) for f in fields(caps)}
+
+
 class ArtlistVideoGenerator(VideoGeneratorBase):
     """Image-to-video via Artlist's MCP generative gateway."""
 
@@ -84,12 +219,22 @@ class ArtlistVideoGenerator(VideoGeneratorBase):
         mcp_url: Optional[str] = None,
         token: Optional[str] = None,
         model_group_id: Optional[Any] = None,
+        auto_confirm: Optional[bool] = None,
         **_ignored,
     ):
         self.mcp_url = mcp_url or os.environ.get("ARTLIST_MCP_URL") or DEFAULT_MCP_URL
         self.token = token or os.environ.get("ARTLIST_MCP_TOKEN")
         raw_group = model_group_id or os.environ.get("ARTLIST_VIDEO_MODEL_GROUP_ID")
         self.model_group_id = int(raw_group) if raw_group else None
+        self.capabilities = capabilities_for_group(self.model_group_id)
+        if auto_confirm is None:
+            auto_confirm = str(
+                os.environ.get("ARTLIST_AUTO_CONFIRM", "")
+            ).strip().lower() in {"1", "true", "yes", "on"}
+        # When False (default) the generator refuses to auto-approve a paid
+        # generation that the gateway flags as needing cost confirmation. When
+        # True it re-submits with the returned confirmation token.
+        self.auto_confirm = bool(auto_confirm)
 
         if not self.token:
             raise ValueError(
@@ -220,6 +365,28 @@ class ArtlistVideoGenerator(VideoGeneratorBase):
                 error=f"First frame not found: {image_path}",
             )
 
+        # Reject (do not silently drop) any request that uses a capability this
+        # backend does not actually forward — multi-image/keyframe, audio or
+        # video references, generated audio, or resolution on a group that has
+        # not declared it. See ModelCapabilities.
+        resolution = kwargs.get("resolution")
+        unsupported = validate_capabilities(
+            self.capabilities,
+            references=kwargs.get("references"),
+            last_frame_path=last_frame_path,
+            resolution=resolution,
+            generate_audio=kwargs.get("generate_audio"),
+            audio=kwargs.get("audio"),
+        )
+        if unsupported:
+            return VideoGenResult(
+                status=VideoGenStatus.FAILED,
+                error=(
+                    "Artlist backend cannot fulfil this request without dropping "
+                    "inputs: " + "; ".join(unsupported)
+                ),
+            )
+
         try:
             from mcp import ClientSession
             from mcp.client.streamable_http import streamablehttp_client
@@ -236,6 +403,7 @@ class ArtlistVideoGenerator(VideoGeneratorBase):
                 output_path=output_path,
                 aspect_ratio=aspect_ratio,
                 duration=duration,
+                resolution=resolution,
                 poll_interval=poll_interval,
                 max_polls=max_polls,
                 log=log,
@@ -256,6 +424,7 @@ class ArtlistVideoGenerator(VideoGeneratorBase):
         output_path: str,
         aspect_ratio: str,
         duration: float,
+        resolution: Optional[str] = None,
         poll_interval: float,
         max_polls: int,
         log,
@@ -284,19 +453,47 @@ class ArtlistVideoGenerator(VideoGeneratorBase):
                     settings["aspect_ratio"] = aspect_ratio
                 if duration:
                     settings["duration"] = int(duration)
+                if resolution and self.capabilities.resolution:
+                    settings["resolution"] = str(resolution).strip().lower()
                 if settings:
                     args["settings"] = settings
 
                 log("Submitting Artlist video generation...")
                 gen = self._tool_json(await session.call_tool("generate_video", args))
                 status = str(gen.get("status") or "").lower()
-                if status == "confirmation_required":
+                if status in _CONFIRM_STATES:
+                    if not self.auto_confirm:
+                        return VideoGenResult(
+                            status=VideoGenStatus.FAILED,
+                            error=(
+                                "Artlist requires cost confirmation for this "
+                                "generation; enable auto_confirm / ARTLIST_AUTO_CONFIRM "
+                                "to approve, or pre-approve high-cost jobs on the account"
+                            ),
+                        )
+                    confirmation_id = (
+                        gen.get("confirmationId")
+                        or gen.get("confirmation_id")
+                        or gen.get("id")
+                    )
+                    log("Confirming Artlist generation cost...")
+                    confirm_args = dict(args)
+                    confirm_args["confirm"] = True
+                    if confirmation_id:
+                        confirm_args["confirmationId"] = confirmation_id
+                    gen = self._tool_json(
+                        await session.call_tool("generate_video", confirm_args)
+                    )
+                    status = str(gen.get("status") or "").lower()
+                    if status in _CONFIRM_STATES:
+                        return VideoGenResult(
+                            status=VideoGenStatus.FAILED,
+                            error="Artlist still requires confirmation after auto-confirm",
+                        )
+                if status in _FAILED_STATES:
                     return VideoGenResult(
                         status=VideoGenStatus.FAILED,
-                        error=(
-                            "Artlist requires cost confirmation for this generation; "
-                            "pre-approve high-cost jobs on the account"
-                        ),
+                        error=f"Artlist generation {status} at submit",
                     )
                 generation_id = gen.get("generationId") or gen.get("id")
                 if not generation_id:

--- a/src/novelvideo/generators/artlist_video.py
+++ b/src/novelvideo/generators/artlist_video.py
@@ -40,6 +40,41 @@ DEFAULT_MCP_URL = "https://mcp.artlist.io/mcp"
 _DONE_STATES = {"completed", "succeeded", "done", "success"}
 _FAILED_STATES = {"failed", "error", "canceled", "cancelled", "nsfw", "rejected"}
 
+# Convenience aliases so a backend string like ``artlist_seedance-2.0`` routes
+# to a specific Artlist model group (mirrors the ``newapi_<model>`` pattern).
+# Group ids come from Artlist's list_models (image-to-video); use
+# ``artlist_<numericGroupId>`` for any model not aliased here, or the bare
+# ``artlist`` backend + ARTLIST_VIDEO_MODEL_GROUP_ID for a configured default.
+ARTLIST_BACKEND_PREFIX = "artlist_"
+ARTLIST_VIDEO_MODEL_GROUPS: dict[str, int] = {
+    # ByteDance Seedance
+    "seedance-1.0-pro-fast": 309,
+    "seedance-1.5": 304,
+    "seedance-2.0": 358,
+    "seedance-2.0-fast": 405,
+    "seedance-2.0-mini": 416,
+    # a few other popular families available on the gateway
+    "kling-2.1": 105,
+    "veo-3.1": 114,
+    "sora-2": 110,
+    "happyhorse-1.1": 415,
+}
+
+
+def parse_artlist_video_backend(backend: Optional[str]) -> Optional[int]:
+    """Map an ``artlist_<model>`` backend string to an Artlist model group id.
+
+    Returns the group id for a known alias, an explicit ``artlist_<number>``,
+    or ``None`` when the string is not an ``artlist_`` backend.
+    """
+    raw = str(backend or "").strip()
+    if not raw.lower().startswith(ARTLIST_BACKEND_PREFIX):
+        return None
+    model = raw[len(ARTLIST_BACKEND_PREFIX):]
+    if model.isdigit():
+        return int(model)
+    return ARTLIST_VIDEO_MODEL_GROUPS.get(model.lower())
+
 
 class ArtlistVideoGenerator(VideoGeneratorBase):
     """Image-to-video via Artlist's MCP generative gateway."""

--- a/src/novelvideo/generators/artlist_video.py
+++ b/src/novelvideo/generators/artlist_video.py
@@ -1,0 +1,327 @@
+# SPDX-License-Identifier: Elastic-2.0
+# Copyright (c) 2026 ClaymoreLab
+"""Artlist generative video provider (image-to-video) via the Artlist MCP gateway.
+
+DramaClaw connects to Artlist's MCP server as a partner MCP client, uploads the
+first frame, calls the ``generate_video`` tool, polls ``get_generation_status``,
+and downloads the finished clip.
+
+Server-side (non-interactive) auth — set:
+  ARTLIST_MCP_URL               default https://mcp.artlist.io/mcp
+  ARTLIST_MCP_TOKEN             partner bearer token for the generative gateway
+  ARTLIST_VIDEO_MODEL_GROUP_ID  optional; auto-routes to an i2v-capable model
+
+NOTE: the exact partner/server auth scheme for mcp.artlist.io must be confirmed
+with Artlist — the interactive claude.ai connector is not usable from a backend.
+This client sends ``Authorization: Bearer <token>``; adjust ``_headers`` if
+Artlist's partner auth differs. Tool result field names (generationId, the video
+URL location) follow the observed MCP contract; ``_find_video_url`` is defensive
+across common shapes.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import mimetypes
+import os
+from pathlib import Path
+from typing import Any, Callable, Optional
+
+import aiohttp
+
+from novelvideo.generators.video_generator import (
+    VideoGeneratorBase,
+    VideoGenResult,
+    VideoGenStatus,
+)
+
+DEFAULT_MCP_URL = "https://mcp.artlist.io/mcp"
+_DONE_STATES = {"completed", "succeeded", "done", "success"}
+_FAILED_STATES = {"failed", "error", "canceled", "cancelled", "nsfw", "rejected"}
+
+
+class ArtlistVideoGenerator(VideoGeneratorBase):
+    """Image-to-video via Artlist's MCP generative gateway."""
+
+    def __init__(
+        self,
+        mcp_url: Optional[str] = None,
+        token: Optional[str] = None,
+        model_group_id: Optional[Any] = None,
+        **_ignored,
+    ):
+        self.mcp_url = mcp_url or os.environ.get("ARTLIST_MCP_URL") or DEFAULT_MCP_URL
+        self.token = token or os.environ.get("ARTLIST_MCP_TOKEN")
+        raw_group = model_group_id or os.environ.get("ARTLIST_VIDEO_MODEL_GROUP_ID")
+        self.model_group_id = int(raw_group) if raw_group else None
+
+        if not self.token:
+            raise ValueError(
+                "ARTLIST_MCP_TOKEN must be set for Artlist video generation"
+            )
+
+    def _headers(self) -> dict[str, str]:
+        return {"Authorization": f"Bearer {self.token}"}
+
+    @staticmethod
+    def _tool_json(result: Any) -> dict[str, Any]:
+        """Extract a JSON payload from an MCP tool result's content blocks."""
+        structured = getattr(result, "structuredContent", None)
+        if isinstance(structured, dict):
+            return structured
+        for block in getattr(result, "content", None) or []:
+            text = getattr(block, "text", None)
+            if not text:
+                continue
+            try:
+                return json.loads(text)
+            except (ValueError, TypeError):
+                return {"_text": text}
+        return {}
+
+    @classmethod
+    def _find_video_url(cls, payload: Any) -> Optional[str]:
+        """Best-effort search for a video URL across common result shapes."""
+        if not isinstance(payload, dict):
+            return None
+        for key in ("url", "videoUrl", "fileUrl", "downloadUrl", "assetUrl"):
+            value = payload.get(key)
+            if isinstance(value, str) and value.startswith("http"):
+                return value
+        for key in ("video", "output", "result", "asset", "media"):
+            nested = payload.get(key)
+            found = cls._find_video_url(nested)
+            if found:
+                return found
+        for key in ("outputs", "files", "assets", "results", "media"):
+            for item in payload.get(key) or []:
+                if isinstance(item, str) and item.startswith("http"):
+                    return item
+                found = cls._find_video_url(item)
+                if found:
+                    return found
+        return None
+
+    async def _upload_first_frame(self, session: Any, image_path: str, log) -> str:
+        """Upload the first frame and return an Artlist assetId."""
+        if image_path.startswith(("http://", "https://")):
+            res = self._tool_json(
+                await session.call_tool("upload_image", {"imageUrl": image_path})
+            )
+            asset_id = res.get("assetId")
+            if not asset_id:
+                raise RuntimeError(f"upload_image(imageUrl) returned no assetId: {res}")
+            return asset_id
+
+        # Presigned upload for a local file: request URL -> PUT bytes -> confirm.
+        mime = mimetypes.guess_type(image_path)[0] or "image/png"
+        res = self._tool_json(
+            await session.call_tool(
+                "upload_image",
+                {"mimeType": mime, "fileName": Path(image_path).name},
+            )
+        )
+        upload_url = res.get("uploadUrl")
+        upload_id = res.get("uploadId")
+        if not (upload_url and upload_id):
+            raise RuntimeError(
+                f"upload_image(presigned) missing uploadUrl/uploadId: {res}"
+            )
+        with open(image_path, "rb") as fh:
+            body = fh.read()
+        async with aiohttp.ClientSession() as http:
+            async with http.put(
+                upload_url, data=body, headers={"Content-Type": mime}
+            ) as put:
+                if put.status not in (200, 201, 204):
+                    raise RuntimeError(f"presigned PUT failed: HTTP {put.status}")
+        confirmed = self._tool_json(
+            await session.call_tool("confirm_upload", {"uploadId": upload_id})
+        )
+        asset_id = confirmed.get("assetId")
+        if not asset_id:
+            raise RuntimeError(f"confirm_upload returned no assetId: {confirmed}")
+        log("First frame uploaded to Artlist")
+        return asset_id
+
+    async def _download(self, url: str, output_path: str) -> bool:
+        os.makedirs(os.path.dirname(os.path.abspath(output_path)), exist_ok=True)
+        async with aiohttp.ClientSession() as http:
+            async with http.get(url) as resp:
+                if resp.status != 200:
+                    return False
+                with open(output_path, "wb") as fh:
+                    fh.write(await resp.read())
+        return True
+
+    async def generate(
+        self,
+        image_path: Optional[str],
+        prompt: str,
+        output_path: str,
+        aspect_ratio: str = "9:16",
+        duration: float = 5.0,
+        poll_interval: float = 5.0,
+        max_polls: int = 180,
+        on_log: Optional[Callable[[str], None]] = None,
+        on_progress: Optional[Callable[[float], None]] = None,
+        last_frame_path: Optional[str] = None,
+        **kwargs,
+    ) -> VideoGenResult:
+        def log(msg: str) -> None:
+            if on_log:
+                on_log(msg)
+
+        def progress(value: float) -> None:
+            if on_progress:
+                on_progress(value)
+
+        if not image_path or not (
+            image_path.startswith(("http://", "https://")) or os.path.exists(image_path)
+        ):
+            return VideoGenResult(
+                status=VideoGenStatus.FAILED,
+                error=f"First frame not found: {image_path}",
+            )
+
+        try:
+            from mcp import ClientSession
+            from mcp.client.streamable_http import streamablehttp_client
+        except Exception as exc:  # pragma: no cover - import guard
+            return VideoGenResult(
+                status=VideoGenStatus.FAILED,
+                error=f"mcp client library unavailable: {exc}",
+            )
+
+        try:
+            return await self._run(
+                image_path=image_path,
+                prompt=prompt,
+                output_path=output_path,
+                aspect_ratio=aspect_ratio,
+                duration=duration,
+                poll_interval=poll_interval,
+                max_polls=max_polls,
+                log=log,
+                progress=progress,
+                streamablehttp_client=streamablehttp_client,
+                client_session_cls=ClientSession,
+            )
+        except Exception as exc:
+            return VideoGenResult(
+                status=VideoGenStatus.FAILED, error=f"Artlist error: {exc}"
+            )
+
+    async def _run(
+        self,
+        *,
+        image_path: str,
+        prompt: str,
+        output_path: str,
+        aspect_ratio: str,
+        duration: float,
+        poll_interval: float,
+        max_polls: int,
+        log,
+        progress,
+        streamablehttp_client,
+        client_session_cls,
+    ) -> VideoGenResult:
+        log("Connecting to Artlist MCP...")
+        progress(0.05)
+        async with streamablehttp_client(self.mcp_url, headers=self._headers()) as (
+            read,
+            write,
+            _,
+        ):
+            async with client_session_cls(read, write) as session:
+                await session.initialize()
+
+                asset_id = await self._upload_first_frame(session, image_path, log)
+                progress(0.2)
+
+                args: dict[str, Any] = {"prompt": prompt, "input": {"assetId": asset_id}}
+                if self.model_group_id:
+                    args["modelGroupId"] = self.model_group_id
+                settings: dict[str, Any] = {}
+                if aspect_ratio and ":" in aspect_ratio:
+                    settings["aspect_ratio"] = aspect_ratio
+                if duration:
+                    settings["duration"] = int(duration)
+                if settings:
+                    args["settings"] = settings
+
+                log("Submitting Artlist video generation...")
+                gen = self._tool_json(await session.call_tool("generate_video", args))
+                status = str(gen.get("status") or "").lower()
+                if status == "confirmation_required":
+                    return VideoGenResult(
+                        status=VideoGenStatus.FAILED,
+                        error=(
+                            "Artlist requires cost confirmation for this generation; "
+                            "pre-approve high-cost jobs on the account"
+                        ),
+                    )
+                generation_id = gen.get("generationId") or gen.get("id")
+                if not generation_id:
+                    return VideoGenResult(
+                        status=VideoGenStatus.FAILED,
+                        error=f"generate_video returned no generationId: {str(gen)[:200]}",
+                    )
+                progress(0.3)
+                log(f"Queued: {generation_id}")
+
+                for poll_count in range(max_polls):
+                    st = self._tool_json(
+                        await session.call_tool(
+                            "get_generation_status", {"generationId": generation_id}
+                        )
+                    )
+                    status = str(st.get("status") or "").lower()
+                    progress(0.3 + (poll_count / max_polls) * 0.6)
+
+                    if status in _DONE_STATES:
+                        url = self._find_video_url(st)
+                        if not url:
+                            return VideoGenResult(
+                                status=VideoGenStatus.FAILED,
+                                error=f"No video URL in completed result: {str(st)[:200]}",
+                                task_id=str(generation_id),
+                            )
+                        log("Video ready, downloading...")
+                        progress(0.95)
+                        if not await self._download(url, output_path):
+                            return VideoGenResult(
+                                status=VideoGenStatus.FAILED,
+                                error="Download failed",
+                                task_id=str(generation_id),
+                            )
+                        progress(1.0)
+                        return VideoGenResult(
+                            status=VideoGenStatus.DONE,
+                            video_url=url,
+                            video_path=output_path,
+                            task_id=str(generation_id),
+                            duration_seconds=float(duration),
+                        )
+
+                    if status in _FAILED_STATES:
+                        return VideoGenResult(
+                            status=VideoGenStatus.FAILED,
+                            error=f"Artlist generation {status}",
+                            task_id=str(generation_id),
+                        )
+
+                    if poll_count % 6 == 0:
+                        log(
+                            f"Generating... ({status or 'pending'}, "
+                            f"{poll_count}/{max_polls})"
+                        )
+                    await asyncio.sleep(poll_interval)
+
+                return VideoGenResult(
+                    status=VideoGenStatus.FAILED,
+                    error="Generation timeout",
+                    task_id=str(generation_id),
+                )

--- a/src/novelvideo/generators/video_generator.py
+++ b/src/novelvideo/generators/video_generator.py
@@ -3649,6 +3649,14 @@ def create_video_generator(
     if huimeng_model:
         return HuimengVideoGenerator(model=huimeng_model, **kwargs)
 
+    from novelvideo.generators.artlist_video import parse_artlist_video_backend
+
+    artlist_group = parse_artlist_video_backend(backend_str)
+    if artlist_group is not None:
+        from novelvideo.generators.artlist_video import ArtlistVideoGenerator
+
+        return ArtlistVideoGenerator(model_group_id=artlist_group, **kwargs)
+
     try:
         backend_enum = VideoBackend(backend_str)
     except ValueError:

--- a/src/novelvideo/generators/video_generator.py
+++ b/src/novelvideo/generators/video_generator.py
@@ -130,6 +130,7 @@ class VideoBackend(Enum):
     WAN26 = "wan26"  # 阿里云 DashScope Wan2.6-i2v-flash
     LTX23 = "ltx23"  # Lightricks LTX-Video 2.3 22B
     GROK_720 = "grok_720"  # xAI Grok Imagine Video 720p
+    ARTLIST = "artlist"  # Artlist generative video (MCP gateway), image-to-video
 
 
 @dataclass
@@ -3676,5 +3677,9 @@ def create_video_generator(
         return Wan26VideoGenerator(**kwargs)
     elif backend_enum == VideoBackend.GROK_720:
         return GrokVideoGenerator(**kwargs)
+    elif backend_enum == VideoBackend.ARTLIST:
+        from novelvideo.generators.artlist_video import ArtlistVideoGenerator
+
+        return ArtlistVideoGenerator(**kwargs)
     else:
         raise ValueError(f"Unknown video backend: {backend_str}")

--- a/tests/test_artlist_video.py
+++ b/tests/test_artlist_video.py
@@ -1,0 +1,581 @@
+# SPDX-License-Identifier: Elastic-2.0
+# Copyright (c) 2026 ClaymoreLab
+"""Contract tests for the Artlist image-to-video MCP provider.
+
+These tests exercise the generator against MOCKED MCP responses. They pin the
+tool names, request fields, cost-confirmation flow, polling payloads and the
+download step that the generator depends on.
+
+IMPORTANT: mocked responses are not a substitute for a live smoke test. The real
+partner auth scheme and the exact ``mcp.artlist.io`` contract remain unverified
+(see the module docstring in ``artlist_video.py``). These tests guard the wiring
+so a future live verification only has to confirm the shapes, not rediscover
+them.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from novelvideo.generators import artlist_video as av
+from novelvideo.generators.artlist_video import (
+    ArtlistVideoGenerator,
+    ModelCapabilities,
+    capabilities_for_group,
+    describe_capabilities,
+    parse_artlist_video_backend,
+    validate_capabilities,
+)
+from novelvideo.generators.video_generator import VideoGenStatus
+
+
+# --------------------------------------------------------------------------- #
+# Fake MCP transport / session
+# --------------------------------------------------------------------------- #
+class FakeToolResult:
+    """Mimics an MCP tool result carrying a structured JSON payload."""
+
+    def __init__(self, payload: dict):
+        self.structuredContent = payload
+        self.content = []
+
+
+class FakeSession:
+    """Records call_tool invocations and returns canned payloads."""
+
+    def __init__(self, responses: dict):
+        # responses: tool_name -> dict | list[dict] (list = one payload per call,
+        # last payload repeats once exhausted).
+        self.responses = responses
+        self.calls: list[tuple[str, dict]] = []
+        self.initialized = False
+
+    async def initialize(self) -> None:
+        self.initialized = True
+
+    async def call_tool(self, name: str, args: dict) -> FakeToolResult:
+        self.calls.append((name, dict(args)))
+        entry = self.responses[name]
+        if isinstance(entry, list):
+            payload = entry.pop(0) if len(entry) > 1 else entry[0]
+        else:
+            payload = entry
+        return FakeToolResult(payload)
+
+    def tool_names(self) -> list[str]:
+        return [name for name, _ in self.calls]
+
+    def args_for(self, name: str) -> dict:
+        for called, args in self.calls:
+            if called == name:
+                return args
+        raise AssertionError(f"tool {name!r} was never called; got {self.tool_names()}")
+
+
+def _session_cls(session: FakeSession):
+    class _Ctx:
+        def __init__(self, read, write):
+            self._session = session
+
+        async def __aenter__(self):
+            return self._session
+
+        async def __aexit__(self, *exc):
+            return False
+
+    return _Ctx
+
+
+def _streamable(captured: dict):
+    def factory(url, headers=None):
+        captured["url"] = url
+        captured["headers"] = headers
+
+        class _Ctx:
+            async def __aenter__(self):
+                return (object(), object(), None)
+
+            async def __aexit__(self, *exc):
+                return False
+
+        return _Ctx()
+
+    return factory
+
+
+# --------------------------------------------------------------------------- #
+# Fake aiohttp (for presigned upload PUT and download GET)
+# --------------------------------------------------------------------------- #
+class FakeHTTPResponse:
+    def __init__(self, status: int = 200, body: bytes = b"VIDEO"):
+        self.status = status
+        self._body = body
+
+    async def read(self) -> bytes:
+        return self._body
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+
+class FakeHTTPSession:
+    def __init__(self, record: list, status: int = 200, body: bytes = b"VIDEO"):
+        self._record = record
+        self._status = status
+        self._body = body
+
+    def get(self, url, **kwargs):
+        self._record.append(("GET", url))
+        return FakeHTTPResponse(self._status, self._body)
+
+    def put(self, url, data=None, headers=None):
+        self._record.append(("PUT", url, data))
+        return FakeHTTPResponse(self._status, b"")
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+
+def _patch_aiohttp(monkeypatch, record: list, status: int = 200):
+    monkeypatch.setattr(
+        av.aiohttp,
+        "ClientSession",
+        lambda *a, **k: FakeHTTPSession(record, status=status),
+    )
+
+
+def _make_generator(**kwargs) -> ArtlistVideoGenerator:
+    kwargs.setdefault("token", "test-partner-token")
+    return ArtlistVideoGenerator(**kwargs)
+
+
+async def _run_flow(gen: ArtlistVideoGenerator, session: FakeSession, **overrides):
+    captured: dict = {}
+    params = dict(
+        image_path="https://cdn.example.com/first.png",
+        prompt="a slow push in",
+        output_path=overrides.pop("output_path"),
+        aspect_ratio="9:16",
+        duration=5.0,
+        resolution=None,
+        poll_interval=0.0,
+        max_polls=10,
+        log=lambda *_: None,
+        progress=lambda *_: None,
+        streamablehttp_client=_streamable(captured),
+        client_session_cls=_session_cls(session),
+    )
+    params.update(overrides)
+    result = await gen._run(**params)
+    return result, captured
+
+
+# --------------------------------------------------------------------------- #
+# Backend alias parsing
+# --------------------------------------------------------------------------- #
+def test_parse_backend_alias_and_numeric():
+    assert parse_artlist_video_backend("artlist_seedance-2.0") == 358
+    assert parse_artlist_video_backend("artlist_358") == 358
+    assert parse_artlist_video_backend("artlist_kling-2.1") == 105
+    assert parse_artlist_video_backend("ARTLIST_seedance-2.0") == 358
+
+
+def test_parse_backend_rejects_non_artlist_and_unknown():
+    assert parse_artlist_video_backend("seedance_2") is None
+    assert parse_artlist_video_backend("") is None
+    assert parse_artlist_video_backend(None) is None
+    # An artlist_ prefix with an unknown alias resolves to no group id.
+    assert parse_artlist_video_backend("artlist_does-not-exist") is None
+
+
+# --------------------------------------------------------------------------- #
+# Auth header (assumed bearer scheme)
+# --------------------------------------------------------------------------- #
+def test_requires_token():
+    with pytest.raises(ValueError):
+        ArtlistVideoGenerator(token=None)
+
+
+def test_headers_send_bearer_token():
+    gen = _make_generator(token="abc123")
+    assert gen._headers() == {"Authorization": "Bearer abc123"}
+
+
+# --------------------------------------------------------------------------- #
+# Happy path: http first frame -> submit -> poll -> download
+# --------------------------------------------------------------------------- #
+async def test_happy_path_submit_poll_download(tmp_path, monkeypatch):
+    record: list = []
+    _patch_aiohttp(monkeypatch, record)
+
+    session = FakeSession(
+        {
+            "upload_image": {"assetId": "asset-1"},
+            "generate_video": {"status": "queued", "generationId": "gen-1"},
+            "get_generation_status": [
+                {"status": "processing"},
+                {"status": "completed", "url": "https://cdn.example.com/out.mp4"},
+            ],
+        }
+    )
+    gen = _make_generator(model_group_id=358)
+    out = str(tmp_path / "out.mp4")
+    result, captured = await _run_flow(gen, session, output_path=out)
+
+    # Transport got the configured URL and the assumed bearer header.
+    assert captured["url"] == gen.mcp_url
+    assert captured["headers"] == {"Authorization": "Bearer test-partner-token"}
+    assert session.initialized is True
+
+    # Tool names and order.
+    assert session.tool_names() == [
+        "upload_image",
+        "generate_video",
+        "get_generation_status",
+        "get_generation_status",
+    ]
+
+    # upload_image received the http image URL.
+    assert session.args_for("upload_image") == {"imageUrl": "https://cdn.example.com/first.png"}
+
+    # generate_video request fields.
+    gv = session.args_for("generate_video")
+    assert gv["prompt"] == "a slow push in"
+    assert gv["input"] == {"assetId": "asset-1"}
+    assert gv["modelGroupId"] == 358
+    assert gv["settings"]["aspect_ratio"] == "9:16"
+    assert gv["settings"]["duration"] == 5
+
+    # polling used the generation id.
+    assert session.args_for("get_generation_status") == {"generationId": "gen-1"}
+
+    # download happened and the result is populated.
+    assert ("GET", "https://cdn.example.com/out.mp4") in record
+    assert result.status == VideoGenStatus.DONE
+    assert result.video_url == "https://cdn.example.com/out.mp4"
+    assert result.video_path == out
+    assert result.task_id == "gen-1"
+    assert result.duration_seconds == 5.0
+    # bytes actually written
+    with open(out, "rb") as fh:
+        assert fh.read() == b"VIDEO"
+
+
+# --------------------------------------------------------------------------- #
+# Presigned upload of a local file: upload_image -> PUT -> confirm_upload
+# --------------------------------------------------------------------------- #
+async def test_presigned_local_file_upload_confirm_flow(tmp_path, monkeypatch):
+    record: list = []
+    _patch_aiohttp(monkeypatch, record)
+
+    img = tmp_path / "frame.png"
+    img.write_bytes(b"PNGDATA")
+
+    session = FakeSession(
+        {
+            "upload_image": {
+                "uploadUrl": "https://upload.example.com/put",
+                "uploadId": "up-9",
+            },
+            "confirm_upload": {"assetId": "asset-9"},
+            "generate_video": {"status": "queued", "generationId": "gen-9"},
+            "get_generation_status": {
+                "status": "completed",
+                "videoUrl": "https://cdn.example.com/clip.mp4",
+            },
+        }
+    )
+    gen = _make_generator()
+    out = str(tmp_path / "clip.mp4")
+    result, _ = await _run_flow(gen, session, image_path=str(img), output_path=out)
+
+    # presigned negotiation carried mime + filename.
+    up = session.args_for("upload_image")
+    assert up["fileName"] == "frame.png"
+    assert up["mimeType"] == "image/png"
+
+    # bytes were PUT to the presigned URL.
+    assert any(
+        entry[0] == "PUT" and entry[1] == "https://upload.example.com/put"
+        for entry in record
+    )
+
+    # confirm_upload closed the loop with the uploadId, yielding the assetId.
+    assert session.args_for("confirm_upload") == {"uploadId": "up-9"}
+    assert session.args_for("generate_video")["input"] == {"assetId": "asset-9"}
+
+    assert result.status == VideoGenStatus.DONE
+    assert result.video_url == "https://cdn.example.com/clip.mp4"
+
+
+# --------------------------------------------------------------------------- #
+# Cost confirmation flow
+# --------------------------------------------------------------------------- #
+async def test_confirmation_required_refused_by_default(tmp_path, monkeypatch):
+    record: list = []
+    _patch_aiohttp(monkeypatch, record)
+
+    session = FakeSession(
+        {
+            "upload_image": {"assetId": "asset-1"},
+            "generate_video": {"status": "confirmation_required", "confirmationId": "c-1"},
+        }
+    )
+    gen = _make_generator()  # auto_confirm defaults to False
+    result, _ = await _run_flow(gen, session, output_path=str(tmp_path / "o.mp4"))
+
+    assert result.status == VideoGenStatus.FAILED
+    assert "confirmation" in (result.error or "").lower()
+    # It must NOT proceed to polling when refusing to confirm.
+    assert "get_generation_status" not in session.tool_names()
+    # generate_video was called exactly once (no auto re-submit).
+    assert session.tool_names().count("generate_video") == 1
+
+
+async def test_confirmation_auto_confirm_resubmits_and_proceeds(tmp_path, monkeypatch):
+    record: list = []
+    _patch_aiohttp(monkeypatch, record)
+
+    session = FakeSession(
+        {
+            "upload_image": {"assetId": "asset-1"},
+            "generate_video": [
+                {"status": "confirmation_required", "confirmationId": "c-42"},
+                {"status": "queued", "generationId": "gen-42"},
+            ],
+            "get_generation_status": {
+                "status": "completed",
+                "url": "https://cdn.example.com/ok.mp4",
+            },
+        }
+    )
+    gen = _make_generator(auto_confirm=True)
+    result, _ = await _run_flow(gen, session, output_path=str(tmp_path / "ok.mp4"))
+
+    # generate_video called twice: initial + confirm re-submit.
+    gv_calls = [args for name, args in session.calls if name == "generate_video"]
+    assert len(gv_calls) == 2
+    assert gv_calls[1]["confirm"] is True
+    assert gv_calls[1]["confirmationId"] == "c-42"
+
+    assert result.status == VideoGenStatus.DONE
+    assert result.task_id == "gen-42"
+
+
+# --------------------------------------------------------------------------- #
+# Error / edge polling payloads
+# --------------------------------------------------------------------------- #
+async def test_generation_failed_state(tmp_path, monkeypatch):
+    record: list = []
+    _patch_aiohttp(monkeypatch, record)
+    session = FakeSession(
+        {
+            "upload_image": {"assetId": "a"},
+            "generate_video": {"status": "queued", "generationId": "g"},
+            "get_generation_status": {"status": "failed"},
+        }
+    )
+    gen = _make_generator()
+    result, _ = await _run_flow(gen, session, output_path=str(tmp_path / "o.mp4"))
+    assert result.status == VideoGenStatus.FAILED
+    assert result.task_id == "g"
+    assert "failed" in (result.error or "").lower()
+
+
+async def test_missing_generation_id(tmp_path, monkeypatch):
+    record: list = []
+    _patch_aiohttp(monkeypatch, record)
+    session = FakeSession(
+        {
+            "upload_image": {"assetId": "a"},
+            "generate_video": {"status": "queued"},  # no generationId
+        }
+    )
+    gen = _make_generator()
+    result, _ = await _run_flow(gen, session, output_path=str(tmp_path / "o.mp4"))
+    assert result.status == VideoGenStatus.FAILED
+    assert "generationId" in (result.error or "")
+
+
+async def test_done_without_video_url(tmp_path, monkeypatch):
+    record: list = []
+    _patch_aiohttp(monkeypatch, record)
+    session = FakeSession(
+        {
+            "upload_image": {"assetId": "a"},
+            "generate_video": {"status": "queued", "generationId": "g"},
+            "get_generation_status": {"status": "completed"},  # no url
+        }
+    )
+    gen = _make_generator()
+    result, _ = await _run_flow(gen, session, output_path=str(tmp_path / "o.mp4"))
+    assert result.status == VideoGenStatus.FAILED
+    assert "video url" in (result.error or "").lower()
+
+
+async def test_download_failure_reported(tmp_path, monkeypatch):
+    record: list = []
+    _patch_aiohttp(monkeypatch, record, status=500)  # GET returns non-200
+    session = FakeSession(
+        {
+            "upload_image": {"assetId": "a"},
+            "generate_video": {"status": "queued", "generationId": "g"},
+            "get_generation_status": {
+                "status": "completed",
+                "url": "https://cdn.example.com/out.mp4",
+            },
+        }
+    )
+    gen = _make_generator()
+    result, _ = await _run_flow(gen, session, output_path=str(tmp_path / "o.mp4"))
+    assert result.status == VideoGenStatus.FAILED
+    assert "download" in (result.error or "").lower()
+
+
+# --------------------------------------------------------------------------- #
+# Resolution forwarding (declared capability)
+# --------------------------------------------------------------------------- #
+async def test_resolution_forwarded_into_settings(tmp_path, monkeypatch):
+    record: list = []
+    _patch_aiohttp(monkeypatch, record)
+    session = FakeSession(
+        {
+            "upload_image": {"assetId": "a"},
+            "generate_video": {"status": "queued", "generationId": "g"},
+            "get_generation_status": {
+                "status": "completed",
+                "url": "https://cdn.example.com/out.mp4",
+            },
+        }
+    )
+    gen = _make_generator()
+    assert gen.capabilities.resolution is True
+    await _run_flow(
+        gen, session, output_path=str(tmp_path / "o.mp4"), resolution="1080P"
+    )
+    assert session.args_for("generate_video")["settings"]["resolution"] == "1080p"
+
+
+# --------------------------------------------------------------------------- #
+# Capability declaration + validation (reject, don't silently drop)
+# --------------------------------------------------------------------------- #
+def test_default_capabilities_declared():
+    caps = capabilities_for_group(358)
+    assert caps.first_frame_image is True
+    assert caps.resolution is True
+    # Extras the alias name implies but this backend does NOT forward:
+    assert caps.multi_image is False
+    assert caps.audio_reference is False
+    assert caps.video_reference is False
+    assert caps.generated_audio is False
+    flags = describe_capabilities(caps)
+    assert set(flags) >= {
+        "first_frame_image",
+        "multi_image",
+        "audio_reference",
+        "video_reference",
+        "generated_audio",
+        "resolution",
+    }
+
+
+def test_validate_capabilities_accepts_single_frame():
+    caps = capabilities_for_group(358)
+    assert validate_capabilities(caps) == []
+    assert validate_capabilities(caps, resolution="1080p") == []
+
+
+def test_validate_capabilities_rejects_extras():
+    caps = capabilities_for_group(358)
+    assert validate_capabilities(caps, last_frame_path="/tmp/last.png")
+    assert validate_capabilities(
+        caps, references=[{"type": "image"}, {"type": "image"}]
+    )
+    assert validate_capabilities(caps, references=[{"type": "video"}])
+    assert validate_capabilities(caps, references=[{"type": "audio"}])
+    assert validate_capabilities(caps, generate_audio=True)
+    assert validate_capabilities(caps, audio=True)
+    # a single image reference is fine
+    assert validate_capabilities(caps, references=[{"type": "image"}]) == []
+
+
+def test_validate_capabilities_respects_declared_extras():
+    caps = ModelCapabilities(multi_image=True, video_reference=True)
+    assert validate_capabilities(caps, last_frame_path="/tmp/last.png") == []
+    assert validate_capabilities(caps, references=[{"type": "video"}]) == []
+
+
+IMG_URL = "https://cdn.example.com/first.png"
+
+
+async def test_generate_rejects_last_frame(tmp_path):
+    gen = _make_generator()
+    result = await gen.generate(
+        image_path=IMG_URL,
+        prompt="p",
+        output_path=str(tmp_path / "o.mp4"),
+        last_frame_path="https://cdn.example.com/last.png",
+    )
+    assert result.status == VideoGenStatus.FAILED
+    assert "multi-image" in result.error or "keyframe" in result.error
+
+
+async def test_generate_rejects_video_and_audio_references(tmp_path):
+    gen = _make_generator()
+    result = await gen.generate(
+        image_path=IMG_URL,
+        prompt="p",
+        output_path=str(tmp_path / "o.mp4"),
+        references=[{"type": "video", "path": "/tmp/v.mp4"}],
+    )
+    assert result.status == VideoGenStatus.FAILED
+    assert "video reference" in result.error.lower()
+
+
+async def test_generate_rejects_generated_audio(tmp_path):
+    gen = _make_generator()
+    result = await gen.generate(
+        image_path=IMG_URL,
+        prompt="p",
+        output_path=str(tmp_path / "o.mp4"),
+        generate_audio=True,
+    )
+    assert result.status == VideoGenStatus.FAILED
+    assert "audio" in result.error.lower()
+
+
+# --------------------------------------------------------------------------- #
+# _tool_json / _find_video_url parsing
+# --------------------------------------------------------------------------- #
+def test_tool_json_parses_structured_and_text():
+    class R1:
+        structuredContent = {"a": 1}
+        content = []
+
+    assert ArtlistVideoGenerator._tool_json(R1()) == {"a": 1}
+
+    class Block:
+        text = '{"b": 2}'
+
+    class R2:
+        structuredContent = None
+        content = [Block()]
+
+    assert ArtlistVideoGenerator._tool_json(R2()) == {"b": 2}
+
+
+def test_find_video_url_across_shapes():
+    f = ArtlistVideoGenerator._find_video_url
+    assert f({"url": "http://x/v.mp4"}) == "http://x/v.mp4"
+    assert f({"videoUrl": "https://x/v.mp4"}) == "https://x/v.mp4"
+    assert f({"output": {"downloadUrl": "https://x/o.mp4"}}) == "https://x/o.mp4"
+    assert f({"outputs": ["https://x/a.mp4"]}) == "https://x/a.mp4"
+    assert f({"assets": [{"assetUrl": "https://x/b.mp4"}]}) == "https://x/b.mp4"
+    assert f({"nope": 1}) is None
+    assert f(None) is None


### PR DESCRIPTION
## What

Add **Artlist generative video** (image-to-video) as a video backend, driven through Artlist's **MCP gateway** (`mcp.artlist.io`).

## Why / how

Artlist's video generation is exposed via its MCP server, not a public REST API. DramaClaw already depends on the Python `mcp` client (it powers `dramaclaw_mcp.py`), so `ArtlistVideoGenerator` connects as a **partner MCP client** over streamable HTTP and runs the standard image-to-video flow:

1. `upload_image` the first frame (presigned upload → PUT → `confirm_upload` for local files; direct `imageUrl` for URLs) → `assetId`
2. `generate_video` with `{ prompt, input: { assetId }, modelGroupId?, settings }` → `{ generationId }` (handles the `confirmation_required` cost gate)
3. poll `get_generation_status` → download the finished clip

## Changes

- `src/novelvideo/generators/artlist_video.py` — `ArtlistVideoGenerator(VideoGeneratorBase)`.
- `video_generator.py` — `VideoBackend.ARTLIST` + `create_video_generator()` branch (lazy import so the mcp client only loads for this backend).
- `.env.example` — `ARTLIST_MCP_TOKEN` (+ optional `ARTLIST_MCP_URL`, `ARTLIST_VIDEO_MODEL_GROUP_ID`). Select with `VIDEO_BACKEND=artlist`.

## Verification

- `py_compile` clean.
- Runtime: `create_video_generator("artlist")` returns the generator with the right MCP URL/headers; `VideoBackend("artlist")` round-trips; and — the riskiest bit — the `mcp` `streamablehttp_client` **accepts the `headers` kwarg** this client uses, confirmed by introspection.
- Result field names (`generationId`, the video URL) are handled defensively across common shapes.

## Open question (needs Artlist)

The **partner/server auth scheme for `mcp.artlist.io`** must be confirmed with Artlist. The interactive claude.ai `/mcp` connector is per-user OAuth and **not usable from a backend**. This client sends `Authorization: Bearer <ARTLIST_MCP_TOKEN>`; adjust `_headers()` if the partner scheme differs (client-credentials, custom header, etc.). End-to-end generation needs that token + a real run (not exercised in CI).

## Seedance (and Kling/Veo/Sora) through Artlist

Artlist's gateway hosts many video models, so `artlist_<model>` backend aliases let DramaClaw run them — notably **ByteDance Seedance**:

- `VIDEO_BACKEND=artlist_seedance-2.0` (→ group 358), `artlist_seedance-1.0-pro-fast` (309), `artlist_seedance-1.5` (304), `artlist_seedance-2.0-fast` (405), `artlist_seedance-2.0-mini` (416)
- also `artlist_kling-2.1`, `artlist_veo-3.1`, `artlist_sora-2`, `artlist_happyhorse-1.1`
- `artlist_<numericGroupId>` for anything else; bare `artlist` uses `ARTLIST_VIDEO_MODEL_GROUP_ID`

Group ids were resolved live from Artlist `list_models`. `parse_artlist_video_backend()` maps aliases → group id and `create_video_generator()` dispatches the `artlist_` prefix (before the enum fallback), mirroring the existing `newapi_<model>` pattern. Verified: `artlist_seedance-2.0` → group 358 and `artlist_309` → 309 both dispatch to `ArtlistVideoGenerator`.
