### PR TITLE
feat(canvas): 底部工具栏加入移动 / 抓手工具（V / H）

### DIFF
--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -2869,6 +2869,9 @@
       "unlock": "Unlock Canvas",
       "organize": "Organize / Locate Canvas",
       "organizeShortcut": "⌥⇧F",
+      "toolMove": "Move",
+      "toolHand": "Hand",
+      "toolGroupLabel": "Canvas pointer tool",
       "hideEdges": "Hide connections",
       "showEdges": "Show connections"
     },

--- a/frontend/public/locales/zh/translation.json
+++ b/frontend/public/locales/zh/translation.json
@@ -2869,6 +2869,9 @@
       "unlock": "解锁画布",
       "organize": "整理 / 定位画布",
       "organizeShortcut": "⌥⇧F",
+      "toolMove": "移动工具",
+      "toolHand": "抓手工具",
+      "toolGroupLabel": "画布指针工具",
       "hideEdges": "隐藏连线",
       "showEdges": "显示连线"
     },

--- a/frontend/src/__tests__/features/canvas/canvas-tool-menu.test.tsx
+++ b/frontend/src/__tests__/features/canvas/canvas-tool-menu.test.tsx
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: Elastic-2.0
+// Copyright (c) 2026 ClaymoreLab
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { CanvasQuickActionBar } from "@/features/canvas/ui/CanvasQuickActionBar";
+import { useCanvasToolStore } from "@/features/canvas/ui/canvasToolStore";
+
+const translations: Record<string, string> = {
+  "canvas.quickbar.addNode": "添加节点",
+  "canvas.quickbar.history": "历史资产",
+  "canvas.quickbar.shortcuts": "快捷键",
+  "canvas.quickbar.help": "帮助",
+  "canvas.quickbar.viewManual": "查看手册",
+  "canvas.toolbar.toolMove": "移动",
+  "canvas.toolbar.toolHand": "抓手工具",
+  "canvas.toolbar.toolGroupLabel": "画布指针工具",
+};
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => translations[key] ?? key }),
+}));
+
+// 这三个面板只有点开对应入口才渲染，但 import 链会把 three.js / 画布 store 一起拖进
+// jsdom。这里只测工具菜单，直接替身掉。
+vi.mock("@/features/canvas/ui/CanvasAddNodePanel", () => ({
+  CanvasAddNodePanel: () => <div data-testid="add-node-panel" />,
+}));
+vi.mock("@/features/canvas/ui/CanvasShortcutsPanel", () => ({
+  CanvasShortcutsPanel: () => <div data-testid="shortcuts-panel" />,
+}));
+vi.mock("@/features/canvas/ui/CanvasHistoryAssetsModal", () => ({
+  CanvasHistoryAssetsModal: () => <div data-testid="history-modal" />,
+}));
+
+function renderBar() {
+  render(
+    <CanvasQuickActionBar
+      skillItems={[]}
+      onAddNode={vi.fn()}
+      onAddSkill={vi.fn()}
+      onUseAsset={vi.fn()}
+      onDeleteNode={vi.fn()}
+    />,
+  );
+  return screen.getByRole("button", { name: "画布指针工具" });
+}
+
+describe("画布底部工具栏 — 移动 / 抓手工具", () => {
+  beforeEach(() => {
+    useCanvasToolStore.setState({ tool: "move" });
+  });
+
+  it("默认是移动工具", () => {
+    expect(useCanvasToolStore.getState().tool).toBe("move");
+  });
+
+  it("点开工具按钮弹出两行菜单，选抓手把画布切到抓手模式并收起菜单", async () => {
+    const user = userEvent.setup();
+    const toolButton = renderBar();
+
+    expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+
+    await user.click(toolButton);
+    const menu = screen.getByRole("menu", { name: "画布指针工具" });
+    expect(menu).toBeInTheDocument();
+
+    const move = screen.getByRole("menuitemradio", { name: /移动/ });
+    const hand = screen.getByRole("menuitemradio", { name: /抓手工具/ });
+    expect(move).toHaveAttribute("aria-checked", "true");
+    expect(hand).toHaveAttribute("aria-checked", "false");
+
+    await user.click(hand);
+    expect(useCanvasToolStore.getState().tool).toBe("hand");
+    expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+  });
+
+  it("菜单里能切回移动工具", async () => {
+    const user = userEvent.setup();
+    useCanvasToolStore.setState({ tool: "hand" });
+    const toolButton = renderBar();
+
+    await user.click(toolButton);
+    await user.click(screen.getByRole("menuitemradio", { name: /移动/ }));
+    expect(useCanvasToolStore.getState().tool).toBe("move");
+  });
+
+  // 菜单收起后，按钮本身是「现在是不是抓手」的唯一提示。
+  it("抓手模式下按钮的悬浮提示报抓手和它的快捷键", async () => {
+    const user = userEvent.setup();
+    const toolButton = renderBar();
+
+    expect(screen.getByText("移动 V")).toBeInTheDocument();
+
+    await user.click(toolButton);
+    await user.click(screen.getByRole("menuitemradio", { name: /抓手工具/ }));
+
+    expect(screen.getByText("抓手工具 H")).toBeInTheDocument();
+    expect(screen.queryByText("移动 V")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/features/canvas/Canvas.tsx
+++ b/frontend/src/features/canvas/Canvas.tsx
@@ -119,6 +119,7 @@ import { CanvasMinimapButton } from './ui/CanvasMinimapButton';
 import { CanvasFpsMeter } from './ui/CanvasFpsMeter';
 import { CanvasSnapAlignButton } from './snap-align/CanvasSnapAlignButton';
 import { useTrackpadPanStore } from './trackpad-pan/trackpadPanStore';
+import { useCanvasToolStore } from './ui/canvasToolStore';
 import { SnapAlignGuides } from './snap-align/SnapAlignGuides';
 import { useSnapAlignStore } from './snap-align/snapAlignStore';
 import {
@@ -148,6 +149,9 @@ const PAN_ACTIVATION_KEY_CODE = 'Space';
 // (button 1). Left drag (0) runs the custom marquee box-select on the empty pane;
 // right click (2) opens the canvas context menu.
 const PAN_ON_DRAG_BUTTONS = [1];
+// 抓手工具（H）下左键也平移。ReactFlow 见到数组里有 0 会给 pane 挂 .draggable，
+// 抓手光标由它自带的样式负责。
+const PAN_ON_DRAG_BUTTONS_HAND = [0, 1];
 const NODE_SPAWN_PLUS_HIDE_DELAY_MS = 400;
 
 function resolveCenteredViewport(
@@ -1008,6 +1012,8 @@ export function Canvas({
   // 触控板平移开关：开启后用 ReactFlow 的 panOnScroll（两指滑动平移、捏合缩放），
   // 关闭则回到默认的滚轮缩放。
   const trackpadPanEnabled = useTrackpadPanStore((state) => state.enabled);
+  // 指针工具：抓手（H）下左键拖动 = 平移画布。
+  const handToolActive = useCanvasToolStore((state) => state.tool === 'hand');
   // 底部任务中心面板展开时，让出底部空间——隐藏画布快捷操作栏，避免与面板重叠。
   const taskPanelOpen = useAppStore((state) => state.taskPanelOpen);
   // Stable signatures of the nodes that need polling / resume, so those effects
@@ -2173,7 +2179,9 @@ export function Canvas({
       }
       // Space + left-drag is a pan gesture (React Flow's panActivationKeyCode).
       // Don't start a marquee on top of it, or a dashed box shows while panning.
-      if (spacePanActiveRef.current) {
+      // 抓手工具是同一回事，只是长按在工具上而不是空格上 —— 从 store 现读，免得
+      // 这个 effect 为了一个开关重新挂一遍 pointer 监听。
+      if (spacePanActiveRef.current || useCanvasToolStore.getState().tool === 'hand') {
         clearMarqueeSelection();
         return;
       }
@@ -2203,7 +2211,8 @@ export function Canvas({
       if (!gesture || event.pointerId !== gesture.pointerId) {
         return;
       }
-      if (spacePanActiveRef.current) {
+      // 拖到一半按下空格或 H 切到抓手：框选就地放弃，别让虚线框跟着平移一起走。
+      if (spacePanActiveRef.current || useCanvasToolStore.getState().tool === 'hand') {
         clearMarqueeSelection();
         return;
       }
@@ -2244,7 +2253,8 @@ export function Canvas({
       if (!gesture || event.pointerId !== gesture.pointerId) {
         return;
       }
-      if (spacePanActiveRef.current) {
+      // 拖到一半按下空格或 H 切到抓手：框选就地放弃，别让虚线框跟着平移一起走。
+      if (spacePanActiveRef.current || useCanvasToolStore.getState().tool === 'hand') {
         clearMarqueeSelection();
         return;
       }
@@ -2583,6 +2593,14 @@ export function Canvas({
       if (isOrganize) {
         event.preventDefault();
         handleOrganizeCanvas();
+        return;
+      }
+
+      // V = 移动工具，H = 抓手（Figma / liblib 同款）。必须是光秃秃的按键：带上
+      // ⌘/Ctrl 的 V 是粘贴，带 Alt 的字母多半是系统输入法在组字。
+      if (!commandPressed && !event.altKey && !event.shiftKey && (key === 'v' || key === 'h')) {
+        event.preventDefault();
+        useCanvasToolStore.getState().setTool(key === 'v' ? 'move' : 'hand');
         return;
       }
 
@@ -4506,6 +4524,7 @@ export function Canvas({
     <CreditDisplayHiddenProvider value={isCeRuntime()}>
     <div
       ref={wrapperRef}
+      data-canvas-tool={handToolActive ? 'hand' : 'move'}
       className="relative h-full w-full bg-background"
       onDragEnter={handleCanvasDragEnter}
       onDragOver={handleCanvasDragOver}
@@ -4544,10 +4563,13 @@ export function Canvas({
         connectionRadius={CONNECTION_SNAP_RADIUS}
         minZoom={0.1}
         maxZoom={8}
-        nodesDraggable
+        // 抓手工具下节点既不可拖也不可选：不可拖，左键落在节点上才会交给 pane 去平移；
+        // 不可选，否则一次「拖着节点平移」松手时还会顺手把它选中。
+        nodesDraggable={!handToolActive}
+        elementsSelectable={!handToolActive}
         nodesConnectable
         edgesReconnectable
-        panOnDrag={PAN_ON_DRAG_BUTTONS}
+        panOnDrag={handToolActive ? PAN_ON_DRAG_BUTTONS_HAND : PAN_ON_DRAG_BUTTONS}
         panOnScroll={trackpadPanEnabled}
         zoomOnScroll={!trackpadPanEnabled}
         panActivationKeyCode={PAN_ACTIVATION_KEY_CODE}

--- a/frontend/src/features/canvas/ui/CanvasQuickActionBar.tsx
+++ b/frontend/src/features/canvas/ui/CanvasQuickActionBar.tsx
@@ -2,7 +2,7 @@
 // Copyright (c) 2026 ClaymoreLab
 import { useEffect, useRef, useState, type ComponentType } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Clock, HelpCircle, Keyboard, Plus } from 'lucide-react';
+import { Clock, Hand, HelpCircle, Keyboard, MousePointer2, Plus } from 'lucide-react';
 
 import type { CanvasNodeType } from '@/features/canvas/domain/canvasNodes';
 import type { CanvasAsset } from '@/features/canvas/domain/canvasAssets';
@@ -11,12 +11,18 @@ import type { SkillDefinition } from '@/features/freezone/context/skillRoles';
 import { CanvasAddNodePanel } from './CanvasAddNodePanel';
 import { CanvasShortcutsPanel } from './CanvasShortcutsPanel';
 import { CanvasHistoryAssetsModal } from './CanvasHistoryAssetsModal';
+import { CanvasToolMenu } from './CanvasToolMenu';
+import { useCanvasToolStore } from './canvasToolStore';
 
-type QuickPanel = 'add' | 'history' | 'shortcuts' | 'help';
+type QuickPanel = 'add' | 'tool' | 'history' | 'shortcuts' | 'help';
 
 // 悬停即开 / 离开延迟关闭的轻量 popover 面板（区别于 history 那种 modal）。
 const HOVER_POPOVER_PANELS: ReadonlySet<QuickPanel> = new Set(['add']);
-const ANCHORED_POPOVER_PANELS: ReadonlySet<QuickPanel> = new Set(['add', 'shortcuts']);
+const ANCHORED_POPOVER_PANELS: ReadonlySet<QuickPanel> = new Set([
+  'add',
+  'tool',
+  'shortcuts',
+]);
 const PRODUCT_MANUAL_URL = 'https://neo-flying.feishu.cn/docx/T2UgdVA4Fo1A5KxCh0vckDz3nTg';
 
 interface CanvasQuickActionBarProps {
@@ -40,6 +46,8 @@ interface QuickActionDef {
 
 const ACTIONS: QuickActionDef[] = [
   { key: 'add', icon: Plus, labelKey: 'canvas.quickbar.addNode', primary: true },
+  // 指针工具。图标跟着当前工具走（见下方 resolveIcon），所以这里的 icon 只是占位。
+  { key: 'tool', icon: MousePointer2, labelKey: 'canvas.toolbar.toolGroupLabel' },
   {
     key: 'history',
     icon: Clock,
@@ -73,6 +81,7 @@ export function CanvasQuickActionBar({
   const [openPanel, setOpenPanel] = useState<QuickPanel | null>(null);
   const popoverCloseTimerRef = useRef<number | null>(null);
   const isTop = placement === 'top-right';
+  const handToolActive = useCanvasToolStore((state) => state.tool === 'hand');
 
   const cancelPopoverClose = () => {
     if (popoverCloseTimerRef.current !== null) {
@@ -183,11 +192,22 @@ export function CanvasQuickActionBar({
 
           <div className="flex h-12 items-center gap-2.5 rounded-[12px] border border-white/[0.08] bg-[#11151d]/95 px-1.5 shadow-[0_14px_36px_rgba(0,0,0,0.42)] backdrop-blur-md">
             {ACTIONS.map((action) => {
-              const { key, icon: Icon, labelKey, tooltipKey, primary } = action;
+              const { key, labelKey, tooltipKey, primary } = action;
               const active = openPanel === key;
+              // 指针工具的图标就是当前工具本身 —— 收起菜单后还得一眼看出现在是抓手。
+              const Icon =
+                key === 'tool' ? (handToolActive ? Hand : MousePointer2) : action.icon;
+              // 指针工具的悬浮提示报当前工具和它的快捷键，别只报「指针工具」这个类别名。
+              const tooltip =
+                key === 'tool'
+                  ? handToolActive
+                    ? `${t('canvas.toolbar.toolHand')} H`
+                    : `${t('canvas.toolbar.toolMove')} V`
+                  : tooltipKey && t(tooltipKey);
               // The "+" is always a white primary chip; the other two only fill
               // white while their panel is open (libtv keyboard-highlight style).
-              const filled = primary || active;
+              // 指针工具多一条：抓手是「画布现在不听左键选择」的状态，菜单关了也要亮着。
+              const filled = primary || active || (key === 'tool' && handToolActive);
               return (
                 <span key={key} className="group relative inline-flex">
                   <button
@@ -211,14 +231,23 @@ export function CanvasQuickActionBar({
                       }`}
                     />
                   </button>
-                  {tooltipKey && (
+                  {/* 面板开着就别再弹提示了：两者都锚在按钮正上方，会糊在一起。 */}
+                  {tooltip && !active && (
                     <span
                       className={`pointer-events-none absolute left-1/2 z-20 -translate-x-1/2 whitespace-nowrap rounded-[6px] border border-white/[0.08] bg-[#11151d]/95 px-2 py-1 text-[11px] leading-none text-white/78 opacity-0 shadow-[0_8px_24px_rgba(0,0,0,0.32)] transition-opacity duration-150 group-hover:opacity-100 group-focus-within:opacity-100 ${
                         isTop ? 'top-full mt-2' : 'bottom-full mb-2'
                       }`}
                     >
-                      {t(tooltipKey)}
+                      {tooltip}
                     </span>
+                  )}
+                  {/* 挂在按钮自己的 span 上，菜单跟着按钮走，不用去算它在这一排里的偏移。 */}
+                  {key === 'tool' && active && (
+                    <div className={`absolute left-0 z-20 ${popoverAnchorClass}`}>
+                      <div className={popoverEnterClass}>
+                        <CanvasToolMenu onSelect={() => setOpenPanel(null)} />
+                      </div>
+                    </div>
                   )}
                 </span>
               );

--- a/frontend/src/features/canvas/ui/CanvasShortcutsPanel.tsx
+++ b/frontend/src/features/canvas/ui/CanvasShortcutsPanel.tsx
@@ -76,6 +76,13 @@ const SHORTCUT_GROUPS: ShortcutGroup[] = [
         noteKey: 'canvas.shortcuts.gestures.middleDrag',
       },
       { labelKey: 'canvas.shortcuts.actions.boxSelect', noteIcons: [MouseLeft], noteKey: 'canvas.shortcuts.gestures.holdLeftDrag' },
+      { labelKey: 'canvas.toolbar.toolMove', keys: ['V'] },
+      {
+        labelKey: 'canvas.toolbar.toolHand',
+        keys: ['H'],
+        noteIcons: [MouseLeft],
+        noteKey: 'canvas.shortcuts.gestures.holdLeftDrag',
+      },
       { labelKey: 'canvas.shortcuts.actions.organize', keys: ['⌥', '⇧', 'F'] },
     ],
   },

--- a/frontend/src/features/canvas/ui/CanvasToolMenu.tsx
+++ b/frontend/src/features/canvas/ui/CanvasToolMenu.tsx
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: Elastic-2.0
+// Copyright (c) 2026 ClaymoreLab
+import { Hand, MousePointer2 } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+
+import { useCanvasToolStore, type CanvasTool } from './canvasToolStore';
+
+export const CANVAS_TOOL_ITEMS: ReadonlyArray<{
+  tool: CanvasTool;
+  Icon: typeof Hand;
+  labelKey: string;
+  shortcut: string;
+}> = [
+  { tool: 'move', Icon: MousePointer2, labelKey: 'canvas.toolbar.toolMove', shortcut: 'V' },
+  { tool: 'hand', Icon: Hand, labelKey: 'canvas.toolbar.toolHand', shortcut: 'H' },
+];
+
+interface CanvasToolMenuProps {
+  onSelect?: () => void;
+}
+
+/** 快捷操作栏里「指针工具」按钮弹出的两行菜单：移动 V / 抓手工具 H。 */
+export function CanvasToolMenu({ onSelect }: CanvasToolMenuProps) {
+  const { t } = useTranslation();
+  const tool = useCanvasToolStore((state) => state.tool);
+  const setTool = useCanvasToolStore((state) => state.setTool);
+
+  return (
+    <div
+      role="menu"
+      aria-label={t('canvas.toolbar.toolGroupLabel')}
+      className="w-[196px] rounded-[12px] border border-white/[0.08] bg-[#11151d]/95 p-1.5 shadow-[0_14px_36px_rgba(0,0,0,0.42)] backdrop-blur-md"
+    >
+      {CANVAS_TOOL_ITEMS.map(({ tool: value, Icon, labelKey, shortcut }) => {
+        const active = tool === value;
+        return (
+          <button
+            key={value}
+            type="button"
+            role="menuitemradio"
+            aria-checked={active}
+            onClick={() => {
+              setTool(value);
+              onSelect?.();
+            }}
+            className={`flex w-full items-center gap-2.5 rounded-[9px] px-2.5 py-2 text-left text-[14px] leading-none transition-colors ${
+              active
+                ? 'bg-white/[0.1] text-white'
+                : 'text-white/68 hover:bg-white/[0.06] hover:text-white'
+            }`}
+          >
+            <Icon className="h-4 w-4 shrink-0" />
+            <span className="flex-1">{t(labelKey)}</span>
+            <span className="text-[12px] tabular-nums text-white/38">{shortcut}</span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/frontend/src/features/canvas/ui/canvasToolStore.ts
+++ b/frontend/src/features/canvas/ui/canvasToolStore.ts
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: Elastic-2.0
+// Copyright (c) 2026 ClaymoreLab
+import { create } from 'zustand';
+
+/**
+ * 画布指针工具。
+ * - `move`：默认模式，左键框选 / 拖节点，中键或空格拖动平移画布。
+ * - `hand`：抓手，左键按住直接拖动画布；节点不可拖、不可框选（拖到节点上也是平移）。
+ */
+export type CanvasTool = 'move' | 'hand';
+
+interface CanvasToolState {
+  tool: CanvasTool;
+  setTool: (tool: CanvasTool) => void;
+}
+
+/**
+ * 刻意不持久化：抓手是「临时换个手势」，不是偏好。上次退出时忘在抓手上，下次进来
+ * 点不动任何节点，用户只会以为画布坏了。刷新一律回到移动工具。
+ *
+ * 单独一个轻量 store（和对齐吸附 / 触控板平移开关同构），订阅它的工具条不会因画布
+ * 节点变动而重渲染。
+ */
+export const useCanvasToolStore = create<CanvasToolState>((set) => ({
+  tool: 'move',
+  setTool: (tool) => set({ tool }),
+}));

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -619,6 +619,13 @@
   cursor: grabbing;
 }
 
+/* 抓手工具（H）下左键拖到节点上也是在平移画布。节点本身已经是 grab（见上面的
+   .react-flow__node），这里只补平移中的握拳——节点在 pane 的子树里，用 .dragging
+   的 pane 当祖先就能盖住节点自己的 grab。 */
+[data-canvas-tool='hand'] .react-flow__pane.dragging .react-flow__node {
+  cursor: grabbing;
+}
+
 .react-flow__handle {
   width: 8px;
   height: 8px;

--- a/license-inventory.csv
+++ b/license-inventory.csv
@@ -332,6 +332,7 @@ frontend/src/__tests__/features/canvas/canvas-add-node-panel.test.tsx,Elastic-2.
 frontend/src/__tests__/features/canvas/canvas-bookmark-context-menu.test.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/__tests__/features/canvas/canvas-node-image-wake-refresh.test.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/__tests__/features/canvas/canvas-skill-manual-connect.test.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
+frontend/src/__tests__/features/canvas/canvas-tool-menu.test.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/__tests__/features/canvas/canvas-viewport-bookmarks.test.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/__tests__/features/canvas/context-prompt-palette.test.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/__tests__/features/canvas/cross-project-assets.test.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
@@ -887,6 +888,7 @@ frontend/src/features/canvas/ui/CanvasMinimapButton.tsx,Elastic-2.0,2026 SuperTa
 frontend/src/features/canvas/ui/CanvasNodeImage.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/features/canvas/ui/CanvasQuickActionBar.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/features/canvas/ui/CanvasShortcutsPanel.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
+frontend/src/features/canvas/ui/CanvasToolMenu.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/features/canvas/ui/CanvasViewportBookmarks.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/features/canvas/ui/CanvasZoomControl.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/features/canvas/ui/CommitTargetHint.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
@@ -929,6 +931,7 @@ frontend/src/features/canvas/ui/VideoViewerModal.tsx,Elastic-2.0,2026 SuperTale 
 frontend/src/features/canvas/ui/ZoomScaledToolbar.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/features/canvas/ui/canvas-node-menu-shared.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/features/canvas/ui/canvasControlStyles.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
+frontend/src/features/canvas/ui/canvasToolStore.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/features/canvas/ui/closeButtonStyles.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/features/canvas/ui/edgeVisibilityStore.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/features/canvas/ui/multi-angle-sphere.css,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation


### PR DESCRIPTION
## PR 类型 / Type of PR
- [x] ✨ 新功能 / Feature

## 改动说明 / What this PR does and why


在此之前画布只能用中键或空格 + 左键平移 —— 没有中键的笔记本用户，一只手要一直按着空格。

抓手不只是换个 `panOnDrag`，四处联动缺一不可：

| 改动 | 不改会怎样 |
| --- | --- |
| `panOnDrag` 从 `[1]`（中键）扩到 `[0, 1]` | 左键不平移 |
| `nodesDraggable={false}` | 左键落在节点上是拖节点，画布拖不动 |
| `elementsSelectable={false}` | 「拖着节点平移」松手时还会把它选中 |
| 自定义框选（marquee）在抓手下不起手 | 虚线选框跟着平移一起走 |

按钮图标跟着当前工具走、抓手时保持白底高亮 —— 菜单收起后这是唯一能看出「画布现在不听左键选择」的地方。

## 关联 issue / Linked issues
N/A

## 给 reviewer 的说明 / Notes for the reviewer

- **工具刻意不持久化**（`canvasToolStore` 注释里也写了）。抓手是临时手势不是偏好：上次退出忘在抓手上、下次进来点不动任何节点，用户只会以为画布坏了。刷新一律回到移动工具。
- **V / H 必须是光秃秃的按键**。`⌘V` 仍然是粘贴；带 Alt 的字母多半是输入法在组字。走的是画布现有那个全局 keydown，`isTypingTarget` 的护栏一起生效，在输入框 / 富文本里打字不会误触。
- **框选的两处守卫都加了**（pointerdown 和 pointermove），覆盖「拖到一半按 H 切过来」。判断从 store 现读而不是订阅，免得这个 effect 为一个开关重挂一遍 pointer 监听。
- **光标**：pane 的 grab / grabbing 是 ReactFlow 自带样式，只在 `index.css` 补了一条 —— 平移中拖过节点时节点也跟着变握拳。
- **顺带改了一处既有行为**：面板打开时不再弹按钮的悬浮提示（两者都锚在按钮正上方会糊在一起），history / shortcuts 也一起受益。
- 快捷键面板的「移动画布」分组里补了 V / H 两行。
- 抓手工具在底部任务面板展开时会跟着整条快捷栏一起隐藏（和 `+` / 历史 / 快捷键 同一条件），此时只能用键盘切换。沿用现状，没单独处理。

## 面向用户的变更 / User-facing change
```release-note
画布底部工具栏新增移动 / 抓手工具切换（快捷键 V / H），抓手模式下按住鼠标左键即可拖动画布。
```

## 自检 / Checklist
- [x] 已自测 / Self-tested — `tsc -b` 干净，`vitest` 1894 passed（新增 4 条覆盖菜单开合与工具切换），`pnpm build` 通过
- [x] 必要的文档已更新 / Docs updated where needed — 快捷键面板已补 V / H
- [x] 提交信息清晰（建议 Conventional Commits）/ Clear commits
- [x] 每个 commit 都已 `git commit -s` 附 DCO 签署 / Every commit signed off

🤖 Generated with [Claude Code](https://claude.com/claude-code)