### PR TITLE
fix(script): tolerate per-line model output failures

### DIFF
--- a/src/novelvideo/task_backend/runners/script.py
+++ b/src/novelvideo/task_backend/runners/script.py
@@ -164,6 +164,9 @@ async def _run_script_writer(envelope: dict[str, Any], ctx: ProjectContext) -> d
             "beats_data": [beat.model_dump() for beat in script.beats],
             "review_passed": workflow.last_review_passed,
             "review_summary": workflow.last_review_summary,
+            "degraded_lines": list(
+                getattr(workflow, "last_degraded_lines", []) or []
+            ),
             "output_dir": str(Path(output_dir)),
         }
         return result

--- a/src/novelvideo/workflows/literal_script_writing.py
+++ b/src/novelvideo/workflows/literal_script_writing.py
@@ -4,9 +4,9 @@ import re
 from dataclasses import dataclass, field
 from typing import Any, Callable, Optional
 
-from pydantic import BaseModel, Field, ValidationInfo, field_validator, model_validator
+from pydantic import BaseModel, Field, ValidationError, ValidationInfo, field_validator, model_validator
 from pydantic_ai import Agent
-from pydantic_ai.exceptions import ContentFilterError
+from pydantic_ai.exceptions import ContentFilterError, UnexpectedModelBehavior
 
 from novelvideo.config import (
     get_newapi_text_pydantic_model,
@@ -391,6 +391,7 @@ class LiteralScriptWritingWorkflow:
         self._prop_section = ""
         self.last_review_passed = True
         self.last_review_summary = "逐行剧本模式"
+        self.last_degraded_lines: list[int] = []
 
     @property
     def agent(self) -> Agent:
@@ -446,6 +447,7 @@ class LiteralScriptWritingWorkflow:
         self._prop_section = ""
         self.last_review_passed = True
         self.last_review_summary = "逐行剧本模式"
+        self.last_degraded_lines = []
 
         await self.cognee_store.load_graph_state()
         episode = await self.sqlite_store.get_episode_from_graph(episode_num)
@@ -511,6 +513,7 @@ class LiteralScriptWritingWorkflow:
 
         for content_index, line_ctx in enumerate(line_contexts, start=1):
             raw_line = line_ctx.raw_line
+            content_filtered = False
             block = line_ctx.scene_block
             if block is not current_block:
                 current_block = block
@@ -642,7 +645,13 @@ class LiteralScriptWritingWorkflow:
 """
 
             try:
-                result = await self.agent.run(prompt)
+                output, degraded = await self._run_line_metadata_with_resilience(
+                    prompt=prompt,
+                    raw_line=raw_line,
+                    content_index=content_index,
+                    total=total,
+                    log=log,
+                )
             except ContentFilterError as exc:
                 for message in self._content_filter_log_messages(
                     content_index=content_index,
@@ -651,12 +660,15 @@ class LiteralScriptWritingWorkflow:
                     error=exc,
                 ):
                     log(message)
-                raise RuntimeError(
-                    f"第 {content_index}/{total} 行触发模型内容安全过滤，剧本生成已停止。"
-                    "请检查该行及前后文是否包含血腥、暴力、胁迫、裸露等高风险表达，"
-                    "或在 RelayClaw 中切换更适合剧本创作的文本模型后重试。"
-                ) from exc
-            output: LiteralBeatMetaOutput = result.output
+                log(
+                    f"[Literal][WARN] 第 {content_index}/{total} 行未重试，"
+                    "已使用安全占位 Beat，后续行继续处理。"
+                )
+                output = self._build_placeholder_line_metadata()
+                degraded = True
+                content_filtered = True
+            if degraded:
+                self.last_degraded_lines.append(content_index)
 
             resolved_scene_id = (current_scene_id or "").strip()
             llm_scene_id = (output.scene_id or "").strip()
@@ -682,7 +694,11 @@ class LiteralScriptWritingWorkflow:
                     )
             time_of_day = (current_time_of_day or "").strip()
             visual_description = output.visual_description.strip()
-            audio_type = self._normalize_audio_type_for_mode(output.audio_type)
+            audio_type = (
+                "silence"
+                if content_filtered
+                else self._normalize_audio_type_for_mode(output.audio_type)
+            )
             speaker_kind = (output.speaker_kind or "character").strip()
             speaker = (output.speaker or "").strip()
             audio_type, speaker = self._normalize_audio_metadata(
@@ -694,7 +710,11 @@ class LiteralScriptWritingWorkflow:
                 speaker_kind = "character"
             if audio_type == "dialogue" and speaker_kind == "character" and speaker:
                 speaker = self._resolve_unit_speaker_label(speaker)
-            narration_segment = self._derive_narration_segment(raw_line, audio_type)
+            narration_segment = (
+                ""
+                if content_filtered
+                else self._derive_narration_segment(raw_line, audio_type)
+            )
 
             beats.append(
                 VisualBeat(
@@ -719,6 +739,14 @@ class LiteralScriptWritingWorkflow:
                     episode_sticky_identities[char_name] = identity_id
             log(f"[Literal] 行 {content_index}/{total} -> {audio_type}")
 
+        if self.last_degraded_lines:
+            self.last_review_passed = False
+            degraded_text = ", ".join(str(index) for index in self.last_degraded_lines)
+            self.last_review_summary = (
+                f"逐行剧本已完成；{len(self.last_degraded_lines)} 行未能由模型正常生成，"
+                f"已使用降级 Beat（内容行: {degraded_text}），建议复核后按需单独重试。"
+            )
+
         self._valid_identity_ids.clear()
         self._valid_identity_ids.update(episode_identity_ids)
         self._valid_prop_ids.clear()
@@ -734,6 +762,96 @@ class LiteralScriptWritingWorkflow:
         await self.cognee_store.persist_narration_script(script)
         report_progress(1.0, "完成")
         return script
+
+    async def _run_line_metadata_with_resilience(
+        self,
+        *,
+        prompt: str,
+        raw_line: str,
+        content_index: int,
+        total: int,
+        log: Callable[[str], None],
+    ) -> tuple[LiteralBeatMetaOutput, bool]:
+        """Retry an exhausted structured output once, then preserve the source line."""
+
+        retryable_errors = (UnexpectedModelBehavior, ValidationError)
+        try:
+            result = await self.agent.run(prompt)
+            return result.output, False
+        except ContentFilterError:
+            raise
+        except retryable_errors as first_error:
+            log(
+                f"[Literal][WARN] 第 {content_index}/{total} 行结构化输出失败，"
+                f"正在重新调用模型: {_short_log_text(str(first_error), limit=180)}"
+            )
+
+        try:
+            result = await self.agent.run(prompt)
+            return result.output, False
+        except ContentFilterError:
+            raise
+        except retryable_errors as second_error:
+            log(
+                f"[Literal][WARN] 第 {content_index}/{total} 行重试仍失败，"
+                "已使用原文生成本地兜底 Beat，后续行继续处理。"
+            )
+            log(
+                f"[Literal][WARN] 第 {content_index}/{total} 行最终模型错误: "
+                f"{_short_log_text(str(second_error), limit=180)}"
+            )
+            return self._build_fallback_line_metadata(raw_line), True
+
+    @staticmethod
+    def _build_placeholder_line_metadata() -> LiteralBeatMetaOutput:
+        """Build a safe beat without reusing content rejected by the provider."""
+
+        return LiteralBeatMetaOutput(
+            audio_type="silence",
+            speaker="",
+            speaker_kind="character",
+            visual_description="该行未能生成，请手动补充。",
+            scene_id="",
+        )
+
+    def _build_fallback_line_metadata(self, raw_line: str) -> LiteralBeatMetaOutput:
+        """Build a minimal usable beat without inventing story information."""
+
+        line = (raw_line or "").strip()
+        speaker, speech = self._split_dialogue_line(line)
+        non_character_tokens = ("旁白", "解说", "画外音", "广播", "系统播报", "字幕")
+        is_non_character = bool(
+            speaker and any(token in speaker for token in non_character_tokens)
+        )
+        if speaker and not is_non_character:
+            audio_type = "dialogue"
+            fallback_speaker = speaker
+            visual_description = f"{speaker}开口说话。"
+        elif speaker and is_non_character:
+            audio_type = "narration"
+            fallback_speaker = ""
+            visual_description = speech or line
+        else:
+            audio_type = "narration" if self.audio_type_mode == "narrated" else "silence"
+            fallback_speaker = ""
+            visual_description = line
+
+        # 不让未经校验的资产标记进入后续生成，但保留原文语义。
+        visual_description = (
+            visual_description.replace("{{", "").replace("}}", "")
+            .replace("[[", "").replace("]]", "")
+            .strip()
+        )
+        if len(visual_description) < 5:
+            visual_description = f"画面保留原文：{visual_description or '空白行'}"
+
+        return LiteralBeatMetaOutput.model_construct(
+            audio_type=audio_type,
+            speaker=fallback_speaker,
+            speaker_kind="non_character" if is_non_character else "character",
+            visual_description=visual_description,
+            scene_id="",
+        )
 
     async def run_all_episodes(self) -> list[NarrationScript]:
         episodes = await self.sqlite_store.list_episodes()

--- a/src/novelvideo/workflows/literal_script_writing.py
+++ b/src/novelvideo/workflows/literal_script_writing.py
@@ -633,14 +633,12 @@ class LiteralScriptWritingWorkflow:
 - 当前场次出场人物: {", ".join(block.characters) if block.characters else "未标注"}
 - 当前场次前文（最多 2 行）:
 {chr(10).join(f"  - {item}" for item in safe_prompt_history) if safe_prompt_history else "  - 无"}
-- 下一行: {line_ctx.next_line or "无"}
 {prev_beat_anchor or "- 上一 beat 已选: 无"}
 {sticky_section or "- 当前场次已锁定结果: 无"}
 ## 当前行
 - 行序号: {content_index}/{total}
 - 上一行: {safe_prompt_history[-1] if safe_prompt_history else "无"}
 - 当前行: {raw_line}
-- 下一行复述: {line_ctx.next_line or "无"}
 ## 约束
 - narration_segment 由系统根据 audio_type 定型：dialogue 提取台词，narration 保留解说文本，silence 留空；你不要输出 narration_segment
 {self._audio_type_mode_instruction()}

--- a/src/novelvideo/workflows/literal_script_writing.py
+++ b/src/novelvideo/workflows/literal_script_writing.py
@@ -4,7 +4,7 @@ import re
 from dataclasses import dataclass, field
 from typing import Any, Callable, Optional
 
-from pydantic import BaseModel, Field, ValidationError, ValidationInfo, field_validator, model_validator
+from pydantic import BaseModel, Field, ValidationInfo, field_validator, model_validator
 from pydantic_ai import Agent
 from pydantic_ai.exceptions import ContentFilterError, UnexpectedModelBehavior
 
@@ -129,6 +129,14 @@ def _content_filter_hint_matches(text: str) -> list[str]:
         if category_matches:
             matches.append(f"{category}: " + "、".join(dict.fromkeys(category_matches)))
     return matches
+
+
+def _is_output_retry_exhaustion(exc: BaseException) -> bool:
+    """Return whether PydanticAI exhausted only its output-validation budget."""
+
+    return isinstance(exc, UnexpectedModelBehavior) and str(exc).strip().startswith(
+        "Exceeded maximum output retries ("
+    )
 
 
 @dataclass
@@ -510,6 +518,7 @@ class LiteralScriptWritingWorkflow:
         current_block: SceneBlock | None = None
         episode_sticky_identities: dict[str, str] = dict(episode_identity_default_map)
         block_sticky_identities: dict[str, str] = {}
+        safe_prompt_history: list[str] = []
 
         for content_index, line_ctx in enumerate(line_contexts, start=1):
             raw_line = line_ctx.raw_line
@@ -518,6 +527,7 @@ class LiteralScriptWritingWorkflow:
             if block is not current_block:
                 current_block = block
                 block_sticky_identities = dict(episode_sticky_identities)
+                safe_prompt_history = []
                 block_ctx = block.context
                 narrowed_identity_ids = (
                     set(block_ctx.candidate_identity_ids)
@@ -622,13 +632,13 @@ class LiteralScriptWritingWorkflow:
 - 当前 time_of_day: {current_time_of_day or "未锁定"}
 - 当前场次出场人物: {", ".join(block.characters) if block.characters else "未标注"}
 - 当前场次前文（最多 2 行）:
-{chr(10).join(f"  - {item}" for item in line_ctx.prev_window) if line_ctx.prev_window else "  - 无"}
+{chr(10).join(f"  - {item}" for item in safe_prompt_history) if safe_prompt_history else "  - 无"}
 - 下一行: {line_ctx.next_line or "无"}
 {prev_beat_anchor or "- 上一 beat 已选: 无"}
 {sticky_section or "- 当前场次已锁定结果: 无"}
 ## 当前行
 - 行序号: {content_index}/{total}
-- 上一行: {line_ctx.prev_window[-1] if line_ctx.prev_window else "无"}
+- 上一行: {safe_prompt_history[-1] if safe_prompt_history else "无"}
 - 当前行: {raw_line}
 - 下一行复述: {line_ctx.next_line or "无"}
 ## 约束
@@ -737,6 +747,10 @@ class LiteralScriptWritingWorkflow:
                     block_sticky_identities[char_name] = identity_id
                 if char_name and char_name not in episode_sticky_identities:
                     episode_sticky_identities[char_name] = identity_id
+            safe_prompt_history.append(
+                "[上一行因内容审核未提供]" if content_filtered else raw_line
+            )
+            safe_prompt_history = safe_prompt_history[-2:]
             log(f"[Literal] 行 {content_index}/{total} -> {audio_type}")
 
         if self.last_degraded_lines:
@@ -774,13 +788,14 @@ class LiteralScriptWritingWorkflow:
     ) -> tuple[LiteralBeatMetaOutput, bool]:
         """Retry an exhausted structured output once, then preserve the source line."""
 
-        retryable_errors = (UnexpectedModelBehavior, ValidationError)
         try:
             result = await self.agent.run(prompt)
             return result.output, False
         except ContentFilterError:
             raise
-        except retryable_errors as first_error:
+        except UnexpectedModelBehavior as first_error:
+            if not _is_output_retry_exhaustion(first_error):
+                raise
             log(
                 f"[Literal][WARN] 第 {content_index}/{total} 行结构化输出失败，"
                 f"正在重新调用模型: {_short_log_text(str(first_error), limit=180)}"
@@ -791,7 +806,9 @@ class LiteralScriptWritingWorkflow:
             return result.output, False
         except ContentFilterError:
             raise
-        except retryable_errors as second_error:
+        except UnexpectedModelBehavior as second_error:
+            if not _is_output_retry_exhaustion(second_error):
+                raise
             log(
                 f"[Literal][WARN] 第 {content_index}/{total} 行重试仍失败，"
                 "已使用原文生成本地兜底 Beat，后续行继续处理。"

--- a/tests/test_literal_script_writing_audio_type.py
+++ b/tests/test_literal_script_writing_audio_type.py
@@ -362,9 +362,11 @@ class _SequencedLiteralAgent:
     def __init__(self, outcomes):
         self.outcomes = list(outcomes)
         self.calls = 0
+        self.prompts = []
 
-    async def run(self, _prompt):
+    async def run(self, prompt):
         self.calls += 1
+        self.prompts.append(prompt)
         outcome = self.outcomes.pop(0)
         if isinstance(outcome, BaseException):
             raise outcome
@@ -485,6 +487,8 @@ async def test_literal_workflow_does_not_retry_content_filter_and_uses_placehold
     assert script.beats[0].visual_description == "该行未能生成，请手动补充。"
     assert "匕首" not in script.beats[0].model_dump_json()
     assert script.beats[1].visual_description == "屋内烛火轻轻摇晃。"
+    assert "沈晚握紧匕首。" not in agent.prompts[1]
+    assert "[上一行因内容审核未提供]" in agent.prompts[1]
     assert workflow.last_degraded_lines == [1]
     assert workflow.last_review_passed is False
     assert any("未重试" in message for message in logs)
@@ -510,5 +514,30 @@ async def test_literal_workflow_does_not_degrade_gateway_403(monkeypatch):
         )
 
     assert exc_info.value.status_code == 403
+    assert agent.calls == 1
+    assert store.persisted is None
+
+
+@pytest.mark.asyncio
+async def test_literal_workflow_does_not_degrade_malformed_gateway_response(
+    monkeypatch,
+):
+    store = _LiteralRunStore()
+    agent = _SequencedLiteralAgent(
+        [UnexpectedModelBehavior("Invalid OpenAI-compatible gateway response")]
+    )
+    monkeypatch.setattr(
+        LiteralScriptWritingWorkflow,
+        "agent",
+        property(lambda _workflow: agent),
+    )
+    workflow = LiteralScriptWritingWorkflow(cognee_store=store, sqlite_store=store)
+
+    with pytest.raises(UnexpectedModelBehavior, match="Invalid OpenAI-compatible"):
+        await workflow.run(
+            episode_num=1,
+            source_text="第1场 苏鸾寝殿 夜 内\n谢铮：走。",
+        )
+
     assert agent.calls == 1
     assert store.persisted is None

--- a/tests/test_literal_script_writing_audio_type.py
+++ b/tests/test_literal_script_writing_audio_type.py
@@ -495,6 +495,42 @@ async def test_literal_workflow_does_not_retry_content_filter_and_uses_placehold
 
 
 @pytest.mark.asyncio
+async def test_literal_workflow_does_not_send_unprocessed_next_line(monkeypatch):
+    store = _LiteralRunStore()
+
+    class _FilteringLiteralAgent:
+        def __init__(self):
+            self.calls = 0
+            self.prompts = []
+
+        async def run(self, prompt):
+            self.calls += 1
+            self.prompts.append(prompt)
+            if "沈晚握紧匕首。" in prompt:
+                raise ContentFilterError("Content filter triggered")
+            return SimpleNamespace(output=_valid_literal_output("屋内烛火轻轻摇晃。"))
+
+    agent = _FilteringLiteralAgent()
+    monkeypatch.setattr(
+        LiteralScriptWritingWorkflow,
+        "agent",
+        property(lambda _workflow: agent),
+    )
+    workflow = LiteralScriptWritingWorkflow(cognee_store=store, sqlite_store=store)
+
+    script = await workflow.run(
+        episode_num=1,
+        source_text="第1场 苏鸾寝殿 夜 内\n△烛火摇晃。\n沈晚握紧匕首。",
+    )
+
+    assert agent.calls == 2
+    assert "沈晚握紧匕首。" not in agent.prompts[0]
+    assert script.beats[0].visual_description == "屋内烛火轻轻摇晃。"
+    assert script.beats[1].visual_description == "该行未能生成，请手动补充。"
+    assert workflow.last_degraded_lines == [2]
+
+
+@pytest.mark.asyncio
 async def test_literal_workflow_does_not_degrade_gateway_403(monkeypatch):
     store = _LiteralRunStore()
     agent = _SequencedLiteralAgent(

--- a/tests/test_literal_script_writing_audio_type.py
+++ b/tests/test_literal_script_writing_audio_type.py
@@ -1,5 +1,10 @@
 import pytest
 from pydantic import ValidationError
+from pydantic_ai.exceptions import (
+    ContentFilterError,
+    ModelHTTPError,
+    UnexpectedModelBehavior,
+)
 from types import SimpleNamespace
 
 from novelvideo.models import build_scene_ref, sync_beat_asset_refs
@@ -318,3 +323,192 @@ async def test_literal_workflow_uses_shared_episode_planning_content(monkeypatch
         await workflow.run(episode_num=1)
 
     assert calls == [(cognee_store, episode)]
+
+
+class _LiteralRunStore:
+    output_dir = ""
+    _props = {}
+
+    def __init__(self) -> None:
+        self.episode = SimpleNamespace(
+            number=1,
+            title="第一集",
+            identity_ids=[],
+            identity_default_map={},
+            scene_menu=[],
+            prop_menu=[],
+        )
+        self.persisted = None
+
+    async def load_graph_state(self):
+        return None
+
+    async def get_episode_from_graph(self, episode_num):
+        assert episode_num == 1
+        return self.episode
+
+    def get_episode(self, episode_num):
+        assert episode_num == 1
+        return self.episode
+
+    def get_all_characters(self):
+        return []
+
+    async def persist_narration_script(self, script):
+        self.persisted = script
+
+
+class _SequencedLiteralAgent:
+    def __init__(self, outcomes):
+        self.outcomes = list(outcomes)
+        self.calls = 0
+
+    async def run(self, _prompt):
+        self.calls += 1
+        outcome = self.outcomes.pop(0)
+        if isinstance(outcome, BaseException):
+            raise outcome
+        return SimpleNamespace(output=outcome)
+
+
+def _valid_literal_output(visual_description: str) -> LiteralBeatMetaOutput:
+    return LiteralBeatMetaOutput(
+        audio_type="silence",
+        speaker="",
+        speaker_kind="character",
+        visual_description=visual_description,
+        scene_id="",
+    )
+
+
+@pytest.mark.asyncio
+async def test_literal_workflow_retries_one_line_with_a_fresh_model_call(monkeypatch):
+    store = _LiteralRunStore()
+    agent = _SequencedLiteralAgent(
+        [
+            UnexpectedModelBehavior("Exceeded maximum output retries (2)"),
+            _valid_literal_output("谢铮站在门口开口说话。"),
+            _valid_literal_output("屋内烛火轻轻摇晃。"),
+        ]
+    )
+    monkeypatch.setattr(
+        LiteralScriptWritingWorkflow,
+        "agent",
+        property(lambda _workflow: agent),
+    )
+    workflow = LiteralScriptWritingWorkflow(cognee_store=store, sqlite_store=store)
+    logs = []
+
+    script = await workflow.run(
+        episode_num=1,
+        source_text="第1场 苏鸾寝殿 夜 内\n谢铮：走。\n△烛火摇晃。",
+        on_log=logs.append,
+    )
+
+    assert agent.calls == 3
+    assert len(script.beats) == 2
+    assert workflow.last_degraded_lines == []
+    assert workflow.last_review_passed is True
+    assert any("正在重新调用模型" in message for message in logs)
+
+
+@pytest.mark.asyncio
+async def test_literal_workflow_falls_back_per_line_and_continues(monkeypatch):
+    store = _LiteralRunStore()
+    agent = _SequencedLiteralAgent(
+        [
+            UnexpectedModelBehavior("Exceeded maximum output retries (2)"),
+            UnexpectedModelBehavior("Exceeded maximum output retries (2)"),
+            _valid_literal_output("屋内烛火轻轻摇晃。"),
+        ]
+    )
+    monkeypatch.setattr(
+        LiteralScriptWritingWorkflow,
+        "agent",
+        property(lambda _workflow: agent),
+    )
+    workflow = LiteralScriptWritingWorkflow(cognee_store=store, sqlite_store=store)
+    logs = []
+
+    script = await workflow.run(
+        episode_num=1,
+        source_text="第1场 苏鸾寝殿 夜 内\n谢铮：走。\n△烛火摇晃。",
+        on_log=logs.append,
+    )
+
+    assert agent.calls == 3
+    assert len(script.beats) == 2
+    assert script.beats[0].audio_type == "dialogue"
+    assert script.beats[0].narration_segment == "走。"
+    assert script.beats[0].visual_description == "谢铮开口说话。"
+    assert script.beats[1].visual_description == "屋内烛火轻轻摇晃。"
+    assert store.persisted is script
+    assert workflow.last_degraded_lines == [1]
+    assert workflow.last_review_passed is False
+    assert "1 行未能由模型正常生成" in workflow.last_review_summary
+    assert any("后续行继续处理" in message for message in logs)
+
+
+@pytest.mark.asyncio
+async def test_literal_workflow_does_not_retry_content_filter_and_uses_placeholder(
+    monkeypatch,
+):
+    store = _LiteralRunStore()
+    agent = _SequencedLiteralAgent(
+        [
+            ContentFilterError("Content filter triggered"),
+            _valid_literal_output("屋内烛火轻轻摇晃。"),
+        ]
+    )
+    monkeypatch.setattr(
+        LiteralScriptWritingWorkflow,
+        "agent",
+        property(lambda _workflow: agent),
+    )
+    workflow = LiteralScriptWritingWorkflow(
+        cognee_store=store,
+        sqlite_store=store,
+        audio_type_mode="narrated",
+    )
+    logs = []
+
+    script = await workflow.run(
+        episode_num=1,
+        source_text="第1场 苏鸾寝殿 夜 内\n沈晚握紧匕首。\n△烛火摇晃。",
+        on_log=logs.append,
+    )
+
+    assert agent.calls == 2
+    assert len(script.beats) == 2
+    assert script.beats[0].audio_type == "silence"
+    assert script.beats[0].narration_segment == ""
+    assert script.beats[0].visual_description == "该行未能生成，请手动补充。"
+    assert "匕首" not in script.beats[0].model_dump_json()
+    assert script.beats[1].visual_description == "屋内烛火轻轻摇晃。"
+    assert workflow.last_degraded_lines == [1]
+    assert workflow.last_review_passed is False
+    assert any("未重试" in message for message in logs)
+
+
+@pytest.mark.asyncio
+async def test_literal_workflow_does_not_degrade_gateway_403(monkeypatch):
+    store = _LiteralRunStore()
+    agent = _SequencedLiteralAgent(
+        [ModelHTTPError(403, "brainclaw", {"error": "insufficient balance"})]
+    )
+    monkeypatch.setattr(
+        LiteralScriptWritingWorkflow,
+        "agent",
+        property(lambda _workflow: agent),
+    )
+    workflow = LiteralScriptWritingWorkflow(cognee_store=store, sqlite_store=store)
+
+    with pytest.raises(ModelHTTPError) as exc_info:
+        await workflow.run(
+            episode_num=1,
+            source_text="第1场 苏鸾寝殿 夜 内\n谢铮：走。",
+        )
+
+    assert exc_info.value.status_code == 403
+    assert agent.calls == 1
+    assert store.persisted is None

--- a/tests/test_task_script_runner_store_lifecycle.py
+++ b/tests/test_task_script_runner_store_lifecycle.py
@@ -123,4 +123,5 @@ async def test_script_writer_runner_closes_cognee_store(monkeypatch, tmp_path):
     )
 
     assert result["beats"] == 0
+    assert result["degraded_lines"] == []
     assert store.closed is True


### PR DESCRIPTION
## What changed

- retry a line with a fresh model call after PydanticAI exhausts structured-output retries
- fall back to a deterministic Beat for repeated structured-output failures and continue the episode
- convert content-filtered lines directly into a safe silent placeholder Beat without retrying or reusing rejected text
- expose degraded line indexes and a review warning in the completed task result
- keep authentication, quota, HTTP, and gateway failures fatal so undelivered scripts follow the existing refund path

## Why

An occasional malformed structured response previously aborted the entire line-by-line script task, even when all preceding and following lines were independently processable. Content-filter errors also need a separate policy: they must not be retried or fed into the source-based fallback.

The new behavior preserves a complete episode structure for line-local failures while leaving systemic provider failures visible to task settlement.

## User impact

- isolated output-format failures no longer discard the whole episode
- content-filtered lines appear as explicit placeholders that users can edit
- completed tasks identify degraded lines and show a review warning
- no changes to batch audio, global prompt optimization, or billing rules

## Verification

- `uv run ruff check src/novelvideo/workflows/literal_script_writing.py src/novelvideo/task_backend/runners/script.py tests/test_literal_script_writing_audio_type.py tests/test_task_script_runner_store_lifecycle.py`
- `uv run pytest tests/test_literal_script_writing_audio_type.py tests/test_task_script_runner_store_lifecycle.py` (26 passed)
- `uv run pytest tests/test_screenplay_scene_parser.py tests/test_newapi_text_gateway.py` (41 passed)
- `git diff --check`
