### PR TITLE
fix(canvas): 音频节点只能连视频/视频合成，音视频分离的背景音不再孤立

### DIFF
--- a/frontend/src/__tests__/features/canvas/canvas-manual-connect.test.tsx
+++ b/frontend/src/__tests__/features/canvas/canvas-manual-connect.test.tsx
@@ -2,7 +2,7 @@
 // Copyright (c) 2026 ClaymoreLab
 import { act, render, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import type { Connection, FinalConnectionState, OnConnectStartParams } from "@xyflow/react";
+import type { Connection, Edge, FinalConnectionState, OnConnectStartParams } from "@xyflow/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { CANVAS_NODE_TYPES } from "@/features/canvas/domain/canvasNodes";
@@ -397,5 +397,79 @@ describe("Canvas manual skill connections", () => {
         reference_target: { kind: "identity", identity_id: "GREEN" },
       },
     });
+  });
+});
+
+// 拖线时的落点校验(isValidConnection)和松手时的建边判定(onConnect)是两处独立代码,
+// 一旦口径不一致,用户看到的是「拖过去高亮成合法、一松手什么也没有」。这里不去断言
+// 某个具体规则,而是断言这两处**对同一对节点给出同一个答案** —— 规则以后怎么改都行,
+// 两边一起改就行。
+describe("Canvas 拖线落点校验与建边判定对齐", () => {
+  const NODES = [
+    { id: "text", type: CANVAS_NODE_TYPES.textAnnotation, data: { text: "旁白" } },
+    { id: "audio", type: CANVAS_NODE_TYPES.audio, data: { audioUrl: "/a.mp3" } },
+    { id: "image", type: CANVAS_NODE_TYPES.imageGen, data: { imageUrl: "/i.png" } },
+    { id: "video", type: CANVAS_NODE_TYPES.video, data: { videoUrl: "/v.mp4" } },
+  ];
+
+  // 至少要覆盖到一对「建边规则放行、但不开放手工创建」的边(视频→音频那条溯源边),
+  // 否则两处都用宽松规则也能让测试全绿。
+  const PAIRS: { source: string; target: string; expected: boolean }[] = [
+    { source: "text", target: "audio", expected: true },
+    { source: "audio", target: "video", expected: true },
+    { source: "audio", target: "image", expected: false },
+    { source: "video", target: "audio", expected: false },
+  ];
+
+  function resetCanvas() {
+    useCanvasStore.getState().setCanvasData(
+      NODES.map((node, index) => ({
+        ...node,
+        position: { x: index * 400, y: 0 },
+      })),
+      [],
+    );
+  }
+
+  beforeEach(() => {
+    capturedOnConnect = null;
+    capturedReactFlowProps = null;
+    vi.stubGlobal("ResizeObserver", ResizeObserverMock);
+    resetCanvas();
+  });
+
+  it("两处判定对每一对节点给出同一个答案", async () => {
+    renderCanvas();
+    await waitFor(() => expect(capturedOnConnect).toBeTruthy());
+
+    for (const pair of PAIRS) {
+      act(() => {
+        resetCanvas();
+      });
+      const connection: Connection = {
+        source: pair.source,
+        sourceHandle: "source",
+        target: pair.target,
+        targetHandle: "target",
+      };
+
+      const isValidConnection = capturedReactFlowProps?.isValidConnection as
+        | ((connection: Connection | Edge) => boolean)
+        | undefined;
+      const highlightedAsValid = isValidConnection?.(connection);
+
+      act(() => {
+        capturedOnConnect?.(connection);
+      });
+      const edgeCreated = useCanvasStore
+        .getState()
+        .edges.some((edge) => edge.source === pair.source && edge.target === pair.target);
+
+      expect({ ...pair, highlightedAsValid, edgeCreated }).toEqual({
+        ...pair,
+        highlightedAsValid: pair.expected,
+        edgeCreated: pair.expected,
+      });
+    }
   });
 });

--- a/frontend/src/__tests__/features/canvas/node-registry.test.ts
+++ b/frontend/src/__tests__/features/canvas/node-registry.test.ts
@@ -76,6 +76,21 @@ describe("建边白名单", () => {
     );
   });
 
