### PR TITLE
fix media model configuration and request handling

### DIFF
--- a/frontend/src/__tests__/api/client.test.ts
+++ b/frontend/src/__tests__/api/client.test.ts
@@ -236,6 +236,53 @@ describe("apiCall backend errors", () => {
     );
   });
 
+  it("maps legacy wrapped Freezone insufficient-credit errors", () => {
+    const error = errorFromBackendBody(
+      503,
+      {
+        detail:
+          "failed to start freezone image-to-video task: insufficient credits for user usr_1: required 40, available 8",
+      },
+      "Service Unavailable",
+    );
+    const tMock = vi.fn((key: string, options?: { defaultValue?: string }) => {
+      if (key === "common.insufficientCredits") {
+        return "积分不足，请联系管理员充值";
+      }
+      return options?.defaultValue ?? key;
+    });
+
+    expect(error).toBeInstanceOf(InsufficientCreditsError);
+    expect(backendErrorToastMessage(error, tMock as unknown as TFunction)).toBe(
+      "积分不足，请联系管理员充值",
+    );
+  });
+
+  it("prefers a structured billing-rule code over legacy message text", () => {
+    const error = errorFromBackendBody(
+      503,
+      {
+        detail: {
+          error_code: "BILLING_RULE_NOT_CONFIGURED",
+          message: "billing rule is not configured; insufficient credits fallback",
+        },
+      },
+      "Service Unavailable",
+    );
+
+    expect(error).toBeInstanceOf(BillingRuleNotConfiguredError);
+  });
+
+  it("does not classify non-5xx legacy text as insufficient credits", () => {
+    const error = errorFromBackendBody(
+      400,
+      { detail: "invalid request: insufficient credits text from client" },
+      "Bad Request",
+    );
+
+    expect(error).not.toBeInstanceOf(InsufficientCreditsError);
+  });
+
   it("uses i18n for missing billing rule display text", () => {
     const error = errorFromBackendBody(
       409,

--- a/frontend/src/lib/api-errors.ts
+++ b/frontend/src/lib/api-errors.ts
@@ -155,6 +155,15 @@ export function errorFromBackendBody(status: number, body: unknown, fallback: st
   if (message.toLowerCase().includes("billing rule is not configured")) {
     return new BillingRuleNotConfiguredError(message, status, body);
   }
+  // Keep legacy/wrapped Freezone 5xx responses on the safe billing path only
+  // after every structured billing code has had a chance to classify them.
+  if (
+    status >= 500 &&
+    status < 600 &&
+    message.toLowerCase().includes("insufficient credits")
+  ) {
+    return new InsufficientCreditsError(message, status, body);
+  }
 
   if (status === 429 && typeof queueKind === "string" && queueKind.trim()) {
     const normalizedScope = limitScope === "user" ? "user" : "project";

--- a/src/novelvideo/api/routes/freezone.py
+++ b/src/novelvideo/api/routes/freezone.py
@@ -94,6 +94,10 @@ from novelvideo.media_model_request_schema import (
     validate_media_model_params,
     validate_media_request_schema,
 )
+from novelvideo.shared.billing_errors import (
+    find_billing_rule_not_configured_error,
+    find_insufficient_credits_error,
+)
 from novelvideo.freezone.audio_node import (
     create_user_audio_voice,
     freezone_audio_eleven_music_output_path,
@@ -323,6 +327,12 @@ def _raise_if_task_limit_exception(exc: RuntimeError) -> None:
 
 def _handle_task_start_runtime_error(message: str, exc: RuntimeError) -> None:
     _raise_if_task_limit_exception(exc)
+    insufficient_credits = find_insufficient_credits_error(exc)
+    if insufficient_credits is not None:
+        raise insufficient_credits
+    billing_rule_not_configured = find_billing_rule_not_configured_error(exc)
+    if billing_rule_not_configured is not None:
+        raise billing_rule_not_configured
     logger.warning("%s: %s", message, exc, exc_info=True)
 
 
@@ -6871,15 +6881,26 @@ async def _resolve_catalog_request(
     mode: str | None = None,
 ) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any] | None]:
     requested = str(model or "").strip()
+    catalog = await _ee_media_model_catalog(media_type)
     entry = next(
         (
             item
-            for item in (await _ee_media_model_catalog(media_type)) or []
+            for item in catalog or []
             if requested in _catalog_entry_identifiers(item)
         ),
         None,
     )
     if entry is None:
+        # In EE the catalog is authoritative. Never fall back to CE's static
+        # model map when no enabled model matches the submitted identifier.
+        if catalog is not None and requested:
+            media_label = "图片" if media_type == "image" else "视频"
+            detail = (
+                f"当前没有可用的{media_label}模型，请联系管理员或刷新后重试"
+                if not catalog
+                else "该媒体模型已停用或不存在，请刷新页面后选择其他模型"
+            )
+            raise HTTPException(409, detail)
         if model_params:
             raise HTTPException(
                 400, "model parameters require a configured media model"

--- a/src/novelvideo/generators/video_generator.py
+++ b/src/novelvideo/generators/video_generator.py
@@ -2125,26 +2125,50 @@ class NewApiVideoGenerator(VideoGeneratorBase):
     ) -> tuple[int, int] | None:
         """Convert a resolution tier and aspect ratio to exact pixel dimensions."""
 
-        resolution_match = re.search(r"(\d+)", str(resolution or ""))
+        resolution_text = str(resolution or "").strip().lower()
+        p_match = re.fullmatch(r"(\d+)p", resolution_text)
+        # Preserve compatibility with older catalogs that stored video tiers
+        # as bare values such as "1080" instead of "1080p".
+        if p_match is None:
+            p_match = re.fullmatch(r"(\d{3,4})", resolution_text)
+        video_k_long_edges = {
+            "2k": 2560,
+            "4k": 3840,
+        }
+        long_edge = video_k_long_edges.get(resolution_text)
         ratio_text = str(ratio or "").strip().lower()
-        if not resolution_match or ratio_text == "adaptive" or ":" not in ratio_text:
+        if (
+            (p_match is None and long_edge is None)
+            or ratio_text == "adaptive"
+            or ":" not in ratio_text
+        ):
             return None
         try:
-            tier = int(resolution_match.group(1))
             ratio_width, ratio_height = (
                 float(part.strip()) for part in ratio_text.split(":", 1)
             )
         except (TypeError, ValueError):
             return None
-        if tier <= 0 or ratio_width <= 0 or ratio_height <= 0:
+        if ratio_width <= 0 or ratio_height <= 0:
             return None
 
-        if ratio_width >= ratio_height:
-            height = tier
-            width = round(tier * ratio_width / ratio_height)
+        if long_edge is not None:
+            if ratio_width >= ratio_height:
+                width = long_edge
+                height = round(long_edge * ratio_height / ratio_width)
+            else:
+                height = long_edge
+                width = round(long_edge * ratio_width / ratio_height)
         else:
-            width = tier
-            height = round(tier * ratio_height / ratio_width)
+            short_edge = int(p_match.group(1))
+            if short_edge <= 0:
+                return None
+            if ratio_width >= ratio_height:
+                height = short_edge
+                width = round(short_edge * ratio_width / ratio_height)
+            else:
+                width = short_edge
+                height = round(short_edge * ratio_height / ratio_width)
 
         # Video encoders generally require even dimensions.
         width += width % 2
@@ -2163,8 +2187,12 @@ class NewApiVideoGenerator(VideoGeneratorBase):
         during phase one. Only the final wire representation is normalized here.
         """
 
-        resolution = metadata.pop("resolution", "")
-        ratio = metadata.pop("ratio", "")
+        # Keep the model-level semantics in metadata even after deriving the
+        # generic width/height fields. NewAPI model adapters may need the
+        # original ratio/resolution (notably for image-to-video) and cannot
+        # reliably reconstruct them from an input image's exact pixel ratio.
+        resolution = metadata.get("resolution", "")
+        ratio = metadata.get("ratio", "")
 
         duration_value = payload.pop("duration", None)
         legacy_seconds = payload.pop("seconds", None)

--- a/tests/test_freezone_image_backend.py
+++ b/tests/test_freezone_image_backend.py
@@ -41,6 +41,10 @@ from novelvideo.freezone.skill_registry import (
     list_skills,
 )
 from novelvideo.project_context import ProjectContext
+from novelvideo.shared.billing_errors import (
+    BillingRuleNotConfiguredError,
+    InsufficientCreditsError,
+)
 from novelvideo.task_backend.limits import ProjectUserTaskLimitExceeded
 from novelvideo.task_state import get_task_manager
 
@@ -356,6 +360,34 @@ async def test_freezone_video_start_runtime_error_is_logged(
     assert exc.value.status_code == 503
     assert "failed to start freezone omni video gen task" in caplog.text
     assert "broker unavailable" in caplog.text
+
+
+def test_freezone_task_start_preserves_insufficient_credit_error() -> None:
+    billing_error = InsufficientCreditsError(
+        user_id="usr_1",
+        cost=40,
+        balance=8,
+    )
+    wrapper = RuntimeError("failed to start freezone image-to-video task")
+    wrapper.__cause__ = billing_error
+
+    with pytest.raises(InsufficientCreditsError) as exc_info:
+        freezone_routes._handle_task_start_runtime_error("start failed", wrapper)
+
+    assert exc_info.value.cost == 40
+    assert exc_info.value.balance == 8
+
+
+def test_freezone_task_start_preserves_missing_billing_rule_error() -> None:
+    billing_error = BillingRuleNotConfiguredError(
+        kind="feature",
+        key="freezone.video_generate",
+    )
+    wrapper = RuntimeError("failed to start freezone video task")
+    wrapper.__cause__ = billing_error
+
+    with pytest.raises(BillingRuleNotConfiguredError):
+        freezone_routes._handle_task_start_runtime_error("start failed", wrapper)
 
 
 @pytest.mark.asyncio
@@ -6337,6 +6369,27 @@ async def test_image_catalog_pixel_floor_is_added_to_execution_schema(
     assert schema["minPixels"] == 3_686_400
     assert values == {}
     assert entry is catalog[0]
+
+
+@pytest.mark.asyncio
+async def test_disabled_or_removed_catalog_model_is_rejected_without_static_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def fake_catalog(media_type: str) -> list[dict[str, object]]:
+        assert media_type == "image"
+        return []
+
+    monkeypatch.setattr(freezone_routes, "_ee_media_model_catalog", fake_catalog)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await freezone_routes._resolve_catalog_request(
+            "image",
+            "disabled-image-model",
+            {},
+        )
+
+    assert exc_info.value.status_code == 409
+    assert "当前没有可用的图片模型" in str(exc_info.value.detail)
 
 
 @pytest.mark.asyncio

--- a/tests/test_seedance2_request.py
+++ b/tests/test_seedance2_request.py
@@ -619,8 +619,8 @@ async def test_newapi_seedance2_generator_preserves_config_resolution_and_scene_
     assert payload["n"] == 1
     assert payload["response_format"] == "url"
     assert metadata["scene_optimize"] == "realistic"
-    assert "resolution" not in metadata
-    assert "ratio" not in metadata
+    assert metadata["resolution"] == "1080p"
+    assert metadata["ratio"] == "16:9"
     assert "image_url" not in metadata
     assert "seconds" not in payload
 
@@ -715,10 +715,10 @@ async def test_newapi_seedance1_generator_preserves_adaptive_ratio(tmp_path, mon
     assert payload["image"] == "https://example.com/first.png"
     assert metadata["aspect_ratio"] == "adaptive"
     assert metadata["resolution"] == "720p"
-    assert "ratio" not in metadata
+    assert metadata["ratio"] == "adaptive"
 
 
-def test_newapi_video_payload_uses_public_fields_and_keeps_only_media_extensions():
+def test_newapi_video_payload_keeps_public_fields_and_model_semantics():
     from novelvideo.generators.video_generator import NewApiVideoGenerator
 
     metadata = {
@@ -751,6 +751,8 @@ def test_newapi_video_payload_uses_public_fields_and_keeps_only_media_extensions
         "n": 1,
         "response_format": "url",
         "metadata": {
+            "resolution": "720p",
+            "ratio": "16:9",
             "last_frame_image": "https://example.com/last.png",
             "reference_images": [
                 f"https://example.com/reference-{index}.png" for index in range(1, 6)
@@ -759,6 +761,71 @@ def test_newapi_video_payload_uses_public_fields_and_keeps_only_media_extensions
             "generate_audio": True,
         },
     }
+
+
+@pytest.mark.parametrize(
+    ("resolution", "ratio", "expected"),
+    [
+        ("480p", "16:9", (854, 480)),
+        ("1080P", "9:16", (1080, 1920)),
+        ("1080", "16:9", (1920, 1080)),
+        ("4k", "16:9", (3840, 2160)),
+        ("4K", "9:16", (2160, 3840)),
+        ("2k", "1:1", (2560, 2560)),
+    ],
+)
+def test_newapi_video_dimensions_distinguish_p_and_k_tiers(
+    resolution: str,
+    ratio: str,
+    expected: tuple[int, int],
+):
+    from novelvideo.generators.video_generator import NewApiVideoGenerator
+
+    assert NewApiVideoGenerator._video_dimensions(resolution, ratio) == expected
+
+
+def test_newapi_video_4k_payload_uses_real_dimensions_and_preserves_request_value():
+    from novelvideo.generators.video_generator import NewApiVideoGenerator
+
+    metadata = {"resolution": "4k", "ratio": "16:9"}
+    payload = {
+        "model": "seedance-2.0",
+        "prompt": "海边日落。",
+        "seconds": "5",
+        "metadata": metadata,
+    }
+
+    NewApiVideoGenerator._canonicalize_video_payload(payload, metadata)
+
+    assert payload["width"] == 3840
+    assert payload["height"] == 2160
+    assert payload["metadata"]["resolution"] == "4k"
+    assert payload["metadata"]["ratio"] == "16:9"
+
+
+def test_newapi_seedance15_payload_preserves_480p_21_9_semantics():
+    from novelvideo.generators.video_generator import NewApiVideoGenerator
+
+    metadata = {
+        "resolution": "480p",
+        "ratio": "21:9",
+        "image_url": "https://example.com/1281x720.jpg",
+        "generate_audio": True,
+    }
+    payload = {
+        "model": "seedance-1.5-pro",
+        "prompt": "人物缓慢转身。",
+        "seconds": "5",
+        "metadata": metadata,
+    }
+
+    NewApiVideoGenerator._canonicalize_video_payload(payload, metadata)
+
+    assert payload["width"] == 1120
+    assert payload["height"] == 480
+    assert payload["image"] == "https://example.com/1281x720.jpg"
+    assert payload["metadata"]["ratio"] == "21:9"
+    assert payload["metadata"]["resolution"] == "480p"
 
 
 def test_newapi_video_task_response_accepts_flat_and_data_wrapped_contracts():
@@ -992,8 +1059,8 @@ async def test_newapi_grok_video_channel_uses_relayclaw_video_payload(tmp_path, 
     metadata = payload["metadata"]
     assert isinstance(metadata, dict)
     assert metadata["reference_images"] == ["https://example.com/ref.png"]
-    assert "resolution" not in metadata
-    assert "ratio" not in metadata
+    assert metadata["resolution"] == "720p"
+    assert metadata["ratio"] == "9:16"
     assert "image_url" not in metadata
     assert "video_url" not in metadata
     assert "generate_audio" not in metadata


### PR DESCRIPTION
## 背景

修复 Freezone 媒体请求在参数适配、分辨率换算和积分不足提示上的边界问题。

## 主要改动

- NewAPI 视频请求在生成通用 width/height 后继续保留 metadata.ratio/resolution
- 区分 480p/720p 等短边档位与 2K/4K 长边档位，生成正确偶数尺寸
- 统一媒体模型配置参数的大小写与选项处理
- 保留结构化积分不足异常，并兼容旧的包装错误响应
- 结构化计费错误优先于旧文案兜底，旧兜底仅作用于 5xx
- EE 模型目录为空时保持 fail-closed 并返回明确提示
- 补充 Freezone 图片/视频请求与前端错误映射测试

## 影响

Seedance 等视频模型可收到完整的公共参数和模型元数据；4K 尺寸不再被误算；积分不足会显示为明确的业务提示。

## 验证

- CE 相关 pytest：199 passed
- 前端 API 测试：14 passed
- CE build：通过
- Ruff / git diff --check：通过
