### PR TITLE
fix(video): handle normalized gateway task results

### DIFF
--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -3538,6 +3538,14 @@
       "submit": "Submit",
       "submitBusy": "Generating, please wait",
       "partialBatchFailed": "Generated {{ok}}/{{total}}, the rest failed",
+      "humanReviewErrors": {
+        "assetFetchFailed": "Reference image {{index}} could not be accessed. Upload it again and retry.",
+        "assetExpired": "The link for reference image {{index}} has expired. Upload it again.",
+        "unsupportedImage": "Reference image {{index}} has an unsupported format or size.",
+        "contentRejected": "Reference image {{index}} did not pass content review. Try another image.",
+        "reviewTimeout": "Reference image review timed out. Try again later.",
+        "unknownReviewError": "Reference image {{index}} failed review and the upstream service provided no reason. Try another image or contact an administrator."
+      },
       "aspect": {
         "title": "Aspect Ratio",
         "auto": "Auto"

--- a/frontend/public/locales/zh/translation.json
+++ b/frontend/public/locales/zh/translation.json
@@ -3538,6 +3538,14 @@
       "submit": "提交",
       "submitBusy": "生成中，请稍候",
       "partialBatchFailed": "已生成 {{ok}}/{{total}} 条，其余生成失败",
+      "humanReviewErrors": {
+        "assetFetchFailed": "第 {{index}} 张参考图片无法读取，请重新上传后重试。",
+        "assetExpired": "第 {{index}} 张参考图片链接已过期，请重新上传。",
+        "unsupportedImage": "第 {{index}} 张参考图片的格式或尺寸不受支持。",
+        "contentRejected": "第 {{index}} 张参考图片未通过内容审核，请更换图片。",
+        "reviewTimeout": "参考图片审核超时，请稍后重试。",
+        "unknownReviewError": "第 {{index}} 张参考图片审核失败，上游未返回具体原因。请更换图片或联系管理员。"
+      },
       "aspect": {
         "title": "比例",
         "auto": "Auto"

--- a/frontend/src/__tests__/lib/gateway-error-classify.test.ts
+++ b/frontend/src/__tests__/lib/gateway-error-classify.test.ts
@@ -11,10 +11,16 @@ import {
 
 // A stub TFunction: return the key, unless a `defaultValue` is supplied and
 // the key is unknown. Our two keys are "known", so return a marker per key.
-const t = ((key: string, opts?: { defaultValue?: string }) => {
+const t = ((key: string, opts?: { defaultValue?: string; index?: number }) => {
   if (key === "common.generationChannelPolicyBlocked") return "POLICY_MSG";
   if (key === "common.generationRateLimited") return "RATE_MSG";
   if (key === "common.error") return "GENERIC_ERROR";
+  if (key === "node.videoNode.humanReviewErrors.contentRejected") {
+    return `IMAGE_${opts?.index}_REJECTED`;
+  }
+  if (key === "node.videoNode.humanReviewErrors.unknownReviewError") {
+    return `IMAGE_${opts?.index}_UNKNOWN`;
+  }
   return opts?.defaultValue ?? key;
 }) as unknown as Parameters<typeof humanizeTaskError>[1];
 
@@ -100,6 +106,24 @@ describe("humanizeTaskError", () => {
     expect(backendErrorToastMessage(new Error(MODERATION_RAW), t)).toBe(
       "Content failed safety review. / 内容未通过安全审核。",
     );
+  });
+
+  it("localizes a structured human-review failure embedded in a video task error", () => {
+    const raw =
+      'freezone video generation failed: DramaClawAPI submit failed: HTTP 422 - ' +
+      '{"code":"human_review_asset_failed","message":"TokenHub asset review failed",' +
+      '"data":{"asset_index":2,"reason_code":"content_rejected"}}';
+
+    expect(humanizeTaskError(raw, t)).toBe("IMAGE_2_REJECTED");
+    expect(backendErrorToastMessage(new Error(raw), t)).toBe("IMAGE_2_REJECTED");
+  });
+
+  it("uses the localized unknown-reason fallback for incomplete upstream errors", () => {
+    const raw =
+      'HTTP 422 - {"code":"human_review_asset_failed",' +
+      '"data":{"asset_index":1,"reason_code":"unknown_review_error"}}';
+
+    expect(backendErrorToastMessage(new Error(raw), t)).toBe("IMAGE_1_UNKNOWN");
   });
 
   it("falls back to the generic error label when input is empty", () => {

--- a/frontend/src/lib/api-errors.ts
+++ b/frontend/src/lib/api-errors.ts
@@ -276,9 +276,21 @@ function providerErrorPayload(raw: string): unknown | null {
   }
 
   const bodyMatch = /\bbody\s*=\s*/gi.exec(text);
-  if (!bodyMatch) return null;
-  const jsonStart = bodyMatch.index + bodyMatch[0].length;
-  return parseJsonValueAt(text, jsonStart);
+  if (bodyMatch) {
+    const jsonStart = bodyMatch.index + bodyMatch[0].length;
+    const payload = parseJsonValueAt(text, jsonStart);
+    if (payload) return payload;
+  }
+
+  // Video task errors use `HTTP <status> - {...}` rather than `body={...}`.
+  // Scan JSON object boundaries so the structured gateway error survives the
+  // Python task wrapper and remains available for localization.
+  for (let index = 0; index < text.length; index += 1) {
+    if (text[index] !== "{") continue;
+    const payload = parseJsonValueAt(text, index);
+    if (payload) return payload;
+  }
+  return null;
 }
 
 function messageFromPayload(payload: unknown): string | null {
@@ -298,6 +310,54 @@ function messageFromPayload(payload: unknown): string | null {
 export function providerErrorMessage(raw: string | null | undefined): string | null {
   if (!raw) return null;
   return messageFromPayload(providerErrorPayload(raw));
+}
+
+interface HumanReviewAssetFailure {
+  index: number;
+  reasonCode: string;
+}
+
+function humanReviewAssetFailure(payload: unknown): HumanReviewAssetFailure | null {
+  if (!payload || typeof payload !== "object") return null;
+  const record = payload as Record<string, unknown>;
+  if (record.code === "human_review_asset_failed") {
+    const data =
+      record.data && typeof record.data === "object"
+        ? (record.data as Record<string, unknown>)
+        : {};
+    return {
+      index:
+        typeof data.asset_index === "number" && Number.isFinite(data.asset_index)
+          ? Math.max(1, Math.floor(data.asset_index))
+          : 1,
+      reasonCode:
+        typeof data.reason_code === "string" && data.reason_code.trim()
+          ? data.reason_code
+          : "unknown_review_error",
+    };
+  }
+  for (const nested of Object.values(record)) {
+    const found = humanReviewAssetFailure(nested);
+    if (found) return found;
+  }
+  return null;
+}
+
+function humanReviewAssetMessage(raw: string, t: TFunction): string | null {
+  const failure = humanReviewAssetFailure(providerErrorPayload(raw));
+  if (!failure) return null;
+  const keyByReason: Record<string, string> = {
+    asset_fetch_failed: "assetFetchFailed",
+    asset_expired: "assetExpired",
+    unsupported_image: "unsupportedImage",
+    content_rejected: "contentRejected",
+    review_timeout: "reviewTimeout",
+    unknown_review_error: "unknownReviewError",
+  };
+  const reasonKey = keyByReason[failure.reasonCode] ?? "unknownReviewError";
+  return t(`node.videoNode.humanReviewErrors.${reasonKey}`, {
+    index: failure.index,
+  });
 }
 
 export function classifyGatewayError(
@@ -331,6 +391,8 @@ export function humanizeTaskError(
       defaultValue: "计费规则未配置，请联系管理员设置积分规则",
     });
   }
+  const reviewMessage = raw ? humanReviewAssetMessage(raw, t) : null;
+  if (reviewMessage) return reviewMessage;
   switch (classifyGatewayError(raw)) {
     case "channel_policy":
       return t("common.generationChannelPolicyBlocked", { defaultValue: fallback });
@@ -368,6 +430,8 @@ export function backendErrorToastMessage(error: unknown, t: TFunction): string {
     });
   }
   if (error instanceof Error && error.message) {
+    const reviewMessage = humanReviewAssetMessage(error.message, t);
+    if (reviewMessage) return reviewMessage;
     return providerErrorMessage(error.message) ?? error.message;
   }
   return t("common.error");

--- a/src/novelvideo/generators/video_generator.py
+++ b/src/novelvideo/generators/video_generator.py
@@ -2307,16 +2307,23 @@ class NewApiVideoGenerator(VideoGeneratorBase):
 
     @staticmethod
     def _extract_video_url(task: dict) -> str:
-        metadata = task.get("metadata") if isinstance(task, dict) else None
+        if not isinstance(task, dict):
+            return ""
+
+        result_url = task.get("result_url")
+        if isinstance(result_url, str) and result_url.strip():
+            return result_url.strip()
+
+        metadata = task.get("metadata")
         if isinstance(metadata, dict):
             for key in ("url", "video_url"):
                 value = metadata.get(key)
-                if isinstance(value, str) and value:
-                    return value
+                if isinstance(value, str) and value.strip():
+                    return value.strip()
         for key in ("url", "video_url"):
-            value = task.get(key) if isinstance(task, dict) else None
-            if isinstance(value, str) and value:
-                return value
+            value = task.get(key)
+            if isinstance(value, str) and value.strip():
+                return value.strip()
         return ""
 
     @staticmethod

--- a/src/novelvideo/generators/video_generator.py
+++ b/src/novelvideo/generators/video_generator.py
@@ -2895,7 +2895,14 @@ class NewApiVideoGenerator(VideoGeneratorBase):
                         duration_seconds=float(duration),
                     )
 
-                if status in {"failed", "error", "canceled", "cancelled", "expired"}:
+                if status in {
+                    "failure",
+                    "failed",
+                    "error",
+                    "canceled",
+                    "cancelled",
+                    "expired",
+                }:
                     error = (
                         task.get("error") or task.get("fail_reason") or "DramaClawAPI video task failed"
                     )

--- a/tests/test_seedance2_request.py
+++ b/tests/test_seedance2_request.py
@@ -735,6 +735,47 @@ def test_newapi_video_task_response_accepts_flat_and_data_wrapped_contracts():
     }
 
 
+def test_newapi_video_result_url_prefers_normalized_task_result():
+    from novelvideo.generators.video_generator import NewApiVideoGenerator
+
+    task = NewApiVideoGenerator._task_response_data(
+        {
+            "code": "success",
+            "data": {
+                "task_id": "task-wrapped",
+                "status": "SUCCESS",
+                "result_url": " https://example.com/normalized.mp4 ",
+                "metadata": {"url": "https://example.com/legacy-metadata.mp4"},
+                "url": "https://example.com/legacy-top-level.mp4",
+            },
+        }
+    )
+
+    assert (
+        NewApiVideoGenerator._extract_video_url(task)
+        == "https://example.com/normalized.mp4"
+    )
+
+
+@pytest.mark.parametrize(
+    ("task", "expected"),
+    [
+        (
+            {"metadata": {"url": "https://example.com/metadata.mp4"}},
+            "https://example.com/metadata.mp4",
+        ),
+        (
+            {"video_url": "https://example.com/top-level.mp4"},
+            "https://example.com/top-level.mp4",
+        ),
+    ],
+)
+def test_newapi_video_result_url_keeps_legacy_fallbacks(task, expected):
+    from novelvideo.generators.video_generator import NewApiVideoGenerator
+
+    assert NewApiVideoGenerator._extract_video_url(task) == expected
+
+
 async def test_newapi_happyhorse_video_generator_uses_happyhorse_payload(tmp_path, monkeypatch):
     from pathlib import Path
 

--- a/tests/test_seedance2_request.py
+++ b/tests/test_seedance2_request.py
@@ -625,6 +625,56 @@ async def test_newapi_seedance2_generator_preserves_config_resolution_and_scene_
     assert "seconds" not in payload
 
 
+async def test_newapi_video_generator_handles_wrapped_failure_status(
+    tmp_path, monkeypatch
+):
+    from novelvideo.generators import video_generator as video_module
+    from novelvideo.generators.video_generator import NewApiVideoGenerator, VideoGenStatus
+
+    generator = NewApiVideoGenerator(
+        api_key="test-key",
+        endpoint="https://newapi.example",
+        model="seedance-2.0-fast",
+    )
+    refunded: dict[str, object] = {}
+
+    async def fake_reserve(*_args, **_kwargs):
+        return "reservation-1"
+
+    async def fake_refund(*_args, **kwargs):
+        refunded.update(kwargs)
+
+    async def fake_post_json(_url: str, _payload: dict):
+        return {"task_id": "task-1"}
+
+    async def fake_get_json(_url: str):
+        return {
+            "code": "success",
+            "data": {
+                "task_id": "task-1",
+                "status": "FAILURE",
+                "fail_reason": "InputImageSensitiveContentDetected.PolicyViolation",
+            },
+        }
+
+    monkeypatch.setattr(video_module, "_reserve_video_model_call", fake_reserve)
+    monkeypatch.setattr(video_module, "_refund_video_model_call", fake_refund)
+    monkeypatch.setattr(generator, "_post_json", fake_post_json)
+    monkeypatch.setattr(generator, "_get_json", fake_get_json)
+
+    result = await generator.generate(
+        image_path=None,
+        prompt="测试视频",
+        output_path=str(tmp_path / "out.mp4"),
+        poll_interval=0,
+        max_polls=2,
+    )
+
+    assert result.status == VideoGenStatus.FAILED
+    assert result.error == "InputImageSensitiveContentDetected.PolicyViolation"
+    assert refunded["error"] == "InputImageSensitiveContentDetected.PolicyViolation"
+
+
 async def test_newapi_seedance1_generator_preserves_adaptive_ratio(tmp_path, monkeypatch):
     from novelvideo.generators import video_generator as video_module
     from novelvideo.generators.video_generator import NewApiVideoGenerator


### PR DESCRIPTION
## PR 类型 / Type of PR
- [x] 🐞 Bug 修复 / Bug fix
- [ ] ✨ 新功能 / Feature
- [ ] 📝 文档 / Documentation
- [ ] 🧹 重构 / 清理 / Refactor or cleanup
- [ ] ⚙️ 构建 / CI / Build or CI
- [ ] ⚠️ 破坏性变更 / Breaking change

## 改动说明 / What this PR does and why

统一处理虾驿视频任务的标准响应：

- 优先读取通用任务响应中的 `result_url`，并保留旧 URL 字段作为历史兼容。
- 将通用任务状态 `FAILURE` 识别为终态失败，立即停止轮询、展示 `fail_reason` 并执行额度退款。
- 改进网关错误提示，对真人审核素材失败给出可操作的本地化信息，同时保留已有计费规则、渠道策略和限流提示。

根因是 DramaClaw 切换到 `/v1/video/generations/{task_id}` 通用任务响应后，只兼容了响应包装，没有完整适配标准 `result_url` 和 `FAILURE` 状态枚举，导致失败任务持续等待。

## 关联 issue / Linked issues

N/A

## 给 reviewer 的说明 / Notes for the reviewer

重点关注通用 `TaskDto` 与旧 OpenAI Video 响应的兼容顺序。该改动不区分 TokenHub、火山或 Huimeng，所有渠道都优先使用虾驿归一化字段。

验证：

- `.venv/bin/pytest tests/test_seedance2_request.py -k 'wrapped_failure or task_response or result_url' -q`：5 passed
- `.venv/bin/ruff check src/novelvideo/generators/video_generator.py tests/test_seedance2_request.py`：passed
- `pnpm --dir frontend exec vitest run src/__tests__/lib/gateway-error-classify.test.ts`：15 passed
- `pnpm --dir frontend exec tsc --noEmit`：passed
- `git diff --check origin/main...HEAD`：passed

前端全量 Vitest 额外执行结果为 1951 passed、5 failed；失败均位于既有 `src/__tests__/lib/local-storage-quota.test.ts`，当前 Node 环境提示 `localStorage is not available`，与本 PR 改动无关。

## 面向用户的变更 / User-facing change

```release-note
修复视频生成失败后界面持续等待的问题，并改进网关失败原因提示。
```

## 自检 / Checklist
- [x] 已自测，`uv run pytest` 通过 / Self-tested, `uv run pytest` passes
- [ ] 必要的文档已更新 / Docs updated where needed
- [x] 提交信息清晰（建议 Conventional Commits）/ Clear commits (Conventional Commits suggested)
- [x] 每个 commit 都已 `git commit -s` 附 DCO 签署 / Every commit signed off with `git commit -s` (DCO)
- [x] 我已阅读并同意[贡献者协议](../CONTRIBUTING.md#贡献者协议) / I've read and agree to the [contributor terms](../CONTRIBUTING.md#贡献者协议)
