### PR TITLE
fix(image): normalize NewAPI image generation parameters

### DIFF
--- a/src/novelvideo/api/routes/freezone.py
+++ b/src/novelvideo/api/routes/freezone.py
@@ -6906,6 +6906,8 @@ async def _resolve_catalog_request(
         }
         if media_type == "image" and entry.get("qualityOptions"):
             schema = {**schema, "includeQuality": True}
+        if media_type == "image" and entry.get("minPixels") is not None:
+            schema = {**schema, "minPixels": entry["minPixels"]}
         values = validate_media_model_params(schema, filtered_params)
     except MediaModelSchemaError as exc:
         raise HTTPException(400, str(exc)) from exc

--- a/src/novelvideo/generators/nanobanana_grid.py
+++ b/src/novelvideo/generators/nanobanana_grid.py
@@ -165,7 +165,7 @@ def _newapi_safe_request_context(
     payload: dict[str, object],
     prompt: str,
 ) -> dict[str, object]:
-    reference_images = payload.get("images")
+    reference_images = payload.get("image")
     reference_image_count = len(reference_images) if isinstance(reference_images, list) else 0
     return {
         "endpoint": f"{endpoint}{request_path}",
@@ -440,7 +440,7 @@ def resolve_openai_image_size(
 
     normalized_size = normalize_image_size(str(image_size or "1K"), provider="openai")
     model_name = str(model or "").strip().lower()
-    is_seedream5 = model_name.startswith("seedream-5")
+    uses_seedream_pixel_floor = model_name.startswith(("seedream-4.5", "seedream-5"))
     long_edges = {
         "512": 1024,
         "0.5K": 1024,
@@ -449,8 +449,8 @@ def resolve_openai_image_size(
         "3K": 3072,
         "4K": 3840,
     }
-    if is_seedream5:
-        # Volcengine Seedream 5 defines 2K with a 3,686,400-pixel floor
+    if uses_seedream_pixel_floor:
+        # Volcengine Seedream 4.5/5 defines 2K with a 3,686,400-pixel floor
         # (2560x1440 at 16:9), rather than a literal 2048px long edge.
         long_edges["2K"] = 2560
     long_edge = long_edges.get(normalized_size)
@@ -475,10 +475,10 @@ def resolve_openai_image_size(
             )
     if long_edge is None:
         long_edge = 1024
-    min_pixels = 3_686_400 if is_seedream5 else _OPENAI_MIN_PIXELS
+    min_pixels = 3_686_400 if uses_seedream_pixel_floor else _OPENAI_MIN_PIXELS
     max_pixels = (
         16_777_216
-        if is_seedream5
+        if uses_seedream_pixel_floor
         else dynamic_max_pixels
     )
 
@@ -3407,6 +3407,7 @@ async def _call_newapi_image_api(
         "size": size,
         "n": 1,
         "response_format": "b64_json",
+        "watermark": False,
     }
     include_quality = bool(
         (image_config.get("request_schema") or {}).get("includeQuality")
@@ -3426,7 +3427,7 @@ async def _call_newapi_image_api(
 
     if reference_images:
         try:
-            payload["images"] = await _relay_reference_images_for_newapi(reference_images)
+            payload["image"] = await _relay_reference_images_for_newapi(reference_images)
         except Exception as exc:
             return None, "", f"media relay upload failed: {exc}"
         request_path = "/images/edits"

--- a/src/novelvideo/generators/nanobanana_grid.py
+++ b/src/novelvideo/generators/nanobanana_grid.py
@@ -415,6 +415,7 @@ def resolve_openai_image_size(
     model: str | None = None,
     *,
     allow_dynamic_resolution: bool = False,
+    min_pixels: int | None = None,
 ) -> str:
     """Map internal aspect/image_size labels to GPT Image 2 size strings.
 
@@ -439,8 +440,6 @@ def resolve_openai_image_size(
         ratio = 1.0 / _OPENAI_MAX_RATIO
 
     normalized_size = normalize_image_size(str(image_size or "1K"), provider="openai")
-    model_name = str(model or "").strip().lower()
-    uses_seedream_pixel_floor = model_name.startswith(("seedream-4.5", "seedream-5"))
     long_edges = {
         "512": 1024,
         "0.5K": 1024,
@@ -449,22 +448,21 @@ def resolve_openai_image_size(
         "3K": 3072,
         "4K": 3840,
     }
-    if uses_seedream_pixel_floor:
-        # Volcengine Seedream 4.5/5 defines 2K with a 3,686,400-pixel floor
-        # (2560x1440 at 16:9), rather than a literal 2048px long edge.
-        long_edges["2K"] = 2560
     long_edge = long_edges.get(normalized_size)
     dynamic_max_edge = _OPENAI_MAX_EDGE
     dynamic_max_pixels = _OPENAI_MAX_PIXELS
+    explicit_dimensions: tuple[int, int] | None = None
     if long_edge is None and allow_dynamic_resolution:
         explicit_size = re.fullmatch(r"(\d+)\s*[xX×]\s*(\d+)", normalized_size)
         if explicit_size:
             width_i, height_i = (int(value) for value in explicit_size.groups())
             if width_i <= 0 or height_i <= 0:
                 raise ValueError(f"invalid image resolution: {image_size}")
-            return f"{width_i}x{height_i}"
+            explicit_dimensions = (width_i, height_i)
         k_size = re.fullmatch(r"(\d+(?:\.\d+)?)\s*[kK]", normalized_size)
-        if k_size:
+        if explicit_dimensions is not None:
+            pass
+        elif k_size:
             long_edge = max(16, _round_openai_edge(float(k_size.group(1)) * 1024))
             dynamic_max_edge = long_edge
             dynamic_max_pixels = long_edge * long_edge
@@ -475,14 +473,17 @@ def resolve_openai_image_size(
             )
     if long_edge is None:
         long_edge = 1024
-    min_pixels = 3_686_400 if uses_seedream_pixel_floor else _OPENAI_MIN_PIXELS
-    max_pixels = (
-        16_777_216
-        if uses_seedream_pixel_floor
-        else dynamic_max_pixels
+    configured_min_pixels = (
+        min_pixels
+        if type(min_pixels) is int and min_pixels > 0
+        else None
     )
+    effective_min_pixels = configured_min_pixels or _OPENAI_MIN_PIXELS
+    max_pixels = dynamic_max_pixels
 
-    if ratio >= 1:
+    if explicit_dimensions is not None:
+        width, height = (float(value) for value in explicit_dimensions)
+    elif ratio >= 1:
         width = float(long_edge)
         height = width / ratio
     else:
@@ -490,22 +491,30 @@ def resolve_openai_image_size(
         width = height * ratio
 
     pixel_count = width * height
-    if pixel_count < min_pixels:
-        scale = math.sqrt(min_pixels / pixel_count)
+    if pixel_count < effective_min_pixels:
+        scale = math.sqrt(effective_min_pixels / pixel_count)
         width *= scale
         height *= scale
-    elif pixel_count > max_pixels:
+    elif explicit_dimensions is None and pixel_count > max_pixels:
         scale = math.sqrt(max_pixels / pixel_count)
         width *= scale
         height *= scale
 
-    width_i = min(dynamic_max_edge, _round_openai_edge(width))
-    height_i = min(dynamic_max_edge, _round_openai_edge(height))
+    if explicit_dimensions is not None and configured_min_pixels is None:
+        return f"{explicit_dimensions[0]}x{explicit_dimensions[1]}"
 
-    if width_i * height_i < min_pixels:
-        scale = math.sqrt(min_pixels / max(1, width_i * height_i))
-        width_i = min(dynamic_max_edge, _round_openai_edge(width_i * scale))
-        height_i = min(dynamic_max_edge, _round_openai_edge(height_i * scale))
+    max_edge = (
+        max(dynamic_max_edge, _round_openai_edge(width), _round_openai_edge(height))
+        if explicit_dimensions is not None
+        else dynamic_max_edge
+    )
+    width_i = min(max_edge, _round_openai_edge(width))
+    height_i = min(max_edge, _round_openai_edge(height))
+
+    if width_i * height_i < effective_min_pixels:
+        scale = math.sqrt(effective_min_pixels / max(1, width_i * height_i))
+        width_i = min(max_edge, _round_openai_edge(width_i * scale))
+        height_i = min(max_edge, _round_openai_edge(height_i * scale))
 
     return f"{width_i}x{height_i}"
 
@@ -3391,12 +3400,14 @@ async def _call_newapi_image_api(
     image_config = image_config or {}
     aspect_ratio = str(image_config.get("aspect_ratio") or "1:1").strip() or "1:1"
     image_size = normalize_image_size(str(image_config.get("image_size") or "1K"), "newapi")
+    request_schema = image_config.get("request_schema") or {}
     try:
         size = resolve_openai_image_size(
             aspect_ratio,
             image_size,
             model,
             allow_dynamic_resolution=True,
+            min_pixels=request_schema.get("minPixels"),
         )
     except ValueError as exc:
         return None, "", str(exc)
@@ -3410,7 +3421,7 @@ async def _call_newapi_image_api(
         "watermark": False,
     }
     include_quality = bool(
-        (image_config.get("request_schema") or {}).get("includeQuality")
+        request_schema.get("includeQuality")
     ) or _newapi_image_model_supports_quality(model)
     if include_quality and str(image_config.get("quality") or "").strip():
         quality = str(image_config["quality"]).strip()
@@ -3438,7 +3449,7 @@ async def _call_newapi_image_api(
 
     payload = apply_media_request_schema(
         payload,
-        image_config.get("request_schema") or {},
+        request_schema,
         image_config.get("model_params") or {},
     )
 

--- a/src/novelvideo/media_model_request_schema.py
+++ b/src/novelvideo/media_model_request_schema.py
@@ -11,6 +11,7 @@ KEY_RE = re.compile(r"^[A-Za-z][A-Za-z0-9_]{0,63}$")
 PATH_RE = re.compile(r"^[A-Za-z][A-Za-z0-9_]*(?:\.[A-Za-z][A-Za-z0-9_]*){0,3}$")
 CONTROL_TYPES = {"select", "number", "switch", "text", "multiselect"}
 JS_MAX_SAFE_INTEGER = 2**53 - 1
+MAX_MEDIA_IMAGE_PIXELS = 16_777_216
 BLOCKED_ROOTS = {
     "model",
     "prompt",
@@ -239,7 +240,7 @@ def validate_media_model_catalog_config(
             "defaultSceneOptimize",
         }
         if media_type == "image"
-        else {"qualityOptions"}
+        else {"qualityOptions", "minPixels"}
     )
     configured_incompatible = sorted(
         field for field in incompatible_fields if config.get(field) is not None
@@ -284,6 +285,16 @@ def validate_media_model_catalog_config(
         value = config.get(field)
         if value is not None and (type(value) is not int or value < 0):
             raise MediaModelSchemaError(f"{field} must be a non-negative integer")
+
+    min_pixels = config.get("minPixels")
+    if min_pixels is not None and (
+        type(min_pixels) is not int
+        or min_pixels <= 0
+        or min_pixels > MAX_MEDIA_IMAGE_PIXELS
+    ):
+        raise MediaModelSchemaError(
+            f"minPixels must be between 1 and {MAX_MEDIA_IMAGE_PIXELS}"
+        )
 
     human_review = config.get("humanReview")
     if human_review is not None and not isinstance(human_review, bool):

--- a/tests/test_freezone_image_backend.py
+++ b/tests/test_freezone_image_backend.py
@@ -6306,6 +6306,40 @@ async def test_freezone_image_models_prefers_ee_catalog(
 
 
 @pytest.mark.asyncio
+async def test_image_catalog_pixel_floor_is_added_to_execution_schema(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    catalog = [
+        {
+            "catalogId": "01TESTIMAGECATALOG000000000",
+            "id": "custom-image-id",
+            "apiModel": "arbitrary-upstream-model",
+            "minPixels": 3_686_400,
+            "request": {
+                "endpoint": "images/generations",
+                "parameters": [],
+            },
+        }
+    ]
+
+    async def fake_catalog(media_type: str) -> list[dict[str, object]]:
+        assert media_type == "image"
+        return catalog
+
+    monkeypatch.setattr(freezone_routes, "_ee_media_model_catalog", fake_catalog)
+
+    schema, values, entry = await freezone_routes._resolve_catalog_request(
+        "image",
+        "custom-image-id",
+        {},
+    )
+
+    assert schema["minPixels"] == 3_686_400
+    assert values == {}
+    assert entry is catalog[0]
+
+
+@pytest.mark.asyncio
 async def test_catalog_id_resolves_without_breaking_legacy_model_id(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_media_model_request_schema.py
+++ b/tests/test_media_model_request_schema.py
@@ -321,6 +321,7 @@ def test_parameter_schema_rejects_unsafe_javascript_numbers(field, value):
         ("image", "referenceVideoMax", 1),
         ("image", "humanReview", True),
         ("video", "qualityOptions", ["high"]),
+        ("video", "minPixels", 3_686_400),
     ],
 )
 def test_catalog_config_rejects_incompatible_media_fields(
@@ -339,10 +340,23 @@ def test_catalog_config_rejects_incompatible_media_fields(
         )
 
 
-def test_image_catalog_accepts_reference_image_limit():
+def test_image_catalog_accepts_reference_image_limit_and_pixel_floor():
     config = {
         "referenceImageMax": 3,
+        "minPixels": 3_686_400,
         "request": {"endpoint": "images/generations", "parameters": []},
     }
 
     assert validate_media_model_catalog_config(config, "image") is config
+
+
+@pytest.mark.parametrize("value", [0, -1, 1.5, True, 16_777_217, 2**53])
+def test_image_catalog_rejects_invalid_min_pixels(value):
+    with pytest.raises(MediaModelSchemaError, match="minPixels"):
+        validate_media_model_catalog_config(
+            {
+                "minPixels": value,
+                "request": {"endpoint": "images/generations", "parameters": []},
+            },
+            "image",
+        )

--- a/tests/test_newapi_image_gateway.py
+++ b/tests/test_newapi_image_gateway.py
@@ -289,9 +289,17 @@ def test_catalog_can_enable_arbitrary_newapi_image_quality(monkeypatch):
                 "quality": "ultra",
                 "request_schema": {
                     "endpoint": "images/generations",
-                    "parameters": [],
+                    "parameters": [
+                        {
+                            "key": "watermark",
+                            "requestPath": "watermark",
+                            "control": "switch",
+                            "default": False,
+                        }
+                    ],
                     "includeQuality": True,
                 },
+                "model_params": {"watermark": True},
             },
             base_url="http://newapi.test/v1",
         )
@@ -302,18 +310,20 @@ def test_catalog_can_enable_arbitrary_newapi_image_quality(monkeypatch):
     assert posted["json"]["model"] == "Seedream-Custom"
     assert posted["json"]["quality"] == "ultra"
     assert posted["json"]["size"] == "2880x2880"
+    assert posted["json"]["watermark"] is True
     assert "extra_fields" not in posted["json"]
 
 
 @pytest.mark.parametrize(
-    ("resolution", "ratio"),
+    ("model", "resolution", "ratio"),
     [
-        ("2K", "16:9"),
-        ("2K", "21:9"),
-        ("3K", "16:9"),
+        ("seedream-4.5", "2K", "3:2"),
+        ("seedream-5.0-lite", "2K", "16:9"),
+        ("seedream-5.0-lite", "2K", "21:9"),
+        ("seedream-5.0-lite", "3K", "16:9"),
     ],
 )
-def test_seedream5_newapi_size_meets_volcengine_pixel_floor(resolution, ratio):
+def test_seedream_newapi_size_meets_volcengine_pixel_floor(model, resolution, ratio):
     from novelvideo.generators.nanobanana_grid import resolve_openai_image_size
 
     width, height = (
@@ -321,7 +331,7 @@ def test_seedream5_newapi_size_meets_volcengine_pixel_floor(resolution, ratio):
         for value in resolve_openai_image_size(
             ratio,
             resolution,
-            "seedream-5.0-lite",
+            model,
         ).split("x")
     )
 
@@ -414,6 +424,7 @@ def test_newapi_seedream5_sends_3k_resolution(monkeypatch):
     assert error == ""
     width, height = (int(value) for value in posted["json"]["size"].split("x"))
     assert width * height >= 3_686_400
+    assert posted["json"]["watermark"] is False
     assert "extra_fields" not in posted["json"]
 
 
@@ -700,10 +711,11 @@ def test_newapi_image_call_relays_reference_images(monkeypatch):
             nanobanana_grid.IMAGE_TRANSFORM_AI_REFERENCE_JPEG,
         ),
     ]
-    assert posted["json"]["images"] == [
+    assert posted["json"]["image"] == [
         "https://relay.test/1.png",
         "https://relay.test/2.png",
     ]
+    assert "images" not in posted["json"]
     assert posted["json"]["output_format"] == "png"
     assert posted["json"]["input_fidelity"] == "high"
     assert "extra_fields" not in posted["json"]

--- a/tests/test_newapi_image_gateway.py
+++ b/tests/test_newapi_image_gateway.py
@@ -317,13 +317,18 @@ def test_catalog_can_enable_arbitrary_newapi_image_quality(monkeypatch):
 @pytest.mark.parametrize(
     ("model", "resolution", "ratio"),
     [
-        ("seedream-4.5", "2K", "3:2"),
-        ("seedream-5.0-lite", "2K", "16:9"),
-        ("seedream-5.0-lite", "2K", "21:9"),
-        ("seedream-5.0-lite", "3K", "16:9"),
+        ("custom-seedream-alias", "2K", "3:2"),
+        ("future-image-model", "2K", "16:9"),
+        ("future-image-model", "2K", "21:9"),
+        ("future-image-model", "3K", "16:9"),
+        ("future-image-model", "2048x1376", "3:2"),
     ],
 )
-def test_seedream_newapi_size_meets_volcengine_pixel_floor(model, resolution, ratio):
+def test_admin_min_pixels_applies_to_named_and_explicit_resolutions(
+    model,
+    resolution,
+    ratio,
+):
     from novelvideo.generators.nanobanana_grid import resolve_openai_image_size
 
     width, height = (
@@ -332,6 +337,8 @@ def test_seedream_newapi_size_meets_volcengine_pixel_floor(model, resolution, ra
             ratio,
             resolution,
             model,
+            allow_dynamic_resolution=True,
+            min_pixels=3_686_400,
         ).split("x")
     )
 
@@ -381,7 +388,7 @@ def test_newapi_image_call_rejects_unrecognized_admin_resolution():
     assert "unsupported image resolution: ultra" in error
 
 
-def test_newapi_seedream5_sends_3k_resolution(monkeypatch):
+def test_newapi_image_call_applies_admin_min_pixels(monkeypatch):
     import httpx
     from novelvideo.generators import nanobanana_grid
 
@@ -413,9 +420,17 @@ def test_newapi_seedream5_sends_3k_resolution(monkeypatch):
     image_bytes, _text, error = run_async(
         nanobanana_grid._call_newapi_image_api(
             api_key="newapi-token",
-            model="seedream-5.0-lite",
+            model="arbitrary-admin-model-id",
             prompt="prompt",
-            image_config={"aspect_ratio": "16:9", "image_size": "3K"},
+            image_config={
+                "aspect_ratio": "3:2",
+                "image_size": "2048x1376",
+                "request_schema": {
+                    "endpoint": "images/generations",
+                    "parameters": [],
+                    "minPixels": 3_686_400,
+                },
+            },
             base_url="http://newapi.test/v1",
         )
     )


### PR DESCRIPTION
## PR 类型 / Type of PR
- [x] 🐞 Bug 修复 / Bug fix
- [x] ✨ 新功能 / Feature
- [ ] 📝 文档 / Documentation
- [ ] 🧹 重构 / 清理 / Refactor or cleanup
- [ ] ⚙️ 构建 / CI / Build or CI
- [ ] ⚠️ 破坏性变更 / Breaking change

## 改动说明 / What this PR does and why

- Restore the singular `image` URL-array field for NewAPI image edits so TokenHub and Volcengine receive reference images correctly.
- Send `watermark: false` by default while preserving Admin request-schema overrides.
- Add an Admin-managed `minPixels` image capability instead of identifying pixel constraints from model names.
- Apply the configured pixel floor to named tiers such as `2K` and explicit dimensions such as `2048x1376`.
- Validate `minPixels` as an image-only integer in the range `1..16777216`.

The original failure was caused by sending a concrete size below the Volcengine Seedream pixel floor. Model-name matching would remain fragile because Admin and NewAPI permit arbitrary model aliases, so the constraint now comes from the EE media model catalog.

Companion Admin UI PR: `claymorelab/supertale-admin-fe#8`.

## 关联 issue / Linked issues

N/A

## 给 reviewer 的说明 / Notes for the reviewer

`minPixels` is an internal catalog capability and is not forwarded to NewAPI. It only affects the concrete `size` generated by Dramaclaw. Existing models must be configured in Admin; for Seedream 4.5/5, use `3686400`.

## 面向用户的变更 / User-facing change

```release-note
修复图片参考、水印和分辨率参数，并支持按媒体模型配置最低像素数。
```

## 自检 / Checklist
- [ ] 已自测，`uv run pytest` 通过 / Self-tested, `uv run pytest` passes
- [x] 必要的文档已更新 / Docs updated where needed
- [x] 提交信息清晰（建议 Conventional Commits）/ Clear commits (Conventional Commits suggested)
- [x] 每个 commit 都已 `git commit -s` 附 DCO 签署 / Every commit signed off with `git commit -s` (DCO)
- [x] 我已阅读并同意[贡献者协议](../CONTRIBUTING.md#贡献者协议) / I've read and agree to the [contributor terms](../CONTRIBUTING.md#贡献者协议)

## 验证 / Validation

```bash
/Users/newyue/claymorelab/SuperTale/.venv/bin/pytest -q \
  tests/test_newapi_image_gateway.py \
  tests/test_media_model_request_schema.py \
  tests/test_freezone_image_backend.py

cd /Users/newyue/claymorelab/SuperTale
.venv/bin/pytest -q tests/test_media_model_catalog.py tests/test_billing_config_transfer.py
```

Results: `231 passed` and `14 passed`. Ruff checks also pass.
