### PR TITLE
chore: prepare v1.1.5 release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "supertale-ce"
-version = "1.1.4"
+version = "1.1.5"
 description = "SuperTale Community Edition API and video pipeline"
 readme = "README.md"
 requires-python = ">=3.11,<3.13"

--- a/src/novelvideo/release-notes.md
+++ b/src/novelvideo/release-notes.md
@@ -1,34 +1,40 @@
 ---
-version: 1.1.4
+version: 1.1.5
 attention: low
 ---
-# v1.1.4
+# v1.1.5
 
 ## User-facing Highlights (zh)
 
-- **知识图谱可视化**: 小说导入完成后可直接查看知识图谱,支持缩放、拖动、展开节点并检查关系和属性。
-- **图片与视频构图更准确**: Seedance 首帧、Beat 渲染和视频裁剪会遵循实际素材或所选输出比例,蒙版编辑也能更准确识别指定区域。
-- **知识图谱构建更稳定**: 项目会固定使用对应的嵌入模型与网关,并限制并发请求,减少配置变化、并行任务和上游限流造成的失败。
-- **操作前置校验更清楚**: 未导入小说时规划角色、场景或剧集会直接提示先导入内容,不会创建无效任务或产生扣费。
+- **视频素材工作流更完整**: 视频节点可一次导入多张图片、视频和音频,并按模型能力提供全能参考、图片参考和首尾帧入口,提交前会明确拦截不支持的素材与越界音频。
+- **画布查找与保存更可靠**: 历史资产支持按提示词和名称搜索,并修复自动保存并发造成的虚假 409 冲突。
+- **小说导入可安全重建**: 知识图谱构建会识别上游失败、空图和不完整结果,失败后可复用原小说安全重试或重建。
+- **登录与设置体验更稳定**: 登录过期后会停止重复请求并正确返回登录页,媒体存储凭据支持只更新需要变更的字段,关键界面的中英文显示也更完整。
 
 ## User-facing Highlights (en)
 
-- **Knowledge graph visualization**: Explore the imported novel's knowledge graph with pan, zoom, node expansion, relationships, and property details.
-- **More accurate image and video framing**: Seedance first frames, Beat renders, and video crops now follow the actual source or selected output ratio, while mask edits identify the intended region more reliably.
-- **More reliable knowledge graph builds**: Projects retain their assigned embedding model and gateway, with bounded concurrency to reduce failures from configuration changes, parallel work, and upstream rate limits.
-- **Clearer prerequisite checks**: Character, scene, and episode planning now asks for an imported novel before creating a task or reserving credits.
+- **More complete video reference workflows**: Import multiple images, videos, and audio clips directly into a video node, choose model-appropriate reference modes, and catch unsupported media or invalid audio durations before submission.
+- **Faster asset discovery and safer saves**: Search generation history by prompt or name, while serialized canvas saves prevent false 409 conflicts caused by overlapping autosaves.
+- **Safe novel import rebuilds**: Knowledge graph imports now detect provider failures, empty graphs, and incomplete runs, then reuse the original novel for a bounded retry or confirmed rebuild.
+- **More reliable sessions and settings**: Expired sessions stop repeated background requests and return to sign-in, media credentials support partial updates, and key screens provide more complete Chinese and English localization.
 
 ## New Features
 
