### PR TITLE
chore: prepare v1.2.1 release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "supertale-ce"
-version = "1.2.0"
+version = "1.2.1"
 description = "SuperTale Community Edition API and video pipeline"
 readme = "README.md"
 requires-python = ">=3.11,<3.13"

--- a/src/novelvideo/release-notes.md
+++ b/src/novelvideo/release-notes.md
@@ -1,47 +1,33 @@
 ---
-version: 1.2.0
-attention: medium
+version: 1.2.1
+attention: low
 ---
-# v1.2.0
+# v1.2.1
 
 ## User-facing Highlights (zh)
 
-- **功能积分更透明**: 统一展示功能价格、预计扣费、账户余额和使用记录,批量创作及图片、视频、音频等任务的扣费状态更清晰。
-- **虾画创作能力升级**: 完善图片参考、视频参考、音频连接和 Seedance 模型模式切换,并修复 NewAPI 图片尺寸、水印、参考图和视频结果兼容问题。
-- **剧本导入更准确**: 导入前可预览原文、章节和场景识别结果,新增对常见中英文场景标题、括号标题和精品短剧格式的支持。
-- **任务执行更稳定**: 构建类任务统一接入任务中心,修复结束任务持续加载、知识图谱日志阻塞队列及多个规划和模型调用超时问题。
-- **外部智能体可连接 CE**: Claude Code 等本地智能体可通过 MCP 直接调用 DramaClaw CE 的项目和创作能力,无需额外配置访问令牌。
+- **媒体生成参数更可靠**: 视频比例、分辨率和模型专用参数会完整传递,并修正 2K、4K 等尺寸换算及积分不足提示。
+- **小说导入进度更清晰**: 构建知识图谱时持续展示当前阶段、完成比例和已用时间,长时间导入不再像卡住一样。
+- **旧项目规划兼容性提升**: 无标准场景标题的历史剧本也可重新规划场景,Beat 生成与资产规划统一使用当前制作正文。
+- **任务与积分界面更稳定**: 修复草图编辑进度回退,积分中心改为更清晰的中性配色并让记录表格独立滚动。
 
 ## User-facing Highlights (en)
 
