### PR TITLE
fix(assets): 把构建类任务的 loading 绑到任务中心

### DIFF
--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -1222,6 +1222,11 @@
       "derivedFrom": "Derived from {{base}}",
       "emptyTitle": "No scenes yet",
       "emptyDescription": "Create a scene or extract scenes from the project graph.",
+      "building": "Building scenes...",
+      "buildingEmpty": {
+        "title": "Building scenes",
+        "description": "The system is extracting scenes from the graph. They will appear here when ready."
+      },
       "confirmDelete": "Delete scene \"{{name}}\"?",
       "deleted": "Scene deleted",
       "master": "Master",

--- a/frontend/public/locales/zh/translation.json
+++ b/frontend/public/locales/zh/translation.json
@@ -1222,6 +1222,11 @@
       "derivedFrom": "派生自 {{base}}",
       "emptyTitle": "暂无场景数据",
       "emptyDescription": "新建场景，或从图谱自动提取项目场景。",
+      "building": "构建场景中...",
+      "buildingEmpty": {
+        "title": "正在构建场景",
+        "description": "系统正在从图谱中提取场景，完成后会显示在这里。"
+      },
       "confirmDelete": "删除场景「{{name}}」？",
       "deleted": "场景已删除",
       "master": "源图",

--- a/frontend/src/__tests__/task-center/use-task-activity.test.tsx
+++ b/frontend/src/__tests__/task-center/use-task-activity.test.tsx
@@ -1,0 +1,164 @@
+// SPDX-License-Identifier: Elastic-2.0
+// Copyright (c) 2026 ClaymoreLab
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { sampleTask } from "@/__mocks__/msw/handlers/tasks";
+import { useTaskCenterStore } from "@/task-center/store";
+import { useTaskActivity } from "@/task-center/use-task-activity";
+import type { TaskState } from "@/task-center/types";
+
+const buildScenes = (overrides: Partial<TaskState> = {}): TaskState =>
+  sampleTask({
+    task_key: "task:build_scenes:alice:demo:0",
+    task_type: "build_scenes",
+    episode: 0,
+    status: "running",
+    progress: 0.4,
+    current_task: "抽取场景…",
+    ...overrides,
+  });
+
+/** 模拟 provider 接管项目：setProject 先发生，补水随后才到。 */
+function mountProvider(projectId = "demo") {
+  act(() => {
+    useTaskCenterStore.getState().setProject(projectId);
+  });
+}
+
+/** 模拟任务中心补水完成（provider 在首次 GET /tasks 之后做的事）。 */
+function hydrateWith(tasks: TaskState[]) {
+  act(() => {
+    useTaskCenterStore.getState().hydrate(tasks);
+    useTaskCenterStore.getState().markHydrated();
+  });
+}
+
+function render() {
+  return renderHook(() => useTaskActivity("build_scenes", { episode: 0 }));
+}
+
+beforeEach(() => {
+  useTaskCenterStore.getState().reset();
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  useTaskCenterStore.getState().reset();
+});
+
+describe("useTaskActivity", () => {
+  it("补水完成前报告 isRestoring，此时 isActive 不可信", () => {
+    const { result } = render();
+    mountProvider();
+    // 硬刷新后的初始状态：store 是空的，但那只是还没拉到 /tasks。
+    expect(result.current.isRestoring).toBe(true);
+    expect(result.current.isActive).toBe(false);
+
+    hydrateWith([buildScenes()]);
+
+    expect(result.current.isRestoring).toBe(false);
+    expect(result.current.isActive).toBe(true);
+  });
+
+  it("没有 provider 在跑时不报 isRestoring，免得把按钮永久禁死", () => {
+    const { result } = render();
+    // 组件被渲染在 TaskCenterProvider 之外：补水永远不会到。
+    expect(result.current.isRestoring).toBe(false);
+    expect(result.current.isActive).toBe(false);
+  });
+
+  it("补水后认出后台仍在跑的任务，并带出进度和步骤文案", () => {
+    const { result } = render();
+    hydrateWith([buildScenes({ progress: 0.4, current_task: "抽取场景…" })]);
+
+    expect(result.current.isActive).toBe(true);
+    expect(result.current.progress).toBe(0.4);
+    expect(result.current.currentTask).toBe("抽取场景…");
+    expect(result.current.task?.task_type).toBe("build_scenes");
+  });
+
+  it("忽略别的类型和别的 episode 的任务", () => {
+    const { result } = render();
+    hydrateWith([
+      sampleTask({ task_key: "a", task_type: "build_characters", episode: 0 }),
+      buildScenes({ task_key: "b", episode: 3 }),
+    ]);
+
+    expect(result.current.isActive).toBe(false);
+  });
+
+  it("终态任务不算活跃", () => {
+    const { result } = render();
+    hydrateWith([buildScenes({ status: "completed", progress: 1 })]);
+
+    expect(result.current.isActive).toBe(false);
+  });
+
+  it("markStarted 兜住任务进任务中心前的空窗", () => {
+    const { result } = render();
+    hydrateWith([]);
+    expect(result.current.isActive).toBe(false);
+
+    act(() => result.current.markStarted());
+    expect(result.current.isActive).toBe(true);
+
+    // 任务随后从 SSE 进来，接管 loading。
+    act(() => {
+      useTaskCenterStore.getState().upsert(buildScenes());
+    });
+    expect(result.current.isActive).toBe(true);
+    expect(result.current.task).not.toBeNull();
+  });
+
+  it("任务始终没出现时，乐观窗口到点自动收回 loading", () => {
+    const { result } = render();
+    hydrateWith([]);
+
+    act(() => result.current.markStarted());
+    expect(result.current.isActive).toBe(true);
+
+    act(() => {
+      vi.advanceTimersByTime(15_000);
+    });
+    expect(result.current.isActive).toBe(false);
+  });
+
+  it("SSE 比入队响应先到时，任务跑完立刻收回 loading（不空等 15 秒）", () => {
+    const { result } = render();
+    hydrateWith([]);
+
+    // 先收到 SSE 推来的任务……
+    act(() => {
+      useTaskCenterStore.getState().upsert(buildScenes());
+    });
+    // ……入队接口这时才返回，组件照常调 markStarted()。
+    act(() => result.current.markStarted());
+    expect(result.current.isActive).toBe(true);
+
+    // 任务完成：活跃任务消失，乐观标记必须一起退场。
+    act(() => {
+      useTaskCenterStore.getState().upsert(buildScenes({ status: "completed", progress: 1 }));
+    });
+    expect(result.current.isActive).toBe(false);
+
+    // 即便再推进到超时点，也不该出现回弹。
+    act(() => {
+      vi.advanceTimersByTime(15_000);
+    });
+    expect(result.current.isActive).toBe(false);
+  });
+
+  it("任务正常跑完后收回 loading", () => {
+    const { result } = render();
+    hydrateWith([buildScenes()]);
+    expect(result.current.isActive).toBe(true);
+
+    act(() => {
+      useTaskCenterStore.getState().upsert(buildScenes({ status: "completed", progress: 1 }));
+    });
+    expect(result.current.isActive).toBe(false);
+    expect(result.current.progress).toBe(0);
+  });
+});

