### PR TITLE
fix(canvas): 视频参考生成分镜脚本真正读视频，角色图/参考列不再恒空

### DIFF
--- a/frontend/src/api/ops.ts
+++ b/frontend/src/api/ops.ts
@@ -2157,13 +2157,30 @@ export async function submitFreezoneStoryScript(
   );
 }
 
+/**
+ * 故事脚本表的一行。字段名必须和后端 `FreezoneStoryScriptRow`
+ * （`src/novelvideo/api/schemas.py`）逐字对齐 —— 早期前端用的是
+ * `character` / `action` 这类简写，后端从来没发过这些 key，表格里就只显示
+ * 「-」（issue #207）。
+ */
 export interface FreezoneStoryScriptRow {
   shot_no?: string | number | null;
   duration?: string | number | null;
   visual_description?: string | null;
-  character?: string | null;
+  character_1?: string | null;
+  character_description_1?: string | null;
+  /** 角色图1 URL，由后端按角色名匹配 character_refs 回填。 */
+  character_image_1?: string | null;
+  character_2?: string | null;
+  character_description_2?: string | null;
+  /** 角色图2 URL，由后端按角色名匹配 character_refs 回填。 */
+  character_image_2?: string | null;
+  /** 参考图 URL，视频参考模式下由后端按 keyframe_index 回填对应关键帧。 */
+  reference?: string | null;
+  /** 视频参考模式下这一镜对应的输入关键帧序号（1-based，0 表示无）。 */
+  keyframe_index?: number | null;
   shot?: string | null;
-  action?: string | null;
+  character_action?: string | null;
   emotion?: string | null;
   scene_tags?: string | null;
   lighting_mood?: string | null;
@@ -2177,6 +2194,8 @@ export interface FreezoneStoryScriptRow {
 export interface FreezoneStoryScriptResult {
   title?: string | null;
   rows: FreezoneStoryScriptRow[];
+  /** 视频参考模式下抽出的关键帧静态 URL，按顺序对应 keyframe_index。 */
+  frame_urls?: string[] | null;
 }
 
 export async function fetchFreezoneStoryScriptResult(

--- a/frontend/src/features/canvas/nodes/ScriptNode.tsx
+++ b/frontend/src/features/canvas/nodes/ScriptNode.tsx
@@ -18,6 +18,7 @@ import {
   ImageIcon,
   Languages,
   Loader2,
+  Upload,
   User,
   Video,
   X,
@@ -62,6 +63,7 @@ import {
   fetchFreezoneTextTranslateResult,
   submitFreezoneStoryScript,
   submitFreezoneTextTranslate,
+  uploadFreezoneImage,
   type FreezoneGenerationHistoryRecord,
   type FreezoneStoryScriptResult,
   type FreezoneStoryScriptRow,
@@ -148,8 +150,8 @@ const SCRIPT_ACTIONS: ScriptActionDef[] = [
 ];
 
 // 与 libtv 脚本表格列对齐：19 列、宽度按像素硬性给定，整体 min-width 由 tailwind 继承。
-// 后端 FreezoneStoryScriptRow 当前未提供 character_2 / character_image_* / reference 字段，
-// 通过 row[key] 软查询：缺值统一渲染 "-"。
+// key 必须和后端 FreezoneStoryScriptRow 的字段名逐字一致 —— 之前 character /
+// character_desc_1 / action 三个 key 后端从来没发过，于是这三列永远显示 "-"（issue #207）。
 type ScriptCellRender = 'text' | 'image';
 
 interface ScriptColumnDef {
@@ -164,15 +166,15 @@ const SCRIPT_COLUMNS: ScriptColumnDef[] = [
   { key: 'shot_no', label: '镜号', widthPx: 60 },
   { key: 'duration', label: '时长', widthPx: 80 },
   { key: 'visual_description', label: '画面描述', widthPx: 200 },
-  { key: 'character', label: '角色1', widthPx: 120 },
-  { key: 'character_desc_1', label: '角色描述1', widthPx: 180 },
+  { key: 'character_1', label: '角色1', widthPx: 120 },
+  { key: 'character_description_1', label: '角色描述1', widthPx: 180 },
   { key: 'character_image_1', label: '角色图1', widthPx: 80, render: 'image' },
   { key: 'character_2', label: '角色2', widthPx: 120 },
-  { key: 'character_desc_2', label: '角色描述2', widthPx: 180 },
+  { key: 'character_description_2', label: '角色描述2', widthPx: 180 },
   { key: 'character_image_2', label: '角色图2', widthPx: 80, render: 'image' },
   { key: 'reference', label: '参考', widthPx: 80, render: 'image' },
   { key: 'shot', label: '景别', widthPx: 120 },
-  { key: 'action', label: '角色动作', widthPx: 120 },
+  { key: 'character_action', label: '角色动作', widthPx: 120 },
   { key: 'emotion', label: '情绪', widthPx: 120 },
   { key: 'scene_tags', label: '场景标签', widthPx: 120 },
   { key: 'lighting_mood', label: '光影氛围', widthPx: 120 },
@@ -314,19 +316,19 @@ function useScriptStorySubmit(
         name: ref.displayName?.trim() || undefined,
       }));
 
-    // 后端 story-script 接口目前只消费文本(source_text/source_url):视频 / 角色图片
-    // 参考仅作为画布上的视觉参考，模型并不直接读取它们。因此真正驱动生成的是用户手动
-    // 输入的提示词(参考 libtv:素材做参考、提示词驱动生成)。优先用上游文本节点内容，
-    // 否则把输入框里用户写的提示词作为 source_text 主输入 —— 而不是塞进 steering 后
-    // 让后端因缺 source_text 报 400(#65 视频参考、#66 图片参考失败的根因)。
-    const sourceText = upstreamText.length > 0 ? upstreamText : trimmedPrompt;
-    // 有上游文本节点时输入框内容退居 steering prompt；否则它已是主输入，不再重复下发。
+    // 视频 / 角色图现在是真正的主输入：后端会对视频抽帧、把关键帧和角色图一起送进
+    // 视觉模型（issue #207 之前它们被 Pydantic 静默丢弃，模型只能照着系统提示词编）。
+    // 所以只有在没有任何素材时，才把输入框内容当 source_text 兜底；有素材时它一律是
+    // steering prompt，不再被冒充成剧本正文。
+    const hasMedia = Boolean(videoRef) || characterRefs.length > 0;
+    const sourceText =
+      upstreamText.length > 0 ? upstreamText : hasMedia ? '' : trimmedPrompt;
     const steeringPrompt =
-      upstreamText.length > 0 ? trimmedPrompt || undefined : undefined;
+      upstreamText.length > 0 || hasMedia ? trimmedPrompt || undefined : undefined;
 
-    if (!sourceText || sourceText.length === 0) {
+    if (!hasMedia && sourceText.length === 0) {
       updateNodeData(nodeId, {
-        generationError: '请输入提示词描述剧情（视频 / 角色图片仅作参考）',
+        generationError: '请输入提示词描述剧情，或连接视频 / 角色图片节点',
       });
       return;
     }
@@ -891,27 +893,10 @@ function ScriptResultCell({ row, col, onCommit }: ScriptResultCellProps) {
   const raw = row[col.key];
 
   if (col.render === 'image') {
-    // 图片列暂不支持 inline 编辑 —— 替换图需要走文件选择器 / URL 输入，
-    // 是另一条交互，等用户后续提。
-    // 角色图/参考是后端占位字符串字段：模型经常写入 `无` 之类的非 URL 文本，
-    // 只有真正的图片来源才渲染 <img>，否则一律回退到空占位（避免 404 裂图）。
-    const url =
-      typeof raw === 'string' && isRenderableImageSrc(raw) ? raw : null;
-    if (!url) {
-      return (
-        <div className="flex h-14 w-14 items-center justify-center rounded border border-dashed border-[rgba(255,255,255,0.14)] text-text-muted/50">
-          <ImageIcon className="h-4 w-4" />
-        </div>
-      );
-    }
-    return (
-      <img
-        src={resolveImageDisplayUrl(url)}
-        alt=""
-        className="h-14 w-14 rounded border border-[rgba(255,255,255,0.08)] object-cover"
-        draggable={false}
-      />
-    );
+    // 角色图/参考由后端回填，但模型偶尔仍会写进 `无` 之类的非 URL 文本，
+    // 只有真正的图片来源才渲染 <img>，否则回退到「点击上传」占位（避免 404 裂图）。
+    const url = typeof raw === 'string' && isRenderableImageSrc(raw) ? raw : null;
+    return <ScriptImageCell url={url} onCommit={onCommit} />;
   }
 
   const initialText =
@@ -932,6 +917,164 @@ function ScriptResultCell({ row, col, onCommit }: ScriptResultCellProps) {
   }
 
   return <EditableTableCell value={initialText} onCommit={onCommit} />;
+}
+
+interface ScriptImageCellProps {
+  url: string | null;
+  /** 传了才可编辑：上传/替换/删除都通过它写回 scriptResult.rows[i][key]。 */
+  onCommit?: (nextValue: string) => void;
+}
+
+/**
+ * 表格里的图片格：空位可点击上传，已有图可预览 / 替换 / 删除。
+ * 生成结果里角色图和参考图经常需要人工补一张（issue #207：以前这里是纯只读的）。
+ */
+function ScriptImageCell({ url, onCommit }: ScriptImageCellProps) {
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  const [uploading, setUploading] = useState(false);
+  const [uploadError, setUploadError] = useState<string | null>(null);
+  const [previewOpen, setPreviewOpen] = useState(false);
+  const editable = Boolean(onCommit);
+
+  const handleFileChange = useCallback(
+    async (event: React.ChangeEvent<HTMLInputElement>) => {
+      const file = event.target.files?.[0];
+      // 立刻清空，保证连续选同一个文件也能触发 change。
+      event.target.value = '';
+      if (!file || !onCommit) return;
+      const project = readUrl().project;
+      if (!project) {
+        setUploadError('缺少 project 参数');
+        return;
+      }
+      setUploading(true);
+      setUploadError(null);
+      try {
+        const result = await uploadFreezoneImage(project, file, file.name);
+        onCommit(result.url);
+      } catch (error) {
+        console.error('[script-node] cell image upload failed', error);
+        setUploadError(error instanceof Error ? error.message : '上传失败');
+      } finally {
+        setUploading(false);
+      }
+    },
+    [onCommit],
+  );
+
+  const openPicker = useCallback(() => {
+    if (uploading) return;
+    inputRef.current?.click();
+  }, [uploading]);
+
+  const fileInput = editable ? (
+    <input
+      ref={inputRef}
+      type="file"
+      accept="image/*"
+      className="hidden"
+      onChange={handleFileChange}
+    />
+  ) : null;
+
+  if (!url) {
+    if (!editable) {
+      return (
+        <div className="flex h-14 w-14 items-center justify-center rounded border border-dashed border-[rgba(255,255,255,0.14)] text-text-muted/50">
+          <ImageIcon className="h-4 w-4" />
+        </div>
+      );
+    }
+    return (
+      <div className="flex flex-col gap-1">
+        <button
+          type="button"
+          onClick={openPicker}
+          disabled={uploading}
+          title="点击上传图片"
+          className="flex h-14 w-14 items-center justify-center rounded border border-dashed border-[rgba(255,255,255,0.14)] text-text-muted/50 transition-colors hover:border-[rgb(var(--accent-rgb)/0.6)] hover:text-text-dark/80 disabled:cursor-wait"
+        >
+          {uploading ? (
+            <Loader2 className="h-4 w-4 animate-spin" />
+          ) : (
+            <ImageIcon className="h-4 w-4" />
+          )}
+        </button>
+        {uploadError ? (
+          <span className="text-[10px] leading-tight text-red-400">{uploadError}</span>
+        ) : null}
+        {fileInput}
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-1">
+      <div className="group relative h-14 w-14">
+        <img
+          src={resolveImageDisplayUrl(url)}
+          alt=""
+          className="h-14 w-14 cursor-zoom-in rounded border border-[rgba(255,255,255,0.08)] object-cover"
+          draggable={false}
+          onClick={() => setPreviewOpen(true)}
+        />
+        {editable ? (
+          <div className="pointer-events-none absolute inset-0 flex items-center justify-center gap-1 rounded bg-black/60 opacity-0 transition-opacity group-hover:pointer-events-auto group-hover:opacity-100">
+            <button
+              type="button"
+              onClick={openPicker}
+              disabled={uploading}
+              title="替换图片"
+              className="rounded p-1 text-white/85 transition-colors hover:bg-white/15 hover:text-white disabled:cursor-wait"
+            >
+              {uploading ? (
+                <Loader2 className="h-3.5 w-3.5 animate-spin" />
+              ) : (
+                <Upload className="h-3.5 w-3.5" />
+              )}
+            </button>
+            <button
+              type="button"
+              onClick={() => onCommit?.('')}
+              title="删除图片"
+              className="rounded p-1 text-white/85 transition-colors hover:bg-white/15 hover:text-white"
+            >
+              <X className="h-3.5 w-3.5" />
+            </button>
+          </div>
+        ) : null}
+      </div>
+      {uploadError ? (
+        <span className="text-[10px] leading-tight text-red-400">{uploadError}</span>
+      ) : null}
+      {fileInput}
+      {previewOpen
+        ? createPortal(
+            <div
+              className="fixed inset-0 z-[120] flex items-center justify-center bg-black/80 p-8"
+              onClick={() => setPreviewOpen(false)}
+            >
+              <img
+                src={resolveImageDisplayUrl(url)}
+                alt=""
+                className="max-h-full max-w-full rounded object-contain"
+                draggable={false}
+                onClick={(event) => event.stopPropagation()}
+              />
+              <button
+                type="button"
+                onClick={() => setPreviewOpen(false)}
+                title="关闭预览"
+                className="absolute right-6 top-6 rounded p-2 text-white/80 transition-colors hover:bg-white/15 hover:text-white"
+              >
+                <X className="h-5 w-5" />
+              </button>
+            </div>,
+            document.body,
+          )
+        : null}
+    </div>
+  );
 }
 
 interface ScriptOperationsPanelProps {

--- a/src/novelvideo/api/routes/freezone.py
+++ b/src/novelvideo/api/routes/freezone.py
@@ -58,6 +58,7 @@ from novelvideo.api.schemas import (
     FreezoneScene360Request,
     FreezoneSketchFromContextRequest,
     FreezoneStageAssetAcceptedResponse,
+    FreezoneStoryScriptCharacterRef,
     FreezoneStoryScriptGenerateRequest,
     FreezoneTemplateEditRequest,
     FreezoneTextTranslateRequest,
@@ -212,7 +213,9 @@ from novelvideo.freezone.slots import (
     validate_source_for_slot,
 )
 from novelvideo.freezone.text_node import (
+    bind_story_script_assets,
     generate_freezone_story_script,
+    generate_freezone_story_script_with_vision,
     translate_freezone_text,
 )
 from novelvideo.freezone.video_node import (
@@ -6226,6 +6229,31 @@ async def get_freezone_audio_voice_media(
     return FileResponse(path=str(resolved.audio_path))
 
 
+def _resolve_story_script_character_refs(
+    character_refs: list[FreezoneStoryScriptCharacterRef],
+    project_dir: Path,
+) -> tuple[list[dict], list[str]]:
+    """把角色参考拆成「给模型的角色卡」和「本地图片路径」。
+
+    外链或解析不出本地文件的图片仍然保留在角色卡里（回填 URL 时照样能用），
+    只是不会作为附件送进视觉模型。
+    """
+    refs: list[dict] = []
+    image_paths: list[str] = []
+    for ref in character_refs:
+        refs.append(ref.model_dump())
+        image_url = (ref.image_url or "").strip()
+        if not image_url:
+            continue
+        try:
+            path = resolve_static_url_to_path(image_url, project_dir)
+        except ValueError:
+            continue
+        if path.exists():
+            image_paths.append(path.as_posix())
+    return refs, image_paths
+
+
 def _start_freezone_story_script_task(
     *,
     username: str,
@@ -6237,6 +6265,8 @@ def _start_freezone_story_script_task(
     model: str,
     canvas_id: str | None = None,
     node_id: str | None = None,
+    character_refs: list[dict] | None = None,
+    character_image_paths: list[str] | None = None,
 ) -> None:
     task_type = "freezone_story_script"
     task_manager = get_task_manager()
@@ -6269,11 +6299,23 @@ def _start_freezone_story_script_task(
                 current_task="generating_story_script",
                 logs=logs,
             )
-            data = await generate_freezone_story_script(
-                source_text=source_text,
-                prompt=prompt,
-                model=model,
-            )
+            if character_image_paths:
+                # 有角色参考图就走视觉模型，让角色描述照着图写；
+                # 纯文本模式仍走原来的 story-script 文本别名。
+                data = await generate_freezone_story_script_with_vision(
+                    character_image_paths=character_image_paths,
+                    source_text=source_text,
+                    prompt=prompt,
+                    character_refs=character_refs,
+                )
+            else:
+                data = await generate_freezone_story_script(
+                    source_text=source_text,
+                    prompt=prompt,
+                    model=model,
+                    character_refs=character_refs,
+                )
+            bind_story_script_assets(data, character_refs=character_refs)
             out = _story_script_output_path(project_dir, job_id)
             out.parent.mkdir(parents=True, exist_ok=True)
             out.write_text(
@@ -6367,8 +6409,25 @@ async def freezone_story_script_generate(
             raise HTTPException(404, f"source not found: {source_path}")
         source_text = _read_freezone_text_file(source_path).strip()
 
-    if not source_text:
-        raise HTTPException(400, "source_text or source_url is required")
+    video_path: Path | None = None
+    if body.video_url:
+        try:
+            video_path = resolve_static_url_to_path(body.video_url, project_dir)
+        except ValueError as exc:
+            raise HTTPException(400, str(exc)) from exc
+        if not video_path.exists():
+            raise HTTPException(404, f"video not found: {video_path}")
+
+    character_refs, character_image_paths = _resolve_story_script_character_refs(
+        body.character_refs, project_dir
+    )
+
+    # 视频 / 角色图本身就是主输入，这时不再强制要求剧本文本
+    # （issue #207：以前只认 source_text，前端只好把提示词当剧本塞进来）。
+    if not source_text and video_path is None and not character_image_paths:
+        raise HTTPException(
+            400, "source_text, source_url, video_url or character_refs is required"
+        )
 
     try:
         job_id = _new_job_id()
@@ -6384,8 +6443,18 @@ async def freezone_story_script_generate(
                     "model": body.model,
                     "canvas_id": body.canvas_id or "",
                     "node_id": body.node_id or "",
+                    "video_path": video_path.as_posix() if video_path else "",
+                    "duration_sec": body.duration_sec,
+                    "max_frames": body.max_frames,
+                    "scene_threshold": body.scene_threshold,
+                    "character_refs": character_refs,
+                    "character_image_paths": character_image_paths,
                 },
             )
+        if video_path is not None:
+            # 抽帧要落盘并生成 /static 地址，没有 ProjectContext 就拼不出 URL。
+            # 与 analyze-video-story 等视频任务保持一致的前置要求。
+            _raise_project_context_required("freezone_story_script")
         _start_freezone_story_script_task(
             username=username,
             project=project_name,
@@ -6396,6 +6465,8 @@ async def freezone_story_script_generate(
             model=body.model,
             canvas_id=body.canvas_id or None,
             node_id=body.node_id or None,
+            character_refs=character_refs,
+            character_image_paths=character_image_paths,
         )
     except ValueError as exc:
         raise HTTPException(400, str(exc)) from exc

--- a/src/novelvideo/api/schemas.py
+++ b/src/novelvideo/api/schemas.py
@@ -1605,16 +1605,56 @@ class FreezoneTextTranslateResponse(BaseModel):
     data: FreezoneTextTranslateData
 
 
+class FreezoneStoryScriptCharacterRef(BaseModel):
+    """角色参考输入项：画布上连进脚本节点的角色图节点。"""
+
+    name: str = Field(default="", description="角色名/角色标签，用于和生成行里的角色名对齐")
+    description: str = Field(default="", description="可选：已有角色描述")
+    image_url: str = Field(default="", description="角色参考图静态 URL（/static/...）")
+    role: str = Field(default="", description="可选：角色定位或叙事功能，如「女主」")
+
+
 class FreezoneStoryScriptGenerateRequest(BaseModel):
-    """Freezone 文本节点：故事脚本生成请求。"""
+    """Freezone 文本节点：故事脚本生成请求。
+
+    四种输入至少给一个：``source_text`` / ``source_url``（剧本文本）、
+    ``video_url``（视频参考，走抽帧 + 视觉模型）、``character_refs``（角色图参考）。
+    早期版本只声明了文本字段，前端发来的 ``video_url`` / ``character_refs`` 会被
+    Pydantic 的 ``extra="ignore"`` 静默丢弃，导致「视频参考生成分镜脚本」实际上
+    从未把视频交给模型（issue #207）。
+    """
 
     source_text: str = Field(
         default="",
-        description="已上传剧本的文本内容。与 source_url 至少提供一个",
+        description="已上传剧本的文本内容。与 source_url / video_url / character_refs 至少提供一个",
     )
     source_url: Optional[str] = Field(
         default=None,
-        description="已上传剧本文本文件的静态 URL。与 source_text 至少提供一个",
+        description="已上传剧本文本文件的静态 URL",
+    )
+    video_url: Optional[str] = Field(
+        default=None,
+        description="视频参考的静态 URL；给了就先抽关键帧再交给视觉模型拆分镜",
+    )
+    duration_sec: Optional[float] = Field(
+        default=None,
+        description="视频总时长（秒），用于让分镜时长分配更贴近原视频",
+    )
+    character_refs: list[FreezoneStoryScriptCharacterRef] = Field(
+        default_factory=list,
+        description="角色参考图列表；生成后按角色名回填 character_image_1/2",
+    )
+    max_frames: int = Field(
+        default=20,
+        ge=3,
+        le=50,
+        description="视频参考时的最大抽帧数",
+    )
+    scene_threshold: float = Field(
+        default=0.3,
+        ge=0.0,
+        le=1.0,
+        description="视频参考时 ffmpeg 场景切换检测阈值",
     )
     prompt: str = Field(
         default="根据我上传的剧本生成一个完整的故事脚本",
@@ -1634,8 +1674,24 @@ class FreezoneStoryScriptRow(BaseModel):
     visual_description: str = Field(description="画面描述")
     character_1: str = Field(default="", description="角色1")
     character_description_1: str = Field(default="", description="角色描述1")
-    character_image_1: str = Field(default="", description="角色图1，占位字段")
-    reference: str = Field(default="", description="参考")
+    character_image_1: str = Field(
+        default="",
+        description="角色图1 URL；模型留空，由后端按角色名匹配 character_refs 回填",
+    )
+    character_2: str = Field(default="", description="角色2")
+    character_description_2: str = Field(default="", description="角色描述2")
+    character_image_2: str = Field(
+        default="",
+        description="角色图2 URL；模型留空，由后端按角色名匹配 character_refs 回填",
+    )
+    reference: str = Field(
+        default="",
+        description="参考图 URL；模型留空，由后端按 keyframe_index 回填对应关键帧",
+    )
+    keyframe_index: int = Field(
+        default=0,
+        description="视频参考模式下，这一镜对应的输入关键帧序号（1-based，0 表示无）",
+    )
     shot: str = Field(default="", description="景别")
     character_action: str = Field(default="", description="角色动作")
     emotion: str = Field(default="", description="情绪")

--- a/src/novelvideo/freezone/jobs.py
+++ b/src/novelvideo/freezone/jobs.py
@@ -16,9 +16,11 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import re
 import shutil
 import subprocess
 import tempfile
+from collections.abc import Iterable
 from pathlib import Path
 from typing import Any, Optional
 
@@ -1219,6 +1221,24 @@ async def run_freezone_video_gen(
 # ============================================================
 
 
+def sort_extracted_frames_by_pts(paths: Iterable[Path]) -> list[Path]:
+    """按文件名尾部的数值排序抽帧结果，而不是按字典序。
+
+    ``-frame_pts true`` 让 ffmpeg 把 ``%03d`` 填成该帧的 PTS 而不是递增计数，
+    于是文件名位数不固定：字典序会把 ``scene_1000.png`` 排到 ``scene_900.png``
+    前面，送进模型的关键帧顺序和 ``keyframe_index`` 映射就全乱了。
+    """
+
+    def sort_key(path: Path) -> tuple[int, int, str]:
+        match = re.search(r"(\d+)$", path.stem)
+        if match is None:
+            # 没有数字后缀的（理论上不该出现）排到最后，按名字兜底。
+            return (1, 0, path.name)
+        return (0, int(match.group(1)), path.name)
+
+    return sorted(paths, key=sort_key)
+
+
 async def run_freezone_extract_frames(
     *,
     project_dir: Path,
@@ -1269,7 +1289,7 @@ async def run_freezone_extract_frames(
     if proc.returncode != 0:
         raise RuntimeError(f"ffmpeg scene detect failed: {proc.stderr[-500:]}")
 
-    scene_files = sorted(out_dir.glob("scene_*.png"))
+    scene_files = sort_extracted_frames_by_pts(out_dir.glob("scene_*.png"))
 
     # Fallback: if too few scene cuts (e.g. talking head static video),
     # sample evenly-spaced frames so the user always gets *something*.
@@ -1505,7 +1525,7 @@ async def _sample_evenly(video_path: Path, out_dir: Path, max_frames: int) -> li
         str(out_dir / "even_%03d.png"),
     ]
     await asyncio.to_thread(subprocess.run, cmd, capture_output=True, text=True, timeout=300)
-    return sorted(out_dir.glob("even_*.png"))
+    return sort_extracted_frames_by_pts(out_dir.glob("even_*.png"))
 
 
 _SIZE_BASE = {

--- a/src/novelvideo/freezone/text_node.py
+++ b/src/novelvideo/freezone/text_node.py
@@ -138,8 +138,12 @@ Example style for `video_motion_prompt`:
 FREEZONE_VIDEO_STORY_SCRIPT_SYSTEM_PROMPT = (
     FREEZONE_STORY_SCRIPT_SYSTEM_PROMPT
     + """
-## Video-reference mode
-You are additionally given an ordered set of keyframes sampled from a reference video.
+## Vision-reference modes
+Images may be attached to the request. The task message states which mode applies; follow that
+mode and ignore the other one.
+
+### Video-keyframe mode
+You are given an ordered set of keyframes sampled from a reference video.
 - The story script MUST describe what is actually visible in those frames. Do not invent an
   unrelated story, and do not fall back on the examples in this prompt.
 - Read the frames as one continuous clip: identify the real subject(s), setting, wardrobe or
@@ -150,6 +154,18 @@ You are additionally given an ordered set of keyframes sampled from a reference 
 - Set `keyframe_index` on every row to the 1-based index of the input frame that best
   represents that shot. This is how the backend attaches the reference thumbnail.
 - Total duration across rows should stay close to the stated video duration.
+
+### Character-reference mode
+You are given one portrait-style reference image per character, in the order the task message
+lists them. There is no reference video.
+- Read every character's real appearance off their image — face, hair, wardrobe, era, species —
+  and write `character_description_1` / `character_description_2` from what you actually see.
+  Do not describe a character the images do not show.
+- Reuse the exact character names given in the task message so the backend can attach each
+  character's reference image.
+- The story itself comes from the user's request (and the source script, when one is supplied),
+  not from the images. The images only fix who the characters are.
+- Set `keyframe_index` to 0 on every row: there are no keyframes to attach.
 """
 )
 
@@ -406,6 +422,39 @@ def build_freezone_video_story_script_task(
     return "\n\n".join(parts)
 
 
+def build_freezone_character_story_script_task(
+    *,
+    image_count: int,
+    prompt: str,
+    source_text: str = "",
+    character_refs: Sequence[Mapping[str, Any]] | None = None,
+) -> str:
+    """构建「角色参考图生成分镜脚本」任务。
+
+    这一路没有参考视频，只有角色参考图：剧情来自用户提示词（和可选的源剧本），
+    图片只负责钉死角色长相，所以 ``keyframe_index`` 一律为 0。
+    """
+    parts = [
+        f"下面按顺序给你 {image_count} 张角色参考图，请据此生成一张完整的故事脚本表。",
+        "这是角色参考模式，没有参考视频：角色1 / 角色2 的外貌、服饰、年代、气质"
+        "必须照着对应的角色参考图写，不要描述图里没有的人。",
+        "剧情本身来自用户要求（以及可选的源剧本），不要凭空照搬系统提示词里的示例剧情。",
+        "每一行的 keyframe_index 一律填 0：本模式没有关键帧可以回填。",
+        *_STORY_SCRIPT_COMMON_RULES,
+    ]
+    if prompt.strip():
+        parts.append(f"用户要求：\n{prompt.strip()}")
+    else:
+        parts.append("用户没有额外要求，请围绕这些角色自行编排一段结构完整的短剧。")
+    character_block = _character_ref_block(character_refs)
+    if character_block:
+        parts.append(character_block)
+    parts.append(_STORY_SCRIPT_STYLE_HINT)
+    if source_text.strip():
+        parts.append(f"源剧本内容：\n{source_text.strip()}")
+    return "\n\n".join(parts)
+
+
 async def generate_freezone_story_script(
     *,
     source_text: str,
@@ -471,8 +520,9 @@ async def generate_freezone_story_script_with_vision(
     覆盖两种入口：
 
     - 「视频参考生成分镜脚本」：``frame_paths`` 是抽出来的关键帧，走视频拆解任务书。
-    - 「角色生成分镜脚本」：只有 ``character_image_paths``，走普通剧本任务书，
-      但把角色图一并交给模型，这样角色描述才是照着图写的而不是凭空编的。
+    - 「角色生成分镜脚本」：只有 ``character_image_paths``，走角色参考任务书 ——
+      剧情来自 ``prompt``（和可选的 ``source_text``），角色图只负责钉死角色长相。
+      这一路不要求 ``source_text``：前端挂了素材时只会发提示词。
     """
     from pydantic_ai import BinaryContent
 
@@ -495,11 +545,12 @@ async def generate_freezone_story_script_with_vision(
             character_refs=character_refs,
         )
     else:
-        if not source_text.strip():
-            raise ValueError("source_text is required when no keyframes are provided")
-        task = build_freezone_story_script_task(
-            source_text=source_text,
+        # 只有角色图：剧情从提示词 / 可选源剧本来，图片只钉角色长相。
+        # 这里不能要求 source_text —— 前端在挂了素材时就只发提示词。
+        task = build_freezone_character_story_script_task(
+            image_count=len(character_images),
             prompt=prompt,
+            source_text=source_text,
             character_refs=character_refs,
         )
 

--- a/src/novelvideo/freezone/text_node.py
+++ b/src/novelvideo/freezone/text_node.py
@@ -7,7 +7,9 @@
 
 from __future__ import annotations
 
-from typing import Literal, Optional
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any, Literal, Optional
 
 from pydantic import BaseModel, Field
 from pydantic_ai import Agent
@@ -123,7 +125,33 @@ Example style for `video_motion_prompt`:
 - Avoid generic outputs like `人物站着`, `镜头推进`, `情绪复杂`.
 - Prefer highly specific physical action, facial detail, scene detail, and camera-language wording.
 - Preserve story logic and character-state progression across rows.
+
+## Asset fields you must NOT invent
+- `character_image_1`, `character_image_2`, `reference` are asset URL slots filled in by the
+  backend after generation. Always output them as an empty string.
+- Never write `无`, a file name, or a made-up URL into those three fields.
+- When two distinct characters appear in one shot, fill `character_2` /
+  `character_description_2` the same way as `character_1` / `character_description_1`.
+  Reuse the exact same character identifier across rows so the same person keeps one name.
 """
+
+FREEZONE_VIDEO_STORY_SCRIPT_SYSTEM_PROMPT = (
+    FREEZONE_STORY_SCRIPT_SYSTEM_PROMPT
+    + """
+## Video-reference mode
+You are additionally given an ordered set of keyframes sampled from a reference video.
+- The story script MUST describe what is actually visible in those frames. Do not invent an
+  unrelated story, and do not fall back on the examples in this prompt.
+- Read the frames as one continuous clip: identify the real subject(s), setting, wardrobe or
+  species, palette, and what physically changes from frame to frame.
+- If the subject is not human (animal, object, mascot, animation), say so plainly in
+  `character_1` and `character_description_1`. Do not substitute a human character.
+- Group consecutive frames into narrative shots rather than describing every frame.
+- Set `keyframe_index` on every row to the 1-based index of the input frame that best
+  represents that shot. This is how the backend attaches the reference thumbnail.
+- Total duration across rows should stay close to the stated video duration.
+"""
+)
 
 FREEZONE_NODE_TYPE_LABELS: dict[str, str] = {
     "generic": "通用提示词",
@@ -135,6 +163,7 @@ FREEZONE_NODE_TYPE_LABELS: dict[str, str] = {
 
 _translation_agent: Optional[Agent] = None
 _story_script_agent: Optional[Agent] = None
+_video_story_script_agent: Optional[Agent] = None
 
 
 class FreezoneTranslationResult(BaseModel):
@@ -264,36 +293,116 @@ async def translate_freezone_text(
     )
 
 
+_STORY_SCRIPT_COMMON_RULES = (
+    "输出字段必须覆盖：镜号、时长、画面描述、角色1、角色描述1、角色图1、角色2、角色描述2、"
+    "角色图2、参考、景别、角色动作、情绪、场景标签、光影氛围、音效、对白、分镜提示词、视频运动提示词。",
+    "如果用户给了额外要求，也必须一起遵守。",
+    "请严格按照影视制片表格思路输出，不要输出散文摘要。",
+    "请让分镜提示词和视频运动提示词都采用括号分段 + 号连接的格式。",
+    "缺失对白时写 `无`。",
+    "角色图1、角色图2、参考三个字段一律输出空字符串——它们由后端回填素材 URL，"
+    "不要写 `无`，也不要编造文件名或链接。",
+    "分镜提示词必须像高质量图像生成提示词，视频运动提示词必须像高质量视频运动提示词，而不是简单一句概括。",
+)
+
+_STORY_SCRIPT_STYLE_HINT = (
+    "参考风格要点：\n"
+    "- 镜号连续递增\n"
+    "- 时长大多 2-5 秒\n"
+    "- 景别写法类似 `近景 / 特写`、`中景 / 仰视`\n"
+    "- 角色描述尽量写成 `[角色ID: ...]` 形式\n"
+    "- 同一个人物在所有行里必须用完全一致的角色名，方便回填角色参考图\n"
+    "- 一镜里出现两个角色时，第二个填进角色2 / 角色描述2\n"
+    "- 分镜提示词最好严格按 8 段写：构图、角色卡/主体描述、空间关系、微表情/状态、环境与道具、光影几何、视觉风格、技术参数\n"
+    "- 如果存在角色1，分镜提示词第二段尽量直接使用或轻改角色描述1，不要换成模糊代称\n"
+    "- 分镜提示词中的技术参数段尽量保留，不要省略\n"
+    "- 视频运动提示词最好严格按 6 段写：运镜轨迹、主体动作、环境动态、音效氛围、对白语气、时长\n"
+    "- 视频运动提示词里的主体动作必须是可见物理动作，不要只写情绪变化"
+)
+
+
+def _character_ref_block(
+    character_refs: Sequence[Mapping[str, Any]] | None,
+) -> str | None:
+    """把角色参考图渲染成任务里的角色卡清单。
+
+    只给模型「名字 + 描述 + 定位」，不给 URL —— 图片本身通过多模态附件传，
+    URL 由后端在生成之后按角色名回填，避免模型把链接抄错或凭空编造。
+    """
+    if not character_refs:
+        return None
+    lines: list[str] = []
+    for index, ref in enumerate(character_refs, start=1):
+        name = str(ref.get("name") or "").strip() or f"角色{index}"
+        description = str(ref.get("description") or "").strip()
+        role = str(ref.get("role") or "").strip()
+        detail = "，".join(part for part in (role, description) if part)
+        lines.append(f"{index}. {name}" + (f"（{detail}）" if detail else ""))
+    return (
+        "已提供的角色参考（按顺序对应随附的角色参考图）：\n"
+        + "\n".join(lines)
+        + "\n请在生成的角色1 / 角色2 字段里使用上面完全一致的角色名，"
+        "这样后端才能把对应的角色参考图回填进去。"
+    )
+
+
 def build_freezone_story_script_task(
     *,
     source_text: str,
     prompt: str,
+    character_refs: Sequence[Mapping[str, Any]] | None = None,
 ) -> str:
     """构建故事脚本生成任务。"""
     parts = [
         "根据以下上传剧本内容生成一个完整的故事脚本表。",
-        "输出字段必须覆盖：镜号、时长、画面描述、角色1、角色描述1、角色图1、参考、景别、角色动作、情绪、场景标签、光影氛围、音效、对白、分镜提示词、视频运动提示词。",
-        "如果用户给了额外要求，也必须一起遵守。",
-        "请严格按照影视制片表格思路输出，不要输出散文摘要。",
-        "请让分镜提示词和视频运动提示词都采用括号分段 + 号连接的格式。",
-        "缺失对白时写 `无`；缺失角色图或参考时可写空字符串或 `无`，但不要发明不存在的素材。",
-        "分镜提示词必须像高质量图像生成提示词，视频运动提示词必须像高质量视频运动提示词，而不是简单一句概括。",
+        *_STORY_SCRIPT_COMMON_RULES,
     ]
     if prompt.strip():
         parts.append(f"用户要求：\n{prompt.strip()}")
-    parts.append(
-        "参考风格要点：\n"
-        "- 镜号连续递增\n"
-        "- 时长大多 2-5 秒\n"
-        "- 景别写法类似 `近景 / 特写`、`中景 / 仰视`\n"
-        "- 角色描述尽量写成 `[角色ID: ...]` 形式\n"
-        "- 分镜提示词最好严格按 8 段写：构图、角色卡/主体描述、空间关系、微表情/状态、环境与道具、光影几何、视觉风格、技术参数\n"
-        "- 如果存在角色1，分镜提示词第二段尽量直接使用或轻改角色描述1，不要换成模糊代称\n"
-        "- 分镜提示词中的技术参数段尽量保留，不要省略\n"
-        "- 视频运动提示词最好严格按 6 段写：运镜轨迹、主体动作、环境动态、音效氛围、对白语气、时长\n"
-        "- 视频运动提示词里的主体动作必须是可见物理动作，不要只写情绪变化"
-    )
+    character_block = _character_ref_block(character_refs)
+    if character_block:
+        parts.append(character_block)
+    parts.append(_STORY_SCRIPT_STYLE_HINT)
     parts.append(f"源剧本内容：\n{source_text.strip()}")
+    return "\n\n".join(parts)
+
+
+def build_freezone_video_story_script_task(
+    *,
+    frame_count: int,
+    prompt: str,
+    duration_sec: float | None = None,
+    character_refs: Sequence[Mapping[str, Any]] | None = None,
+) -> str:
+    """构建「视频参考生成分镜脚本」任务。
+
+    与文本模式共用同一张输出表，区别是源素材换成了按时间顺序抽取的关键帧，
+    并要求模型给出 ``keyframe_index`` 以便后端回填每一镜的参考图。
+    """
+    duration_hint = (
+        f"该视频总时长约 {duration_sec:.2f} 秒，所有镜头时长加起来应接近这个值。"
+        if duration_sec and duration_sec > 0
+        else "视频总时长未知，请按关键帧的疏密给出合理时长。"
+    )
+    parts = [
+        f"下面按时间顺序给你 {frame_count} 张从参考视频里抽取的关键帧，"
+        "请把这段视频拆解成一张完整的故事脚本表。",
+        "这是视频拆解任务，不是原创任务：表格内容必须如实描述这些关键帧里真实出现的"
+        "主体、场景、动作和风格。严禁套用系统提示词里的示例角色或示例场景。",
+        "先通读全部关键帧判断这究竟是什么内容（人物？动物？动画？实拍？），"
+        "再决定角色名和角色描述。主体不是人时，就照实写成该动物 / 物体 / 形象，不要替换成人物。",
+        duration_hint,
+        "把连续的关键帧归纳成若干叙事镜头，不要逐帧机械罗列。",
+        "每一行都必须给出 keyframe_index：最能代表这一镜的输入关键帧序号"
+        f"（1 到 {frame_count} 之间的整数）。后端靠它回填这一镜的参考图。",
+        *_STORY_SCRIPT_COMMON_RULES,
+    ]
+    if prompt.strip():
+        parts.append(f"用户额外要求：\n{prompt.strip()}")
+    character_block = _character_ref_block(character_refs)
+    if character_block:
+        parts.append(character_block)
+    parts.append(_STORY_SCRIPT_STYLE_HINT)
     return "\n\n".join(parts)
 
 
@@ -302,14 +411,157 @@ async def generate_freezone_story_script(
     source_text: str,
     prompt: str = "",
     model: str | None = None,
+    character_refs: Sequence[Mapping[str, Any]] | None = None,
 ):
-    """执行故事脚本生成。"""
+    """执行故事脚本生成（文本 / 角色图模式）。"""
     if not source_text or not source_text.strip():
         raise ValueError("source_text is required")
 
     task = build_freezone_story_script_task(
         source_text=source_text,
         prompt=prompt,
+        character_refs=character_refs,
     )
     response = await get_freezone_story_script_agent(model).run(task)
     return response.output
+
+
+def create_freezone_video_story_script_agent() -> Agent:
+    """创建「视频参考生成分镜脚本」的视觉 Agent。
+
+    走 ``FREEZONE_VISION_MODEL``（``DC-freezone-vision-LLM``）而不是纯文本的
+    story-script 别名 —— 带图请求只有视觉渠道能接。
+    """
+    from novelvideo.api.schemas import FreezoneStoryScriptGenerateData
+    from novelvideo.config import get_newapi_text_pydantic_model
+    from novelvideo.official_defaults import DEFAULT_FREEZONE_VISION_MODEL
+
+    return Agent(
+        get_newapi_text_pydantic_model(
+            "FREEZONE_VISION_MODEL",
+            DEFAULT_FREEZONE_VISION_MODEL,
+            timeout_seconds_override=300.0,
+        ),
+        system_prompt=FREEZONE_VIDEO_STORY_SCRIPT_SYSTEM_PROMPT,
+        output_type=FreezoneStoryScriptGenerateData,
+        output_retries=3,
+        name="Freezone Video Story Script Generator",
+    )
+
+
+def get_freezone_video_story_script_agent() -> Agent:
+    """获取视频分镜脚本 Agent 单例。"""
+    global _video_story_script_agent
+    if _video_story_script_agent is None:
+        _video_story_script_agent = create_freezone_video_story_script_agent()
+    return _video_story_script_agent
+
+
+async def generate_freezone_story_script_with_vision(
+    *,
+    frame_paths: Sequence[str | Path] | None = None,
+    character_image_paths: Sequence[str | Path] | None = None,
+    source_text: str = "",
+    prompt: str = "",
+    duration_sec: float | None = None,
+    character_refs: Sequence[Mapping[str, Any]] | None = None,
+):
+    """带图的分镜脚本生成：视频关键帧 / 角色参考图 → 结构化脚本表。
+
+    覆盖两种入口：
+
+    - 「视频参考生成分镜脚本」：``frame_paths`` 是抽出来的关键帧，走视频拆解任务书。
+    - 「角色生成分镜脚本」：只有 ``character_image_paths``，走普通剧本任务书，
+      但把角色图一并交给模型，这样角色描述才是照着图写的而不是凭空编的。
+    """
+    from pydantic_ai import BinaryContent
+
+    from novelvideo.freezone.vision_gateway import image_media_type
+
+    frames = [Path(path) for path in (frame_paths or []) if Path(path).exists()]
+    character_images = [
+        Path(path) for path in (character_image_paths or []) if Path(path).exists()
+    ]
+    if not frames and not character_images:
+        raise ValueError(
+            "vision story script requires at least one keyframe or character image"
+        )
+
+    if frames:
+        task = build_freezone_video_story_script_task(
+            frame_count=len(frames),
+            prompt=prompt,
+            duration_sec=duration_sec,
+            character_refs=character_refs,
+        )
+    else:
+        if not source_text.strip():
+            raise ValueError("source_text is required when no keyframes are provided")
+        task = build_freezone_story_script_task(
+            source_text=source_text,
+            prompt=prompt,
+            character_refs=character_refs,
+        )
+
+    attachments: list[Any] = [
+        BinaryContent(data=path.read_bytes(), media_type=image_media_type(str(path)))
+        for path in (*frames, *character_images)
+    ]
+    response = await get_freezone_video_story_script_agent().run([task, *attachments])
+    return response.output
+
+
+def bind_story_script_assets(
+    data: Any,
+    *,
+    frame_urls: Sequence[str] | None = None,
+    character_refs: Sequence[Mapping[str, Any]] | None = None,
+) -> Any:
+    """把关键帧 / 角色参考图的 URL 回填进生成好的脚本行。
+
+    模型只负责写角色名和 ``keyframe_index``，素材 URL 一律由这里补齐 ——
+    这样模型没有机会编造出 404 的链接（issue #207 里角色图列恒为空的另一半原因）。
+    """
+    frames = [url for url in (frame_urls or []) if url]
+    by_name: dict[str, str] = {}
+    for ref in character_refs or []:
+        name = str(ref.get("name") or "").strip()
+        image_url = str(ref.get("image_url") or "").strip()
+        if name and image_url:
+            by_name[name.casefold()] = image_url
+    ordered_images = [
+        str(ref.get("image_url") or "").strip()
+        for ref in character_refs or []
+        if str(ref.get("image_url") or "").strip()
+    ]
+
+    def _match(name: str) -> str:
+        clean = str(name or "").strip()
+        if not clean:
+            return ""
+        folded = clean.casefold()
+        if folded in by_name:
+            return by_name[folded]
+        # 模型常把角色名写成 `沈昭昭_现代` 这类带状态后缀的稳定 ID，
+        # 精确匹配不到时退到包含匹配，仍匹配不到才放弃。
+        for candidate, url in by_name.items():
+            if candidate in folded or folded in candidate:
+                return url
+        return ""
+
+    for index, row in enumerate(getattr(data, "rows", []) or []):
+        keyframe_index = int(getattr(row, "keyframe_index", 0) or 0)
+        if not (1 <= keyframe_index <= len(frames)):
+            # 模型没给或给错序号时退回按行号顺序取帧，保证参考列不至于整列为空。
+            keyframe_index = index + 1 if index < len(frames) else 0
+        row.reference = frames[keyframe_index - 1] if keyframe_index else ""
+        row.keyframe_index = keyframe_index
+
+        row.character_image_1 = _match(getattr(row, "character_1", ""))
+        row.character_image_2 = _match(getattr(row, "character_2", ""))
+        # 只有一张角色图、且模型没写出可匹配的角色名时，直接绑定唯一那张，
+        # 否则「角色生成分镜脚本」在模型改写角色名后又会退化成空列。
+        if not row.character_image_1 and len(ordered_images) == 1:
+            row.character_image_1 = ordered_images[0]
+
+    return data

--- a/src/novelvideo/model_gateway_runtime.py
+++ b/src/novelvideo/model_gateway_runtime.py
@@ -18,7 +18,11 @@ def _runtime_version(api_key: str, base_url: str) -> str:
 def _clear_agent_singletons() -> list[str]:
     cleared: list[str] = []
     targets = {
-        "novelvideo.freezone.text_node": ("_translation_agent", "_story_script_agent"),
+        "novelvideo.freezone.text_node": (
+            "_translation_agent",
+            "_story_script_agent",
+            "_video_story_script_agent",
+        ),
         "novelvideo.agents.global_video_optimizer": ("_global_video_optimizer",),
     }
     for module_name, attrs in targets.items():

--- a/src/novelvideo/task_backend/runners/freezone.py
+++ b/src/novelvideo/task_backend/runners/freezone.py
@@ -805,20 +805,72 @@ async def _run_freezone_story_script_async(
     ctx: ProjectContext,
 ) -> dict[str, Any]:
     from novelvideo.api.deps import make_static_url_for_context
-    from novelvideo.freezone.jobs import ensure_freezone_dirs
+    from novelvideo.freezone.jobs import ensure_freezone_dirs, run_freezone_extract_frames
     from novelvideo.freezone.paths import outputs_dir
-    from novelvideo.freezone.text_node import generate_freezone_story_script
+    from novelvideo.freezone.text_node import (
+        bind_story_script_assets,
+        generate_freezone_story_script,
+        generate_freezone_story_script_with_vision,
+    )
 
     payload = envelope.get("payload") or {}
     job_id = str(payload["job_id"])
     project_dir = Path(str(payload.get("project_dir") or ctx.output_dir))
     ensure_freezone_dirs(project_dir)
-    _update(ctx, "freezone_story_script", job_id, 0.1, "开始生成故事脚本...")
-    data = await generate_freezone_story_script(
-        source_text=str(payload.get("source_text") or ""),
-        prompt=str(payload.get("prompt") or ""),
-        model=str(payload.get("model") or ""),
-    )
+
+    source_text = str(payload.get("source_text") or "")
+    prompt = str(payload.get("prompt") or "")
+    character_refs = list(payload.get("character_refs") or [])
+    character_image_paths = [str(path) for path in payload.get("character_image_paths") or []]
+    video_path = str(payload.get("video_path") or "")
+    duration_sec = payload.get("duration_sec")
+
+    frame_paths: list[Path] = []
+    frame_urls: list[str] = []
+    if video_path:
+        _update(ctx, "freezone_story_script", job_id, 0.1, "ffmpeg 抽取关键帧...")
+        frame_paths = await run_freezone_extract_frames(
+            project_dir=project_dir,
+            job_id=job_id,
+            video_path=Path(video_path),
+            max_frames=int(payload.get("max_frames") or 20),
+            scene_threshold=float(payload.get("scene_threshold") or 0.3),
+        )
+        frame_urls = [
+            make_static_url_for_context(ctx, path.relative_to(project_dir).as_posix())
+            for path in frame_paths
+        ]
+
+    if frame_paths or character_image_paths:
+        _update(
+            ctx,
+            "freezone_story_script",
+            job_id,
+            0.55,
+            (
+                f"视觉模型解析 {len(frame_paths)} 帧为分镜脚本..."
+                if frame_paths
+                else "视觉模型读取角色参考图生成故事脚本..."
+            ),
+        )
+        data = await generate_freezone_story_script_with_vision(
+            frame_paths=[str(path) for path in frame_paths],
+            character_image_paths=character_image_paths,
+            source_text=source_text,
+            prompt=prompt,
+            duration_sec=float(duration_sec) if duration_sec else None,
+            character_refs=character_refs,
+        )
+    else:
+        _update(ctx, "freezone_story_script", job_id, 0.1, "开始生成故事脚本...")
+        data = await generate_freezone_story_script(
+            source_text=source_text,
+            prompt=prompt,
+            model=str(payload.get("model") or ""),
+            character_refs=character_refs,
+        )
+
+    bind_story_script_assets(data, frame_urls=frame_urls, character_refs=character_refs)
     out = outputs_dir(project_dir, "freezone_story_script") / f"{job_id}.json"
     out.parent.mkdir(parents=True, exist_ok=True)
     import json
@@ -833,6 +885,8 @@ async def _run_freezone_story_script_async(
         "output_url": make_static_url_for_context(ctx, rel),
         **payload_data,
     }
+    if frame_urls:
+        result["frame_urls"] = frame_urls
     history_record = _append_node_history(
         ctx=ctx,
         project_dir=project_dir,

--- a/tests/test_freezone_text_backend.py
+++ b/tests/test_freezone_text_backend.py
@@ -12,6 +12,7 @@ from novelvideo.freezone.text_node import (
     FREEZONE_TRANSLATION_PROVIDER,
     FreezoneTranslationResult,
     bind_story_script_assets,
+    build_freezone_character_story_script_task,
     build_freezone_story_script_task,
     build_freezone_translation_task,
     build_freezone_video_story_script_task,
@@ -447,6 +448,63 @@ async def test_generate_story_script_with_vision_attaches_frames(
     # 三张关键帧必须真的作为附件送进模型，而不是只在提示词里被提一句。
     assert len(messages) == 1 + len(frames)
     assert all(getattr(item, "data", None) == b"png-bytes" for item in messages[1:])
+
+
+def test_build_freezone_character_story_script_task_uses_prompt_as_story() -> None:
+    task = build_freezone_character_story_script_task(
+        image_count=2,
+        prompt="以这两个角色生成一段雪山对决",
+        character_refs=[{"name": "宁姚"}, {"name": "青衣剑客"}],
+    )
+
+    assert "2 张角色参考图" in task
+    assert "以这两个角色生成一段雪山对决" in task
+    # 角色图模式没有关键帧，必须明确要求 keyframe_index 填 0，别乱指帧。
+    assert "keyframe_index 一律填 0" in task
+    assert "宁姚" in task
+    assert "青衣剑客" in task
+    assert "关键帧" not in task.replace("没有关键帧可以回填", "")
+
+
+@pytest.mark.asyncio
+async def test_generate_story_script_with_vision_accepts_character_images_only(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # 前端一旦挂了素材就只发提示词、把 source_text 留空；
+    # 「仅角色图」这一路以前会在这里抛 ValueError，任务必挂。
+    portrait = tmp_path / "ningyao.png"
+    portrait.write_bytes(b"png-bytes")
+    captured: dict[str, object] = {}
+
+    class FakeAgent:
+        async def run(self, messages):
+            captured["messages"] = messages
+
+            class Response:
+                output = FreezoneStoryScriptGenerateData(title="", rows=[])
+
+            return Response()
+
+    monkeypatch.setattr(
+        "novelvideo.freezone.text_node.get_freezone_video_story_script_agent",
+        FakeAgent,
+    )
+
+    await generate_freezone_story_script_with_vision(
+        character_image_paths=[portrait],
+        source_text="",
+        prompt="以这个角色生成一段雪山对决",
+        character_refs=[{"name": "宁姚", "image_url": "/static/ningyao.png"}],
+    )
+
+    messages = captured["messages"]
+    task = messages[0]
+    assert isinstance(task, str)
+    assert "角色参考图" in task
+    assert "以这个角色生成一段雪山对决" in task
+    assert len(messages) == 2
+    assert getattr(messages[1], "data", None) == b"png-bytes"
 
 
 def test_bind_story_script_assets_fills_frames_and_character_images() -> None:

--- a/tests/test_freezone_text_backend.py
+++ b/tests/test_freezone_text_backend.py
@@ -11,8 +11,11 @@ from novelvideo.freezone.text_node import (
     FREEZONE_TRANSLATION_MODEL,
     FREEZONE_TRANSLATION_PROVIDER,
     FreezoneTranslationResult,
+    bind_story_script_assets,
     build_freezone_story_script_task,
     build_freezone_translation_task,
+    build_freezone_video_story_script_task,
+    generate_freezone_story_script_with_vision,
     translate_freezone_text,
 )
 
@@ -261,6 +264,269 @@ async def test_freezone_story_script_route_reads_source_url_file(
     assert result["ok"] is True
     assert result["data"]["task_type"] == "freezone_story_script"
     assert captured["source_text"] == "沈昭昭在深夜办公室醒来。"
+
+
+def test_story_script_request_keeps_video_and_character_fields() -> None:
+    """issue #207 回归：前端发的视频 / 角色参考字段不能再被 Pydantic 静默丢掉。
+
+    这些字段以前没在模型里声明，``extra="ignore"`` 会把它们连同 duration_sec 一起
+    吃掉，于是「视频参考生成分镜脚本」从头到尾都没把视频交给模型。
+    """
+    body = freezone_routes.FreezoneStoryScriptGenerateRequest.model_validate(
+        {
+            "video_url": "/static/admin/58/freezone/_uploads/clip.mp4",
+            "duration_sec": 15.0,
+            "character_refs": [
+                {
+                    "name": "沈昭昭",
+                    "image_url": "/static/admin/58/freezone/_uploads/shen.png",
+                    "role": "女主",
+                }
+            ],
+            "prompt": "生成视频脚本",
+        }
+    )
+
+    assert body.video_url == "/static/admin/58/freezone/_uploads/clip.mp4"
+    assert body.duration_sec == 15.0
+    assert body.character_refs[0].name == "沈昭昭"
+    assert body.character_refs[0].image_url.endswith("shen.png")
+
+
+@pytest.mark.asyncio
+async def test_freezone_story_script_route_enqueues_video_reference(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project_dir = tmp_path / "project"
+    video = project_dir / "freezone" / "_uploads" / "clip.mp4"
+    video.parent.mkdir(parents=True, exist_ok=True)
+    video.write_bytes(b"fake-mp4")
+
+    async def _fake_resolve(project: str, user: dict, *, required_role: str = "editor"):
+        del user, required_role
+        return object(), "admin", project, project_dir, str(project_dir)
+
+    monkeypatch.setattr(freezone_routes, "_resolve_freezone_project", _fake_resolve)
+    captured: dict[str, object] = {}
+
+    async def _fake_enqueue(**kwargs):
+        captured.update(kwargs)
+        return {"ok": True, "data": {"task_type": kwargs["task_type"]}}
+
+    monkeypatch.setattr(
+        freezone_routes, "_enqueue_freezone_background_job", _fake_enqueue
+    )
+
+    result = await freezone_routes.freezone_story_script_generate(
+        project="58",
+        body=freezone_routes.FreezoneStoryScriptGenerateRequest(
+            video_url="/static/admin/58/freezone/_uploads/clip.mp4",
+            duration_sec=15.0,
+            prompt="生成视频脚本",
+        ),
+        user={"username": "admin"},
+    )
+
+    assert result["ok"] is True
+    payload = captured["payload"]
+    assert payload["video_path"] == video.as_posix()
+    assert payload["duration_sec"] == 15.0
+    assert payload["max_frames"] == 20
+    assert payload["prompt"] == "生成视频脚本"
+    # 视频是主输入，不再要求前端把提示词伪装成剧本正文。
+    assert payload["source_text"] == ""
+
+
+@pytest.mark.asyncio
+async def test_freezone_story_script_route_forwards_character_refs(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project_dir = tmp_path / "project"
+    portrait = project_dir / "freezone" / "_uploads" / "shen.png"
+    portrait.parent.mkdir(parents=True, exist_ok=True)
+    portrait.write_bytes(b"png")
+
+    _patch_project_resolution(monkeypatch, project_dir)
+    captured: dict[str, object] = {}
+
+    def _fake_start_story_script_task(**kwargs):
+        captured.update(kwargs)
+
+    monkeypatch.setattr(
+        freezone_routes, "_start_freezone_story_script_task", _fake_start_story_script_task
+    )
+
+    result = await freezone_routes.freezone_story_script_generate(
+        project="58",
+        body=freezone_routes.FreezoneStoryScriptGenerateRequest(
+            character_refs=[
+                freezone_routes.FreezoneStoryScriptCharacterRef(
+                    name="沈昭昭",
+                    image_url="/static/admin/58/freezone/_uploads/shen.png",
+                    role="女主",
+                )
+            ],
+            prompt="生成一段职场逆袭脚本",
+        ),
+        user={"username": "admin"},
+    )
+
+    assert result["ok"] is True
+    assert captured["character_refs"][0]["name"] == "沈昭昭"
+    assert captured["character_image_paths"] == [portrait.as_posix()]
+
+
+@pytest.mark.asyncio
+async def test_freezone_story_script_route_rejects_empty_input(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from fastapi import HTTPException
+
+    _patch_project_resolution(monkeypatch, tmp_path / "project")
+
+    with pytest.raises(HTTPException) as excinfo:
+        await freezone_routes.freezone_story_script_generate(
+            project="58",
+            body=freezone_routes.FreezoneStoryScriptGenerateRequest(),
+            user={"username": "admin"},
+        )
+
+    assert excinfo.value.status_code == 400
+
+
+def test_build_freezone_video_story_script_task_describes_the_real_video() -> None:
+    task = build_freezone_video_story_script_task(
+        frame_count=6,
+        prompt="生成视频脚本",
+        duration_sec=15.0,
+    )
+
+    assert "6" in task
+    assert "15" in task
+    assert "keyframe_index" in task
+    assert "生成视频脚本" in task
+
+
+@pytest.mark.asyncio
+async def test_generate_story_script_with_vision_attaches_frames(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    frames = []
+    for index in range(3):
+        frame = tmp_path / f"frame_{index}.png"
+        frame.write_bytes(b"png-bytes")
+        frames.append(frame)
+    captured: dict[str, object] = {}
+
+    class FakeAgent:
+        async def run(self, messages):
+            captured["messages"] = messages
+
+            class Response:
+                output = FreezoneStoryScriptGenerateData(title="", rows=[])
+
+            return Response()
+
+    monkeypatch.setattr(
+        "novelvideo.freezone.text_node.get_freezone_video_story_script_agent",
+        FakeAgent,
+    )
+
+    await generate_freezone_story_script_with_vision(
+        frame_paths=frames,
+        prompt="生成视频脚本",
+        duration_sec=15.0,
+    )
+
+    messages = captured["messages"]
+    assert isinstance(messages[0], str)
+    # 三张关键帧必须真的作为附件送进模型，而不是只在提示词里被提一句。
+    assert len(messages) == 1 + len(frames)
+    assert all(getattr(item, "data", None) == b"png-bytes" for item in messages[1:])
+
+
+def test_bind_story_script_assets_fills_frames_and_character_images() -> None:
+    data = FreezoneStoryScriptGenerateData(
+        title="猫猫散步",
+        rows=[
+            FreezoneStoryScriptRow(
+                shot_no=1,
+                duration=4,
+                visual_description="猫从画面左侧走入",
+                character_1="香蕉猫",
+                keyframe_index=2,
+            ),
+            FreezoneStoryScriptRow(
+                shot_no=2,
+                duration=4,
+                visual_description="猫停下回头",
+                character_1="香蕉猫_特写",
+                character_2="路人",
+                keyframe_index=1,
+            ),
+        ],
+    )
+
+    bind_story_script_assets(
+        data,
+        frame_urls=["/static/f1.png", "/static/f2.png"],
+        character_refs=[
+            {"name": "香蕉猫", "image_url": "/static/cat.png"},
+            {"name": "路人", "image_url": "/static/passerby.png"},
+        ],
+    )
+
+    assert data.rows[0].reference == "/static/f2.png"
+    assert data.rows[1].reference == "/static/f1.png"
+    assert data.rows[0].character_image_1 == "/static/cat.png"
+    # 模型把角色名写成带后缀的稳定 ID 时仍要匹配上。
+    assert data.rows[1].character_image_1 == "/static/cat.png"
+    assert data.rows[1].character_image_2 == "/static/passerby.png"
+
+
+def test_bind_story_script_assets_falls_back_to_row_order_on_bad_index() -> None:
+    data = FreezoneStoryScriptGenerateData(
+        title="",
+        rows=[
+            FreezoneStoryScriptRow(
+                shot_no=1, duration=3, visual_description="第一镜", keyframe_index=99
+            ),
+            FreezoneStoryScriptRow(
+                shot_no=2, duration=3, visual_description="第二镜", keyframe_index=0
+            ),
+            FreezoneStoryScriptRow(
+                shot_no=3, duration=3, visual_description="第三镜", keyframe_index=0
+            ),
+        ],
+    )
+
+    bind_story_script_assets(data, frame_urls=["/static/f1.png", "/static/f2.png"])
+
+    assert data.rows[0].reference == "/static/f1.png"
+    assert data.rows[1].reference == "/static/f2.png"
+    # 帧数不够时多出来的镜头留空，而不是循环复用一张图。
+    assert data.rows[2].reference == ""
+
+
+def test_bind_story_script_assets_binds_sole_character_image() -> None:
+    data = FreezoneStoryScriptGenerateData(
+        title="",
+        rows=[
+            FreezoneStoryScriptRow(
+                shot_no=1, duration=3, visual_description="第一镜", character_1="女主角"
+            )
+        ],
+    )
+
+    bind_story_script_assets(
+        data, character_refs=[{"name": "沈昭昭", "image_url": "/static/shen.png"}]
+    )
+
+    assert data.rows[0].character_image_1 == "/static/shen.png"
 
 
 @pytest.mark.asyncio

--- a/tests/test_freezone_video_story_backend.py
+++ b/tests/test_freezone_video_story_backend.py
@@ -8,6 +8,7 @@ from novelvideo.api.routes import freezone as freezone_routes
 from novelvideo.freezone import vision_gateway
 from novelvideo.freezone.jobs import build_video_story_analysis_prompt
 from novelvideo.freezone.jobs import run_freezone_analyze_shots
+from novelvideo.freezone.jobs import sort_extracted_frames_by_pts
 
 
 def _patch_project_resolution(
@@ -21,6 +22,40 @@ def _patch_project_resolution(
         return None, username, project, project_dir, str(project_dir)
 
     monkeypatch.setattr(freezone_routes, "_resolve_freezone_project", _fake_resolve)
+
+
+def test_extracted_frames_sort_by_numeric_pts_not_lexicographically() -> None:
+    # `-frame_pts true` 让文件名里的数字是 PTS 而不是计数，位数不固定：
+    # 字典序会把 scene_1000 排到 scene_900 前面，关键帧顺序和 keyframe_index 全乱。
+    out_dir = Path("/tmp/freezone_extract/job")
+    paths = [
+        out_dir / "scene_1000.png",
+        out_dir / "scene_90.png",
+        out_dir / "scene_900.png",
+        out_dir / "scene_1.png",
+    ]
+
+    ordered = sort_extracted_frames_by_pts(paths)
+
+    assert [path.name for path in ordered] == [
+        "scene_1.png",
+        "scene_90.png",
+        "scene_900.png",
+        "scene_1000.png",
+    ]
+
+
+def test_extracted_frames_sort_keeps_zero_padded_even_samples_in_order() -> None:
+    out_dir = Path("/tmp/freezone_extract/job")
+    paths = [out_dir / "even_010.png", out_dir / "even_002.png", out_dir / "even_001.png"]
+
+    ordered = sort_extracted_frames_by_pts(paths)
+
+    assert [path.name for path in ordered] == [
+        "even_001.png",
+        "even_002.png",
+        "even_010.png",
+    ]
 
 
 def test_video_story_prompt_requests_libtv_story_table() -> None:


### PR DESCRIPTION
## PR 类型 / Type of PR
- [x] 🐞 Bug 修复 / Bug fix

## 改动说明 / What this PR does and why

「视频参考生成分镜脚本」产出的脚本和原视频毫无关系，且角色图 / 参考列永远是空占位。排查出**四个独立缺陷**：

### 1. 视频从未送进模型（脚本与视频无关的根因）

前端一直在发 `video_url`，但后端 `FreezoneStoryScriptGenerateRequest` **没有声明这个字段** —— Pydantic v2 默认 `extra="ignore"`，于是它连同 `duration_sec` / `character_refs` 一起被静默丢掉（无报错、无日志）。模型拿到的输入是空的，只能照抄系统提示词里的示例角色：issue 截图里那个「沈昭昭 / 深夜办公室 / 现代职业装」正是 `FREEZONE_STORY_SCRIPT_SYSTEM_PROMPT` 的原文，而用户上传的是一只穿香蕉皮走路的猫。

修法：补齐字段声明；视频走 ffmpeg 抽帧 + `DC-freezone-vision-LLM` 视觉模型（带图请求只有视觉渠道能接，裸模型名会 503）。复用仓库里已有的 `run_freezone_extract_frames` 管线，不新造一套视频理解。视觉模式的提示词明确要求「描述画面里实际存在的东西，不许回退到本提示词的示例」「主体不是人就照实写，不要换成人类角色」。

`character_refs` 同样是被丢掉的，所以「角色生成分镜脚本」也一样瞎 —— 一并修好。

### 2. 三列恒为「-」

前端 `SCRIPT_COLUMNS` 的 key 与后端字段名对不上：`character` ↔ `character_1`、`character_desc_1` ↔ `character_description_1`、`action` ↔ `character_action`。后端从来没发过这三个 key，所以这三列必然是「-」（而同一行的景别 / 情绪 / 场景标签有值）。

### 3. 角色图 / 参考图列恒空

这两个字段原本被注释为「占位字段」，系统提示词还专门叫模型留空 —— 设计上就永远是空的。新增 `bind_story_script_assets()`：模型只负责写角色名和 `keyframe_index`，素材 URL 一律由后端回填，模型没机会编造出 404 链接。帧序号越界时退回按行号取帧；角色名被模型改写成 `香蕉猫_特写` 这类带状态后缀的稳定 ID 时走包含匹配；只有一张角色图且没匹配上时直接绑定唯一那张。

### 4. 表格图片格只读

原代码注释写着 inline 编辑「等用户后续提」。新增 `ScriptImageCell`：空位点击上传、已有图 hover 出替换 / 删除、点击放大预览，全部复用原有 `handleCellCommit` → `updateNodeData` 落盘路径。

### 顺带

移除前端「把用户提示词伪装成 `source_text`」的权宜之计（#65 / #66 时期为绕开 400 留下的，正好掩盖了缺陷 1）。视频 / 角色图现在是合法主输入，有素材时输入框内容老实退回 steering prompt。

## 关联 issue / Linked issues

Closes #207

## 给 reviewer 的说明 / Notes for the reviewer

- **重点看 `_resolve_story_script_character_refs` 的宽容度**：外链或解析不出本地文件的角色图仍保留在角色卡里（回填 URL 照样能用），只是不作为附件送进模型 —— 避免一张外链图让整个任务 400。
- **视频模式要求 `ProjectContext`**：抽帧要落盘并生成 `/static` URL，没有 ctx 就拼不出地址，因此走 `_raise_project_context_required`，与 `analyze-video-story` 等视频任务的前置要求一致。
- **视觉 Agent 单例已登记进 `model_gateway_runtime._clear_agent_singletons`**，CE 改网关配置后不会留旧 client。
- 未新增被跟踪文件，`license-inventory.csv` 无需变更。
- 已在本地 EE 全栈实测通过（重启 API + celery worker 后，视频 → 抽帧 → 视觉模型 → 参考列贴回关键帧）。

## 面向用户的变更 / User-facing change

```release-note
修复画布「视频参考 / 角色生成分镜脚本」：生成结果现在真正基于上传的视频与角色图，角色列和角色图 / 参考图列不再为空，表格里的图片可直接上传、替换、预览。
```

## 自检 / Checklist
- [x] 已自测，`uv run pytest` 通过 / Self-tested, `uv run pytest` passes
- [x] 必要的文档已更新 / Docs updated where needed
- [x] 提交信息清晰（建议 Conventional Commits）/ Clear commits (Conventional Commits suggested)
- [x] 每个 commit 都已 `git commit -s` 附 DCO 签署 / Every commit signed off with `git commit -s` (DCO)
- [x] 我已阅读并同意[贡献者协议](../CONTRIBUTING.md#贡献者协议) / I've read and agree to the [contributor terms](../CONTRIBUTING.md#贡献者协议)

🤖 Generated with [Claude Code](https://claude.com/claude-code)