### PR TITLE
fix(scene): support headerless legacy drama planning

### DIFF
--- a/src/novelvideo/agents/asset_compiler.py
+++ b/src/novelvideo/agents/asset_compiler.py
@@ -480,19 +480,32 @@ class AssetCompiler:
         else:
             report(0.08, "解析本集剧本场景...")
             scene_blocks = await self._load_scene_blocks(episode)
-            report(0.1, "AI 逐场校对场景元数据...")
-            scene_blocks = await self._normalize_scene_block_headers(scene_blocks, log)
-            log(f"[AssetCompiler] 共识别 {len(scene_blocks)} 个场景块")
-
-            report(0.18, "AI校对基础场景...")
-            await self._reconcile_base_scenes_from_text(source_text, episode, log)
-
-            report(0.25, "编译场景资产...")
-            scene_menu, pending_scenes = await self._compile_scenes(
-                scene_blocks,
-                episode,
-                log,
+            has_scene_headers = any(
+                str(block.header_line or "").strip() for block in scene_blocks
             )
+            if not has_scene_headers:
+                log(
+                    "[AssetCompiler] 当前精品剧未识别到有效场景头，"
+                    "已回退为正文语义场景规划；项目类型仍保持精品剧。"
+                )
+                report(0.2, "从正文语义规划场景资产...")
+                scene_menu, pending_scenes = await self._compile_narrated_scenes(
+                    source_text, episode, log
+                )
+            else:
+                report(0.1, "AI 逐场校对场景元数据...")
+                scene_blocks = await self._normalize_scene_block_headers(scene_blocks, log)
+                log(f"[AssetCompiler] 共识别 {len(scene_blocks)} 个场景块")
+
+                report(0.18, "AI校对基础场景...")
+                await self._reconcile_base_scenes_from_text(source_text, episode, log)
+
+                report(0.25, "编译场景资产...")
+                scene_menu, pending_scenes = await self._compile_scenes(
+                    scene_blocks,
+                    episode,
+                    log,
+                )
         if not scene_menu:
             raise ValueError("未识别到任何场景，请先生成逐行解说工作稿或补充场次地点")
 

--- a/tests/test_asset_compiler_scene_enrichment.py
+++ b/tests/test_asset_compiler_scene_enrichment.py
@@ -378,6 +378,79 @@ async def test_compile_episode_scenes_uses_narrated_fallback_without_scene_heade
 
 
 @pytest.mark.asyncio
+async def test_drama_without_scene_headers_uses_semantic_scene_planning(monkeypatch, tmp_path):
+    import novelvideo.agents.asset_compiler as asset_compiler
+
+    async def fake_load_scene_blocks(self, episode):
+        return [
+            SimpleNamespace(
+                header_line="",
+                location="",
+                time_of_day="",
+                interior_exterior="",
+                characters=[],
+                lines=["林晚冲进医院走廊，护士站前的灯牌闪烁。"],
+            )
+        ]
+
+    async def fake_extract(self, source_text, episode, log):
+        assert "医院走廊" in source_text
+        return [
+            NovelScene(
+                name="医院走廊",
+                scene_type="interior",
+                environment_prompt="正面：护士站\n左侧：病房门\n右侧：候诊椅\n背面：电梯间",
+                description="急诊楼医院走廊",
+            )
+        ]
+
+    async def fail_normalize(self, scene_blocks, log):
+        pytest.fail("无场景头的历史精品剧不应调用 screenplay normalizer")
+
+    async def fail_reconcile(self, source_text, episode, log):
+        pytest.fail("语义 fallback 不应进入场景头校对链路")
+
+    monkeypatch.setattr(
+        asset_compiler.AssetCompiler,
+        "_load_scene_blocks",
+        fake_load_scene_blocks,
+    )
+    monkeypatch.setattr(
+        asset_compiler.AssetCompiler,
+        "_extract_narrated_episode_scenes",
+        fake_extract,
+    )
+    monkeypatch.setattr(
+        asset_compiler.AssetCompiler,
+        "_normalize_scene_block_headers",
+        fail_normalize,
+    )
+    monkeypatch.setattr(
+        asset_compiler.AssetCompiler,
+        "_reconcile_base_scenes_from_text",
+        fail_reconcile,
+    )
+
+    store = _FakeCogneeStore(
+        raw_content="林晚冲进医院走廊，护士站前的灯牌闪烁。",
+        project_dir=str(tmp_path),
+    )
+    compiler = asset_compiler.AssetCompiler(store)
+    compiler.spine_template = "drama"
+    logs: list[str] = []
+
+    scene_menu, new_count = await compiler.compile_episode_scenes(
+        SimpleNamespace(number=1, title="第一集", beat_source_text=""),
+        logs.append,
+    )
+
+    assert new_count == 1
+    assert [item.scene_id for item in scene_menu] == ["医院走廊"]
+    assert store.updated == [(1, {"scene_menu": scene_menu})]
+    assert any("项目类型仍保持精品剧" in message for message in logs)
+
+
+@pytest.mark.asyncio
 async def test_compile_scenes_promotes_stable_visual_states_to_pending_scenes(monkeypatch):
     import novelvideo.agents.asset_compiler as asset_compiler
 


### PR DESCRIPTION
## What changed

- detect historical drama episodes whose production text contains no parsed scene headers
- fall back to the existing semantic scene planner for those episodes
- keep the persisted project type as drama and continue writing the resulting episode scene menu
- add regression coverage that prevents the screenplay normalizer and header reconciliation path from running during this fallback

## Why

Older projects could be classified as drama before scene-header validation was enforced. Their scene-planning task currently fails with “AI 未识别到有效场景”, leaving Beat generation without an episode scene menu.

This compatibility fallback lets those projects derive episode scene candidates from their text without changing the imported source, rebuilding the knowledge graph, or changing later drama behavior.

## Impact

- normal drama episodes with scene headers continue through the existing structured screenplay path
- narrated projects are unchanged
- new headerless drama imports remain governed by the existing import validation
- historical headerless drama episodes can re-run scene planning successfully

## Verification

- `uv run pytest tests/test_asset_compiler_scene_enrichment.py tests/test_api_episode_detail.py tests/test_asset_compiler_prop_planning.py -q` — 30 passed
- `uv run ruff check src/novelvideo/agents/asset_compiler.py tests/test_asset_compiler_scene_enrichment.py`
- `git diff --check`
