### PR TITLE
fix(task-center): 首轮采样撞上终态时立刻收回 loading

### DIFF
--- a/frontend/src/__tests__/task-center/use-task-activity.test.tsx
+++ b/frontend/src/__tests__/task-center/use-task-activity.test.tsx
@@ -150,6 +150,62 @@ describe("useTaskActivity", () => {
     expect(result.current.isActive).toBe(false);
   });
 
+  it("首轮采样就撞上终态时，凭 task_id 立刻收回 loading", () => {
+    const { result } = render();
+    hydrateWith([]);
+
+    act(() => result.current.markStarted({ taskId: "run-2" }));
+    expect(result.current.isActive).toBe(true);
+
+    // 轮询兜底（5s）下任务在两次采样之间跑完：这一轮 GET /tasks 回来时
+    // 已经是终态，活跃态从头到尾没被观察到。
+    act(() => {
+      useTaskCenterStore
+        .getState()
+        .hydrate([buildScenes({ task_id: "run-2", status: "completed", progress: 1 })]);
+    });
+
+    expect(result.current.isActive).toBe(false);
+  });
+
+  it("任务入队后立刻失败时，凭 task_id 立刻收回 loading", () => {
+    const { result } = render();
+    hydrateWith([]);
+
+    act(() => result.current.markStarted({ taskId: "run-2" }));
+    act(() => {
+      useTaskCenterStore
+        .getState()
+        .upsert(buildScenes({ task_id: "run-2", status: "failed", error: "boom" }));
+    });
+
+    expect(result.current.isActive).toBe(false);
+  });
+
+  it("上一轮的旧终态记录不该把新一轮的乐观窗口提前清掉", () => {
+    const { result } = render();
+    // task_key 跨轮复用，上一轮跑完的记录会在 store 里躺到被 prune 为止。
+    hydrateWith([buildScenes({ task_id: "run-1", status: "completed", progress: 1 })]);
+
+    act(() => result.current.markStarted({ taskId: "run-2" }));
+
+    // 新一轮刚入队、任务中心还没更新：loading 必须继续。
+    expect(result.current.isActive).toBe(true);
+  });
+
+  it("没拿到 task_id 时退回 15 秒兜底，不误伤旧调用方", () => {
+    const { result } = render();
+    hydrateWith([buildScenes({ task_id: "run-1", status: "completed", progress: 1 })]);
+
+    act(() => result.current.markStarted());
+    expect(result.current.isActive).toBe(true);
+
+    act(() => {
+      vi.advanceTimersByTime(15_000);
+    });
+    expect(result.current.isActive).toBe(false);
+  });
+
   it("任务正常跑完后收回 loading", () => {
     const { result } = render();
     hydrateWith([buildScenes()]);

--- a/frontend/src/components/assets/scenes-panel.tsx
+++ b/frontend/src/components/assets/scenes-panel.tsx
@@ -1288,7 +1288,7 @@ export function ScenesPanel({
       toast.error(backendErrorResponseToastMessage(res, t));
       return;
     }
-    buildActivity.markStarted();
+    buildActivity.markStarted({ taskId: res.task_id });
     toast.success(res.message);
   }
 

--- a/frontend/src/routes/_app/projects.$project/characters.lazy.tsx
+++ b/frontend/src/routes/_app/projects.$project/characters.lazy.tsx
@@ -3246,7 +3246,7 @@ function CharactersPageContent() {
         toast.error(backendErrorResponseToastMessage(res, t));
         return;
       }
-      buildActivity.markStarted();
+      buildActivity.markStarted({ taskId: res.task_id });
     } catch (error) {
       toast.error(backendErrorToastMessage(error, t));
     }

--- a/frontend/src/task-center/use-task-activity.ts
+++ b/frontend/src/task-center/use-task-activity.ts
@@ -2,7 +2,7 @@
 // Copyright (c) 2026 ClaymoreLab
 import { useCallback, useEffect, useRef, useState } from "react";
 
-import { isActive as isActiveTask } from "./derivations";
+import { isActive as isActiveTask, isTerminal } from "./derivations";
 import { useTaskCenterStore } from "./store";
 import type { TaskState } from "./types";
 
@@ -54,8 +54,13 @@ export interface TaskActivity {
   progress: number;
   /** 后端回报的当前步骤文案。 */
   currentTask: string;
-  /** 入队接口成功返回后调用，用于兜住任务进任务中心前的空窗。 */
-  markStarted: () => void;
+  /**
+   * 入队接口成功返回后调用，用于兜住任务进任务中心前的空窗。
+   *
+   * 尽量把入队响应里的 `task_id` 传进来：任务中心一旦见到同 id 的终态记录就能立刻
+   * 收掉空窗，不必空等 15 秒。不传则退回纯超时兜底。
+   */
+  markStarted: (override?: { taskId?: string }) => void;
 }
 
 /**
@@ -75,14 +80,41 @@ export function useTaskActivity(
     (state) => state.projectId != null && !state.isHydrated,
   );
   const [startedAt, setStartedAt] = useState<number | null>(null);
+  const [startedTaskId, setStartedTaskId] = useState<string | null>(null);
   // 本轮乐观窗口里是否已经认领过任务中心的记录。
   const sawTaskRef = useRef(false);
+
+  const clearOptimistic = useCallback(() => {
+    setStartedAt(null);
+    setStartedTaskId(null);
+  }, []);
+
+  // 本轮任务是否已经以终态出现在任务中心。
+  //
+  // 上面的 `task` 只认活跃任务，所以「第一次采样就撞上终态」时它前后都是 null，
+  // 下面那条 sawTaskRef 的收尾分支根本不会触发。这里改按 task_id 直接盯终态：
+  // task_key 是跨轮复用的，只有 task_id 才唯一标识这一次运行，用它才不会被上一轮
+  // 遗留的终态记录（要到 1 小时后才裁剪）误判成本轮已结束。
+  //
+  // selector 只能返回原始值：返回对象会因每次新引用触发无限重渲染。
+  const startedTaskSettled = useTaskCenterStore(
+    useCallback(
+      (state) => {
+        if (startedTaskId == null) return false;
+        for (const candidate of state.tasks.values()) {
+          if (candidate.task_id === startedTaskId) return isTerminal(candidate);
+        }
+        return false;
+      },
+      [startedTaskId],
+    ),
+  );
 
   useEffect(() => {
     if (task) {
       // 任务真出现在任务中心，本地乐观标记退场，之后完全以任务中心为准。
       sawTaskRef.current = true;
-      setStartedAt(null);
+      clearOptimistic();
       return;
     }
     // 认领过的任务又消失了 = 它已经跑完/失败/被取消。这里必须主动收尾：
@@ -91,17 +123,24 @@ export function useTaskActivity(
     // 到 15s 超时。
     if (sawTaskRef.current) {
       sawTaskRef.current = false;
-      setStartedAt(null);
+      clearOptimistic();
     }
-  }, [task]);
+  }, [task, clearOptimistic]);
+
+  useEffect(() => {
+    if (startedTaskSettled) clearOptimistic();
+  }, [startedTaskSettled, clearOptimistic]);
 
   useEffect(() => {
     if (startedAt == null) return;
-    const timer = window.setTimeout(() => setStartedAt(null), OPTIMISTIC_GRACE_MS);
+    const timer = window.setTimeout(clearOptimistic, OPTIMISTIC_GRACE_MS);
     return () => window.clearTimeout(timer);
-  }, [startedAt]);
+  }, [startedAt, clearOptimistic]);
 
-  const markStarted = useCallback(() => setStartedAt(Date.now()), []);
+  const markStarted = useCallback((override?: { taskId?: string }) => {
+    setStartedTaskId(override?.taskId ?? null);
+    setStartedAt(Date.now());
+  }, []);
 
   return {
     task,


### PR DESCRIPTION
## 问题

`useTaskActivity` 的乐观窗口只在「先观察到活跃任务、随后它消失」这条路径上收尾（`sawTaskRef`）。如果任务在两次采样之间就跑完，或者入队后直接失败，活跃态从头到尾没被观察到 —— selector 前后都返回 `null`，`useEffect` 的依赖 `[task]` 不变、不会重跑，`startedAt` 只能空转到 15s 超时。

期间生成按钮持续禁用并停在 0%；角色任务完成或报错后按钮也继续转。

两条现实触发路径：

1. SSE 连续 3 轮重连失败后降级到 5s 轮询兜底，任务在一个窗口内跑完
2. 任务入队后立刻失败，活跃态压根没产生过

影响有界（15s 后自愈）且 fail-closed（按钮保持禁用，不会重复入队），所以是 P2 不是阻断项。

## 改法

`markStarted` 可以带上本轮的 `task_id`，并按 `task_id` 订阅该任务的终态；store 里出现同 id 的终态记录就立刻收掉乐观窗口。

**为什么不按 `task_key` 匹配**：`task_key` 跨轮复用，且终态记录要到 1 小时后才被裁剪。直接匹配「该类型的任意终态任务」会被上一轮遗留的旧记录把新一轮的乐观窗口提前清掉。只有 `task_id` 唯一标识这一次运行。

也没有用时间戳比较 —— 服务端 UTC 与客户端 `Date.now()` 存在时钟偏移。

不传 `task_id` 时行为与改动前完全一致（退回纯超时兜底），不影响其他调用方。

后端无需改动：`build_scenes` / `build_characters` 本来就返回 `task_id`，`TaskResponse.task_id` 也早在类型里。本 PR 只是把它接到两个调用点上。

## 测试

新增 4 条：

- 首轮采样就撞上终态时，凭 `task_id` 立刻收回 loading
- 任务入队后立刻失败时，凭 `task_id` 立刻收回 loading
- 回归守卫：上一轮的旧终态记录不该把新一轮的乐观窗口提前清掉
- 回归守卫：没拿到 `task_id` 时退回 15 秒兜底

前两条在改动前先跑红（`isActive` 卡在 `true`），实现后转绿。

- `src/__tests__/task-center/` — 13 文件 / 129 通过
- 连同 `src/__tests__/components/` — 78 文件 / 557 通过
- `tsc -b` 干净，`pnpm build` 成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)