+  it("「人声/背景音分离」留下的视频 → 音频溯源边合法", () => {
+    // NodeActionToolbar 的音视频分离动作从一个视频节点同时产出「背景音」音频节点
+    // 与「无声」视频节点，两条边都画回源视频。音频那条边曾被建边收口静默丢掉。
+    expect(isUpstreamConnectionAllowed(CANVAS_NODE_TYPES.video, CANVAS_NODE_TYPES.audio)).toBe(
+      true,
+    );
+    expect(isUpstreamConnectionAllowed(CANVAS_NODE_TYPES.video, CANVAS_NODE_TYPES.video)).toBe(
+      true,
+    );
+    // 放开 video 不等于放开所有类型：图片仍然连不进音频节点。
+    expect(isUpstreamConnectionAllowed(CANVAS_NODE_TYPES.imageGen, CANVAS_NODE_TYPES.audio)).toBe(
+      false,
+    );
+  });
+
   it("新增的下游白名单不误伤既有连线", () => {
     // 文本 → 音频（音频节点唯一的合法上游）仍然放行。
     expect(

--- a/frontend/src/__tests__/features/canvas/node-registry.test.ts
+++ b/frontend/src/__tests__/features/canvas/node-registry.test.ts
@@ -8,7 +8,11 @@ import {
   getAllowedDownstreamTargetTypes,
   getDownstreamSpawnTypes,
   getMenuNodeDefinitions,
+  getUpstreamSpawnTypes,
+  isManualConnectionAllowed,
   isUpstreamConnectionAllowed,
+  DOWNSTREAM_SPAWN_WHITELIST,
+  UPSTREAM_SPAWN_WHITELIST,
 } from "@/features/canvas/domain/nodeRegistry";
 
 describe("canvas node registry", () => {
@@ -106,18 +110,66 @@ describe("建边白名单", () => {
     ).toBe(true);
   });
 
-  it("菜单给出的下游候选必然是建边规则放行的", () => {
-    // 这条守的是「菜单能创建、边却被拒」这类漂移：用户点了以后新节点建出来了，
-    // 边被 store 的建边收口丢掉，画布上只剩一个连不上的孤立节点。
-    const orphans: string[] = [];
-    for (const originType of Object.keys(canvasNodeDefinitions) as CanvasNodeType[]) {
-      for (const spawnType of getDownstreamSpawnTypes(originType)) {
-        if (!isUpstreamConnectionAllowed(originType, spawnType)) {
-          orphans.push(`${originType} -> ${spawnType}`);
+  it("菜单的产品白名单不与建边规则冲突", () => {
+    // 断言落在**声明**的白名单上，而不是 getXxxSpawnTypes 的返回值 —— 那两个函数
+    // 出口处就用建边规则过了一道，拿同一个谓词去断言它们的输出必然恒真，守不住
+    // 任何漂移。这里查的是「产品意图里写了、但建边规则根本不放行」的格子：运行时
+    // 会被静默过滤掉，菜单和白名单从此对不上，而没人会发现。
+    const conflicts: string[] = [];
+    for (const [source, targets] of Object.entries(DOWNSTREAM_SPAWN_WHITELIST)) {
+      for (const target of targets ?? []) {
+        if (!isUpstreamConnectionAllowed(source as CanvasNodeType, target)) {
+          conflicts.push(`下游白名单 ${source} -> ${target}`);
+        }
+      }
+    }
+    for (const [target, sources] of Object.entries(UPSTREAM_SPAWN_WHITELIST)) {
+      for (const source of sources ?? []) {
+        if (!isUpstreamConnectionAllowed(source, target as CanvasNodeType)) {
+          conflicts.push(`上游白名单 ${source} -> ${target}`);
         }
       }
     }
 
-    expect(orphans).toEqual([]);
+    expect(conflicts).toEqual([]);
+  });
+});
+
+describe("连线菜单候选", () => {
+  it("音频节点的上游菜单里没有视频", () => {
+    // 视频 → 音频那条边是「人声/背景音分离」程序建的溯源边，建边收口必须放行
+    // （否则存量边会被加载规范化丢掉），但用户手工连一根视频进来什么都不会发生
+    // —— AudioOperationsPanel 只读 text 上游。菜单和手动拖线都不该提供。
+    expect(getUpstreamSpawnTypes(CANVAS_NODE_TYPES.audio)).toEqual([
+      CANVAS_NODE_TYPES.textAnnotation,
+    ]);
+    expect(isManualConnectionAllowed(CANVAS_NODE_TYPES.video, CANVAS_NODE_TYPES.audio)).toBe(
+      false,
+    );
+    // 但建边规则本身仍放行 —— 这正是两者要分开的原因。
+    expect(isUpstreamConnectionAllowed(CANVAS_NODE_TYPES.video, CANVAS_NODE_TYPES.audio)).toBe(
+      true,
+    );
+  });
+
+  it("其余节点的菜单候选不受影响", () => {
+    expect(getUpstreamSpawnTypes(CANVAS_NODE_TYPES.video)).toEqual([
+      CANVAS_NODE_TYPES.textAnnotation,
+      CANVAS_NODE_TYPES.imageGen,
+      CANVAS_NODE_TYPES.audio,
+    ]);
+    expect(getUpstreamSpawnTypes(CANVAS_NODE_TYPES.imageGen)).toEqual([
+      CANVAS_NODE_TYPES.textAnnotation,
+      CANVAS_NODE_TYPES.script,
+      CANVAS_NODE_TYPES.upload,
+    ]);
+    expect(getDownstreamSpawnTypes(CANVAS_NODE_TYPES.audio)).toEqual([
+      CANVAS_NODE_TYPES.video,
+      CANVAS_NODE_TYPES.videoCompose,
+    ]);
+    // 图片类节点的下游不含音频。
+    expect(getDownstreamSpawnTypes(CANVAS_NODE_TYPES.imageGen)).not.toContain(
+      CANVAS_NODE_TYPES.audio,
+    );
   });
 });

--- a/frontend/src/__tests__/features/canvas/node-registry.test.ts
+++ b/frontend/src/__tests__/features/canvas/node-registry.test.ts
@@ -2,10 +2,13 @@
 // Copyright (c) 2026 ClaymoreLab
 import { describe, expect, it } from "vitest";
 
-import { CANVAS_NODE_TYPES } from "@/features/canvas/domain/canvasNodes";
+import { CANVAS_NODE_TYPES, type CanvasNodeType } from "@/features/canvas/domain/canvasNodes";
 import {
   canvasNodeDefinitions,
+  getAllowedDownstreamTargetTypes,
+  getDownstreamSpawnTypes,
   getMenuNodeDefinitions,
+  isUpstreamConnectionAllowed,
 } from "@/features/canvas/domain/nodeRegistry";
 
 describe("canvas node registry", () => {
@@ -43,5 +46,63 @@ describe("canvas node registry", () => {
       syncStatus: "fresh",
     });
     expect(data).not.toHaveProperty("mainline_context");
+  });
+});
+
+const IMAGE_NODE_TYPES = [
+  CANVAS_NODE_TYPES.imageGen,
+  CANVAS_NODE_TYPES.imageEdit,
+  CANVAS_NODE_TYPES.upload,
+  CANVAS_NODE_TYPES.exportImage,
+] as const;
+
+describe("建边白名单", () => {
+  it("音频节点连不到图片节点上", () => {
+    for (const imageType of IMAGE_NODE_TYPES) {
+      expect(isUpstreamConnectionAllowed(CANVAS_NODE_TYPES.audio, imageType)).toBe(false);
+    }
+  });
+
+  it("音频节点的下游只有视频与视频合成", () => {
+    // 只有这两种节点会读上游音频（视频的声轨素材 / 合成的音频轨），连到别处
+    // 不会有任何效果，只是画布上一根骗人的线。
+    const allTypes = Object.keys(canvasNodeDefinitions) as CanvasNodeType[];
+    const reachable = allTypes.filter((type) =>
+      isUpstreamConnectionAllowed(CANVAS_NODE_TYPES.audio, type),
+    );
+
+    expect([...reachable].sort()).toEqual(
+      [CANVAS_NODE_TYPES.video, CANVAS_NODE_TYPES.videoCompose].sort(),
+    );
+  });
+
+  it("新增的下游白名单不误伤既有连线", () => {
+    // 文本 → 音频（音频节点唯一的合法上游）仍然放行。
+    expect(
+      isUpstreamConnectionAllowed(CANVAS_NODE_TYPES.textAnnotation, CANVAS_NODE_TYPES.audio),
+    ).toBe(true);
+    // 没有下游白名单的源类型不受新表影响。
+    expect(getAllowedDownstreamTargetTypes(CANVAS_NODE_TYPES.imageGen)).toBeNull();
+    expect(
+      isUpstreamConnectionAllowed(CANVAS_NODE_TYPES.imageGen, CANVAS_NODE_TYPES.video),
+    ).toBe(true);
+    expect(
+      isUpstreamConnectionAllowed(CANVAS_NODE_TYPES.video, CANVAS_NODE_TYPES.videoCompose),
+    ).toBe(true);
+  });
+
+  it("菜单给出的下游候选必然是建边规则放行的", () => {
+    // 这条守的是「菜单能创建、边却被拒」这类漂移：用户点了以后新节点建出来了，
+    // 边被 store 的建边收口丢掉，画布上只剩一个连不上的孤立节点。
+    const orphans: string[] = [];
+    for (const originType of Object.keys(canvasNodeDefinitions) as CanvasNodeType[]) {
+      for (const spawnType of getDownstreamSpawnTypes(originType)) {
+        if (!isUpstreamConnectionAllowed(originType, spawnType)) {
+          orphans.push(`${originType} -> ${spawnType}`);
+        }
+      }
+    }
+
+    expect(orphans).toEqual([]);
   });
 });

--- a/frontend/src/__tests__/stores/canvas-store-convert-node-type.test.ts
+++ b/frontend/src/__tests__/stores/canvas-store-convert-node-type.test.ts
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: Elastic-2.0
+// Copyright (c) 2026 ClaymoreLab
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { useCanvasStore } from "@/stores/canvasStore";
+import { CANVAS_NODE_TYPES } from "@/features/canvas/domain/canvasNodes";
+
+function edgesOf(nodeId: string) {
+  return useCanvasStore
+    .getState()
+    .edges.filter((edge) => edge.source === nodeId || edge.target === nodeId);
+}
+
+describe("canvasStore.convertNodeType — 换类型后同步清理不再合法的边", () => {
+  beforeEach(() => {
+    useCanvasStore.getState().setCanvasData([], []);
+  });
+
+  it("Upload 转成音频后，原来连向图片节点的边被清掉", () => {
+    // 空 Upload 节点先连到图片节点（合法），之后用户往里丢了个音频文件，
+    // UploadNode 会把它转成 Audio —— 那条边从此不合法。不清掉的话它会一直留在
+    // 画布上，直到下次加载被规范化静默删除。
+    const store = useCanvasStore.getState();
+    const upload = store.addNode(CANVAS_NODE_TYPES.upload, { x: 0, y: 0 }, {});
+    const image = store.addNode(CANVAS_NODE_TYPES.imageGen, { x: 400, y: 0 }, {});
+
+    useCanvasStore.getState().onConnect({
+      source: upload,
+      target: image,
+      sourceHandle: "source",
+      targetHandle: "target",
+    });
+    expect(edgesOf(upload)).toHaveLength(1);
+
+    const ok = useCanvasStore
+      .getState()
+      .convertNodeType(upload, CANVAS_NODE_TYPES.audio, { audioUrl: "a.mp3" });
+
+    expect(ok).toBe(true);
+    expect(edgesOf(upload)).toEqual([]);
+  });
+
+  it("换类型后仍然合法的边原样保留", () => {
+    // 音频 → 视频是合法的，Upload 转成 Audio 之后这条边不该被误伤。
+    const store = useCanvasStore.getState();
+    const upload = store.addNode(CANVAS_NODE_TYPES.upload, { x: 0, y: 0 }, {});
+    const video = store.addNode(CANVAS_NODE_TYPES.video, { x: 400, y: 0 }, {});
+
+    useCanvasStore.getState().onConnect({
+      source: upload,
+      target: video,
+      sourceHandle: "source",
+      targetHandle: "target",
+    });
+    expect(edgesOf(upload)).toHaveLength(1);
+
+    useCanvasStore
+      .getState()
+      .convertNodeType(upload, CANVAS_NODE_TYPES.audio, { audioUrl: "a.mp3" });
+
+    expect(edgesOf(upload)).toHaveLength(1);
+  });
+
+  it("清理后的边可以被撤销恢复", () => {
+    const store = useCanvasStore.getState();
+    const upload = store.addNode(CANVAS_NODE_TYPES.upload, { x: 0, y: 0 }, {});
+    const image = store.addNode(CANVAS_NODE_TYPES.imageGen, { x: 400, y: 0 }, {});
+
+    useCanvasStore.getState().onConnect({
+      source: upload,
+      target: image,
+      sourceHandle: "source",
+      targetHandle: "target",
+    });
+    useCanvasStore
+      .getState()
+      .convertNodeType(upload, CANVAS_NODE_TYPES.audio, { audioUrl: "a.mp3" });
+    expect(edgesOf(upload)).toEqual([]);
+
+    useCanvasStore.getState().undo();
+
+    expect(edgesOf(upload)).toHaveLength(1);
+    const restored = useCanvasStore.getState().nodes.find((node) => node.id === upload);
+    expect(restored?.type).toBe(CANVAS_NODE_TYPES.upload);
+  });
+});

--- a/frontend/src/features/canvas/Canvas.tsx
+++ b/frontend/src/features/canvas/Canvas.tsx
@@ -87,10 +87,11 @@ import { readUrl } from '@/lib/url-params';
 import { useQueryClient } from '@tanstack/react-query';
 import { prefetchEpisodeBeats, prefetchEpisodeDetail } from '@/lib/queries/episodes';
 import {
-  getConnectMenuNodeTypes,
   getDownstreamSpawnTypes,
+  getUpstreamSpawnTypes,
   getAllowedDownstreamTargetTypes,
   getAllowedUpstreamSourceTypes,
+  isManualConnectionAllowed,
   isUpstreamConnectionAllowed,
   nodeHasSourceHandle,
   nodeHasTargetHandle,
@@ -483,56 +484,12 @@ function resolveAllowedNodeTypes(
   handleType: HandleType,
   originNodeType?: CanvasNodeType,
 ): CanvasNodeType[] {
-  // 拖线落空时弹出的「创建新节点」菜单，与 NodeSpawnPlusOverlay 的 + 菜单
-  // 共用同一份白名单：source 端用 getDownstreamSpawnTypes(originType)。
-  if (handleType === 'source') {
-    return getDownstreamSpawnTypes(originNodeType);
-  }
-  // 候选上游里先剔掉「下游白名单不含本节点类型」的类型（如音频只能连视频 / 视频
-  // 合成）。不剔的话菜单里能创建，但创建完那条边会被建边规则拒掉，画布上只剩一个
-  // 孤零零的新节点。
-  const base = getConnectMenuNodeTypes(handleType).filter(
-    (type) => !originNodeType || isUpstreamConnectionAllowed(type, originNodeType),
-  );
-  // 3D 世界节点的上游仅允许文本 / 图片节点（Phase 1）。
-  if (originNodeType === CANVAS_NODE_TYPES.threeDWorld && handleType === 'target') {
-    const allowed = new Set<CanvasNodeType>([
-      CANVAS_NODE_TYPES.textAnnotation,
-      CANVAS_NODE_TYPES.imageGen,
-    ]);
-    return base.filter((type) => allowed.has(type));
-  }
-  // 图片节点的上游仅允许 文本（textAnnotation / script）+ 图片（upload）
-  // —— 不收音频 / 视频 / 3D 世界。这里不沿用 base 过滤，因为 base 只看
-  // `fromTarget: true`，textAnnotation / imageGen 等 fromTarget 默认为 false
-  // 会被错杀；我们对 imageGen target 直接重写候选集。
-  if (originNodeType === CANVAS_NODE_TYPES.imageGen && handleType === 'target') {
-    return [
-      CANVAS_NODE_TYPES.textAnnotation,
-      CANVAS_NODE_TYPES.script,
-      CANVAS_NODE_TYPES.upload,
-    ];
-  }
-  // 视频节点的上游仅允许 文本 / 图片（imageGen） / 音频 —— 跟
-  // NodeSpawnPlusOverlay 左侧「+」按钮的白名单保持一致。
-  if (originNodeType === CANVAS_NODE_TYPES.video && handleType === 'target') {
-    return [
-      CANVAS_NODE_TYPES.textAnnotation,
-      CANVAS_NODE_TYPES.imageGen,
-      CANVAS_NODE_TYPES.audio,
-    ];
-  }
-  // 受上游类型白名单约束的目标（如音频←文本）：直接返回领域层白名单，保证连线
-  // 菜单、手动拖线、isValidConnection、store 建边收口共用同一份规则。这里不沿用
-  // base 过滤——base 只看 connectMenu.fromTarget，textAnnotation 的 fromTarget
-  // 为 false 会被错杀。
-  if (handleType === 'target' && originNodeType) {
-    const allowedUpstream = getAllowedUpstreamSourceTypes(originNodeType);
-    if (allowedUpstream) {
-      return [...allowedUpstream];
-    }
-  }
-  return base;
+  // 拖线落空时弹出的「创建新节点」菜单，与 NodeSpawnPlusOverlay 的 + 菜单共用
+  // 同一份产品白名单，两侧都住在 nodeRegistry 里（连同建边规则一起，便于测试
+  // 「菜单候选 vs 建边规则」是否打架）。
+  return handleType === 'source'
+    ? getDownstreamSpawnTypes(originNodeType)
+    : getUpstreamSpawnTypes(originNodeType);
 }
 
 // 3D 世界节点的目标允许的手动拖线源：任何可以承载图片或文本结果的节点。
@@ -564,11 +521,13 @@ function canNodeTypeBeManualConnectionSource(
     return targetType ? PANO_360_DOWNSTREAM_IMAGE_TYPES.has(targetType) : true;
   }
   // 受类型白名单约束的连接（音频←文本、音频→视频/视频合成）走领域层统一规则。
+  // 这里查的是「手工」建边规则：视频→音频那条溯源边由「人声/背景音分离」程序建立，
+  // 建边收口放行，但不该让用户自己拖出来。
   if (
     targetType &&
     (getAllowedUpstreamSourceTypes(targetType) || getAllowedDownstreamTargetTypes(type))
   ) {
-    return isUpstreamConnectionAllowed(type, targetType);
+    return isManualConnectionAllowed(type, targetType);
   }
   // 只要 getDownstreamSpawnTypes 给这种类型留了至少一个合法下游，就允许从右侧
   // source handle 拖线创建 —— 这样 + 菜单和拖线菜单始终对齐，新增节点类型时

--- a/frontend/src/features/canvas/Canvas.tsx
+++ b/frontend/src/features/canvas/Canvas.tsx
@@ -92,7 +92,6 @@ import {
   getAllowedDownstreamTargetTypes,
   getAllowedUpstreamSourceTypes,
   isManualConnectionAllowed,
-  isUpstreamConnectionAllowed,
   nodeHasSourceHandle,
   nodeHasTargetHandle,
 } from '@/features/canvas/domain/nodeRegistry';
@@ -1746,11 +1745,14 @@ export function Canvas({
       if (!targetId) return true;
       const targetNode = nodes.find((node) => node.id === targetId);
       if (!targetNode) return true;
-      // 上游类型规则：拖线过程中即把不合法的源（如音频连音频）变灰、禁止落点。
+      // 类型规则：拖线过程中就把不合法的源（如音频连图片）变灰、禁止落点。刻意复用
+      // handleConnect 松手时那把尺子本身 —— 只查领域层的手工建边规则是不够的，那样
+      // 3D 世界 / 360° 全景的额外限制会漏在外面，表现成「拖过去高亮成合法、一松手
+      // 什么也没有」（视频→音频那条溯源边就是这样：建边规则放行，但不开放手工创建）。
       const sourceNode = connection.source
         ? nodes.find((node) => node.id === connection.source)
         : undefined;
-      if (sourceNode && !isUpstreamConnectionAllowed(sourceNode.type, targetNode.type)) {
+      if (sourceNode && !canNodeTypeBeManualConnectionSource(sourceNode.type, targetNode.type)) {
         return false;
       }
       if (targetNode.type !== CANVAS_NODE_TYPES.threeDWorld) return true;

--- a/frontend/src/features/canvas/Canvas.tsx
+++ b/frontend/src/features/canvas/Canvas.tsx
@@ -89,6 +89,7 @@ import { prefetchEpisodeBeats, prefetchEpisodeDetail } from '@/lib/queries/episo
 import {
   getConnectMenuNodeTypes,
   getDownstreamSpawnTypes,
+  getAllowedDownstreamTargetTypes,
   getAllowedUpstreamSourceTypes,
   isUpstreamConnectionAllowed,
   nodeHasSourceHandle,
@@ -487,7 +488,12 @@ function resolveAllowedNodeTypes(
   if (handleType === 'source') {
     return getDownstreamSpawnTypes(originNodeType);
   }
-  const base = getConnectMenuNodeTypes(handleType);
+  // 候选上游里先剔掉「下游白名单不含本节点类型」的类型（如音频只能连视频 / 视频
+  // 合成）。不剔的话菜单里能创建，但创建完那条边会被建边规则拒掉，画布上只剩一个
+  // 孤零零的新节点。
+  const base = getConnectMenuNodeTypes(handleType).filter(
+    (type) => !originNodeType || isUpstreamConnectionAllowed(type, originNodeType),
+  );
   // 3D 世界节点的上游仅允许文本 / 图片节点（Phase 1）。
   if (originNodeType === CANVAS_NODE_TYPES.threeDWorld && handleType === 'target') {
     const allowed = new Set<CanvasNodeType>([
@@ -557,8 +563,11 @@ function canNodeTypeBeManualConnectionSource(
   if (type === CANVAS_NODE_TYPES.pano360Viewer) {
     return targetType ? PANO_360_DOWNSTREAM_IMAGE_TYPES.has(targetType) : true;
   }
-  // 受上游类型白名单约束的目标（如音频←文本）走领域层统一规则。
-  if (targetType && getAllowedUpstreamSourceTypes(targetType)) {
+  // 受类型白名单约束的连接（音频←文本、音频→视频/视频合成）走领域层统一规则。
+  if (
+    targetType &&
+    (getAllowedUpstreamSourceTypes(targetType) || getAllowedDownstreamTargetTypes(type))
+  ) {
     return isUpstreamConnectionAllowed(type, targetType);
   }
   // 只要 getDownstreamSpawnTypes 给这种类型留了至少一个合法下游，就允许从右侧

--- a/frontend/src/features/canvas/domain/nodeRegistry.ts
+++ b/frontend/src/features/canvas/domain/nodeRegistry.ts
@@ -709,6 +709,30 @@ export function isUpstreamConnectionAllowed(
   return true;
 }
 
+// 只由系统动作建立、**不开放给用户手工创建**的边。上面两张表必须放行它们（否则
+// 加载规范化会把存量边丢掉），但连线菜单和手动拖线不该提供 —— 用户自己画一根出来
+// 没有任何消费方，又是一根骗人的线。
+const SYSTEM_ONLY_CONNECTIONS: readonly (readonly [CanvasNodeType, CanvasNodeType])[] = [
+  // 「人声/背景音分离」把产出的「背景音」音频节点画回源视频，是条溯源边。音频节点
+  // 自己只读文本上游（AudioOperationsPanel 只取 text），手工连一根视频进来什么都
+  // 不会发生。
+  [CANVAS_NODE_TYPES.video, CANVAS_NODE_TYPES.audio],
+];
+
+// 判断用户能不能**手工**建立这条边：建边规则放行，且不是系统专用边。菜单候选与
+// 手动拖线查这条；store 的建边收口查的仍是 isUpstreamConnectionAllowed。
+export function isManualConnectionAllowed(
+  sourceType: CanvasNodeType,
+  targetType: CanvasNodeType,
+): boolean {
+  if (!isUpstreamConnectionAllowed(sourceType, targetType)) {
+    return false;
+  }
+  return !SYSTEM_ONLY_CONNECTIONS.some(
+    ([source, target]) => source === sourceType && target === targetType,
+  );
+}
+
 export function getConnectMenuNodeTypes(handleType: 'source' | 'target'): CanvasNodeType[] {
   const fromSource = handleType === 'source';
   return Object.values(canvasNodeDefinitions)
@@ -721,69 +745,120 @@ export function getConnectMenuNodeTypes(handleType: 'source' | 'target'): Canvas
     .map((definition) => definition.type);
 }
 
-// 给定起源节点类型，返回「从右侧 source handle 出发能创建的下游节点类型集」。
-// 这是 + 菜单（NodeSpawnPlusOverlay）和拖线落空菜单（Canvas.handleConnectEnd）
-// 共用的产品级白名单，必须保持单一事实来源。
+// 图片类节点（upload / imageEdit / imageGen / exportImage）共用的下游候选。
+const IMAGE_DOWNSTREAM_SPAWN_TYPES: readonly CanvasNodeType[] = [
+  CANVAS_NODE_TYPES.textAnnotation,
+  CANVAS_NODE_TYPES.imageGen,
+  CANVAS_NODE_TYPES.video,
+  CANVAS_NODE_TYPES.script,
+  CANVAS_NODE_TYPES.pano360Viewer,
+  CANVAS_NODE_TYPES.threeDWorld,
+];
+
+// 「从右侧 source handle 出发能创建哪些下游节点」的产品白名单。这是 + 菜单
+// （NodeSpawnPlusOverlay）和拖线落空菜单（Canvas.handleConnectEnd）共用的那一份。
+// 不在表中的源类型回落到注册表的 connectMenu.fromSource 默认列表。
 //
-// - 视频：仅允许 文本 / 视频 / 脚本 —— 图片/音频/多版本不该作为视频下游。
-// - 图片类（upload/imageEdit/imageGen/exportImage）：允许 文本 / 图片 / 视频 /
-//   脚本 / 360° / 3D 世界，排除 多版本 与 音频。
-// - 其他：回落到注册表中 connectMenu.fromSource 默认列表。
+// 这里写的是**产品意图**，不代表边一定建得起来 —— 建边规则（上面两张表 +
+// SYSTEM_ONLY_CONNECTIONS）才是最终裁决，取用时会再过一道。两者若打架，测试
+// 「菜单白名单不与建边规则冲突」会红。
+export const DOWNSTREAM_SPAWN_WHITELIST: Partial<
+  Record<CanvasNodeType, readonly CanvasNodeType[]>
+> = {
+  // 视频：仅允许 文本 / 视频 / 视频合成 / 脚本 —— 图片、音频、多版本不该作为下游。
+  [CANVAS_NODE_TYPES.video]: [
+    CANVAS_NODE_TYPES.textAnnotation,
+    CANVAS_NODE_TYPES.video,
+    CANVAS_NODE_TYPES.videoCompose,
+    CANVAS_NODE_TYPES.script,
+  ],
+  // 音频：下游只有视频（声轨素材）与视频合成（音频轨）读得懂。
+  [CANVAS_NODE_TYPES.audio]: [CANVAS_NODE_TYPES.video, CANVAS_NODE_TYPES.videoCompose],
+  // 360° 全景查看器：截图都是图片，下游只接图片类节点。
+  [CANVAS_NODE_TYPES.pano360Viewer]: [
+    CANVAS_NODE_TYPES.imageGen,
+    CANVAS_NODE_TYPES.imageEdit,
+    CANVAS_NODE_TYPES.exportImage,
+    CANVAS_NODE_TYPES.upload,
+  ],
+  [CANVAS_NODE_TYPES.upload]: IMAGE_DOWNSTREAM_SPAWN_TYPES,
+  [CANVAS_NODE_TYPES.imageEdit]: IMAGE_DOWNSTREAM_SPAWN_TYPES,
+  [CANVAS_NODE_TYPES.imageGen]: IMAGE_DOWNSTREAM_SPAWN_TYPES,
+  [CANVAS_NODE_TYPES.exportImage]: IMAGE_DOWNSTREAM_SPAWN_TYPES,
+};
+
+// 给定起源节点类型，返回「从右侧 source handle 出发能创建的下游节点类型集」。
 export function getDownstreamSpawnTypes(
   originType: CanvasNodeType | undefined,
 ): CanvasNodeType[] {
   const base = getConnectMenuNodeTypes('source');
   if (!originType) return base;
-  // 先过一遍建边白名单：菜单里出现的候选必须真的连得上。否则用户点了以后新节点
-  // 建出来了、边被建边规则拒掉，画布上留下一个孤立节点（如脚本 → 音频）。
-  const connectable = base.filter((type) => isUpstreamConnectionAllowed(originType, type));
+  // 再过一遍手工建边规则：菜单里出现的候选必须真的连得上。否则用户点了以后新节点
+  // 建出来了、边被建边收口拒掉，画布上留下一个孤立节点（如脚本 → 音频）。
+  const connectable = base.filter((type) => isManualConnectionAllowed(originType, type));
+  const allowed = DOWNSTREAM_SPAWN_WHITELIST[originType];
+  return allowed ? connectable.filter((type) => allowed.includes(type)) : connectable;
+}
 
-  if (originType === CANVAS_NODE_TYPES.video) {
-    const allowed = new Set<CanvasNodeType>([
-      CANVAS_NODE_TYPES.textAnnotation,
-      CANVAS_NODE_TYPES.video,
-      CANVAS_NODE_TYPES.videoCompose,
-      CANVAS_NODE_TYPES.script,
-    ]);
-    return connectable.filter((type) => allowed.has(type));
+// 「从左侧 target handle 出发能创建哪些上游节点」的产品白名单 —— 上面那张表的
+// 镜像。同样只是产品意图，取用时仍要过手工建边规则。
+export const UPSTREAM_SPAWN_WHITELIST: Partial<
+  Record<CanvasNodeType, readonly CanvasNodeType[]>
+> = {
+  // 3D 世界：上游仅允许文本 / 图片节点（Phase 1）。
+  [CANVAS_NODE_TYPES.threeDWorld]: [
+    CANVAS_NODE_TYPES.textAnnotation,
+    CANVAS_NODE_TYPES.imageGen,
+  ],
+  // 图片节点：上游仅允许 文本（textAnnotation / script）+ 图片（upload），
+  // 不收音频 / 视频 / 3D 世界。
+  [CANVAS_NODE_TYPES.imageGen]: [
+    CANVAS_NODE_TYPES.textAnnotation,
+    CANVAS_NODE_TYPES.script,
+    CANVAS_NODE_TYPES.upload,
+  ],
+  // 视频节点：上游仅允许 文本 / 图片 / 音频，跟 NodeSpawnPlusOverlay 左侧「+」
+  // 按钮的白名单保持一致。
+  [CANVAS_NODE_TYPES.video]: [
+    CANVAS_NODE_TYPES.textAnnotation,
+    CANVAS_NODE_TYPES.imageGen,
+    CANVAS_NODE_TYPES.audio,
+  ],
+};
+
+// 给定目标节点类型，返回「从左侧 target handle 出发能创建的上游节点类型集」。
+//
+// 与下游那侧不同，这里多数分支**不沿用 base**：base 只收 connectMenu.fromTarget
+// 为 true 的类型，而 textAnnotation / imageGen 的 fromTarget 是 false，沿用就会
+// 被错杀。所以白名单在这里是「重写候选集」而不是「过滤候选集」。
+export function getUpstreamSpawnTypes(
+  originType: CanvasNodeType | undefined,
+): CanvasNodeType[] {
+  const base = getConnectMenuNodeTypes('target');
+  if (!originType) return base;
+  // 所有分支最后都过一道手工建边规则：菜单给的候选必须是用户真能连的。少了这道，
+  // 音频节点的上游菜单会冒出「视频」——那是「人声/背景音分离」的溯源边，音频节点
+  // 只读文本上游，用户手工连一根视频进来什么都不会发生。
+  const manual = (types: readonly CanvasNodeType[]) =>
+    types.filter((type) => isManualConnectionAllowed(type, originType));
+
+  // 3D 世界是唯一与 base 取交集的分支（历史行为，未在本次改动中调整）。
+  if (originType === CANVAS_NODE_TYPES.threeDWorld) {
+    const allowed = UPSTREAM_SPAWN_WHITELIST[originType] ?? [];
+    return manual(base.filter((type) => allowed.includes(type)));
   }
 
-  // 音频节点：下游允许视频（作为声轨素材）与视频合成（音频轨）。
-  if (originType === CANVAS_NODE_TYPES.audio) {
-    const allowed = new Set<CanvasNodeType>([
-      CANVAS_NODE_TYPES.video,
-      CANVAS_NODE_TYPES.videoCompose,
-    ]);
-    return connectable.filter((type) => allowed.has(type));
+  const declared = UPSTREAM_SPAWN_WHITELIST[originType];
+  if (declared) {
+    return manual(declared);
   }
 
-  // 360° 全景查看器：下游只能是图片节点（截图都是图片，手动连线也只接图片）。
-  if (originType === CANVAS_NODE_TYPES.pano360Viewer) {
-    const allowed = new Set<CanvasNodeType>([
-      CANVAS_NODE_TYPES.imageGen,
-      CANVAS_NODE_TYPES.imageEdit,
-      CANVAS_NODE_TYPES.exportImage,
-      CANVAS_NODE_TYPES.upload,
-    ]);
-    return connectable.filter((type) => allowed.has(type));
+  // 受上游类型白名单约束的目标（如音频←文本）：直接用领域层白名单，保证连线菜单、
+  // 手动拖线、isValidConnection、store 建边收口共用同一份规则。
+  const allowedUpstream = getAllowedUpstreamSourceTypes(originType);
+  if (allowedUpstream) {
+    return manual(allowedUpstream);
   }
 
-  if (
-    originType === CANVAS_NODE_TYPES.upload ||
-    originType === CANVAS_NODE_TYPES.imageEdit ||
-    originType === CANVAS_NODE_TYPES.imageGen ||
-    originType === CANVAS_NODE_TYPES.exportImage
-  ) {
-    const allowed = new Set<CanvasNodeType>([
-      CANVAS_NODE_TYPES.textAnnotation,
-      CANVAS_NODE_TYPES.imageGen,
-      CANVAS_NODE_TYPES.video,
-      CANVAS_NODE_TYPES.script,
-      CANVAS_NODE_TYPES.pano360Viewer,
-      CANVAS_NODE_TYPES.threeDWorld,
-    ]);
-    return connectable.filter((type) => allowed.has(type));
-  }
-
-  return connectable;
+  return manual(base);
 }

--- a/frontend/src/features/canvas/domain/nodeRegistry.ts
+++ b/frontend/src/features/canvas/domain/nodeRegistry.ts
@@ -651,14 +651,29 @@ export function nodeHasTargetHandle(type: CanvasNodeType): boolean {
   return canvasNodeDefinitions[type].connectivity.targetHandle;
 }
 
-// 「目标节点类型」→ 允许的上游（源）节点类型白名单。这是建边规则的单一事实
-// 来源：UI 层（连线菜单 / 手动拖线 / isValidConnection）与 store 建边收口
-// （onConnect / addEdge / addEdgeWithData / 加载规范化）都查这张表，避免任何
-// 一条建边路径绕过规则。不在表中的目标类型表示「不额外限制类型」，仅受 handle
-// 级默认规则约束。
+// 「目标节点类型」→ 允许的上游（源）节点类型白名单。这张表和下面的
+// DOWNSTREAM_TARGET_WHITELIST 一起，是建边规则的单一事实来源：UI 层（连线菜单 /
+// 手动拖线 / isValidConnection）与 store 建边收口（onConnect / addEdge /
+// addEdgeWithData / 加载规范化）都经由 isUpstreamConnectionAllowed 查它们，避免
+// 任何一条建边路径绕过规则。不在表中的目标类型表示「不额外限制类型」，仅受
+// handle 级默认规则约束。
 const UPSTREAM_SOURCE_WHITELIST: Partial<Record<CanvasNodeType, readonly CanvasNodeType[]>> = {
   // 音频节点的上游只能是文本节点。
   [CANVAS_NODE_TYPES.audio]: [CANVAS_NODE_TYPES.textAnnotation],
+};
+
+// 「源节点类型」→ 允许的下游（目标）节点类型白名单。与上面那张表对称：那张按
+// 目标收口（谁能连进我），这张按源收口（我能连去谁）。两张表一起构成建边规则，
+// 同样被所有建边路径查询。不在表中的源类型表示「不额外限制下游类型」。
+//
+// 音频是目前唯一需要按源收口的类型：只有视频节点（声轨素材）和视频合成（音频轨）
+// 会读上游音频，连到图片 / 脚本 / 3D 等节点上不产生任何效果，只是画布上一根骗人
+// 的线。这条规则本来就写在别处了 —— getDownstreamSpawnTypes(audio) 只给
+// [video, videoCompose]，Canvas.resolveAllowedNodeTypes 里图片节点的上游菜单也
+// 明写「不收音频」—— 但那两处只管菜单能创建什么，拖线落到一个**既有**节点上时
+// 谁都没拦。放进这里才真正收口。
+const DOWNSTREAM_TARGET_WHITELIST: Partial<Record<CanvasNodeType, readonly CanvasNodeType[]>> = {
+  [CANVAS_NODE_TYPES.audio]: [CANVAS_NODE_TYPES.video, CANVAS_NODE_TYPES.videoCompose],
 };
 
 // 返回某目标类型允许的上游源类型；返回 null 表示该类型不施加额外类型限制。
@@ -668,13 +683,27 @@ export function getAllowedUpstreamSourceTypes(
   return UPSTREAM_SOURCE_WHITELIST[targetType] ?? null;
 }
 
-// 判断从 sourceType 连向 targetType 的上游连接是否合法。
+// 返回某源类型允许的下游目标类型；返回 null 表示该类型不施加额外类型限制。
+export function getAllowedDownstreamTargetTypes(
+  sourceType: CanvasNodeType,
+): readonly CanvasNodeType[] | null {
+  return DOWNSTREAM_TARGET_WHITELIST[sourceType] ?? null;
+}
+
+// 判断从 sourceType 连向 targetType 的连接是否合法：两张白名单都要过。
 export function isUpstreamConnectionAllowed(
   sourceType: CanvasNodeType,
   targetType: CanvasNodeType,
 ): boolean {
-  const allowed = UPSTREAM_SOURCE_WHITELIST[targetType];
-  return allowed ? allowed.includes(sourceType) : true;
+  const allowedSources = UPSTREAM_SOURCE_WHITELIST[targetType];
+  if (allowedSources && !allowedSources.includes(sourceType)) {
+    return false;
+  }
+  const allowedTargets = DOWNSTREAM_TARGET_WHITELIST[sourceType];
+  if (allowedTargets && !allowedTargets.includes(targetType)) {
+    return false;
+  }
+  return true;
 }
 
 export function getConnectMenuNodeTypes(handleType: 'source' | 'target'): CanvasNodeType[] {
@@ -702,6 +731,9 @@ export function getDownstreamSpawnTypes(
 ): CanvasNodeType[] {
   const base = getConnectMenuNodeTypes('source');
   if (!originType) return base;
+  // 先过一遍建边白名单：菜单里出现的候选必须真的连得上。否则用户点了以后新节点
+  // 建出来了、边被建边规则拒掉，画布上留下一个孤立节点（如脚本 → 音频）。
+  const connectable = base.filter((type) => isUpstreamConnectionAllowed(originType, type));
 
   if (originType === CANVAS_NODE_TYPES.video) {
     const allowed = new Set<CanvasNodeType>([
@@ -710,7 +742,7 @@ export function getDownstreamSpawnTypes(
       CANVAS_NODE_TYPES.videoCompose,
       CANVAS_NODE_TYPES.script,
     ]);
-    return base.filter((type) => allowed.has(type));
+    return connectable.filter((type) => allowed.has(type));
   }
 
   // 音频节点：下游允许视频（作为声轨素材）与视频合成（音频轨）。
@@ -719,7 +751,7 @@ export function getDownstreamSpawnTypes(
       CANVAS_NODE_TYPES.video,
       CANVAS_NODE_TYPES.videoCompose,
     ]);
-    return base.filter((type) => allowed.has(type));
+    return connectable.filter((type) => allowed.has(type));
   }
 
   // 360° 全景查看器：下游只能是图片节点（截图都是图片，手动连线也只接图片）。
@@ -730,7 +762,7 @@ export function getDownstreamSpawnTypes(
       CANVAS_NODE_TYPES.exportImage,
       CANVAS_NODE_TYPES.upload,
     ]);
-    return base.filter((type) => allowed.has(type));
+    return connectable.filter((type) => allowed.has(type));
   }
 
   if (
@@ -747,8 +779,8 @@ export function getDownstreamSpawnTypes(
       CANVAS_NODE_TYPES.pano360Viewer,
       CANVAS_NODE_TYPES.threeDWorld,
     ]);
-    return base.filter((type) => allowed.has(type));
+    return connectable.filter((type) => allowed.has(type));
   }
 
-  return base;
+  return connectable;
 }

--- a/frontend/src/features/canvas/domain/nodeRegistry.ts
+++ b/frontend/src/features/canvas/domain/nodeRegistry.ts
@@ -658,8 +658,11 @@ export function nodeHasTargetHandle(type: CanvasNodeType): boolean {
 // 任何一条建边路径绕过规则。不在表中的目标类型表示「不额外限制类型」，仅受
 // handle 级默认规则约束。
 const UPSTREAM_SOURCE_WHITELIST: Partial<Record<CanvasNodeType, readonly CanvasNodeType[]>> = {
-  // 音频节点的上游只能是文本节点。
-  [CANVAS_NODE_TYPES.audio]: [CANVAS_NODE_TYPES.textAnnotation],
+  // 音频节点的上游只能是文本节点（生成来源），外加视频节点 —— 后者是「人声/背景音
+  // 分离」动作留下的溯源边：那个动作从一个视频节点同时产出「背景音」音频节点和
+  // 「无声」视频节点，两条边一起画回源视频。少了 video 这一项，音频那条边会被建边
+  // 收口静默丢掉，画布上一边连着无声视频、一边孤零零挂着背景音。
+  [CANVAS_NODE_TYPES.audio]: [CANVAS_NODE_TYPES.textAnnotation, CANVAS_NODE_TYPES.video],
 };
 
 // 「源节点类型」→ 允许的下游（目标）节点类型白名单。与上面那张表对称：那张按

--- a/frontend/src/stores/canvasStore.ts
+++ b/frontend/src/stores/canvasStore.ts
@@ -276,10 +276,12 @@ interface CanvasState {
     options?: { lockManualSize?: boolean; data?: Partial<CanvasNodeData> },
   ) => void;
   /**
-   * Swap a node's `type` in place while keeping its `id`, position, and any
-   * already-attached edges. Used when an UploadNode's user picks a video file
-   * and the node needs to morph into a VideoNode so the header / toolbar /
-   * connectivity match the new resource type.
+   * Swap a node's `type` in place while keeping its `id` and position. Used
+   * when an UploadNode's user picks a video file and the node needs to morph
+   * into a VideoNode so the header / toolbar / connectivity match the new
+   * resource type. Attached edges survive the swap **unless** the new type
+   * makes them illegal (same rules the load-time normalizer applies), in which
+   * case they are dropped along with it — one undo restores both.
    */
   convertNodeType: (
     nodeId: string,
@@ -2336,8 +2338,29 @@ export const useCanvasStore = create<CanvasState>((set, get) => ({
           } as CanvasNode)
         : node
     );
+    // 换了类型，原本合法的关联边可能不再合法：空 Upload 先连到图片节点，之后
+    // 上传音频转成 Audio —— audio → 图片就不再放行了。不在这里清掉，那条边会一直
+    // 留在画布上（还能提交生成），直到下次加载被规范化静默删除。口径与加载规范化
+    // 那道过滤保持一致：handle 有无 + 建边类型规则。
+    const nextNodeTypeById = new Map(nextNodes.map((node) => [node.id, node.type]));
+    const nextEdges = state.edges.filter((edge) => {
+      if (edge.source !== nodeId && edge.target !== nodeId) {
+        return true;
+      }
+      const sourceType = nextNodeTypeById.get(edge.source);
+      const targetType = nextNodeTypeById.get(edge.target);
+      if (!sourceType || !targetType) {
+        return true;
+      }
+      if (!nodeHasSourceHandle(sourceType) || !nodeHasTargetHandle(targetType)) {
+        return false;
+      }
+      return isUpstreamConnectionAllowed(sourceType, targetType);
+    });
+
     set({
       nodes: nextNodes,
+      edges: nextEdges,
       history: {
         past: pushSnapshot(state.history.past, createSnapshot(state.nodes, state.edges)),
         future: [],

--- a/license-inventory.csv
+++ b/license-inventory.csv
@@ -330,8 +330,8 @@ frontend/src/__tests__/features/canvas/background-cropper-dialog.test.ts,Elastic
 frontend/src/__tests__/features/canvas/beat-context-node.test.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/__tests__/features/canvas/canvas-add-node-panel.test.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/__tests__/features/canvas/canvas-bookmark-context-menu.test.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
+frontend/src/__tests__/features/canvas/canvas-manual-connect.test.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/__tests__/features/canvas/canvas-node-image-wake-refresh.test.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
-frontend/src/__tests__/features/canvas/canvas-skill-manual-connect.test.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/__tests__/features/canvas/canvas-tool-menu.test.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/__tests__/features/canvas/canvas-viewport-bookmarks.test.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/__tests__/features/canvas/context-prompt-palette.test.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
@@ -516,6 +516,7 @@ frontend/src/__tests__/stores/app-store-task-panel.test.ts,Elastic-2.0,2026 Supe
 frontend/src/__tests__/stores/auth-store.test.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/__tests__/stores/canvas-store-3d-upstream.test.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/__tests__/stores/canvas-store-auto-group-spawn.test.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
+frontend/src/__tests__/stores/canvas-store-convert-node-type.test.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/__tests__/stores/canvas-store-draft-hydrate.test.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/__tests__/stores/canvas-store-group-grow.test.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/__tests__/stores/canvas-store-image-resize-aspect.test.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation


### PR DESCRIPTION
## PR 类型 / Type of PR
- [x] 🐛 Bug 修复 / Bug fix

## 改动说明 / What this PR does and why

### 1. 音频节点能被拖到图片节点上

音频只有视频节点（声轨素材）和视频合成（音频轨）读得懂。连到图片 / 脚本 / 3D 等节点上不产生任何效果，只是画布上一根骗人的线。

这条产品规则其实早就写下来了，只是没写在能生效的地方：

| 出处 | 已有的口径 |
| --- | --- |
| `getDownstreamSpawnTypes(audio)` | 只给 `[video, videoCompose]` |
| `Canvas.resolveAllowedNodeTypes` | 图片节点的上游候选注释明写「不收音频」 |

但这两处只管**菜单能创建什么**。领域层的建边规则只有一张按**目标**收口的 `UPSTREAM_SOURCE_WHITELIST`，图片类节点不在表里，`isUpstreamConnectionAllowed(audio, imageGen)` 直接返回 `true`；而手动拖线守卫在目标没有白名单时，回落到一个**不看目标类型**的检查（`getDownstreamSpawnTypes(type).length > 0`，音频是 2 > 0）。于是把线拖到一个**既有**图片节点上时无人拦截。

补一张对称的 `DOWNSTREAM_TARGET_WHITELIST`（按源收口，`audio → [video, videoCompose]`），由 `isUpstreamConnectionAllowed` 一并校验。

### 2. 顺手堵上同一形状的反向漏洞

拖线落空菜单里，`beatContext / group / storyboard / storyboardGen / videoStory / videoCompose / script / threeDWorld / skill` 这 9 种节点都把「音频」列为可创建的下游，但音频的上游白名单只收文本 —— 点下去新节点建出来了、边被 store 静默丢掉，画布上留一个孤立节点。两侧菜单候选现在都先过一遍建边白名单。

### 3. 音视频分离产出的「背景音」是孤立节点

`NodeActionToolbar` 的「人声/背景音分离」从一个视频节点同时产出「背景音」音频节点和「无声」视频节点，两条边一起画回源视频。但 `addEdge(视频, 音频)` 撞上「音频上游只收文本」这条规则被静默丢掉 —— 无声视频连着、背景音孤零零挂在旁边。把 `video` 加进音频的上游白名单。

### 4. 评审后：溯源边不该进连线菜单

放开 `video → audio` 之后，音频节点的**上游创建菜单**里冒出了「视频」——`resolveAllowedNodeTypes` 的上游白名单分支直接 `return`，绕过了菜单过滤；而 `AudioOperationsPanel` 只读 `text` 上游，手工连一根视频进来什么都不会发生。正是第 1 条要消灭的那根骗人的线，方向反过来而已。

把**建边规则**和**手工建边规则**分开：`SYSTEM_ONLY_CONNECTIONS` 登记「由系统动作建立、不开放给用户手工创建」的边（目前只有音视频分离那条 `video → audio`），`isManualConnectionAllowed` = 建边规则放行 && 不是系统专用边。菜单候选与手动拖线查后者，store 的建边收口仍查前者 —— 存量溯源边照样活得下来。

### 5. 二轮评审：另外两个没收住的入口

- **`convertNodeType` 只换类型不校验边**。空 Upload 先连到图片节点，之后往里丢音频文件转成 Audio —— `audio → 图片` 这条边就不合法了，却一直留在画布上（还能参与生成），直到下次加载被规范化静默删除。改成换类型时按加载规范化的同一口径（handle 有无 + 建边类型规则）过一遍关联边。
- **`isValidConnection` 与 `handleConnect` 口径不一致**（第 4 条改动带进来的）。前者查建边规则，后者查手工建边规则；视频→音频那条溯源边建边规则放行、不开放手工创建，于是「拖过去高亮成合法、一松手什么也没有」。

## 关联 issue / Linked issues
N/A

## 给 reviewer 的说明 / Notes for the reviewer

- **为什么补一张新表而不是给图片类节点写上游白名单**。给 `imageGen / imageEdit / upload / exportImage` 各写一份上游白名单，等于要把「图片节点合法的上游」（文本 / 脚本 / 图片 / 视频 / 360° / 3D 世界 / 分镜…）全枚举一遍，漏一个就是新 bug。真正的约束在音频这一侧：**它的产物只有两种节点消费得了**。按源收口一条就够，而且和已有的 `getDownstreamSpawnTypes(audio)` 是同一句话。
- **7 个建边收口点一行没动**。`Canvas` 的 `isValidConnection` / 手动拖线，store 的 `onConnect` / `addEdge` / `addEdgeWithData` / 加载规范化，全都经由 `isUpstreamConnectionAllowed` 查表，新表挂上去就自动生效 —— 这正是原设计留的口子。
- **存量画布里的音频→图片边会在加载规范化时被丢掉**（`canvasStore.ts` 的 edge filter）。跟「音频←非文本」现有的行为一致，那条边本来也不产生任何效果。
- **第 3 条不走「绕过收口直接建边」那条路**。加载规范化查的是同一张表，绕过去建的边活不过一次刷新；而且「所有建边路径都收口、不允许绕过」是这套设计明写要防的事。放开 `video` 不等于放开所有类型（图片等仍连不进音频节点），`getDownstreamSpawnTypes(video)` 的白名单是写死的 `[文本, 视频, 视频合成, 脚本]`，不含音频，右侧生成菜单不受影响。
- **「菜单/规则对齐」的断言落在输入侧**。第一版遍历 `getDownstreamSpawnTypes` 的返回值再用建边规则去断言 —— 而那个函数出口处就用同一个谓词过了一道，按构造恒真，守不住任何漂移（评审指出，已改）。现在把两侧菜单的产品白名单提成 `DOWNSTREAM_SPAWN_WHITELIST` / `UPSTREAM_SPAWN_WHITELIST` 两张导出的表，直接查「产品意图里写了、但建边规则不放行」的格子：那种格子运行时被静默过滤掉，菜单和白名单从此对不上而没人会发现。
- **上游那侧的菜单白名单从 `Canvas.tsx` 搬进了 `nodeRegistry`**（`getUpstreamSpawnTypes`，与 `getDownstreamSpawnTypes` 作镜像）。原来它三个分支各自直接 `return`，新加的过滤只覆盖 fall-through 一条路（评审第 3 条）；现在所有分支统一在出口过一道手工建边规则，顺带让菜单候选可被单测直接覆盖。**3D 世界分支与 `base` 取交集的历史行为原样保留**，未在本次调整。
- **`isValidConnection` 没有改成 `isManualConnectionAllowed`，而是直接复用 `handleConnect` 那把尺子本身**（`canNodeTypeBeManualConnectionSource`）。只换成领域层规则的话，3D 世界 / 360° 全景那两条额外限制仍然漏在外面 —— 同一个「显示能连、松手没反应」的形状，只是换了对节点。
- **`convertNodeType` 清掉的边和节点类型进同一个 history 快照**，撤销一次两者一起还原（有测试覆盖）。
- **新测试断言的是「两处判定对同一对节点给出同一个答案」，不是某条具体规则**。规则以后怎么改都行，只要两边一起改；把 `isValidConnection` 换回 `isUpstreamConnectionAllowed` 立刻红在 `video → audio` 那一格（`highlightedAsValid: true` / `edgeCreated: false`），正是评审描述的症状。
- 其余新测试也都做了反向实验确认非空转：去掉下游白名单 → 音频那 2 条红；把 `video` 从上游白名单收回 → 溯源边那条红；拿掉 `SYSTEM_ONLY_CONNECTIONS` → 菜单那条红；往图片下游白名单里塞一个 `audio` → 对齐那条红；`convertNodeType` 不过滤边 → 新增的 store 测试 3 条里红 2 条（第 3 条是「合法边不误伤」的对照，本就该绿）。
- **`canvas-skill-manual-connect.test.tsx` 更名为 `canvas-manual-connect.test.tsx`**：落点校验的测试要复用它那套 Canvas 渲染 mock（~180 行），另起一个文件就得整套复制；文件里已有的内容本来也是「手工连线」，改名后名副其实。license-inventory 已同步该行。

### 顺带发现、**未**在本 PR 处理的既有问题

- `getConnectMenuNodeTypes('target')` 只有 `[upload, audio, script, threeDWorld, skill]`（`textAnnotation` / `imageGen` 的 `connectMenu.fromTarget` 都是 `false`），所以 3D 世界节点那条 `base.filter(∈{文本, 图片})` 实际算出来是**空数组** —— 它的上游创建菜单目前是空的，与注释声称的「仅允许文本 / 图片节点」对不上。改它会动到 3D 世界的 UI，不属于本 PR 范围，原样保留。
- `NodeActionToolbar` 的「提取背景音」等动作走 `store.addEdge`，成功与否无任何提示。本 PR 修了音频那条，但这类静默失败的模式仍在。

## 面向用户的变更 / User-facing change
```release-note
修复画布上音频节点可以连到图片等无法消费它的节点的问题（画布中已存在的这类连线会在下次打开时被自动清理，不影响节点本身），以及「人声/背景音分离」产出的背景音节点不与源视频相连的问题。
```

## 自检 / Checklist
- [x] 已自测 / Self-tested — `tsc -b` 干净，`vitest` 1927 passed（288 files，新增 12 条），`pnpm build` 通过
- [x] 必要的文档已更新 / Docs updated where needed — 建边规则写在 `nodeRegistry.ts` 两张白名单的注释里
- [x] 提交信息清晰（建议 Conventional Commits）/ Clear commits
- [x] 每个 commit 都已 `git commit -s` 附 DCO 签署 / Every commit signed off

🤖 Generated with [Claude Code](https://claude.com/claude-code)
