### PR TITLE
fix(canvas): Seedance 1.x 单图不再置灰，接入视频/音频自动换 2.0 全能参考

### DIFF
--- a/frontend/src/__tests__/features/canvas/video-model-capabilities.test.ts
+++ b/frontend/src/__tests__/features/canvas/video-model-capabilities.test.ts
@@ -16,7 +16,8 @@ import {
   videoEmptyStateCtaModes,
   videoModeRequiresPrompt,
   videoModelReferenceDisabledReason,
-  videoReferenceAutoSwitch,
+  videoReferenceAutoSwitchAction,
+  type VideoReferenceAutoSwitchAction,
   videoSubmitMediaRejectionReason,
   videoUpstreamImageDefaultMode,
 } from "@/features/canvas/nodes/shared/videoModelCapabilities";
@@ -303,75 +304,221 @@ describe("置灰守卫 × 提交守卫 — 不置灰的组合必须存在可提�
   });
 });
 
-describe("videoReferenceAutoSwitch — 接入视频/音频时替 1.x 换成 2.0", () => {
-  // 选择器的真实顺序：Fast 排在基础款 2.0 前面（见 ProviderModelPicker VIDEO_MODELS）。
-  // 这个顺序是关键——挑目标不能图省事取「第一个 2.0」，那会落到 Fast 上。
-  const SEEDANCE2_BASE = "newapi_seedance-2.0";
-  const MODELS = [
-    { id: SEEDANCE2_FAST, apiModel: SEEDANCE2_FAST },
-    { id: SEEDANCE2_BASE, apiModel: SEEDANCE2_BASE },
-    { id: SEEDANCE2_VALUE, apiModel: SEEDANCE2_VALUE },
-    { id: SEEDANCE15_PRO, apiModel: SEEDANCE15_PRO },
-    { id: SEEDANCE10_PRO_FAST, apiModel: SEEDANCE10_PRO_FAST },
-  ];
+// 选择器的真实顺序：Fast 排在基础款 2.0 前面（见 ProviderModelPicker VIDEO_MODELS）。
+// 这个顺序是关键——挑目标不能图省事取「第一个 2.0」，那会落到 Fast 上。
+const SEEDANCE2_BASE = "newapi_seedance-2.0";
+const MODELS = [
+  { id: SEEDANCE2_FAST, apiModel: SEEDANCE2_FAST },
+  { id: SEEDANCE2_BASE, apiModel: SEEDANCE2_BASE },
+  { id: SEEDANCE2_VALUE, apiModel: SEEDANCE2_VALUE },
+  { id: SEEDANCE15_PRO, apiModel: SEEDANCE15_PRO },
+  { id: SEEDANCE10_PRO_FAST, apiModel: SEEDANCE10_PRO_FAST },
+];
+
+function expectSwitch(action: VideoReferenceAutoSwitchAction) {
+  if (action.kind !== "switch") {
+    throw new Error(`期望 switch，实际拿到 ${action.kind}`);
+  }
+  return action;
+}
+
+describe("videoReferenceAutoSwitchAction — 接入视频/音频时替 1.x 换成 2.0", () => {
+  // 常态入参：列表已就绪、还没落闩。加载时序与闩锁本身在下一个 describe 里按帧验。
+  const pick = (
+    currentModelId: string | null | undefined,
+    counts: { videos: number; audios: number },
+    models: readonly { id: string; apiModel?: string }[],
+  ) =>
+    videoReferenceAutoSwitchAction({
+      counts,
+      currentModelId,
+      models,
+      modelsLoading: false,
+      alreadySwitched: false,
+    });
 
   it("Seedance 1.x + 视频 → 换成基础款 2.0（不是排在前面的 Fast），并落到全能参考", () => {
-    expect(videoReferenceAutoSwitch(SEEDANCE10_PRO_FAST, { videos: 1, audios: 0 }, MODELS)).toEqual(
-      { modelId: SEEDANCE2_BASE, genMode: "allReference" },
-    );
+    expect(pick(SEEDANCE10_PRO_FAST, { videos: 1, audios: 0 }, MODELS)).toEqual({
+      kind: "switch",
+      modelId: SEEDANCE2_BASE,
+      genMode: "allReference",
+    });
   });
 
   it("Seedance 1.x + 音频 → 同样切到基础款 2.0", () => {
-    expect(videoReferenceAutoSwitch(SEEDANCE15_PRO, { videos: 0, audios: 1 }, MODELS)).toEqual({
+    expect(pick(SEEDANCE15_PRO, { videos: 0, audios: 1 }, MODELS)).toEqual({
+      kind: "switch",
       modelId: SEEDANCE2_BASE,
       genMode: "allReference",
     });
   });
 
   it("候选里没有基础款（只下发了 fast / value 变体）→ 退到任意一个 2.0", () => {
-    expect(
-      videoReferenceAutoSwitch(SEEDANCE10_PRO_FAST, { videos: 1, audios: 0 }, [
-        { id: SEEDANCE2_VALUE, apiModel: SEEDANCE2_VALUE },
-        { id: SEEDANCE2_FAST, apiModel: SEEDANCE2_FAST },
-      ])?.modelId,
-    ).toBe(SEEDANCE2_VALUE);
+    const action = pick(SEEDANCE10_PRO_FAST, { videos: 1, audios: 0 }, [
+      { id: SEEDANCE2_VALUE, apiModel: SEEDANCE2_VALUE },
+      { id: SEEDANCE2_FAST, apiModel: SEEDANCE2_FAST },
+    ]);
+    expect(expectSwitch(action).modelId).toBe(SEEDANCE2_VALUE);
   });
 
-  it("Seedance 1.x 但只有图片 / 什么都没连 → 不动（单图首帧是它的正常用法）", () => {
-    expect(videoReferenceAutoSwitch(SEEDANCE10_PRO_FAST, { videos: 0, audios: 0 }, MODELS)).toBeNull();
+  it("素材没接 / 已撤走 → release（松闩），不写任何 patch", () => {
+    expect(pick(SEEDANCE10_PRO_FAST, { videos: 0, audios: 0 }, MODELS)).toEqual({
+      kind: "release",
+    });
   });
 
   it("返回的是 id 而非 apiModel —— 存进 VideoNodeData.model 的是 id", () => {
     const renamed = [{ id: "picker-id-2.0", apiModel: "newapi_seedance-2.0" }];
-    expect(videoReferenceAutoSwitch(SEEDANCE15_PRO, { videos: 1, audios: 0 }, renamed)?.modelId).toBe(
-      "picker-id-2.0",
-    );
+    const action = pick(SEEDANCE15_PRO, { videos: 1, audios: 0 }, renamed);
+    expect(expectSwitch(action).modelId).toBe("picker-id-2.0");
   });
 
   it("2.0 / HappyHorse / Grok 都不抢：各有自己的路径或渠道", () => {
     for (const id of [SEEDANCE2_FAST, HAPPYHORSE, "newapi_grok-video-channel"]) {
-      expect(videoReferenceAutoSwitch(id, { videos: 1, audios: 1 }, MODELS)).toBeNull();
+      expect(pick(id, { videos: 1, audios: 1 }, MODELS)).toEqual({ kind: "none" });
     }
   });
 
   it("候选列表里没有 2.0（接口异常）→ 宁可不动也不瞎切", () => {
     expect(
-      videoReferenceAutoSwitch(SEEDANCE10_PRO_FAST, { videos: 1, audios: 0 }, [
+      pick(SEEDANCE10_PRO_FAST, { videos: 1, audios: 0 }, [
         { id: SEEDANCE15_PRO, apiModel: SEEDANCE15_PRO },
       ]),
-    ).toBeNull();
-    expect(videoReferenceAutoSwitch(SEEDANCE10_PRO_FAST, { videos: 1, audios: 0 }, [])).toBeNull();
+    ).toEqual({ kind: "none" });
+    expect(pick(SEEDANCE10_PRO_FAST, { videos: 1, audios: 0 }, [])).toEqual({ kind: "none" });
   });
 
   // 切完必须自洽：新模型 + 新模式既不该被选择器置灰，也不该被提交守卫拦下，
   // 否则就是把用户从一个死胡同推进另一个。
   it("切换结果自洽：目标模型在同样的素材下既不置灰也不被提交守卫拦", () => {
     const counts = { images: 1, videos: 1, audios: 1 };
-    const next = videoReferenceAutoSwitch(SEEDANCE10_PRO_FAST, counts, MODELS);
-    expect(next).not.toBeNull();
-    expect(videoModelReferenceDisabledReason(next!.modelId, counts)).toBeNull();
-    expect(videoSubmitMediaRejectionReason(next!.genMode, next!.modelId, counts)).toBeNull();
-    expect(isVideoModeSupportedByModel(next!.genMode, next!.modelId)).toBe(true);
+    const next = expectSwitch(pick(SEEDANCE10_PRO_FAST, counts, MODELS));
+    expect(videoModelReferenceDisabledReason(next.modelId, counts)).toBeNull();
+    expect(videoSubmitMediaRejectionReason(next.genMode, next.modelId, counts)).toBeNull();
+    expect(isVideoModeSupportedByModel(next.genMode, next.modelId)).toBe(true);
+  });
+});
+
+// useFreezoneVideoModels 在 pending 期间返回的**不是空数组**，而是硬编码的
+// VIDEO_MODELS（isLoading: true / isFallback: true）。所以「列表非空」根本不能当作
+// 「列表已就绪」用——照着 fallback 挑出来的 2.0 未必存在于该项目的真列表里，提前切了
+// 还落闩，真列表回来也不再纠正，节点就卡在一个后端不认识的模型上。下面按帧回放组件那
+// 条 effect，专门盯这段时序。
+describe("videoReferenceAutoSwitchAction — 模型列表异步加载期间的闸门", () => {
+  // 加载中先给出的硬编码 fallback：里面有 2.0。
+  const FALLBACK_WITH_2 = MODELS;
+  // 该项目真列表：接口只下发了 1.x，没有任何 2.0。
+  const REAL_ONLY_1X = [
+    { id: SEEDANCE15_PRO, apiModel: SEEDANCE15_PRO },
+    { id: SEEDANCE10_PRO_FAST, apiModel: SEEDANCE10_PRO_FAST },
+  ];
+  // 该项目真列表：模型 id 与硬编码那份不同名，但确实有基础款 2.0。
+  const REAL_WITH_2 = [
+    { id: "proj-2.0-fast", apiModel: SEEDANCE2_FAST },
+    { id: "proj-2.0", apiModel: SEEDANCE2_BASE },
+  ];
+
+  interface Frame {
+    currentModelId: string;
+    models: readonly { id: string; apiModel?: string }[];
+    modelsLoading: boolean;
+    counts?: { videos: number; audios: number };
+  }
+
+  /** 原样跑一遍组件里那条 effect 的分支：算 action → 更新闩锁 / 记录写入。 */
+  function replay(frames: readonly Frame[]) {
+    let latched = false;
+    const writes: { modelId: string; genMode: VideoGenMode }[] = [];
+    for (const frame of frames) {
+      const action = videoReferenceAutoSwitchAction({
+        counts: frame.counts ?? { videos: 1, audios: 0 },
+        currentModelId: frame.currentModelId,
+        models: frame.models,
+        modelsLoading: frame.modelsLoading,
+        alreadySwitched: latched,
+      });
+      if (action.kind === "release") {
+        latched = false;
+      } else if (action.kind === "switch") {
+        latched = true;
+        writes.push({ modelId: action.modelId, genMode: action.genMode });
+      }
+    }
+    return { writes, latched };
+  }
+
+  // 这条是 reviewer 点名要的回归：fallback 里有 2.0，真列表却只有 1.x。
+  it("fallback 有 2.0 但真列表只有 1.x → 全程不写，绝不写入列表里不存在的模型", () => {
+    const { writes, latched } = replay([
+      { currentModelId: SEEDANCE15_PRO, models: FALLBACK_WITH_2, modelsLoading: true },
+      { currentModelId: SEEDANCE15_PRO, models: REAL_ONLY_1X, modelsLoading: false },
+      { currentModelId: SEEDANCE15_PRO, models: REAL_ONLY_1X, modelsLoading: false },
+    ]);
+    expect(writes).toEqual([]);
+    // 也没落闩：真列表哪天补上 2.0，这次跳变仍然有机会被救。
+    expect(latched).toBe(false);
+  });
+
+  it("加载中不动；真列表到了才切，且切的是真列表里的 id，只切一次", () => {
+    const { writes } = replay([
+      { currentModelId: SEEDANCE15_PRO, models: FALLBACK_WITH_2, modelsLoading: true },
+      { currentModelId: SEEDANCE15_PRO, models: FALLBACK_WITH_2, modelsLoading: true },
+      { currentModelId: SEEDANCE15_PRO, models: REAL_WITH_2, modelsLoading: false },
+      // 切完后 selectedVideoModelId 变成新模型，effect 还会再跑几帧。
+      { currentModelId: "proj-2.0", models: REAL_WITH_2, modelsLoading: false },
+    ]);
+    expect(writes).toEqual([{ modelId: "proj-2.0", genMode: "allReference" }]);
+  });
+
+  // isFallback 刻意不作为入参：它在「URL 没 project」「拉取失败」「后端返回空列表」
+  // 这三种**已落定**的情况下会一直是 true，而此时选择器渲染的就是这份 VIDEO_MODELS，
+  // 2.0 就在里面、用户手动也能选。跟着 isFallback 一起挡 = 永久关掉救场。
+  it("已落定的 fallback（isLoading 已 false）照常救场，不因为「是 fallback」而放弃", () => {
+    const { writes } = replay([
+      { currentModelId: SEEDANCE15_PRO, models: FALLBACK_WITH_2, modelsLoading: true },
+      { currentModelId: SEEDANCE15_PRO, models: FALLBACK_WITH_2, modelsLoading: false },
+    ]);
+    expect(writes).toEqual([{ modelId: SEEDANCE2_BASE, genMode: "allReference" }]);
+  });
+
+  // 闩锁的意义：undo 把 model 恢复成 1.x、而视频边还在时，不能再纠正回去，
+  // 否则 updateNodeData 会再压一条 past 并清空 future，⌘Z 看起来毫无反应。
+  it("落闩后即使模型被 undo 回 1.x（素材边仍在）也不再纠正", () => {
+    const { writes } = replay([
+      { currentModelId: SEEDANCE15_PRO, models: MODELS, modelsLoading: false },
+      { currentModelId: SEEDANCE2_BASE, models: MODELS, modelsLoading: false },
+      // ⌘Z：model 回到 1.x，视频边还在
+      { currentModelId: SEEDANCE15_PRO, models: MODELS, modelsLoading: false },
+      { currentModelId: SEEDANCE15_PRO, models: MODELS, modelsLoading: false },
+    ]);
+    expect(writes).toHaveLength(1);
+  });
+
+  it("素材撤走后松闩，下次再接入还能救一次", () => {
+    const { writes } = replay([
+      { currentModelId: SEEDANCE15_PRO, models: MODELS, modelsLoading: false },
+      // 拔线：videos 归零 → release
+      {
+        currentModelId: SEEDANCE15_PRO,
+        models: MODELS,
+        modelsLoading: false,
+        counts: { videos: 0, audios: 0 },
+      },
+      // 重新连上
+      { currentModelId: SEEDANCE15_PRO, models: MODELS, modelsLoading: false },
+    ]);
+    expect(writes).toHaveLength(2);
+  });
+
+  it("加载中素材就被撤走 → 仍然松闩（松闩只是复位 ref，没必要等列表）", () => {
+    const action = videoReferenceAutoSwitchAction({
+      counts: { videos: 0, audios: 0 },
+      currentModelId: SEEDANCE15_PRO,
+      models: FALLBACK_WITH_2,
+      modelsLoading: true,
+      alreadySwitched: true,
+    });
+    expect(action).toEqual({ kind: "release" });
   });
 });
 

--- a/frontend/src/__tests__/features/canvas/video-model-capabilities.test.ts
+++ b/frontend/src/__tests__/features/canvas/video-model-capabilities.test.ts
@@ -15,6 +15,8 @@ import {
   isVideoModeSupportedByModel,
   videoEmptyStateCtaModes,
   videoModeRequiresPrompt,
+  videoModelReferenceDisabledReason,
+  videoReferenceAutoSwitch,
   videoSubmitMediaRejectionReason,
   videoUpstreamImageDefaultMode,
 } from "@/features/canvas/nodes/shared/videoModelCapabilities";
@@ -184,6 +186,133 @@ describe("videoSubmitMediaRejectionReason — 提交前素材守卫 (P1/P2)", ()
     expect(
       videoSubmitMediaRejectionReason("imageReference", HAPPYHORSE, { images: 5, videos: 0, audios: 0 }),
     ).toBeNull();
+  });
+});
+
+describe("videoModelReferenceDisabledReason — 模型选择器置灰守卫", () => {
+  const none = { images: 0, videos: 0, audios: 0 };
+
+  // 回归：曾经写成 `counts.images > 0` 一律置灰，一张图片节点就把整个 Seedance 1 系列
+  // 锁死 —— 而单图首帧恰恰是 1.x 唯一能用的模式，后端也只在 >1 图时才 400。
+  it("Seedance 1.x：单图 → 可选（不置灰）", () => {
+    for (const id of [SEEDANCE10_PRO_FAST, SEEDANCE15_PRO]) {
+      expect(videoModelReferenceDisabledReason(id, { ...none, images: 1 })).toBeNull();
+      expect(videoModelReferenceDisabledReason(id, none)).toBeNull();
+    }
+  });
+
+  it("Seedance 1.x：>1 图 → 置灰", () => {
+    expect(
+      videoModelReferenceDisabledReason(SEEDANCE15_PRO, { ...none, images: 2 }),
+    ).toBeTruthy();
+  });
+
+  it("Seedance 1.x：接入视频 / 音频 → 置灰", () => {
+    expect(
+      videoModelReferenceDisabledReason(SEEDANCE10_PRO_FAST, { ...none, videos: 1 }),
+    ).toBeTruthy();
+    expect(
+      videoModelReferenceDisabledReason(SEEDANCE10_PRO_FAST, { ...none, audios: 1 }),
+    ).toBeTruthy();
+  });
+
+  // 两条守卫是一对，阈值漂开就会出现「能选但一提交就被拦」或反过来的自相矛盾。
+  it("与提交守卫同阈值：单图放行 / 多图拦截的判定一致", () => {
+    for (const images of [0, 1, 2, 9]) {
+      const counts = { ...none, images };
+      const pickerBlocked = videoModelReferenceDisabledReason(SEEDANCE15_PRO, counts) != null;
+      const submitBlocked =
+        videoSubmitMediaRejectionReason("imageToVideo", SEEDANCE15_PRO, counts) != null;
+      expect(pickerBlocked).toBe(submitBlocked);
+    }
+  });
+
+  it("Seedance 2.0 / HappyHorse：多图 + 视频 + 音频都不置灰", () => {
+    for (const id of [SEEDANCE2_FAST, SEEDANCE2_VALUE, HAPPYHORSE]) {
+      expect(
+        videoModelReferenceDisabledReason(id, { images: 9, videos: 1, audios: 1 }),
+      ).toBeNull();
+    }
+  });
+
+  it("Grok Video Channel：仅图片、且最多 8 张", () => {
+    const GROK = "newapi_grok-video-channel";
+    expect(videoModelReferenceDisabledReason(GROK, { ...none, images: 8 })).toBeNull();
+    expect(videoModelReferenceDisabledReason(GROK, { ...none, images: 9 })).toBeTruthy();
+    expect(videoModelReferenceDisabledReason(GROK, { ...none, videos: 1 })).toBeTruthy();
+    expect(videoModelReferenceDisabledReason(GROK, { ...none, audios: 1 })).toBeTruthy();
+  });
+});
+
+describe("videoReferenceAutoSwitch — 接入视频/音频时替 1.x 换成 2.0", () => {
+  // 选择器的真实顺序：Fast 排在基础款 2.0 前面（见 ProviderModelPicker VIDEO_MODELS）。
+  // 这个顺序是关键——挑目标不能图省事取「第一个 2.0」，那会落到 Fast 上。
+  const SEEDANCE2_BASE = "newapi_seedance-2.0";
+  const MODELS = [
+    { id: SEEDANCE2_FAST, apiModel: SEEDANCE2_FAST },
+    { id: SEEDANCE2_BASE, apiModel: SEEDANCE2_BASE },
+    { id: SEEDANCE2_VALUE, apiModel: SEEDANCE2_VALUE },
+    { id: SEEDANCE15_PRO, apiModel: SEEDANCE15_PRO },
+    { id: SEEDANCE10_PRO_FAST, apiModel: SEEDANCE10_PRO_FAST },
+  ];
+
+  it("Seedance 1.x + 视频 → 换成基础款 2.0（不是排在前面的 Fast），并落到全能参考", () => {
+    expect(videoReferenceAutoSwitch(SEEDANCE10_PRO_FAST, { videos: 1, audios: 0 }, MODELS)).toEqual(
+      { modelId: SEEDANCE2_BASE, genMode: "allReference" },
+    );
+  });
+
+  it("Seedance 1.x + 音频 → 同样切到基础款 2.0", () => {
+    expect(videoReferenceAutoSwitch(SEEDANCE15_PRO, { videos: 0, audios: 1 }, MODELS)).toEqual({
+      modelId: SEEDANCE2_BASE,
+      genMode: "allReference",
+    });
+  });
+
+  it("候选里没有基础款（只下发了 fast / value 变体）→ 退到任意一个 2.0", () => {
+    expect(
+      videoReferenceAutoSwitch(SEEDANCE10_PRO_FAST, { videos: 1, audios: 0 }, [
+        { id: SEEDANCE2_VALUE, apiModel: SEEDANCE2_VALUE },
+        { id: SEEDANCE2_FAST, apiModel: SEEDANCE2_FAST },
+      ])?.modelId,
+    ).toBe(SEEDANCE2_VALUE);
+  });
+
+  it("Seedance 1.x 但只有图片 / 什么都没连 → 不动（单图首帧是它的正常用法）", () => {
+    expect(videoReferenceAutoSwitch(SEEDANCE10_PRO_FAST, { videos: 0, audios: 0 }, MODELS)).toBeNull();
+  });
+
+  it("返回的是 id 而非 apiModel —— 存进 VideoNodeData.model 的是 id", () => {
+    const renamed = [{ id: "picker-id-2.0", apiModel: "newapi_seedance-2.0" }];
+    expect(videoReferenceAutoSwitch(SEEDANCE15_PRO, { videos: 1, audios: 0 }, renamed)?.modelId).toBe(
+      "picker-id-2.0",
+    );
+  });
+
+  it("2.0 / HappyHorse / Grok 都不抢：各有自己的路径或渠道", () => {
+    for (const id of [SEEDANCE2_FAST, HAPPYHORSE, "newapi_grok-video-channel"]) {
+      expect(videoReferenceAutoSwitch(id, { videos: 1, audios: 1 }, MODELS)).toBeNull();
+    }
+  });
+
+  it("候选列表里没有 2.0（接口异常）→ 宁可不动也不瞎切", () => {
+    expect(
+      videoReferenceAutoSwitch(SEEDANCE10_PRO_FAST, { videos: 1, audios: 0 }, [
+        { id: SEEDANCE15_PRO, apiModel: SEEDANCE15_PRO },
+      ]),
+    ).toBeNull();
+    expect(videoReferenceAutoSwitch(SEEDANCE10_PRO_FAST, { videos: 1, audios: 0 }, [])).toBeNull();
+  });
+
+  // 切完必须自洽：新模型 + 新模式既不该被选择器置灰，也不该被提交守卫拦下，
+  // 否则就是把用户从一个死胡同推进另一个。
+  it("切换结果自洽：目标模型在同样的素材下既不置灰也不被提交守卫拦", () => {
+    const counts = { images: 1, videos: 1, audios: 1 };
+    const next = videoReferenceAutoSwitch(SEEDANCE10_PRO_FAST, counts, MODELS);
+    expect(next).not.toBeNull();
+    expect(videoModelReferenceDisabledReason(next!.modelId, counts)).toBeNull();
+    expect(videoSubmitMediaRejectionReason(next!.genMode, next!.modelId, counts)).toBeNull();
+    expect(isVideoModeSupportedByModel(next!.genMode, next!.modelId)).toBe(true);
   });
 });
 

--- a/frontend/src/__tests__/features/canvas/video-model-capabilities.test.ts
+++ b/frontend/src/__tests__/features/canvas/video-model-capabilities.test.ts
@@ -227,12 +227,23 @@ describe("videoModelReferenceDisabledReason — 模型选择器置灰守卫", ()
     }
   });
 
-  it("Seedance 2.0 / HappyHorse：多图 + 视频 + 音频都不置灰", () => {
-    for (const id of [SEEDANCE2_FAST, SEEDANCE2_VALUE, HAPPYHORSE]) {
+  it("Seedance 2.0：多图 + 视频 + 音频都不置灰（全能参考全吃）", () => {
+    for (const id of [SEEDANCE2_FAST, SEEDANCE2_VALUE]) {
       expect(
         videoModelReferenceDisabledReason(id, { images: 9, videos: 1, audios: 1 }),
       ).toBeNull();
     }
+  });
+
+  it("HappyHorse：多图 / 视频不置灰（r2v 与视频编辑各有路径），音频置灰", () => {
+    expect(
+      videoModelReferenceDisabledReason(HAPPYHORSE, { images: 9, videos: 1, audios: 0 }),
+    ).toBeNull();
+    // 音频只有全能参考(2.0)能消费，而 HappyHorse 永远到不了 allReference —— 不拦
+    // 就会把用户放进「选得进去、提交必被拦」的死胡同。
+    expect(
+      videoModelReferenceDisabledReason(HAPPYHORSE, { ...none, audios: 1 }),
+    ).toBeTruthy();
   });
 
   it("Grok Video Channel：仅图片、且最多 8 张", () => {
@@ -241,6 +252,54 @@ describe("videoModelReferenceDisabledReason — 模型选择器置灰守卫", ()
     expect(videoModelReferenceDisabledReason(GROK, { ...none, images: 9 })).toBeTruthy();
     expect(videoModelReferenceDisabledReason(GROK, { ...none, videos: 1 })).toBeTruthy();
     expect(videoModelReferenceDisabledReason(GROK, { ...none, audios: 1 })).toBeTruthy();
+  });
+});
+
+// 两条守卫真正要维持的不变量——不是逐条阈值相等（HappyHorse 的多图/视频由它自己的
+// 路径消化，两边判断本就不同），而是「选得进去就必须走得通」。这条网格测试就是当年
+// 「HappyHorse + 音频」那类死胡同的探照灯：选择器放行、却没有任何一个它支持的模式能
+// 通过提交守卫。Grok 不在网格里：后端 FREEZONE_DISABLED_VIDEO_BACKENDS 把它关掉了，
+// 压根不会出现在选择器中，它那条分支是休眠的。
+describe("置灰守卫 × 提交守卫 — 不置灰的组合必须存在可提交的模式", () => {
+  const ALL_MODES: VideoGenMode[] = [
+    "textToVideo",
+    "imageToVideo",
+    "imageReference",
+    "allReference",
+    "firstLastFrame",
+    "videoEdit",
+  ];
+  const PICKER_MODELS = [
+    SEEDANCE10_PRO_FAST,
+    SEEDANCE15_PRO,
+    SEEDANCE2_FAST,
+    SEEDANCE2_VALUE,
+    HAPPYHORSE,
+  ];
+
+  it("对每个模型 × 每种素材组合都成立", () => {
+    const deadEnds: string[] = [];
+    for (const modelId of PICKER_MODELS) {
+      for (const images of [0, 1, 2, 9]) {
+        for (const videos of [0, 1]) {
+          for (const audios of [0, 1]) {
+            const counts = { images, videos, audios };
+            if (videoModelReferenceDisabledReason(modelId, counts) != null) {
+              continue; // 已置灰 —— 用户选不进来，谈不上死胡同
+            }
+            const usable = ALL_MODES.some(
+              (mode) =>
+                isVideoModeSupportedByModel(mode, modelId) &&
+                videoSubmitMediaRejectionReason(mode, modelId, counts) == null,
+            );
+            if (!usable) {
+              deadEnds.push(`${modelId} + ${JSON.stringify(counts)}`);
+            }
+          }
+        }
+      }
+    }
+    expect(deadEnds).toEqual([]);
   });
 });
 

--- a/frontend/src/features/canvas/nodes/VideoNode.tsx
+++ b/frontend/src/features/canvas/nodes/VideoNode.tsx
@@ -68,13 +68,13 @@ import {
   formatAudioDurationClips,
   MAX_AUDIO_REFERENCE_DURATION_MS,
   MIN_AUDIO_REFERENCE_DURATION_MS,
-  isGrokVideoChannelModel,
   isHappyHorseVideoModel,
-  isSeedance1xVideoModel,
   isSeedance2VideoModel,
   isVideoModeSupportedByModel,
   videoEmptyStateCtaModes,
   videoModeRequiresPrompt,
+  videoModelReferenceDisabledReason,
+  videoReferenceAutoSwitch,
   videoSubmitMediaRejectionReason,
   videoUpstreamImageDefaultMode,
   type VideoEmptyStateCtaMode,
@@ -423,29 +423,10 @@ function isSeedance2ValueModel(modelId: string | null | undefined): boolean {
 
 // 模型能力判定（isHappyHorseVideoModel / isSeedance1xVideoModel /
 // isSeedance2VideoModel / isGrokVideoChannelModel / isVideoModeSupportedByModel）
-// 统一收敛到 nodes/shared/videoModelCapabilities.ts，作为 CTA / tab / 提交校验的
-// 单一事实来源，避免「非 HappyHorse 一律当 Seedance 2.0」的假设散落在组件里。
-
-function videoModelReferenceDisabledReason(
-  modelId: string | null | undefined,
-  counts: { images: number; videos: number; audios: number },
-): string | null {
-  if (isGrokVideoChannelModel(modelId)) {
-    if (counts.videos > 0 || counts.audios > 0) {
-      return "Grok Video Channel 仅支持图片素材";
-    }
-    if (counts.images > 8) {
-      return "Grok Video Channel 最多支持 1 张首帧和 7 张参考图";
-    }
-    return null;
-  }
-  if (isSeedance1xVideoModel(modelId)) {
-    if (counts.images > 0 || counts.videos > 0 || counts.audios > 0) {
-      return "该模型不支持当前接入的素材";
-    }
-  }
-  return null;
-}
+// 以及两条素材守卫（选择器置灰 videoModelReferenceDisabledReason / 提交拦截
+// videoSubmitMediaRejectionReason）统一收敛到 nodes/shared/videoModelCapabilities.ts，
+// 作为 CTA / tab / 提交校验的单一事实来源，避免「非 HappyHorse 一律当 Seedance 2.0」
+// 的假设散落在组件里，也避免两条守卫的阈值各写一份后悄悄漂开。
 
 function sceneOptimizeOptionsForModel(
   model: {
@@ -1813,12 +1794,36 @@ export const VideoNode = memo(
       updateNodeData,
     ]);
 
+    // Seedance 1.x 吃不下视频 / 音频，留在上面只能收获一次必然失败的提交。用户把
+    // 视频或音频节点连上来就是明确意图，直接替他换成 Seedance 2.0 + 全能参考。
+    // 判定走 upstreamTypeCounts（按节点类型）：空的视频节点也算 —— 先连节点、后生成
+    // 是正常顺序，等它出了 URL 再切模型就太迟了（用户中间会看见一个不该出现的 1.x）。
+    // 模型和模式必须一次 patch 写完：分两步会先渲染出「2.0 + 图生视频」的中间态，
+    // 再被下面那条 videos→allReference 的 effect 纠一次，白闪一帧。
+    useEffect(() => {
+      const next = videoReferenceAutoSwitch(
+        selectedVideoModelId,
+        upstreamTypeCounts,
+        availableVideoModels,
+      );
+      if (!next) return;
+      updateNodeData(id, { model: next.modelId, genMode: next.genMode });
+      // 刻意不调 writeLastVideoModel：这是替用户救场，不是他表达的偏好，不该顺手
+      // 把后续新建视频节点继承的默认模型也改掉。
+    }, [
+      availableVideoModels,
+      id,
+      selectedVideoModelId,
+      updateNodeData,
+      upstreamTypeCounts,
+    ]);
+
     // 上游接入视频素材时，只有「全能参考」能消费视频；其它模式（文生 / 图生 /
     // 首尾帧 / 图片参考）都会把视频丢弃。所以只要上游存在视频就强制切到
     // allReference 并锁死——下面的 tab 禁用规则会把其它 tab 一并禁用。
     // 与音频的「0→≥1 transition」不同，这里每次都纠正，确保视频在场期间无法切走。
-    // 仅 Seedance 2.0 能消费视频（omni）；非 2.0（Seedance 1.x）不支持视频素材，
-    // 由模型选择器拦截，这里不强推 allReference 以免顶进提交必 400 的模式。
+    // 仅 Seedance 2.0 能消费视频（omni）；1.x 已由上面那条 effect 换成 2.0，剩下
+    // 的非 2.0 情形（Grok 等显式渠道）不强推 allReference，以免顶进必 400 的模式。
     useEffect(() => {
       if (upstreamCounts.videos === 0) return;
       if (isHappyHorseModel) return;
@@ -3343,7 +3348,14 @@ export const VideoNode = memo(
                     domain="video"
                     popoverPlacement="top"
                     getOptionDisabledReason={(model) =>
-                      videoModelReferenceDisabledReason(model.apiModel ?? model.id, upstreamCounts)
+                      videoModelReferenceDisabledReason(model.apiModel ?? model.id, {
+                        images: upstreamCounts.images,
+                        // 视频 / 音频必须和自动切模型的 effect 同一口径（按节点类型，
+                        // 空节点也算）。若这里用「已解析 URL」口径，连着空视频节点时
+                        // 1.x 不置灰、用户能选回去，又被 effect 立刻切走，来回打架。
+                        videos: upstreamTypeCounts.videos,
+                        audios: upstreamTypeCounts.audios,
+                      })
                     }
                   />
                   <VideoConfigChip

--- a/frontend/src/features/canvas/nodes/VideoNode.tsx
+++ b/frontend/src/features/canvas/nodes/VideoNode.tsx
@@ -1800,7 +1800,27 @@ export const VideoNode = memo(
     // 是正常顺序，等它出了 URL 再切模型就太迟了（用户中间会看见一个不该出现的 1.x）。
     // 模型和模式必须一次 patch 写完：分两步会先渲染出「2.0 + 图生视频」的中间态，
     // 再被下面那条 videos→allReference 的 effect 纠一次，白闪一帧。
+    //
+    // 只在「没有 → 有视频/音频」这一次跳变时触发，**不能每次渲染都无条件纠正**：
+    // updateNodeData 每次都 pushSnapshot 且清空 future（canvasStore），若持续纠正，
+    // 用户 ⌘Z 恢复回 1.x 后边还在，effect 立刻把 2.0 写回去、再压一条 past ——
+    // 撤销看起来毫无反应，redo 栈还被清空，等于把「回到连线之前」这条路堵死。改的
+    // 又是 model 这种用户显式挑过的值，无声覆盖且撤不回来，性质比 genMode 重得多。
+    // 一次性触发也不会被绕过：素材在场期间选择器已经把 1.x 置灰了，切不回去。
+    // 与紧邻上面那条音频 → allReference 的 effect 用的是同一套闩锁。
+    const autoSwitchedForMediaRef = useRef(false);
     useEffect(() => {
+      const hasReferenceMedia =
+        upstreamTypeCounts.videos > 0 || upstreamTypeCounts.audios > 0;
+      if (!hasReferenceMedia) {
+        autoSwitchedForMediaRef.current = false;
+        return;
+      }
+      // 模型列表还没拉到时先别落闩：否则「挂载时素材已在场 + 列表未就绪」会把这次
+      // 跳变白白消耗掉，列表到了也不再补救。
+      if (availableVideoModels.length === 0) return;
+      if (autoSwitchedForMediaRef.current) return;
+      autoSwitchedForMediaRef.current = true;
       const next = videoReferenceAutoSwitch(
         selectedVideoModelId,
         upstreamTypeCounts,

--- a/frontend/src/features/canvas/nodes/VideoNode.tsx
+++ b/frontend/src/features/canvas/nodes/VideoNode.tsx
@@ -74,7 +74,7 @@ import {
   videoEmptyStateCtaModes,
   videoModeRequiresPrompt,
   videoModelReferenceDisabledReason,
-  videoReferenceAutoSwitch,
+  videoReferenceAutoSwitchAction,
   videoSubmitMediaRejectionReason,
   videoUpstreamImageDefaultMode,
   type VideoEmptyStateCtaMode,
@@ -1810,24 +1810,22 @@ export const VideoNode = memo(
     // 与紧邻上面那条音频 → allReference 的 effect 用的是同一套闩锁。
     const autoSwitchedForMediaRef = useRef(false);
     useEffect(() => {
-      const hasReferenceMedia =
-        upstreamTypeCounts.videos > 0 || upstreamTypeCounts.audios > 0;
-      if (!hasReferenceMedia) {
+      // 所有判断（加载态、闩锁、该不该换、换成谁）都在 videoReferenceAutoSwitchAction
+      // 里，这里只负责改 ref 和发 patch —— 那边是纯函数，异步加载时序才测得到。
+      const action = videoReferenceAutoSwitchAction({
+        counts: upstreamTypeCounts,
+        currentModelId: selectedVideoModelId,
+        models: availableVideoModels,
+        modelsLoading: videoModelsLoading,
+        alreadySwitched: autoSwitchedForMediaRef.current,
+      });
+      if (action.kind === "release") {
         autoSwitchedForMediaRef.current = false;
         return;
       }
-      // 模型列表还没拉到时先别落闩：否则「挂载时素材已在场 + 列表未就绪」会把这次
-      // 跳变白白消耗掉，列表到了也不再补救。
-      if (availableVideoModels.length === 0) return;
-      if (autoSwitchedForMediaRef.current) return;
+      if (action.kind === "none") return;
       autoSwitchedForMediaRef.current = true;
-      const next = videoReferenceAutoSwitch(
-        selectedVideoModelId,
-        upstreamTypeCounts,
-        availableVideoModels,
-      );
-      if (!next) return;
-      updateNodeData(id, { model: next.modelId, genMode: next.genMode });
+      updateNodeData(id, { model: action.modelId, genMode: action.genMode });
       // 刻意不调 writeLastVideoModel：这是替用户救场，不是他表达的偏好，不该顺手
       // 把后续新建视频节点继承的默认模型也改掉。
     }, [
@@ -1836,6 +1834,7 @@ export const VideoNode = memo(
       selectedVideoModelId,
       updateNodeData,
       upstreamTypeCounts,
+      videoModelsLoading,
     ]);
 
     // 上游接入视频素材时，只有「全能参考」能消费视频；其它模式（文生 / 图生 /

--- a/frontend/src/features/canvas/nodes/shared/videoModelCapabilities.ts
+++ b/frontend/src/features/canvas/nodes/shared/videoModelCapabilities.ts
@@ -251,13 +251,23 @@ export function videoSubmitMediaRejectionReason(
  * 模型选择器里某个候选**为什么不能选**（非 null 则置灰 + 悬浮显示这句理由）。
  *
  * 与上面的 `videoSubmitMediaRejectionReason` 是一对：那条管「选定模型后能不能提交」，
- * 这条管「带着当前这堆上游素材，还能不能切到这个模型」。两者的阈值必须一致，否则会出现
- * 「提交守卫说单图可以，选择器却不让你选」这种自相矛盾的状态。
+ * 这条管「带着当前这堆上游素材，还能不能切到这个模型」。要维持的不变量是
+ * **「不置灰 ⇒ 存在一个该模型支持、且提交守卫放行的模式」**——不是逐条阈值相等。
+ * 逐条相等这个说法在这里不成立：HappyHorse 的多图 / 视频都由它自己的 r2v / 视频编辑
+ * 路径消化，两条守卫本来就写着不同的判断；真正不能破的是「选得进去就必须走得通」，
+ * 否则用户会被放进一个提交必被拦、界面上又毫无预兆的死胡同。
  *
- * Seedance 1.x 的阈值是 **>1 图**，不是 >0：后端 i2v 端点只在 `len(source_paths) > 1`
- * 且非 2.0 非 HappyHorse 时才 400（freezone.py），单图首帧正是 1.x 唯一能用、也是
- * `videoEmptyStateCtaModes` 明确推荐给它的模式。写成 >0 会把「一张图 + Seedance 1.5 Pro」
- * 这个完全合法的常规组合整个锁死。
+ * 三处阈值的由来：
+ * - Seedance 1.x 是 **>1 图**，不是 >0：后端 i2v 端点只在 `len(source_paths) > 1`
+ *   且非 2.0 非 HappyHorse 时才 400（freezone.py），单图首帧正是 1.x 唯一能用、也是
+ *   `videoEmptyStateCtaModes` 明确推荐给它的模式。写成 >0 会把「一张图 + Seedance
+ *   1.5 Pro」这个完全合法的常规组合整个锁死。
+ * - HappyHorse 只拦音频：音频只有全能参考(omni, 2.0)能消费，而
+ *   `isVideoModeSupportedByModel` 里 HappyHorse 永远到不了 allReference——不拦的话
+ *   「HappyHorse + 音频节点」就是上面说的那种死胡同（选得进去、提交必被拦）。
+ *   它的多图（r2v）和视频（视频编辑）都能消化，不拦。
+ * - Grok Video Channel 只支持图片。注：它当前在后端是关掉的
+ *   （`FREEZONE_DISABLED_VIDEO_BACKENDS`），不会出现在选择器里，这条分支是休眠的。
  */
 export function videoModelReferenceDisabledReason(
   modelId: string | null | undefined,
@@ -269,6 +279,12 @@ export function videoModelReferenceDisabledReason(
     }
     if (counts.images > 8) {
       return "Grok Video Channel 最多支持 1 张首帧和 7 张参考图";
+    }
+    return null;
+  }
+  if (isHappyHorseVideoModel(modelId)) {
+    if (counts.audios > 0) {
+      return "该模型不支持音频素材";
     }
     return null;
   }

--- a/frontend/src/features/canvas/nodes/shared/videoModelCapabilities.ts
+++ b/frontend/src/features/canvas/nodes/shared/videoModelCapabilities.ts
@@ -327,7 +327,7 @@ export interface VideoReferenceAutoSwitch {
  * 时退到任意一个 2.0——总比让他卡在必然失败的 1.x 上强；一个 2.0 都没有则返回 null，
  * 宁可不动也不要瞎切。
  */
-export function videoReferenceAutoSwitch(
+function pickVideoReferenceAutoSwitch(
   currentModelId: string | null | undefined,
   counts: { videos: number; audios: number },
   models: readonly { id: string; apiModel?: string }[],
@@ -342,4 +342,53 @@ export function videoReferenceAutoSwitch(
     models.find((model) => isBaseSeedance2VideoModel(model.apiModel ?? model.id)) ??
     models.find((model) => isSeedance2VideoModel(model.apiModel ?? model.id));
   return target ? { modelId: target.id, genMode: "allReference" } : null;
+}
+
+export type VideoReferenceAutoSwitchAction =
+  /** 什么都别做（还在加载 / 已经救过一次 / 本来就不需要换）。 */
+  | { kind: "none" }
+  /** 视频音频都撤走了 —— 松开一次性闩锁，为下一次接入做准备。 */
+  | { kind: "release" }
+  /** 写这一个 patch（模型 + 模式一次写完），并落闩。 */
+  | { kind: "switch"; modelId: string; genMode: VideoGenMode };
+
+/**
+ * 自动救场的**完整闸门**——组件那条 effect 该调的就是这一个，除了改 ref 和发 patch
+ * 之外不该再自己判断任何条件。把闸门做成纯函数是为了能整段测：异步加载时序（下面第
+ * 一条）光测「该换成谁」是覆盖不到的，而它恰恰是最容易出事的地方。
+ *
+ * 三道闸，顺序有讲究：
+ * 1. **素材撤走优先于一切**（含加载中）——松闩只是复位一个 ref，没有任何副作用，
+ *    没必要等列表；等了反而会漏掉「加载期间用户又把线拔了」这种收尾。
+ * 2. **`modelsLoading` 期间一律不动**。`useFreezoneVideoModels` 在 pending 时返回的
+ *    不是空数组，而是硬编码的 `VIDEO_MODELS`——照着它挑出来的 2.0 未必存在于该项目
+ *    的真列表里。提前切了还落闩，真列表回来也不再纠正，节点就卡在一个后端不认识的
+ *    模型上，提交直接 400。**注意只看 `isLoading`，不要连 `isFallback` 一起挡**：
+ *    isFallback 在「URL 没有 project」「拉取失败」「后端返回空列表」这三种**已落定**
+ *    的情况下会一直是 true，而此时选择器渲染的正是同一份 `VIDEO_MODELS`（
+ *    `ProviderModelPicker` 用的就是这个 hook 的 models），2.0 就在里面、用户手动也
+ *    能选中；连它一起挡等于在这些情况下永久关掉救场。
+ * 3. **`alreadySwitched` 落闩后不再纠正**，避免把 undo 堵死（见组件里的注释）。
+ *
+ * 「没切成」不落闩：列表里一个 2.0 都没有时返回 `none`，把这次跳变留着，等列表变了
+ * 还有机会补救。
+ */
+export function videoReferenceAutoSwitchAction(input: {
+  counts: { videos: number; audios: number };
+  currentModelId: string | null | undefined;
+  models: readonly { id: string; apiModel?: string }[];
+  modelsLoading: boolean;
+  alreadySwitched: boolean;
+}): VideoReferenceAutoSwitchAction {
+  const { counts, currentModelId, models, modelsLoading, alreadySwitched } = input;
+  if (counts.videos === 0 && counts.audios === 0) {
+    return { kind: "release" };
+  }
+  if (modelsLoading || alreadySwitched) {
+    return { kind: "none" };
+  }
+  const target = pickVideoReferenceAutoSwitch(currentModelId, counts, models);
+  return target
+    ? { kind: "switch", modelId: target.modelId, genMode: target.genMode }
+    : { kind: "none" };
 }

--- a/frontend/src/features/canvas/nodes/shared/videoModelCapabilities.ts
+++ b/frontend/src/features/canvas/nodes/shared/videoModelCapabilities.ts
@@ -44,6 +44,12 @@ export function isSeedance2VideoModel(modelId: string | null | undefined): boole
   return /seedance2/.test(normalizeVideoModelId(modelId));
 }
 
+// 基础款 Seedance 2.0（`…seedance-2.0` 本体，不含 fast / value / fast-value 变体）。
+// 归一化后以 `seedance20` 结尾即为基础款——变体都会在后面多出 `fast` / `value` 后缀。
+function isBaseSeedance2VideoModel(modelId: string | null | undefined): boolean {
+  return /seedance20$/.test(normalizeVideoModelId(modelId));
+}
+
 /**
  * 指定模型是否支持某 genMode（与可见 tab / 切模型时是否重置残留模式口径一致）。
  * - HappyHorse：文生 / 首帧(i2v) / 图片参考(r2v) / 视频编辑。
@@ -239,4 +245,85 @@ export function videoSubmitMediaRejectionReason(
     return "该模型单次仅支持 1 张图片";
   }
   return null;
+}
+
+/**
+ * 模型选择器里某个候选**为什么不能选**（非 null 则置灰 + 悬浮显示这句理由）。
+ *
+ * 与上面的 `videoSubmitMediaRejectionReason` 是一对：那条管「选定模型后能不能提交」，
+ * 这条管「带着当前这堆上游素材，还能不能切到这个模型」。两者的阈值必须一致，否则会出现
+ * 「提交守卫说单图可以，选择器却不让你选」这种自相矛盾的状态。
+ *
+ * Seedance 1.x 的阈值是 **>1 图**，不是 >0：后端 i2v 端点只在 `len(source_paths) > 1`
+ * 且非 2.0 非 HappyHorse 时才 400（freezone.py），单图首帧正是 1.x 唯一能用、也是
+ * `videoEmptyStateCtaModes` 明确推荐给它的模式。写成 >0 会把「一张图 + Seedance 1.5 Pro」
+ * 这个完全合法的常规组合整个锁死。
+ */
+export function videoModelReferenceDisabledReason(
+  modelId: string | null | undefined,
+  counts: { images: number; videos: number; audios: number },
+): string | null {
+  if (isGrokVideoChannelModel(modelId)) {
+    if (counts.videos > 0 || counts.audios > 0) {
+      return "Grok Video Channel 仅支持图片素材";
+    }
+    if (counts.images > 8) {
+      return "Grok Video Channel 最多支持 1 张首帧和 7 张参考图";
+    }
+    return null;
+  }
+  if (isSeedance1xVideoModel(modelId)) {
+    if (counts.videos > 0 || counts.audios > 0) {
+      return "该模型仅支持图片素材";
+    }
+    if (counts.images > 1) {
+      return "该模型单次仅支持 1 张图片";
+    }
+  }
+  return null;
+}
+
+export interface VideoReferenceAutoSwitch {
+  /** 目标模型的 `id`（存进 `VideoNodeData.model` 的那个值，不是 apiModel）。 */
+  modelId: string;
+  genMode: VideoGenMode;
+}
+
+/**
+ * 上游接入视频 / 音频时的**自动救场**：Seedance 1.x 根本消费不了这两类素材
+ * （i2v 端点只收图，omni 端点非 2.0 直接 400），把用户留在 1.x 上只能得到一次
+ * 必然失败的提交。用户连上视频/音频节点这个动作本身就是明确意图，所以直接替他
+ * 换成能吃这些素材的 Seedance 2.0，并落到唯一能消费它们的「全能参考」。
+ *
+ * 只管 Seedance 1.x：
+ * - HappyHorse 有自己的「视频编辑」路径，能吃视频，不该被抢走；
+ * - Grok Video Channel 是用户显式选的独立渠道，只支持图片，这里不替他改渠道，
+ *   继续由选择器置灰 + 提交守卫兜底；
+ * - 2.0 本来就支持，无需动。
+ *
+ * 素材计数请传**按节点类型**的口径（空的视频节点也算），并且和喂给
+ * `videoModelReferenceDisabledReason` 的口径保持同源 —— 否则会出现「effect 把模型
+ * 切走、选择器又允许切回来」的来回打架。
+ *
+ * 目标锁定**基础款 Seedance 2.0**，而不是列表里排最前的 `Seedance2.0 Fast`：fast 是
+ * 提速降档的变体，替用户救场时把他悄悄放到降档模型上不合适；基础款也正是后端
+ * `FreezoneVideoGenRequest.model` 的默认值。基础款不在候选列表里（接口只下发了变体）
+ * 时退到任意一个 2.0——总比让他卡在必然失败的 1.x 上强；一个 2.0 都没有则返回 null，
+ * 宁可不动也不要瞎切。
+ */
+export function videoReferenceAutoSwitch(
+  currentModelId: string | null | undefined,
+  counts: { videos: number; audios: number },
+  models: readonly { id: string; apiModel?: string }[],
+): VideoReferenceAutoSwitch | null {
+  if (counts.videos === 0 && counts.audios === 0) {
+    return null;
+  }
+  if (!isSeedance1xVideoModel(currentModelId)) {
+    return null;
+  }
+  const target =
+    models.find((model) => isBaseSeedance2VideoModel(model.apiModel ?? model.id)) ??
+    models.find((model) => isSeedance2VideoModel(model.apiModel ?? model.id));
+  return target ? { modelId: target.id, genMode: "allReference" } : null;
 }


### PR DESCRIPTION
## PR 类型 / Type of PR
- [x] 🐛 Bug 修复 / Bug fix

## 改动说明 / What this PR does and why

### 1. 单图不该锁死 Seedance 1 系列

模型选择器的置灰守卫把 1 系列写成「只要连了图就不能选」：

```ts
if (isSeedance1xVideoModel(modelId)) {
  if (counts.images > 0 || ...) return "该模型不支持当前接入的素材";
}
```

一张图片节点就把 Seedance1.0 Pro Fast / Seedance1.5 Pro 整个锁死。但**单图首帧恰恰是 1.x 唯一能用的模式**，这条判定和另外三处口径全都对不上：

| 出处 | 对 1.x + 单图的口径 |
| --- | --- |
| 后端 `freezone.py` i2v 端点 | 只有 `len(source_paths) > 1` 才对非 2.0 / 非 HappyHorse 报 400 —— 单图放行 |
| `videoSubmitMediaRejectionReason`（提交守卫） | 同样只拦 `images > 1` |
| `videoEmptyStateCtaModes` | 给 1.x 明确返回 `["imageToVideo"]` |

来源是 `a1b97f2`（support grok-video-channel）顺手加的守卫写宽了。阈值改回 `> 1`，并按素材类型分开报理由（视频/音频 → 「仅支持图片素材」，多图 → 「单次仅支持 1 张图片」）。

### 2. 接入视频 / 音频时自动换 2.0

1.x 吃不下视频和音频，留在上面只能收获一次必然失败的提交。上游连上视频或音频节点时自动换成**基础款 Seedance 2.0** + **全能参考**（唯一能消费它们的模式）。

不取列表里排最前的 `Seedance2.0 Fast`：那是提速降档变体，替用户救场时不该悄悄降档；基础款也正是后端 `FreezoneVideoGenRequest.model` 的默认值。

### 3. 顺手补掉「HappyHorse + 音频」这个同形的死胡同（评审提出）

`isVideoModeSupportedByModel` 里 HappyHorse 永远到不了 `allReference`，而音频只有全能参考能消费 —— 于是「HappyHorse + 上游音频节点」和本 PR 要消灭的 1.x 症状完全同形：选择器放行、提交必被拦、也没有自动救场。这里把它一起堵上（选择器带音频即置灰），HappyHorse 的多图 / 视频仍放行，它们分别由 r2v 和视频编辑消化。

## 关联 issue / Linked issues
N/A

## 给 reviewer 的说明 / Notes for the reviewer

- **把 `videoModelReferenceDisabledReason` 搬进了 `videoModelCapabilities.ts`**。不只是整理：它和 `videoSubmitMediaRejectionReason` 是一对守卫（一条管「能不能切到这个模型」、一条管「切了能不能提交」），**分居两个文件正是这次漂开的原因**。两者要维持的不变量不是逐条阈值相等（HappyHorse 的多图 / 视频由它自己的路径消化，两边判断本就不同），而是**「不置灰 ⇒ 存在一个该模型支持、且提交守卫放行的模式」**。测试里有一张 5 模型 × images{0,1,2,9} × videos{0,1} × audios{0,1} 的网格直接守这条，任何「选得进去却走不通」的格子都会红。
- **自动切换的素材计数走「节点类型」口径**（`upstreamTypeCounts`，空的视频节点也算）。先连节点、后生成是正常顺序，等它出了 URL 再切模型，用户中间已经看见一个不该出现的 1.x 了。
- **选择器置灰的视频/音频维度同步改为同源**。这条不改就是 bug：连着空视频节点时 1.x 不置灰，用户能选回去，又被 effect 立刻切走，来回打架。图片维度仍走「已解析 URL」口径。
- **整个闸门是一个纯函数 `videoReferenceAutoSwitchAction`**（加载态 / 闩锁 / 该不该换 / 换成谁全在里面），组件那条 effect 只剩改 ref 和发 patch。这么切分是为了**异步加载时序能被测到** —— 光测「该换成谁」覆盖不到它，而那正是最容易出事的一段；测试里按帧回放 effect 的分支来验。
- **必须等 `isLoading` 落定才动**。`useFreezoneVideoModels` 在 pending 期间返回的不是空数组，而是硬编码的 `VIDEO_MODELS`：照着 fallback 挑出来的 2.0 未必存在于该项目的真列表里，提前切了还落闩，真列表回来也不再纠正，节点就卡在一个后端不认识的模型上、提交直接 400。
- **但只挡 `isLoading`，没有连 `isFallback` 一起挡**。`isFallback` 在「URL 没有 project」「拉取失败」「后端返回空列表」这三种**已落定**的情况下会一直是 true，而此时选择器渲染的正是同一份 `VIDEO_MODELS`（`ProviderModelPicker` 用的就是这个 hook 的 `models`），2.0 就在里面、用户手动也能选中 —— 跟着它一起挡等于在这些情况下永久关掉救场，把用户留在 1.x + 视频这个必 400 的组合里。有一条测试专门钉住这个区别。
- **自动切换是一次性闩锁**（`autoSwitchedForMediaRef`，只在「没有 → 有视频/音频」这一次跳变时触发），和紧邻上面那条音频 effect 的 `prevHasAudioRef` 同一套写法。`updateNodeData` 每次都 pushSnapshot 且清空 `future`，若持续纠正，用户 ⌘Z 恢复回 1.x 后边还在、立刻被写回 2.0，撤销看起来毫无反应且 redo 栈被清空。「没切成」不落闩：列表里一个 2.0 都没有时把这次跳变留着，列表变了还有机会补救。
- **模型 + 模式一次 patch 写完**，不靠已有的 `videos → allReference` effect 补第二刀 —— 分两步会先渲染出「2.0 + 图生视频」的中间态再被纠正，白闪一帧。
- **只抢 Seedance 1.x**：HappyHorse 有自己的视频编辑路径能吃视频；Grok Video Channel 是用户显式选的独立渠道，替它改渠道太越权，继续由置灰 + 提交守卫兜底（且它当前在后端 `FREEZONE_DISABLED_VIDEO_BACKENDS` 里是关掉的，那条分支休眠）；2.0 本来就支持。候选列表里一个 2.0 都没有（接口异常）时不动。
- **自动切换刻意不调 `writeLastVideoModel`**：这是替用户救场、不是他表达的偏好，不该顺手把后续新建视频节点继承的默认模型也改掉。
- 测试都加在既有的 `video-model-capabilities.test.ts` 里（没有新增文件，license-inventory 无需变更）。其中「切换结果自洽」一条会把新模型 + 新模式拿同一份素材再过一遍置灰守卫 / 提交守卫 / 模式支持判定，防的是把用户从一个死胡同推进另一个。

## 面向用户的变更 / User-facing change
```release-note
修复画布视频节点连接单张图片时无法选择 Seedance 1 系列模型的问题；接入视频或音频素材时会自动切换到 Seedance 2.0 的全能参考模式。
```

## 自检 / Checklist
- [x] 已自测 / Self-tested — `tsc -b` 干净，`vitest` 1912 passed（286 files，新增 22 条），`pnpm build` 通过
- [x] 必要的文档已更新 / Docs updated where needed — 判定口径写在 `videoModelCapabilities.ts` 的注释里
- [x] 提交信息清晰（建议 Conventional Commits）/ Clear commits
- [x] 每个 commit 都已 `git commit -s` 附 DCO 签署 / Every commit signed off

🤖 Generated with [Claude Code](https://claude.com/claude-code)