-- 新增导入小说知识图谱的交互式可视化,支持查看节点、关系和属性 (#161).
+- 历史资产支持按提示词和名称搜索,并提供跨分类命中提示 (#178).
+- 视频节点支持一次选择多张本地图片、视频和音频,自动创建上游素材节点和分组 (#181).
+- EE 登录页新增可配置的“更多信息”菜单,支持链接、图片和 Markdown 内容 (#184).
 
 ## Bug Fixes
 
-- 未导入小说时阻止角色、场景和剧集规划,避免无效任务及扣费 (#162).
-- 修复 Seedance 首帧方向、Beat 渲染比例和视频输入裁剪与目标比例不一致的问题 (#166, #167, #168).
-- 修复不同项目的知识图谱嵌入模型和网关配置相互影响的问题 (#170).
-- 修复蒙版编辑区域仅存在于透明通道、视觉模型无法准确定位的问题 (#174).
+- 修复画布自动保存并发导致的虚假版本冲突和跨画布误写风险 (#179).
+- 修复 Seedance 1.x 静默忽略视频、音频或多图素材的问题,提交前会给出明确原因 (#187).
+- 修复 Seedance 2.0 音频参考时长越界后才由厂商返回错误的问题 (#196).
+- 修复登录过期后任务流和后台请求持续重试,以及无效 cookie 无法清理的问题 (Fixes #197, #198).
+- 修复 Freezone AI 摆件在发送模型请求前因失效导入而失败的问题 (#199).
+- 修复知识图谱构建失败被误报成功,并支持复用原小说安全重试和重建 (#200).
 
 ## Improvements
 
-- 限制单次知识图谱流水线的模型与嵌入并发请求,降低上游限流导致的导入失败 (#171).
+- 视频空态入口按模型能力展示全能参考、图片参考和首尾帧等可用模式 (#185).
+- OSS 与 Cloudinary 媒体存储凭据支持部分更新,无需重复填写整组配置 (Fixes #182, #183).
+- 补齐角色统计、风格、Beat 工作台、分享弹窗和虾画等关键界面的中英文文案 (#191).

--- a/tests/test_release_feed.py
+++ b/tests/test_release_feed.py
@@ -114,7 +114,7 @@ def test_built_wheel_contains_parseable_release_notes_artifact(tmp_path: Path) -
 def test_project_version_is_single_source_of_truth() -> None:
     pyproject = tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))
 
-    assert pyproject["project"]["version"] == "1.1.4"
+    assert pyproject["project"]["version"] == "1.1.5"
     assert importlib.metadata.version("supertale-ce") == pyproject["project"]["version"]
     assert "__version__" not in Path("src/novelvideo/__init__.py").read_text(encoding="utf-8")
 

--- a/uv.lock
+++ b/uv.lock
@@ -3419,7 +3419,7 @@ wheels = [
 
 [[package]]
 name = "supertale-ce"
-version = "1.1.4"
+version = "1.1.5"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## PR 类型 / Type of PR
- [ ] 🐞 Bug 修复 / Bug fix
- [ ] ✨ 新功能 / Feature
- [x] 📝 文档 / Documentation
- [ ] 🧹 重构 / 清理 / Refactor or cleanup
- [x] ⚙️ 构建 / CI / Build or CI
- [ ] ⚠️ 破坏性变更 / Breaking change

## 改动说明 / What this PR does and why

- 将 `supertale-ce` 版本从 `1.1.4` 更新为 `1.1.5`,并同步锁文件和版本单一真源测试。
- 按发布规范更新包内中英文 release notes,整理 v1.1.4 之后合入的视频素材、画布保存、小说导入、登录与设置相关改进。
- 为合入后创建 `v1.1.5` tag、GitHub Release 和发布镜像做好准备。

## 关联 issue / Linked issues

N/A

## 给 reviewer 的说明 / Notes for the reviewer

- 分支直接基于创建时最新的 `origin/main` (`ed100f0`)。
- 本 PR 仅准备版本元数据和包内发布说明;审核合入前不会创建 tag 或 GitHub Release。
- 请重点核对中英文 Highlights 和分类条目是否准确覆盖 #178、#179、#181、#183、#184、#185、#187、#191、#196、#198、#199、#200。

## 面向用户的变更 / User-facing change

```release-note
v1.1.5 完善视频素材工作流和历史资产搜索,并改进画布保存、小说导入重建、登录会话与媒体设置稳定性。
```

## 自检 / Checklist
- [x] 已自测,`uv run pytest` 通过 / Self-tested, `uv run pytest` passes
- [x] 必要的文档已更新 / Docs updated where needed
- [x] 提交信息清晰（建议 Conventional Commits）/ Clear commits (Conventional Commits suggested)
- [x] 每个 commit 都已 `git commit -s` 附 DCO 签署 / Every commit signed off with `git commit -s` (DCO)
- [x] 我已阅读并同意[贡献者协议](../CONTRIBUTING.md#贡献者协议) / I've read and agree to the [contributor terms](../CONTRIBUTING.md#贡献者协议)

## 验证 / Verification

- `UV_CACHE_DIR=/claymorelab/.uv-cache uv lock`
- `UV_CACHE_DIR=/claymorelab/.uv-cache uv pip install -e .`
- `UV_CACHE_DIR=/claymorelab/.uv-cache uv run pytest tests/test_release_feed.py` (12 passed)
- `UV_CACHE_DIR=/claymorelab/.uv-cache uv run pytest tests/test_p0b_compliance_generator.py` (15 passed)
- `git diff --check`
