### PR TITLE
fix billing unit quantity semantics

### DIFF
--- a/frontend/src/__tests__/components/episode/beat-workbench/audio-pane.test.tsx
+++ b/frontend/src/__tests__/components/episode/beat-workbench/audio-pane.test.tsx
@@ -66,14 +66,11 @@ beforeAll(async () => {
 });
 
 vi.mock("@/lib/queries/audio", () => ({
+  useAudioBillingQuote: () => ({ data: { ok: true, data: { display: "" } } }),
   useRegenerateBeatAudio: () => ({
     mutateAsync: mutateRegenerate,
     isPending: false,
   }),
-}));
-
-vi.mock("@/lib/queries/generation-credit-cost", () => ({
-  useGenerationCreditCost: () => ({ data: { ok: true, data: { display: "" } } }),
 }));
 
 vi.mock("@/hooks/use-task-controller", () => ({

--- a/frontend/src/components/episode/beat-workbench/audio-pane.tsx
+++ b/frontend/src/components/episode/beat-workbench/audio-pane.tsx
@@ -6,8 +6,10 @@ import { useNavigate } from "@tanstack/react-router";
 import { toast } from "sonner";
 import { Loader2, RefreshCw } from "lucide-react";
 
-import { useRegenerateBeatAudio } from "@/lib/queries/audio";
-import { useGenerationCreditCost } from "@/lib/queries/generation-credit-cost";
+import {
+  useAudioBillingQuote,
+  useRegenerateBeatAudio,
+} from "@/lib/queries/audio";
 import { resolveMediaUrl } from "@/lib/media-url";
 import { CreditCostInline } from "@/components/credit-cost-inline";
 import {
@@ -43,7 +45,6 @@ interface AudioPaneProps {
 type VoiceConfigTarget = "characters" | "voices";
 
 const ASSET_TAB_STORAGE_KEY_PREFIX = "supertale-asset-tab:";
-const BEAT_AUDIO_GENERATION_FEATURE_KEY = "mainline.beat_audio_generation";
 
 function assetTabStorageKey(project: string): string {
   return `${ASSET_TAB_STORAGE_KEY_PREFIX}${encodeURIComponent(project)}`;
@@ -75,10 +76,11 @@ export function AudioPane({
   const { t } = useTranslation();
   const navigate = useNavigate();
   const regenerate = useRegenerateBeatAudio(project, episode);
-  const audioCost = useGenerationCreditCost(
-    "feature",
-    BEAT_AUDIO_GENERATION_FEATURE_KEY,
-    { quantity: 1 },
+  const audioCost = useAudioBillingQuote(
+    project,
+    episode,
+    { beatNumbers: [beat.beat_number], mode: "redo_selected" },
+    [beat.audio_type, beat.speaker, beat.narration_segment].join(":"),
   );
   const audioCostDisplay =
     audioCost.data?.data.display ??

--- a/src/novelvideo/api/routes/generation.py
+++ b/src/novelvideo/api/routes/generation.py
@@ -2209,7 +2209,7 @@ async def _audio_generation_plan(
     episode: int,
     beat_numbers,
     mode: str,
-) -> tuple[list[int], list[str]]:
+) -> tuple[list[int], list[str], int]:
     from novelvideo.audio.indextts2_beat_audio_task import (
         build_indextts2_audio_generation_plan,
     )
@@ -2223,7 +2223,11 @@ async def _audio_generation_plan(
             beat_numbers=beat_numbers,
             mode=mode,
         )
-        return list(plan.beat_numbers), list(plan.errors)
+        return (
+            list(plan.beat_numbers),
+            list(plan.errors),
+            int(getattr(plan, "billable_chars", 0) or 0),
+        )
     except AttributeError:
         # Narrow route-test stores do not expose the voice and audio-state
         # surfaces used by the production planner.
@@ -2235,16 +2239,42 @@ async def _audio_generation_plan(
             if int(beat.get("beat_number") or 0) > 0
             and (not selected or int(beat.get("beat_number") or 0) in selected)
         ]
-        return planned, []
+        from novelvideo.seedance2_i2v.voice_clone import (
+            dialogue_text,
+            narration_beat_text,
+            normalize_seedance2_audio_type,
+        )
+        from novelvideo.utils.document_parsers import count_billable_text_chars
+
+        planned_set = set(planned)
+        billable_chars = 0
+        for beat in beats:
+            if int(beat.get("beat_number") or 0) not in planned_set:
+                continue
+            audio_type = normalize_seedance2_audio_type(beat)
+            text = (
+                narration_beat_text(beat)
+                if audio_type == "narration"
+                else dialogue_text(beat)
+            )
+            billable_chars += count_billable_text_chars(text)
+        return planned, [], billable_chars
 
 
-def _audio_billing_payload(beat_numbers: list[int]) -> dict:
+def _audio_billing_payload(
+    beat_numbers: list[int],
+    *,
+    billable_chars: int = 0,
+) -> dict:
     from novelvideo.audio.indextts2_beat_audio_task import (
         indextts2_audio_billing_params,
     )
 
     return {
-        **indextts2_audio_billing_params(len(beat_numbers)),
+        **indextts2_audio_billing_params(
+            len(beat_numbers),
+            billable_chars=billable_chars,
+        ),
         "beat_numbers": list(beat_numbers),
     }
 
@@ -2274,7 +2304,7 @@ async def audio_generation_billing_quote(
         else await make_sqlite_store(resolved.username, resolved.project_name)
     )
     mode = body.mode or "sync_changed"
-    beat_numbers, errors = await _audio_generation_plan(
+    beat_numbers, errors, billable_chars = await _audio_generation_plan(
         store=store,
         username=resolved.username,
         project=resolved.project_name,
@@ -2298,7 +2328,10 @@ async def audio_generation_billing_quote(
     quote_args = {
         "kind": "feature",
         "model": "mainline.beat_audio_generation",
-        "params": _audio_billing_payload(beat_numbers),
+        "params": _audio_billing_payload(
+            beat_numbers,
+            billable_chars=billable_chars,
+        ),
         "quantity": quantity,
     }
     try:
@@ -2357,7 +2390,7 @@ async def generate_audio(
         return {"ok": False, "error": f"No beats found for episode {episode_num}"}
 
     mode = body.mode or "sync_changed"
-    billable_beat_numbers, missing_voice = await _audio_generation_plan(
+    billable_beat_numbers, missing_voice, billable_chars = await _audio_generation_plan(
         store=store,
         username=username,
         project=project_name,
@@ -2386,7 +2419,10 @@ async def generate_audio(
                 "beat_numbers": billable_beat_numbers,
                 "output_dir": output_dir,
                 "state_dir": state_dir,
-                "billing": _audio_billing_payload(billable_beat_numbers),
+                "billing": _audio_billing_payload(
+                    billable_beat_numbers,
+                    billable_chars=billable_chars,
+                ),
             },
         )
         return {
@@ -2464,7 +2500,12 @@ async def global_optimize_video_billing_quote(
     quote_args = {
         "kind": "feature",
         "model": "mainline.beat_video_prompt",
-        "params": {},
+        "params": {
+            "pricing_metrics": {
+                "call_count": quantity,
+                "item_count": quantity,
+            }
+        },
         "quantity": quantity,
     }
     try:
@@ -2563,6 +2604,10 @@ async def global_optimize_video(
                 "billing": {
                     "items": billable_beat_count,
                     "beat_numbers": billable_beat_numbers,
+                    "pricing_metrics": {
+                        "call_count": billable_beat_count,
+                        "item_count": billable_beat_count,
+                    },
                 },
                 "beat_numbers": billable_beat_numbers,
             },
@@ -5250,7 +5295,7 @@ async def regenerate_beat_audio(
         else:
             return {"ok": False, "error": f"Beat {beat_num} not found"}
 
-    billable_beat_numbers, missing_voice = await _audio_generation_plan(
+    billable_beat_numbers, missing_voice, billable_chars = await _audio_generation_plan(
         store=store,
         username=username,
         project=project_name,
@@ -5279,7 +5324,10 @@ async def regenerate_beat_audio(
                 "beat_numbers": billable_beat_numbers,
                 "output_dir": output_dir,
                 "state_dir": state_dir,
-                "billing": _audio_billing_payload(billable_beat_numbers),
+                "billing": _audio_billing_payload(
+                    billable_beat_numbers,
+                    billable_chars=billable_chars,
+                ),
             },
         )
         return {

--- a/src/novelvideo/api/routes/model_credits.py
+++ b/src/novelvideo/api/routes/model_credits.py
@@ -377,6 +377,11 @@ def _video_backend_feature_billing_params(params: dict) -> dict:
         "pricing_model": pricing_model,
         "pricing_params": _video_backend_billing_params(params),
         "pricing_quantity": pricing_quantity,
+        "pricing_metrics": {
+            "call_count": 1,
+            "item_count": 1,
+            "duration_seconds": pricing_quantity,
+        },
         "pricing_model_selection": video_backend,
     }
 
@@ -395,8 +400,6 @@ def freezone_video_generate_task_billing(params: dict) -> dict:
 
 def freezone_audio_speech_billing_params(params: dict) -> dict:
     """Resolve Freezone speech metadata for quotes and task reservations."""
-    if str(params.get("pricing_model") or "").strip():
-        return params
     from novelvideo.audio.indextts2_beat_audio_task import (
         indextts2_audio_billing_params,
     )
@@ -405,13 +408,23 @@ def freezone_audio_speech_billing_params(params: dict) -> dict:
         quantity = max(int(params.get("pricing_quantity") or 1), 1)
     except (TypeError, ValueError):
         quantity = 1
-    return {**params, **indextts2_audio_billing_params(quantity)}
+    resolved = (
+        params
+        if str(params.get("pricing_model") or "").strip()
+        else {**params, **indextts2_audio_billing_params(quantity)}
+    )
+    return {
+        **resolved,
+        "pricing_metrics": {
+            "call_count": 1,
+            "item_count": 1,
+            "billable_chars": quantity,
+        },
+    }
 
 
 def freezone_audio_music_billing_params(params: dict) -> dict:
     """Resolve Freezone music metadata for quotes and task reservations."""
-    if str(params.get("pricing_model") or "").strip():
-        return params
     from novelvideo.freezone.audio_node import freezone_audio_music_billing_seconds
 
     try:
@@ -422,16 +435,22 @@ def freezone_audio_music_billing_params(params: dict) -> dict:
         pricing_quantity = freezone_audio_music_billing_seconds(
             int(params.get("music_length_ms") or 0)
         )
-    pricing_model = (
-        str(params.get("model") or "LingShan-MU-11").strip()
+    pricing_model = str(
+        params.get("pricing_model")
+        or params.get("model")
         or "LingShan-MU-11"
-    )
+    ).strip() or "LingShan-MU-11"
     return {
         **params,
         "pricing_kind": "audio",
         "pricing_model": pricing_model,
         "pricing_params": {},
         "pricing_quantity": pricing_quantity,
+        "pricing_metrics": {
+            "call_count": 1,
+            "item_count": 1,
+            "duration_seconds": pricing_quantity,
+        },
     }
 
 
@@ -447,8 +466,6 @@ def freezone_audio_task_billing(feature_key: str, params: dict) -> dict:
 
 def freezone_image_reverse_prompt_billing_params(params: dict) -> dict:
     """Resolve vision-model metadata for reverse-prompt quotes and reservations."""
-    if str(params.get("pricing_model") or "").strip():
-        return params
     from novelvideo.freezone.vision_gateway import resolve_freezone_vision_model
 
     try:
@@ -462,12 +479,23 @@ def freezone_image_reverse_prompt_billing_params(params: dict) -> dict:
         )
     except (TypeError, ValueError):
         pricing_quantity = 1
+    resolved = dict(params)
+    if not str(resolved.get("pricing_model") or "").strip():
+        resolved.update(
+            {
+                "pricing_kind": "text",
+                "pricing_model": resolve_freezone_vision_model(),
+                "pricing_params": {},
+            }
+        )
     return {
-        **params,
-        "pricing_kind": "text",
-        "pricing_model": resolve_freezone_vision_model(),
-        "pricing_params": {},
+        **resolved,
         "pricing_quantity": pricing_quantity,
+        "pricing_metrics": {
+            "call_count": 1,
+            "item_count": 1,
+            "billable_chars": pricing_quantity,
+        },
     }
 
 
@@ -523,6 +551,10 @@ def freezone_image_feature_billing_params(feature_key: str, params: dict) -> dic
             ),
             "pricing_params": pricing_params,
             "pricing_quantity": pricing_quantity,
+            "pricing_metrics": {
+                "call_count": pricing_quantity,
+                "item_count": pricing_quantity,
+            },
         }
     if explicit_pricing_model:
         try:
@@ -542,6 +574,10 @@ def freezone_image_feature_billing_params(feature_key: str, params: dict) -> dic
             "pricing_model": explicit_pricing_model,
             "pricing_params": pricing_params,
             "pricing_quantity": pricing_quantity,
+            "pricing_metrics": {
+                "call_count": pricing_quantity,
+                "item_count": pricing_quantity,
+            },
         }
     image_selection = str(params.get("image_selection") or "").strip()
     if not image_selection:
@@ -570,6 +606,10 @@ def freezone_image_feature_billing_params(feature_key: str, params: dict) -> dic
             quality=str(params.get("quality") or ""),
         ),
         "pricing_quantity": pricing_quantity,
+        "pricing_metrics": {
+            "call_count": pricing_quantity,
+            "item_count": pricing_quantity,
+        },
         "pricing_model_selection": selection,
         "pricing_model_label": str(model_cfg.get("label") or selection),
     }
@@ -608,8 +648,6 @@ def _feature_billing_params(value: str, params: dict, *, mode_key: str = "") -> 
     if feature_key == "mainline.beat_video_generation":
         return _video_backend_feature_billing_params(params)
     if feature_key == "mainline.beat_audio_generation":
-        if str(params.get("pricing_model") or "").strip():
-            return params
         from novelvideo.audio.indextts2_beat_audio_task import (
             indextts2_audio_billing_params,
         )
@@ -618,6 +656,14 @@ def _feature_billing_params(value: str, params: dict, *, mode_key: str = "") -> 
             quantity = max(int(params.get("pricing_quantity") or 1), 1)
         except (TypeError, ValueError):
             quantity = 1
+        if str(params.get("pricing_model") or "").strip():
+            return {
+                **params,
+                "pricing_metrics": {
+                    "call_count": quantity,
+                    "item_count": quantity,
+                },
+            }
         return {**params, **indextts2_audio_billing_params(quantity)}
     if feature_key == "mainline.scene_pano_generation":
         if str(params.get("pricing_model") or "").strip():
@@ -741,14 +787,57 @@ def _default_billing_params(
     value: str,
     model: str,
     explicit_params: dict,
+    quantity: int = 1,
     mode_key: str = "",
     image_role: str = "",
 ) -> dict:
+    def feature_params(params: dict) -> dict:
+        action_count = max(int(quantity or 0), 1)
+        feature_input = dict(params)
+        feature_key = str(value or "").strip()
+        if feature_key in {
+            "freezone.video_generate",
+            "mainline.beat_video_generation",
+        }:
+            try:
+                total_duration = max(int(feature_input.get("pricing_quantity") or 0), 0)
+            except (TypeError, ValueError):
+                total_duration = 0
+            if total_duration > 0 and action_count > 1:
+                # Canvas asks for N videos with a total duration of N * seconds.
+                # Normalize the duration of one provider request first, then
+                # aggregate it again below. Otherwise a batch total can be
+                # mistaken for one long video and clamped by backend limits.
+                feature_input["pricing_quantity"] = total_duration / action_count
+
+        resolved = _feature_billing_params(value, feature_input, mode_key=mode_key)
+        if not str(resolved.get("pricing_model") or resolved.get("catalog_id") or "").strip():
+            return resolved
+        raw_metrics = resolved.get("pricing_metrics")
+        metrics = dict(raw_metrics) if isinstance(raw_metrics, dict) else {}
+        if "billable_chars" in resolved:
+            metrics.update(
+                {
+                    "call_count": 1,
+                    "item_count": 1,
+                    "billable_chars": max(int(resolved.get("billable_chars") or 0), 1),
+                }
+            )
+        elif "items" in resolved:
+            item_count = max(int(resolved.get("items") or 0), 1)
+            metrics.update({"call_count": item_count, "item_count": item_count})
+        else:
+            metrics.update({"call_count": action_count, "item_count": action_count})
+            if str(resolved.get("pricing_kind") or "").strip() == "video":
+                per_call_duration = max(int(metrics.get("duration_seconds") or 0), 1)
+                metrics["duration_seconds"] = per_call_duration * action_count
+        return {**resolved, "pricing_metrics": metrics}
+
     if surface == "canvas":
         if kind == "video_backend":
             return _video_backend_billing_params(explicit_params)
         if kind == "feature":
-            return _feature_billing_params(value, explicit_params, mode_key=mode_key)
+            return feature_params(explicit_params)
         return explicit_params
 
     if kind == "fixed_image":
@@ -768,7 +857,7 @@ def _default_billing_params(
     if kind == "video_backend":
         return _video_backend_billing_params(explicit_params)
     if kind == "feature":
-        return _feature_billing_params(value, explicit_params, mode_key=mode_key)
+        return feature_params(explicit_params)
     return explicit_params
 
 
@@ -799,6 +888,7 @@ async def get_generation_credit_cost(
             value=value,
             model=model,
             explicit_params=parsed_params,
+            quantity=_clean_quantity(quantity),
             mode_key=_clean_query_value(mode_key),
             image_role=_clean_query_value(image_role),
         ),

--- a/src/novelvideo/api/routes/props.py
+++ b/src/novelvideo/api/routes/props.py
@@ -379,6 +379,10 @@ async def batch_generate_prop_references(
                     "pricing_params": _fixed_image_billing_params(
                         "prop_reference", model=pricing_model
                     ),
+                    "pricing_metrics": {
+                        "call_count": pending_count,
+                        "item_count": pending_count,
+                    },
                 },
             },
         )

--- a/src/novelvideo/audio/indextts2_beat_audio_task.py
+++ b/src/novelvideo/audio/indextts2_beat_audio_task.py
@@ -37,6 +37,7 @@ from novelvideo.seedance2_i2v.voice_clone import (
     resolve_dialogue_reference_audio,
     resolve_narrator_source,
 )
+from novelvideo.utils.document_parsers import count_billable_text_chars
 
 IndexTTS2BeatAudioMode = Literal[
     "sync_changed",
@@ -81,15 +82,28 @@ class IndexTTS2BeatAudioTaskResult:
 class IndexTTS2AudioGenerationPlan:
     beat_numbers: list[int] = field(default_factory=list)
     errors: list[str] = field(default_factory=list)
+    billable_chars: int = 0
 
 
-def indextts2_audio_billing_params(quantity: int = 1) -> dict:
+def indextts2_audio_billing_params(
+    quantity: int = 1,
+    *,
+    billable_chars: int = 0,
+) -> dict:
     clean_quantity = max(int(quantity or 0), 0)
+    clean_billable_chars = max(int(billable_chars or 0), 0)
+    pricing_metrics = {
+        "call_count": clean_quantity,
+        "item_count": clean_quantity,
+    }
+    if clean_billable_chars > 0:
+        pricing_metrics["billable_chars"] = clean_billable_chars
     return {
         "pricing_kind": "audio",
         "pricing_model": INDEXTTS2_RECORD_MODEL,
         "pricing_params": {},
         "pricing_quantity": clean_quantity,
+        "pricing_metrics": pricing_metrics,
         "items": clean_quantity,
     }
 
@@ -353,6 +367,7 @@ async def build_indextts2_audio_generation_plan(
                 )
             else:
                 plan.beat_numbers.append(beat_num)
+                plan.billable_chars += count_billable_text_chars(text)
             continue
 
         resolved_voice = await _resolve_dialogue_voice(beat, store)
@@ -378,6 +393,7 @@ async def build_indextts2_audio_generation_plan(
             continue
 
         plan.beat_numbers.append(beat_num)
+        plan.billable_chars += count_billable_text_chars(text)
 
     return plan
 

--- a/tests/contract/test_m09_route_contracts.py
+++ b/tests/contract/test_m09_route_contracts.py
@@ -186,7 +186,9 @@ class _FakeCreditQuote:
     async def generation_credit_quote(self, *, kind, model, params, quantity):
         assert kind == "feature"
         assert model == "mainline.beat_video_prompt"
-        assert params == {}
+        assert params == {
+            "pricing_metrics": {"call_count": quantity, "item_count": quantity}
+        }
         return SimpleNamespace(
             total_cost=6 * quantity,
             display=str(6 * quantity),
@@ -563,6 +565,10 @@ def test_global_video_prompt_batch_bills_existing_sketches(
     )
     assert call["payload"]["billing"]["items"] == 2
     assert call["payload"]["billing"]["beat_numbers"] == [1, 2]
+    assert call["payload"]["billing"]["pricing_metrics"] == {
+        "call_count": 2,
+        "item_count": 2,
+    }
     assert call["payload"]["beat_numbers"] == [1, 2]
 
 

--- a/tests/test_api_audio_indextts2_cutover.py
+++ b/tests/test_api_audio_indextts2_cutover.py
@@ -190,7 +190,7 @@ async def test_audio_generate_route_dispatches_indextts2(monkeypatch, tmp_path):
                 "beat_numbers": [2],
                 "output_dir": str(tmp_path),
                 "state_dir": str(tmp_path / "state"),
-                "billing": generation._audio_billing_payload([2]),
+                "billing": generation._audio_billing_payload([2], billable_chars=2),
             },
         }
     ]
@@ -230,7 +230,7 @@ def test_audio_generate_http_route_dispatches_indextts2(monkeypatch, tmp_path):
         "beat_numbers": [2],
         "output_dir": str(tmp_path),
         "state_dir": str(tmp_path / "state"),
-        "billing": generation._audio_billing_payload([2]),
+        "billing": generation._audio_billing_payload([2], billable_chars=2),
     }
 
 
@@ -248,7 +248,7 @@ async def test_audio_billing_quote_uses_server_planned_quantity(monkeypatch, tmp
     async def fake_plan(**kwargs):
         assert kwargs["mode"] == "redo_selected"
         assert kwargs["beat_numbers"] == [2, 4]
-        return [2, 4], []
+        return [2, 4], [], 9
 
     class FakeCreditQuote:
         async def generation_credit_quote(self, **kwargs):
@@ -288,7 +288,7 @@ async def test_audio_billing_quote_uses_server_planned_quantity(monkeypatch, tmp
     assert captured == {
         "kind": "feature",
         "model": "mainline.beat_audio_generation",
-        "params": generation._audio_billing_payload([2, 4]),
+        "params": generation._audio_billing_payload([2, 4], billable_chars=9),
         "quantity": 2,
         "user_id": "user_1",
     }
@@ -327,7 +327,7 @@ async def test_single_beat_audio_route_dispatches_indextts2(monkeypatch, tmp_pat
                 "beat_numbers": [2],
                 "output_dir": str(tmp_path),
                 "state_dir": str(tmp_path / "state"),
-                "billing": generation._audio_billing_payload([2]),
+                "billing": generation._audio_billing_payload([2], billable_chars=2),
             },
         }
     ]
@@ -474,6 +474,11 @@ async def test_seedance2_single_video_passes_prepared_config_and_duration(
         "pricing_model_selection": "huimeng_seedance-2.0-fast",
         "pricing_params": {"resolution": "720p"},
         "pricing_quantity": 11,
+        "pricing_metrics": {
+            "call_count": 1,
+            "item_count": 1,
+            "duration_seconds": 11,
+        },
         "resolution": "720p",
         "video_backend": "huimeng_seedance-2.0-fast",
     }

--- a/tests/test_api_audio_prereq.py
+++ b/tests/test_api_audio_prereq.py
@@ -25,7 +25,7 @@ async def test_audio_generate_prereq_error_does_not_start_task(monkeypatch, tmp_
         return _FakeStore()
 
     async def fake_audio_generation_plan(**kwargs):
-        return [], ["Beat 01 解说声线缺失：请上传旁白声线"]
+        return [], ["Beat 01 解说声线缺失：请上传旁白声线"], 0
 
     async def fake_resolve_project_scope(project, user, *, required_role="viewer"):
         return ProjectResolution(

--- a/tests/test_api_model_credit_cost.py
+++ b/tests/test_api_model_credit_cost.py
@@ -1,3 +1,5 @@
+from types import SimpleNamespace
+
 import pytest
 from fastapi import HTTPException
 
@@ -35,6 +37,44 @@ def patch_quote_expect(
     from novelvideo.ports.credit_quote import CreditQuote
     from novelvideo.ports.registry import register_port
 
+    expected_with_metrics = dict(expected_params)
+    if expected_kind == "feature" and expected_params.get("pricing_model"):
+        pricing_kind = expected_params.get("pricing_kind")
+        pricing_quantity = int(expected_params.get("pricing_quantity") or 1)
+        if pricing_kind == "video":
+            metrics = {
+                "call_count": 1,
+                "item_count": 1,
+                "duration_seconds": pricing_quantity,
+            }
+        elif pricing_kind == "audio" and "billable_chars" in expected_params:
+            metrics = {
+                "call_count": 1,
+                "item_count": 1,
+                "billable_chars": int(expected_params["billable_chars"]),
+            }
+        elif pricing_kind == "audio" and "music_length_ms" in expected_params:
+            metrics = {
+                "call_count": 1,
+                "item_count": 1,
+                "duration_seconds": pricing_quantity,
+            }
+        elif pricing_kind == "text" and "billable_chars" in expected_params:
+            metrics = {
+                "call_count": 1,
+                "item_count": 1,
+                "billable_chars": int(expected_params["billable_chars"]),
+            }
+        elif pricing_kind == "image" or "items" in expected_params:
+            metrics = {
+                "call_count": pricing_quantity,
+                "item_count": pricing_quantity,
+            }
+        else:
+            metrics = {"call_count": expected_quantity, "item_count": expected_quantity}
+        if metrics is not None:
+            expected_with_metrics["pricing_metrics"] = metrics
+
     class FakeCreditQuotePort:
         async def generation_credit_quote(
             self,
@@ -46,7 +86,7 @@ def patch_quote_expect(
         ):
             assert kind == expected_kind
             assert model == expected_model
-            assert params == expected_params
+            assert params == expected_with_metrics
             assert quantity == expected_quantity
             return CreditQuote(total_cost=cost, display=str(cost))
 
@@ -374,6 +414,26 @@ async def test_generation_credit_cost_route_prices_freezone_audio_music_by_featu
     )
 
     assert result == {"ok": True, "data": {"cost": 93, "display": "93"}}
+
+
+def test_freezone_audio_music_explicit_model_keeps_duration_metric() -> None:
+    from novelvideo.api.routes.model_credits import freezone_audio_music_billing_params
+
+    params = freezone_audio_music_billing_params(
+        {
+            "pricing_model": "custom-music-model",
+            "music_length_ms": 30_500,
+        }
+    )
+
+    assert params["pricing_kind"] == "audio"
+    assert params["pricing_model"] == "custom-music-model"
+    assert params["pricing_quantity"] == 31
+    assert params["pricing_metrics"] == {
+        "call_count": 1,
+        "item_count": 1,
+        "duration_seconds": 31,
+    }
 
 
 @pytest.mark.asyncio
@@ -989,6 +1049,47 @@ async def test_generation_credit_cost_route_prices_freezone_video_generate_by_fe
     )
 
     assert result == {"ok": True, "data": {"cost": 48, "display": "48"}}
+
+
+@pytest.mark.asyncio
+async def test_generation_credit_cost_route_prices_video_batch_by_calls_and_total_seconds(
+    monkeypatch,
+):
+    from novelvideo.api.routes import model_credits
+
+    captured = {}
+
+    class FakeCreditQuotePort:
+        async def generation_credit_quote(self, **kwargs):
+            captured.update(kwargs)
+            return SimpleNamespace(
+                total_cost=30,
+                original_total_cost=30,
+                discount_amount=0,
+            )
+
+    monkeypatch.setattr(model_credits, "get_credit_quote", lambda: FakeCreditQuotePort())
+
+    result = await model_credits.get_generation_credit_cost(
+        kind="feature",
+        surface="canvas",
+        value="freezone.video_generate",
+        params=(
+            '{"video_backend":"newapi_seedance-1.0-pro-fast",'
+            '"resolution":"720p","pricing_quantity":15}'
+        ),
+        quantity=3,
+        user={"user_id": "usr_1"},
+    )
+
+    assert result == {"ok": True, "data": {"cost": 30, "display": "30"}}
+    assert captured["params"]["pricing_quantity"] == 5
+    assert captured["params"]["pricing_metrics"] == {
+        "call_count": 3,
+        "item_count": 3,
+        "duration_seconds": 15,
+    }
+    assert captured["quantity"] == 3
 
 
 @pytest.mark.asyncio

--- a/tests/test_freezone_image_backend.py
+++ b/tests/test_freezone_image_backend.py
@@ -444,6 +444,11 @@ async def test_freezone_video_generation_enqueues_feature_billing(
         "pricing_kind": "video",
         "pricing_model": "seedance-1.0-pro-fast",
         "pricing_params": {"resolution": "1080p"},
+        "pricing_metrics": {
+            "call_count": 1,
+            "item_count": 1,
+            "duration_seconds": 8,
+        },
         "pricing_model_selection": "newapi_seedance-1.0-pro-fast",
     }
 
@@ -496,6 +501,11 @@ async def test_freezone_audio_generation_enqueues_two_feature_billings(
         "pricing_kind": "audio",
         "pricing_model": INDEXTTS2_RECORD_MODEL,
         "pricing_params": {},
+        "pricing_metrics": {
+            "call_count": 1,
+            "item_count": 1,
+            "billable_chars": 7,
+        },
         "items": 7,
     }
 
@@ -510,6 +520,11 @@ async def test_freezone_audio_generation_enqueues_two_feature_billings(
         "pricing_model": "LingShan-MU-11",
         "pricing_params": {},
         "pricing_quantity": 31,
+        "pricing_metrics": {
+            "call_count": 1,
+            "item_count": 1,
+            "duration_seconds": 31,
+        },
     }
 
 
@@ -557,6 +572,11 @@ async def test_freezone_image_reverse_prompt_enqueues_feature_billing(
         "pricing_kind": "text",
         "pricing_model": "freezone-vision-model",
         "pricing_params": {},
+        "pricing_metrics": {
+            "call_count": 1,
+            "item_count": 1,
+            "billable_chars": 5,
+        },
     }
     assert captured["payload"]["instruction"] == "电影感光影"
 

--- a/tests/test_indextts2_beat_audio_task.py
+++ b/tests/test_indextts2_beat_audio_task.py
@@ -842,6 +842,7 @@ async def test_indextts2_audio_plan_returns_only_billable_beats(tmp_path, monkey
 
     assert plan.beat_numbers == [1]
     assert plan.errors == ["Beat 02 角色声线缺失：谢铮_青年时期"]
+    assert plan.billable_chars == 5
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## 背景

生成任务此前使用含义混杂的 pricing_quantity，底层按 call、item、second、character 定价时存在数量误用风险。

## 改动

- 视频、图片、批量道具、TTS 和音乐任务提交类型明确的 pricing_metrics
- 按次只提交调用次数，按条只提交生成条数
- 视频提交实际计费秒数，文本提交计费字符数
- 文字生音乐在默认或显式指定模型时均保留 duration_seconds
- 补充主线、Freezone、音频和批量生成回归测试

## 验证

- 250 项定向 pytest 通过
- Ruff 检查通过
- git diff --check 通过