-- **More transparent feature credits**: See feature prices, estimated charges, account balances, and usage history consistently across batch creation, image, video, and audio workflows.
-- **Upgraded canvas creation workflows**: Improved image, video, and audio references, automatic Seedance mode selection, and compatibility for NewAPI image sizing, watermarks, references, and normalized video results.
-- **More accurate screenplay imports**: Preview source text, chapters, and detected scenes before import, with broader support for common Chinese and English scene headings, bracketed headings, and premium short-drama formats.
-- **More reliable task execution**: Build operations now report through the task center, while completed-task loading, queue-blocking graph logs, planning failures, and model timeouts are handled more reliably.
-- **External agents can connect to CE**: Local agents such as Claude Code can use MCP to operate DramaClaw CE projects and creation workflows without configuring an additional access token.
-
-## New Features
-
-- 新增统一功能积分价格、预估扣费、余额与使用记录展示 (#210).
-- 虾画底部工具栏新增移动和抓手工具,支持快捷键 V/H (#202).
-- CE 提供无需额外令牌的 MCP 接入,支持外部智能体操作项目与创作流程 (#190).
-- 小说导入页新增原文、章节和场景识别预览 (#220).
-- 支持更多常见中英文剧本场景标题格式 (#227).
+- **More reliable media parameters**: Video ratios, resolutions, and model-specific options are preserved, with corrected 2K/4K sizing and clearer insufficient-credit errors.
+- **Clearer novel import progress**: Knowledge-graph imports now show live stages, percentage, and elapsed time so long-running work no longer appears stalled.
+- **Better compatibility for existing projects**: Legacy scripts without standard scene headings can be planned again, while Beat generation and asset planning use the same production text.
+- **More stable task and credit screens**: Sketch-edit progress no longer jumps backward, and the credit center gains clearer neutral styling with an independently scrolling history table.
 
 ## Bug Fixes
 
-- Beat 生成与剧集规划统一使用同一正文来源优先级：显式 `beat_source_text` 优先，其次为改编稿、原文和内容摘要；存量项目若已有改编稿且未显式指定 Beat 来源，重新生成时将改用改编稿。
-- 修复 Seedance 1.x 单图模式被错误禁用,并在接入视频或音频时自动切换到 Seedance 2.0 全能参考 (#203).
-- 修复音频节点连接范围和音视频分离后背景音节点孤立的问题 (#204).
-- 修复视频参考生成脚本未读取视频内容,以及角色图和参考列为空的问题 (#209).
-- 修复知识图谱日志阻塞 Celery 心跳和规划任务超时的问题 (#206, #215).
-- 修复括号场景标题及精品短剧场景标题识别问题 (#213, #214).
-- 完善剧本格式错误说明和上传限制校验,避免无效或超限内容进入导入流程 (#229).
-- 修复虾驿标准化视频任务结果无法读取的问题 (#217).
-- 修复构建类任务和已结束任务仍持续显示加载状态的问题 (#219, #222).
-- 修复 NewAPI 图片生成与编辑中的参考图、默认水印和分辨率参数问题 (#221).
+- 修复 NewAPI 视频请求丢失比例、分辨率和模型专用参数的问题,并修正 2K、4K 尺寸换算及积分不足提示 (#235).
+- 修复知识图谱导入期间普通日志导致进度归零的问题,新增实时阶段和计时展示 (#232).
+- 修复历史剧本缺少标准场景标题时无法重新规划场景的问题 (#230).
+- 统一 Beat 生成与资产规划的制作正文来源,避免跳过改编稿 (#231).
+- 修复草图编辑任务在输出日志时进度条回退到零的问题 (#233).
 
 ## Improvements
 
-- 降低积分汇总接口的重复请求压力 (#223).
-- 统一界面视觉规范和设计变量,提升页面样式一致性 (#212).
+- 移除 Beat 脚本流程中未使用的旧图谱工具和重复状态加载,保持现有生成行为不变 (#234).
+- 优化积分中心配色、筛选控件及长列表滚动体验 (#237).
+- 虾导入口暂时显示升级提示,避免用户进入尚未完成的功能 (#216).

--- a/tests/test_release_feed.py
+++ b/tests/test_release_feed.py
@@ -114,7 +114,7 @@ def test_built_wheel_contains_parseable_release_notes_artifact(tmp_path: Path) -
 def test_project_version_is_single_source_of_truth() -> None:
     pyproject = tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))
 
-    assert pyproject["project"]["version"] == "1.2.0"
+    assert pyproject["project"]["version"] == "1.2.1"
     assert importlib.metadata.version("supertale-ce") == pyproject["project"]["version"]
     assert "__version__" not in Path("src/novelvideo/__init__.py").read_text(encoding="utf-8")
 

--- a/uv.lock
+++ b/uv.lock
@@ -3419,7 +3419,7 @@ wheels = [
 
 [[package]]
 name = "supertale-ce"
-version = "1.2.0"
+version = "1.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## PR 类型 / Type of PR
- [ ] 🐞 Bug 修复 / Bug fix
- [ ] ✨ 新功能 / Feature
- [x] 📝 文档 / Documentation
- [ ] 🧹 重构 / 清理 / Refactor or cleanup
- [x] ⚙️ 构建 / CI / Build or CI
- [ ] ⚠️ 破坏性变更 / Breaking change

## 改动说明 / What this PR does and why
- 将项目版本从 `1.2.0` 更新为 `1.2.1`，并同步 `uv.lock` 与版本单一真源测试。
- 按发布模板更新包内双语 Release Notes，汇总 `v1.2.0...origin/main` 的用户可见改进与修复。
- 为合入后创建 `v1.2.1` tag、GitHub Release 和 Docker 镜像发布做准备。

## 关联 issue / Linked issues
N/A

## 给 reviewer 的说明 / Notes for the reviewer
请重点检查双语 Highlights 是否准确覆盖 #230、#231、#232、#233、#234、#235、#237 和 #216，以及 `attention: low` 是否符合补丁版本提醒级别。此 PR 不包含业务代码改动。

## 面向用户的变更 / User-facing change
```release-note
v1.2.1 improves media request compatibility, live import progress, legacy project planning, task progress, and the credit center experience.
```

## 自检 / Checklist
- [x] 已自测，`uv run pytest` 通过 / Self-tested, `uv run pytest` passes
- [x] 必要的文档已更新 / Docs updated where needed
- [x] 提交信息清晰（建议 Conventional Commits）/ Clear commits (Conventional Commits suggested)
- [x] 每个 commit 都已 `git commit -s` 附 DCO 签署 / Every commit signed off with `git commit -s` (DCO)
- [x] 我已阅读并同意[贡献者协议](../CONTRIBUTING.md#贡献者协议) / I've read and agree to the [contributor terms](../CONTRIBUTING.md#贡献者协议)

## 验证 / Verification
- `UV_CACHE_DIR=/Users/newyue/claymorelab/.uv-cache uv lock`
- `UV_CACHE_DIR=/Users/newyue/claymorelab/.uv-cache uv pip install -e .`
- `uv run pytest tests/test_release_feed.py` (12 passed)
- `git diff --check`