--- a/frontend/src/components/assets/props-panel.tsx
+++ b/frontend/src/components/assets/props-panel.tsx
@@ -405,6 +405,9 @@ export function PropsPanel({
   const gridRef = useAssetFocus(focusId, !props.isLoading && items.length > 0);
   const showBatchTask =
     batchTask.started || batchTask.stream.status !== "idle" || batchTask.logs.length > 0;
+  // isPending 只覆盖入队那一次 POST，批量生成本身在后台跑；按钮要跟着任务态走，
+  // 否则 POST 一返回就恢复可点，刷新后更是完全不知道任务还在跑。
+  const isBatchGenerating = batchGenerate.isPending || batchTask.started;
   const lastBatchLog = batchTask.logs[batchTask.logs.length - 1];
   const batchLogs =
     lastBatchLog === batchTask.stream.currentTask
@@ -469,10 +472,10 @@ export function PropsPanel({
           variant="outline"
           size="sm"
           onClick={handleBatchGenerate}
-          disabled={batchGenerate.isPending}
+          disabled={isBatchGenerating}
           className={cn(SUBTLE_HEADER_ACTION_BUTTON_CLASS, "relative")}
         >
-          {batchGenerate.isPending ? (
+          {isBatchGenerating ? (
             <Loader2 className="size-3.5 animate-spin" />
           ) : (
             <Sparkles className="size-3.5" />

--- a/frontend/src/components/assets/scenes-panel.tsx
+++ b/frontend/src/components/assets/scenes-panel.tsx
@@ -1158,6 +1158,9 @@ export function ScenesPanel({
   // 真正的构建在后台跑，刷新后也只有任务中心还认得它。
   const buildActivity = useTaskActivity("build_scenes", { episode: 0 });
   const isBuildingScenes = buildScenes.isPending || buildActivity.isActive;
+  // 补水完成前 isActive 还不可信，按钮先禁用，避免硬刷新后重复入队。进度条和
+  // 「构建中」空态不看这个标志，否则补水那一瞬会闪一下假的构建中。
+  const buildDisabled = isBuildingScenes || buildActivity.isRestoring;
   const imageSourceQuery = useAssetImageSourceSelection(project, "scene");
   const imageSourceSelection = imageSourceQuery.data?.data.image_source_selection ?? "";
   const buildScenesCost = useGenerationCreditCost("feature", "mainline.build_scenes");
@@ -1348,7 +1351,7 @@ export function ScenesPanel({
         <Button
           size="sm"
           onClick={handleBuildScenes}
-          disabled={isBuildingScenes}
+          disabled={buildDisabled}
           className="h-8 gap-1.5 rounded-[8px] bg-primary px-3 text-xs font-normal text-primary-foreground shadow-none hover:bg-primary/85 active:bg-primary/75"
         >
           {isBuildingScenes ? (

--- a/frontend/src/components/assets/scenes-panel.tsx
+++ b/frontend/src/components/assets/scenes-panel.tsx
@@ -62,6 +62,7 @@ import {
 } from "@/components/ui/tooltip";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { Progress } from "@/components/ui/progress";
 import {
   Select,
   SelectContent,
@@ -71,6 +72,7 @@ import {
 } from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
 import { useTaskController } from "@/hooks/use-task-controller";
+import { useTaskActivity } from "@/task-center/use-task-activity";
 import {
   sceneReferenceAssetScope,
   stageAssetScope,
@@ -1152,6 +1154,10 @@ export function ScenesPanel({
   const updateScene = useUpdateScene(project, editing?.name ?? "");
   const deleteScene = useDeleteScene(project);
   const buildScenes = useBuildScenes(project);
+  // loading 绑任务中心而不是 mutation.isPending：isPending 只覆盖入队那一次 POST，
+  // 真正的构建在后台跑，刷新后也只有任务中心还认得它。
+  const buildActivity = useTaskActivity("build_scenes", { episode: 0 });
+  const isBuildingScenes = buildScenes.isPending || buildActivity.isActive;
   const imageSourceQuery = useAssetImageSourceSelection(project, "scene");
   const imageSourceSelection = imageSourceQuery.data?.data.image_source_selection ?? "";
   const buildScenesCost = useGenerationCreditCost("feature", "mainline.build_scenes");
@@ -1279,6 +1285,7 @@ export function ScenesPanel({
       toast.error(backendErrorResponseToastMessage(res, t));
       return;
     }
+    buildActivity.markStarted();
     toast.success(res.message);
   }
 
@@ -1292,6 +1299,21 @@ export function ScenesPanel({
     }
     toast.success(t("assets.scenes.deleted"));
   }
+
+  // 进度条：任务中心里有记录就用它的进度/步骤文案，乐观空窗期先显示 0% 占位。
+  const buildingProgress = (
+    <div className="w-full max-w-[220px] rounded-[8px] bg-white/[0.05] p-3">
+      <div className="flex items-center justify-between gap-3 text-xs text-muted-foreground">
+        <span className="min-w-0 truncate">
+          {buildActivity.currentTask || t("assets.scenes.building")}
+        </span>
+        <span className="shrink-0 font-mono tabular-nums text-foreground/80">
+          {Math.round(buildActivity.progress * 100)}%
+        </span>
+      </div>
+      <Progress value={buildActivity.progress * 100} className="mt-3 h-1.5" />
+    </div>
+  );
 
   return (
     <div className="flex min-h-0 flex-1 flex-col overflow-hidden bg-background">
@@ -1326,10 +1348,10 @@ export function ScenesPanel({
         <Button
           size="sm"
           onClick={handleBuildScenes}
-          disabled={buildScenes.isPending}
+          disabled={isBuildingScenes}
           className="h-8 gap-1.5 rounded-[8px] bg-primary px-3 text-xs font-normal text-primary-foreground shadow-none hover:bg-primary/85 active:bg-primary/75"
         >
-          {buildScenes.isPending ? (
+          {isBuildingScenes ? (
             <Loader2 className="size-3.5 animate-spin" />
           ) : (
             <Sparkles className="size-3.5" />
@@ -1347,6 +1369,21 @@ export function ScenesPanel({
         <div className="flex min-h-0 flex-1 items-center justify-center text-sm text-muted-foreground">
           <Loader2 className="mr-2 size-4 animate-spin" />
           {t("common.loading")}
+        </div>
+      ) : allItems.length === 0 && isBuildingScenes ? (
+        <div className="flex min-h-0 flex-1 flex-col items-center justify-center text-center">
+          <div className="mb-3 flex size-12 items-center justify-center rounded-full border border-border bg-card">
+            <Loader2 className="size-5 animate-spin text-muted-foreground" />
+          </div>
+          <div>
+            <h3 className="mb-1.5 text-sm font-semibold text-foreground">
+              {t("assets.scenes.buildingEmpty.title")}
+            </h3>
+            <p className="max-w-[15rem] text-xs leading-5 text-muted-foreground">
+              {t("assets.scenes.buildingEmpty.description")}
+            </p>
+          </div>
+          <div className="mt-4 flex justify-center">{buildingProgress}</div>
         </div>
       ) : allItems.length === 0 ? (
         <div className="flex min-h-0 flex-1 flex-col items-center justify-center text-center">
@@ -1393,6 +1430,9 @@ export function ScenesPanel({
               </div>
             </div>
             <div className="min-h-0 flex-1 overflow-y-auto px-3 pb-3 pt-2">
+              {isBuildingScenes && (
+                <div className="mb-2 flex justify-center">{buildingProgress}</div>
+              )}
               {sceneGroups.length === 0 ? (
                 <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
                   {t("assets.common.noMatch")}

--- a/frontend/src/routes/_app/projects.$project/characters.lazy.tsx
+++ b/frontend/src/routes/_app/projects.$project/characters.lazy.tsx
@@ -70,6 +70,7 @@ import { isCeRuntime } from "@/lib/runtime-config";
 import { useMediaQuery } from "@/hooks/use-media-query";
 import { useTaskController } from "@/hooks/use-task-controller";
 import { useTaskStream } from "@/hooks/use-task-stream";
+import { useTaskActivity } from "@/task-center/use-task-activity";
 import { TaskControllerProvider } from "@/components/episode/task-controller-provider";
 import { SlidingTabs } from "@/components/nav/sliding-tabs";
 import { CharacterSearch, filterCharacters } from "@/components/assets/character-search";
@@ -607,7 +608,11 @@ function CharactersPageHeader({
               disabled={rebuildDisabled}
               className="h-8 gap-1.5 rounded-[8px] bg-primary px-3 text-xs font-normal text-primary-foreground shadow-none hover:bg-primary/85 active:bg-primary/75"
             >
-              <RefreshCw className="size-3.5" />
+              {rebuildDisabled ? (
+                <Loader2 className="size-3.5 animate-spin" />
+              ) : (
+                <RefreshCw className="size-3.5" />
+              )}
               {t("characters.autoExtract")}
               <CreditCostInline
                 display={buildCharactersCostDisplay}
@@ -2903,6 +2908,13 @@ function AddCharacterDialog({
 
 // ─── Main page ───────────────────────────────────────────────────────────────
 
+/** 角色提取的展示态：活跃与否取自任务中心，进度/步骤文案优先取自 SSE。 */
+interface ExtractionState {
+  active: boolean;
+  progress: number;
+  label: string;
+}
+
 /**
  * Character-list / detail split.
  *
@@ -2912,8 +2924,7 @@ function AddCharacterDialog({
 function CharactersSplit({
   project,
   isDesktop,
-  buildStarted,
-  taskStream,
+  extraction,
   isLoading,
   characters,
   totalCharacters,
@@ -2933,8 +2944,7 @@ function CharactersSplit({
 }: {
   project: string;
   isDesktop: boolean;
-  buildStarted: boolean;
-  taskStream: ReturnType<typeof useTaskStream>;
+  extraction: ExtractionState;
   isLoading: boolean;
   characters: Character[];
   totalCharacters: number;
@@ -2953,7 +2963,7 @@ function CharactersSplit({
   buildCharactersPromotion?: CreditPromotionDisplay | null;
 }) {
   const { t } = useTranslation();
-  const isExtracting = buildStarted && taskStream.status !== "idle";
+  const isExtracting = extraction.active;
   const searchActive = searchQuery.trim().length > 0;
   const listScrollRef = useRef<HTMLDivElement | null>(null);
   const previousCharacterCountRef = useRef(characters.length);
@@ -2971,13 +2981,13 @@ function CharactersSplit({
     >
       <div className="flex items-center justify-between gap-3 text-xs text-muted-foreground">
         <span className="min-w-0 truncate">
-          {taskStream.currentTask || t("characters.extracting")}
+          {extraction.label || t("characters.extracting")}
         </span>
         <span className="shrink-0 font-mono tabular-nums text-foreground/80">
-          {Math.round(taskStream.progress * 100)}%
+          {Math.round(extraction.progress * 100)}%
         </span>
       </div>
-      <Progress value={taskStream.progress * 100} className="mt-3 h-1.5" />
+      <Progress value={extraction.progress * 100} className="mt-3 h-1.5" />
     </div>
   );
 
@@ -3030,7 +3040,11 @@ function CharactersSplit({
               disabled={rebuildDisabled}
               className={EMPTY_STATE_ACTION_BUTTON_CLASS}
             >
-              <RefreshCw className="size-3.5" />
+              {rebuildDisabled ? (
+                <Loader2 className="size-3.5 animate-spin" />
+              ) : (
+                <RefreshCw className="size-3.5" />
+              )}
               {t("characters.autoExtract")}
               <CreditCostInline
                 display={buildCharactersCostDisplay}
@@ -3126,7 +3140,8 @@ function CharactersPageContent() {
       : null);
 
   const [selectedName, setSelectedName] = useState<string | null>(null);
-  const [buildStarted, setBuildStarted] = useState(false);
+  // loading 绑任务中心而不是组件本地 state：刷新后后台还在跑的提取任务仍能认出来。
+  const buildActivity = useTaskActivity("build_characters", { episode: 0 });
   const [rebuildDialogOpen, setRebuildDialogOpen] = useState(false);
   const [addDialogOpen, setAddDialogOpen] = useState(false);
   const [attempts, setAttempts] = useState<Record<string, number>>({});
@@ -3139,15 +3154,21 @@ function CharactersPageContent() {
   const [searchQuery, setSearchQuery] = useState("");
   const [imageModel, setImageModel] = useState("");
 
+  // SSE 只用来拿细粒度进度/步骤文案；活跃与否由任务中心裁决。
   const taskStream = useTaskStream({
     taskType: "build_characters",
     project,
     episode: 0,
-    enabled: buildStarted,
+    enabled: buildActivity.isActive,
     invalidateKeys: [queryKeys.characters(project)],
-    onComplete: () => setBuildStarted(false),
-    onError: () => setBuildStarted(false),
   });
+
+  const extraction: ExtractionState = {
+    active: buildActivity.isActive,
+    // SSE 还没吐出第一帧时退回任务中心记录的进度，避免刷新后进度条从 0 重来。
+    progress: taskStream.status === "idle" ? buildActivity.progress : taskStream.progress,
+    label: taskStream.currentTask || buildActivity.currentTask,
+  };
 
   const characters = charsRes?.data ?? [];
   const projectConfig = projectRes?.data;
@@ -3221,7 +3242,7 @@ function CharactersPageContent() {
         toast.error(backendErrorResponseToastMessage(res, t));
         return;
       }
-      setBuildStarted(true);
+      buildActivity.markStarted();
     } catch (error) {
       toast.error(backendErrorToastMessage(error, t));
     }
@@ -3243,7 +3264,7 @@ function CharactersPageContent() {
       <div className="-m-6 flex h-[calc(100%+3rem)] flex-col overflow-hidden">
       <CharactersPageHeader
         onRebuild={() => setRebuildDialogOpen(true)}
-        rebuildDisabled={buildChars.isPending || buildStarted}
+        rebuildDisabled={buildChars.isPending || buildActivity.isActive}
         buildCharactersCostDisplay={buildCharactersCostDisplay}
         buildCharactersPromotion={buildCharactersCost.data?.data.promotion}
         onAdd={() => setAddDialogOpen(true)}
@@ -3265,8 +3286,7 @@ function CharactersPageContent() {
           <CharactersSplit
             project={project}
             isDesktop={isDesktop}
-            buildStarted={buildStarted}
-            taskStream={taskStream}
+            extraction={extraction}
             isLoading={isLoading}
             characters={filteredCharacters}
             totalCharacters={characters.length}
@@ -3280,7 +3300,7 @@ function CharactersPageContent() {
             attempts={attempts}
             handleAttempt={handleAttempt}
             onRebuild={() => setRebuildDialogOpen(true)}
-            rebuildDisabled={buildChars.isPending || buildStarted}
+            rebuildDisabled={buildChars.isPending || buildActivity.isActive}
             buildCharactersCostDisplay={buildCharactersCostDisplay}
             buildCharactersPromotion={buildCharactersCost.data?.data.promotion}
           />

--- a/frontend/src/routes/_app/projects.$project/characters.lazy.tsx
+++ b/frontend/src/routes/_app/projects.$project/characters.lazy.tsx
@@ -3169,6 +3169,10 @@ function CharactersPageContent() {
     progress: taskStream.status === "idle" ? buildActivity.progress : taskStream.progress,
     label: taskStream.currentTask || buildActivity.currentTask,
   };
+  // 补水完成前 isActive 还不可信，按钮先禁用，避免硬刷新后重复入队。
+  // 提取中的进度条/空态不看这个标志，否则补水那一瞬会闪一下假的「提取中」。
+  const rebuildDisabled =
+    buildChars.isPending || buildActivity.isActive || buildActivity.isRestoring;
 
   const characters = charsRes?.data ?? [];
   const projectConfig = projectRes?.data;
@@ -3264,7 +3268,7 @@ function CharactersPageContent() {
       <div className="-m-6 flex h-[calc(100%+3rem)] flex-col overflow-hidden">
       <CharactersPageHeader
         onRebuild={() => setRebuildDialogOpen(true)}
-        rebuildDisabled={buildChars.isPending || buildActivity.isActive}
+        rebuildDisabled={rebuildDisabled}
         buildCharactersCostDisplay={buildCharactersCostDisplay}
         buildCharactersPromotion={buildCharactersCost.data?.data.promotion}
         onAdd={() => setAddDialogOpen(true)}
@@ -3300,7 +3304,7 @@ function CharactersPageContent() {
             attempts={attempts}
             handleAttempt={handleAttempt}
             onRebuild={() => setRebuildDialogOpen(true)}
-            rebuildDisabled={buildChars.isPending || buildActivity.isActive}
+            rebuildDisabled={rebuildDisabled}
             buildCharactersCostDisplay={buildCharactersCostDisplay}
             buildCharactersPromotion={buildCharactersCost.data?.data.promotion}
           />

--- a/frontend/src/task-center/use-task-activity.ts
+++ b/frontend/src/task-center/use-task-activity.ts
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: Elastic-2.0
+// Copyright (c) 2026 ClaymoreLab
+import { useCallback, useEffect, useState } from "react";
+
+import { isActive as isActiveTask } from "./derivations";
+import { useTaskCenterStore } from "./store";
+import type { TaskState } from "./types";
+
+/**
+ * 接口已受理、但任务还没进任务中心的空窗兜底时长。
+ *
+ * 入队接口返回后要经一次 SSE/轮询往返任务才会出现在 store 里；这段空窗如果不认，
+ * 按钮的 loading 会闪一下就掉回去。反过来，如果任务因为丢事件/被裁剪始终没出现，
+ * 到点也必须收回 loading，否则按钮就永远转下去了。
+ */
+const OPTIMISTIC_GRACE_MS = 15_000;
+
+/** 任务中心里该类型第一条仍在跑的任务；没有则 null。 */
+export function useActiveTaskOfType(
+  taskType: string,
+  options: { episode?: number } = {},
+): TaskState | null {
+  const { episode } = options;
+  return useTaskCenterStore(
+    useCallback(
+      (state) => {
+        for (const task of state.tasks.values()) {
+          if (task.task_type !== taskType) continue;
+          if (episode !== undefined && task.episode !== episode) continue;
+          if (isActiveTask(task)) return task;
+        }
+        return null;
+      },
+      [taskType, episode],
+    ),
+  );
+}
+
+export interface TaskActivity {
+  /** 任务中心里的活跃任务记录；处于乐观空窗时为 null。 */
+  task: TaskState | null;
+  /** 是否应该展示 loading。 */
+  isActive: boolean;
+  /** 0~1。 */
+  progress: number;
+  /** 后端回报的当前步骤文案。 */
+  currentTask: string;
+  /** 入队接口成功返回后调用，用于兜住任务进任务中心前的空窗。 */
+  markStarted: () => void;
+}
+
+/**
+ * 把某类项目级任务的 loading 状态绑到任务中心上。
+ *
+ * 和只用组件本地 state 的写法相比，关键差别是刷新后仍然准确——任务中心启动时会
+ * 从 `GET /tasks` 拉一次全量，所以后台还在跑的任务能被重新认出来。
+ */
+export function useTaskActivity(
+  taskType: string,
+  options: { episode?: number } = {},
+): TaskActivity {
+  const task = useActiveTaskOfType(taskType, options);
+  const [startedAt, setStartedAt] = useState<number | null>(null);
+
+  // 任务一旦真出现在任务中心，本地乐观标记就退场，之后完全以任务中心为准
+  // （包括它变成终态时的收尾）。
+  useEffect(() => {
+    if (task) setStartedAt(null);
+  }, [task]);
+
+  useEffect(() => {
+    if (startedAt == null) return;
+    const timer = window.setTimeout(() => setStartedAt(null), OPTIMISTIC_GRACE_MS);
+    return () => window.clearTimeout(timer);
+  }, [startedAt]);
+
+  const markStarted = useCallback(() => setStartedAt(Date.now()), []);
+
+  return {
+    task,
+    isActive: task != null || startedAt != null,
+    progress: task?.progress ?? 0,
+    currentTask: task?.current_task ?? "",
+    markStarted,
+  };
+}

--- a/frontend/src/task-center/use-task-activity.ts
+++ b/frontend/src/task-center/use-task-activity.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Elastic-2.0
 // Copyright (c) 2026 ClaymoreLab
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 import { isActive as isActiveTask } from "./derivations";
 import { useTaskCenterStore } from "./store";
@@ -41,6 +41,15 @@ export interface TaskActivity {
   task: TaskState | null;
   /** 是否应该展示 loading。 */
   isActive: boolean;
+  /**
+   * 任务中心已经接管本项目、但首轮 `GET /tasks` 还没回来，`isActive` 此刻不可信
+   * （硬刷新后 store 初始为空，任何任务都会被判成「没在跑」）。触发类控件应该一并
+   * 禁用，避免重复入队。
+   *
+   * 没有 TaskCenterProvider 在跑时恒为 false——那种场景下永远等不到补水，
+   * 认它只会把按钮永久禁死。
+   */
+  isRestoring: boolean;
   /** 0~1。 */
   progress: number;
   /** 后端回报的当前步骤文案。 */
@@ -60,12 +69,30 @@ export function useTaskActivity(
   options: { episode?: number } = {},
 ): TaskActivity {
   const task = useActiveTaskOfType(taskType, options);
+  // provider 在开始补水前就会 setProject，所以 projectId 非空即代表「有人在管，
+  // 补水一定会到」；为空则说明压根没挂 provider，不能靠这个标志禁按钮。
+  const isRestoring = useTaskCenterStore(
+    (state) => state.projectId != null && !state.isHydrated,
+  );
   const [startedAt, setStartedAt] = useState<number | null>(null);
+  // 本轮乐观窗口里是否已经认领过任务中心的记录。
+  const sawTaskRef = useRef(false);
 
-  // 任务一旦真出现在任务中心，本地乐观标记就退场，之后完全以任务中心为准
-  // （包括它变成终态时的收尾）。
   useEffect(() => {
-    if (task) setStartedAt(null);
+    if (task) {
+      // 任务真出现在任务中心，本地乐观标记退场，之后完全以任务中心为准。
+      sawTaskRef.current = true;
+      setStartedAt(null);
+      return;
+    }
+    // 认领过的任务又消失了 = 它已经跑完/失败/被取消。这里必须主动收尾：
+    // SSE 有可能比入队接口的响应先到，那样 markStarted() 是在任务出现之后才被
+    // 调用的，`task` 不会再变化，光靠上面那条分支清不掉乐观标记，按钮会一直转
+    // 到 15s 超时。
+    if (sawTaskRef.current) {
+      sawTaskRef.current = false;
+      setStartedAt(null);
+    }
   }, [task]);
 
   useEffect(() => {
@@ -79,6 +106,7 @@ export function useTaskActivity(
   return {
     task,
     isActive: task != null || startedAt != null,
+    isRestoring,
     progress: task?.progress ?? 0,
     currentTask: task?.current_task ?? "",
     markStarted,

--- a/license-inventory.csv
+++ b/license-inventory.csv
@@ -1221,6 +1221,7 @@ frontend/src/task-center/store.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.
 frontend/src/task-center/stream-client.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/task-center/task-errors.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/task-center/types.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
+frontend/src/task-center/use-task-activity.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/task-center/use-task-subscribe.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/types/api.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/types/beat-state.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation

--- a/license-inventory.csv
+++ b/license-inventory.csv
@@ -553,6 +553,7 @@ frontend/src/__tests__/task-center/rendering-reactivity.test.tsx,Elastic-2.0,202
 frontend/src/__tests__/task-center/store.test.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/__tests__/task-center/stream-client.test.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/__tests__/task-center/task-errors.test.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
+frontend/src/__tests__/task-center/use-task-activity.test.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/__tests__/task-center/use-task-subscribe.test.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/api/assets.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/api/backgroundAnchor.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
@@ -1747,6 +1748,7 @@ tests/test_freezone_video_story_backend.py,Elastic-2.0,2026 SuperTale contributo
 tests/test_freezone_video_upscale_backend.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_freezone_vision_gateway.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_global_prop_marker_colors.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
+tests/test_graph_build_progress.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_graph_preview.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_hermes_dramaclaw_plugin.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_hermes_pool_session_resume.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation

--- a/src/novelvideo/task_backend/runners/graph_build.py
+++ b/src/novelvideo/task_backend/runners/graph_build.py
@@ -18,7 +18,15 @@ def _run_async(coro, envelope: dict[str, Any], task_type: str):
     )
 
 
-def _progress(ctx: ProjectContext, task_type: str, progress: float, task: str) -> None:
+def _progress(
+    ctx: ProjectContext, task_type: str, progress: float | None, task: str
+) -> None:
+    """进度/日志上报。
+
+    `progress=None` 表示「只更新步骤文案和日志，保留原有进度」。普通日志行必须
+    走这条路径：图谱构建的 on_log 回调本身不带进度，早期用 0.0 占位会让前端进
+    度条在 10% → 0% → 80% → 0% 之间反复倒退。
+    """
     get_task_manager().update_progress_for_project(
         ctx,
         task_type,
@@ -52,7 +60,7 @@ async def _run_build_characters(ctx: ProjectContext) -> dict[str, Any]:
     try:
         characters = await store.build_characters_from_graph(
             on_progress=lambda progress, task: _progress(ctx, "build_characters", progress, task),
-            on_log=lambda message: _progress(ctx, "build_characters", 0.0, message),
+            on_log=lambda message: _progress(ctx, "build_characters", None, message),
         )
         return {"characters": len(characters), "added_characters": len(characters)}
     finally:
@@ -69,7 +77,7 @@ async def _run_build_scenes(ctx: ProjectContext) -> dict[str, Any]:
     try:
         scenes = await store.build_scenes_from_graph(
             on_progress=lambda progress, task: _progress(ctx, "build_scenes", progress, task),
-            on_log=lambda message: _progress(ctx, "build_scenes", 0.0, message),
+            on_log=lambda message: _progress(ctx, "build_scenes", None, message),
         )
         return {"scenes": len(scenes), "added_scenes": len(scenes)}
     finally:
@@ -85,7 +93,7 @@ async def _run_build_props(ctx: ProjectContext) -> dict[str, Any]:
     try:
         props = await store.build_props_from_graph(
             on_progress=lambda progress, task: _progress(ctx, "build_props", progress, task),
-            on_log=lambda message: _progress(ctx, "build_props", 0.0, message),
+            on_log=lambda message: _progress(ctx, "build_props", None, message),
         )
         return {"props": len(props)}
     finally:
@@ -108,20 +116,20 @@ async def _run_build_episodes(envelope: dict[str, Any], ctx: ProjectContext) -> 
     require_imported_novel(ctx.output_dir)
     store = await _load_store(ctx)
     try:
-        def update(progress: float, task: str) -> None:
+        def update(progress: float | None, task: str) -> None:
             _progress(ctx, "build_episodes", progress, task)
 
         if planning_mode == "chapters":
             episodes = await store.build_episodes_from_chapters(
                 generate_metadata=generate_metadata,
                 on_progress=update,
-                on_log=lambda message: update(0.0, message),
+                on_log=lambda message: update(None, message),
             )
         elif planning_mode == "ai_events":
             episodes = await store.build_episodes_from_events(
                 target_episodes=target,
                 on_progress=update,
-                on_log=lambda message: update(0.0, message),
+                on_log=lambda message: update(None, message),
             )
         elif use_agent:
             try:
@@ -129,13 +137,13 @@ async def _run_build_episodes(envelope: dict[str, Any], ctx: ProjectContext) -> 
                 episodes = await planner.plan_episodes(
                     target_episodes=target,
                     on_progress=update,
-                    on_log=lambda message: update(0.0, message),
+                    on_log=lambda message: update(None, message),
                 )
             except Exception:
                 episodes = await store.build_episodes(
                     target_episodes=target,
                     on_progress=update,
-                    on_log=lambda message: update(0.0, message),
+                    on_log=lambda message: update(None, message),
                 )
             else:
                 await store.replace_episodes(episodes)
@@ -143,7 +151,7 @@ async def _run_build_episodes(envelope: dict[str, Any], ctx: ProjectContext) -> 
             episodes = await store.build_episodes(
                 target_episodes=target,
                 on_progress=update,
-                on_log=lambda message: update(0.0, message),
+                on_log=lambda message: update(None, message),
             )
         return {"episodes": len(episodes)}
     finally:

--- a/tests/test_graph_build_progress.py
+++ b/tests/test_graph_build_progress.py
@@ -1,0 +1,124 @@
+"""图谱构建任务的进度上报语义。
+
+图谱构建的 on_log 回调本身不带进度。早期实现用 0.0 占位调 _progress,于是
+每来一行普通日志进度都被打回 0,前端进度条呈现 10% → 0% → 80% → 0% 的反复
+倒退。日志行必须传 progress=None,让任务状态保留原有进度。
+"""
+
+from pathlib import Path
+
+import pytest
+
+from novelvideo.project_context import ProjectContext
+from novelvideo.task_state import TaskStateManager
+
+pytestmark = pytest.mark.m07
+
+
+def _ctx(tmp_path: Path) -> ProjectContext:
+    return ProjectContext(
+        project_id="proj_graph_build",
+        project_name="demo",
+        owner_type="user",
+        owner_id="owner",
+        owner_username="alice",
+        requester_user_id="editor",
+        requester_username="bob",
+        requester_principals=(("user", "editor"),),
+        effective_role="editor",
+        home_node_id="node_a",
+        output_dir=tmp_path / "output",
+        state_dir=tmp_path / "state",
+        runtime_dir=tmp_path / "runtime",
+        is_home_node=True,
+    )
+
+
+class _RecordingTaskManager:
+    def __init__(self) -> None:
+        self.updates: list[dict] = []
+
+    def update_progress_for_project(self, ctx, task_type, episode, **kwargs):
+        self.updates.append({"task_type": task_type, "episode": episode, **kwargs})
+
+
+class _FakeStore:
+    """按真实调用顺序交替吐进度和日志。"""
+
+    def __init__(self) -> None:
+        self.closed = False
+
+    async def _emit(self, on_progress, on_log):
+        on_progress(0.1, "读取图谱")
+        on_log("命中缓存")
+        on_progress(0.8, "写入数据库")
+        on_log("跳过 3 条重复记录")
+        return [{"name": "a"}]
+
+    async def build_scenes_from_graph(self, on_progress, on_log):
+        return await self._emit(on_progress, on_log)
+
+    async def build_characters_from_graph(self, on_progress, on_log):
+        return await self._emit(on_progress, on_log)
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+@pytest.mark.parametrize(
+    ("runner_name", "task_type"),
+    [
+        ("_run_build_scenes", "build_scenes"),
+        ("_run_build_characters", "build_characters"),
+    ],
+)
+async def test_log_updates_do_not_reset_progress(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    runner_name: str,
+    task_type: str,
+) -> None:
+    from novelvideo.task_backend.runners import graph_build
+
+    manager = _RecordingTaskManager()
+    store = _FakeStore()
+
+    async def fake_load_store(_ctx):
+        return store
+
+    monkeypatch.setattr(graph_build, "get_task_manager", lambda: manager)
+    monkeypatch.setattr(graph_build, "_load_store", fake_load_store)
+    monkeypatch.setattr(graph_build, "require_imported_novel", lambda _dir: None)
+
+    await getattr(graph_build, runner_name)(_ctx(tmp_path))
+
+    assert store.closed
+    assert [u["task_type"] for u in manager.updates] == [task_type] * 4
+    # 关键断言:日志行传 None(保留原进度),而不是 0.0(把进度打回原点)。
+    assert [u["progress"] for u in manager.updates] == [0.1, None, 0.8, None]
+    # 步骤文案和日志仍照常更新。
+    assert [u["current_task"] for u in manager.updates] == [
+        "读取图谱",
+        "命中缓存",
+        "写入数据库",
+        "跳过 3 条重复记录",
+    ]
+
+
+def test_update_progress_with_none_keeps_stored_progress(tmp_path: Path) -> None:
+    """runner 依赖的 manager 侧契约:progress=None 不动已存进度。"""
+    manager = TaskStateManager()
+    ctx = _ctx(tmp_path)
+    manager.create_task_for_project(ctx, "build_scenes", 0)
+    manager.update_progress_for_project(
+        ctx, "build_scenes", 0, progress=0.8, current_task="写入数据库"
+    )
+
+    manager.update_progress_for_project(
+        ctx, "build_scenes", 0, progress=None, current_task="跳过 3 条重复记录"
+    )
+
+    task = manager.get_task_for_project(ctx, "build_scenes", 0)
+    assert task is not None
+    assert task.progress == 0.8
+    assert task.current_task == "跳过 3 条重复记录"


### PR DESCRIPTION
## 问题

点击「自动提取角色」（虾塘 → 角色）和「从图谱构建」（虾塘 → 场景）时，按钮和左侧列表都没有 loading 态；刷新页面后更是完全看不出后台任务还在跑。

根因是这两处的 loading 各自绑在了活不过刷新的状态上：

| 位置 | 原来绑的 | 问题 |
|---|---|---|
| `characters.lazy.tsx` | 组件本地 `buildStarted` | 刷新即丢；提取中的进度条/空态其实早就写好了，只是永远等不到 `true` |
| `scenes-panel.tsx` | `buildScenes.isPending` | 只覆盖入队那一次 POST，真正的构建在后台跑 |
| `props-panel.tsx` | `batchGenerate.isPending` | 同上，POST 一返回按钮就恢复可点 |

## 改法

任务中心（`frontend/src/task-center/`）本来就会在 mount 时从 `GET /api/v1/projects/{id}/tasks` 补水、并靠 SSE 保持实时，是唯一能扛住刷新的状态源；完成时也已经会失效 `queryKeys.characters` / `queryKeys.scenes`。所以把 loading 直接绑上去就行。

新增 `useTaskActivity(taskType, { episode })`，从任务中心按 `task_type` 取第一条活跃任务，返回 `{ task, isActive, progress, currentTask, markStarted }`。

带 15s 乐观空窗兜底（`markStarted()`）：入队接口返回到任务真正进 store 之间要经一次 SSE/轮询往返，不认这段空窗按钮的 loading 会闪一下就掉回去；同时到点自动收回，避免任务丢事件或被裁剪时 loading 永远转下去。

- **characters**：删掉 `buildStarted`，改用 `useTaskActivity("build_characters", { episode: 0 })`；SSE 还没吐第一帧时进度退回任务中心记录的值，避免刷新后进度条从 0 重来；两处「自动提取」按钮加转圈图标。
- **scenes**：新增任务绑定，补进度条 + 构建中空态（含中英文案）。
- **props**：「批量生成参考图」按钮改 gate 在 `batchGenerate.isPending || batchTask.started`。同文件里 `batchTask` 这个 `useTaskController` 早就有了，只是按钮没用上；`useTaskController` 自身会在 mount 时对账 `/tasks`，所以不需要乐观兜底。

## 验证

- `tsc -b` ✅
- `pnpm build` ✅
- `vitest run` 297 文件 / 1956 测试全过 ✅

顺带全项目扫了一遍其它 `enqueue_project_task` 调用点（16 个文件、50+ 处）对应的前端：ingest / episodes / script / compose / batch-bar / audio / video / sketch / render / 画布自由区等都已经走 `useTaskController` 或 `useNodeGenerationTaskState`，本来就扛刷新；`detect-identities`、`seedance2-prompt/generate`、styles 的增删改是同步接口，`isPending` 就是对的 gate。

🤖 Generated with [Claude Code](https://claude.com/claude-code)