### PR TITLE
fix(storage): persist Docker media and relay Cloudinary assets

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -292,7 +292,10 @@ RELEASE_NOTIFICATIONS_GITHUB_TOKEN=
 
 
 # =============================================================================
-# 11. 输出目录
+# 11. 数据目录
 # =============================================================================
 
-NOVELVIDEO_OUTPUT_DIR=output
+# output、state、runtime 默认都从 NOVELVIDEO_DATA_ROOT 派生。
+# 本地默认使用当前目录；Docker Compose 固定使用持久化卷 /data。
+# 如需整体迁移数据目录，请配置一个绝对路径。
+# NOVELVIDEO_DATA_ROOT=

--- a/.env.example
+++ b/.env.example
@@ -299,3 +299,6 @@ RELEASE_NOTIFICATIONS_GITHUB_TOKEN=
 # 本地默认使用当前目录；Docker Compose 固定使用持久化卷 /data。
 # 如需整体迁移数据目录，请配置一个绝对路径。
 # NOVELVIDEO_DATA_ROOT=
+
+# 高级覆盖：通常无需单独配置；Docker Compose 会强制使用 /data/output。
+# NOVELVIDEO_OUTPUT_DIR=

--- a/docker-compose.release.yml
+++ b/docker-compose.release.yml
@@ -21,7 +21,9 @@ services:
       ST_CELERY_BROKER_URL: ""
       ST_CELERY_RESULT_BACKEND: ""
       NOVELVIDEO_DATA_ROOT: /data
+      NOVELVIDEO_OUTPUT_DIR: /data/output
       NOVELVIDEO_STATE_DIR: /data/state
+      NOVELVIDEO_RUNTIME_DIR: /data/runtime
       DRAMACLAW_CHAT_BACKEND: hermes
       HERMES_CLI_PATH: /root/.local/bin/hermes
       # 默认「官方 DC key」路径:模型网关地址/密钥来自 .env(NEWAPI_BASE_URL / NEWAPI_API_KEY),

--- a/docker-compose.selfhosted.release.yml
+++ b/docker-compose.selfhosted.release.yml
@@ -22,7 +22,9 @@ services:
       ST_CELERY_BROKER_URL: ""
       ST_CELERY_RESULT_BACKEND: ""
       NOVELVIDEO_DATA_ROOT: /data
+      NOVELVIDEO_OUTPUT_DIR: /data/output
       NOVELVIDEO_STATE_DIR: /data/state
+      NOVELVIDEO_RUNTIME_DIR: /data/runtime
       DRAMACLAW_CHAT_BACKEND: hermes
       HERMES_CLI_PATH: /root/.local/bin/hermes
       # 内置 newapi 网关:后端服务端调用走容器内网,覆盖 .env 里的外部网关地址,

--- a/docker-compose.selfhosted.yml
+++ b/docker-compose.selfhosted.yml
@@ -24,10 +24,9 @@ services:
       ST_CELERY_BROKER_URL: ""
       ST_CELERY_RESULT_BACKEND: ""
       NOVELVIDEO_DATA_ROOT: /data
-      # Keep project outputs (including imported novel.txt) on the persistent
-      # ce-data volume even when .env.example sets the relative value "output".
       NOVELVIDEO_OUTPUT_DIR: /data/output
       NOVELVIDEO_STATE_DIR: /data/state
+      NOVELVIDEO_RUNTIME_DIR: /data/runtime
       DRAMACLAW_CHAT_BACKEND: hermes
       HERMES_CLI_PATH: /root/.local/bin/hermes
       # 内置 newapi 网关：后端服务端调用走容器内网，覆盖 .env 里的外部网关地址，

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,9 @@ services:
       ST_CELERY_BROKER_URL: ""
       ST_CELERY_RESULT_BACKEND: ""
       NOVELVIDEO_DATA_ROOT: /data
+      NOVELVIDEO_OUTPUT_DIR: /data/output
       NOVELVIDEO_STATE_DIR: /data/state
+      NOVELVIDEO_RUNTIME_DIR: /data/runtime
       DRAMACLAW_CHAT_BACKEND: hermes
       HERMES_CLI_PATH: /root/.local/bin/hermes
       # 默认「官方 DC key」路径:模型网关地址/密钥来自 .env(NEWAPI_BASE_URL / NEWAPI_API_KEY),

--- a/docs/en/guides/self-hosting.md
+++ b/docs/en/guides/self-hosting.md
@@ -28,7 +28,7 @@ Key points in `docker-compose.yml` (already set for you, no changes needed):
 | Services | `api` + `web` | No PG/Redis (the self-hosted-gateway variant adds `newapi`) |
 | Port | `8780:8780` | REST API |
 | Enforced environment | `ST_EDITION=ce`, control-plane/Redis/Celery cleared | CE mode cannot be downgraded |
-| Data volume | `ce-data:/data` (`NOVELVIDEO_DATA_ROOT=/data`) | Persists project data |
+| Data volume | `ce-data:/data` (output at `/data/output`) | Persists project databases, settings, and generated media |
 
 ## 3. Configure `.env`
 
@@ -56,7 +56,7 @@ docker compose down              # stop (keeps the data volume)
 
 ## 5. Where the data lives / Backup, restore & migrate
 
-- Project data lives in the named volume `ce-data` (`/data` inside the container); output is in `NOVELVIDEO_OUTPUT_DIR` (default `output`).
+- Project databases, settings, and generated media live in the named volume `ce-data` (`/data` inside the container); generated media is written to `/data/output`. Removing or rebuilding a container keeps this volume. Only an explicit `docker compose down -v` removes it.
 - Back up the data volume:
 
 ```bash
@@ -73,7 +73,7 @@ docker run --rm -v dramaclaw-ce_ce-data:/data -v "$PWD":/backup alpine \
   tar xzf /backup/ce-data-backup.tar.gz -C /data
 ```
 
-Then bring the stack up as usual (`docker compose -f docker-compose.selfhosted.yml up -d`). Copy the `output` directory (`NOVELVIDEO_OUTPUT_DIR`) and your `.env` across too if you want generated media and settings to carry over.
+Then bring the stack up as usual (`docker compose -f docker-compose.selfhosted.yml up -d`). The volume backup already includes generated media; back up `.env` separately.
 
 ## 6. Upgrades
 
@@ -83,6 +83,24 @@ Then bring the stack up as usual (`docker compose -f docker-compose.selfhosted.y
 git pull
 docker compose up -d --build
 ```
+
+If an older release wrote media to `/app/output` inside the container, run the one-time migration **before** rebuilding that old container:
+
+```bash
+git pull
+docker compose exec -T api python - < scripts/migrate_docker_output.py
+docker compose up -d --build
+```
+
+On Windows PowerShell:
+
+```powershell
+git pull
+Get-Content scripts/migrate_docker_output.py -Raw | docker compose exec -T api python -
+docker compose up -d --build
+```
+
+The script copies only missing files, never overwrites or deletes the source, and backs up `projects.db` before updating project paths. Files that existed only in an already-removed container layer cannot be recovered from the data volume.
 
 After the formal release this will switch to **pulling published, pinned-version images** + env-sync (upgrades preserve your custom `.env` values) — this section will be updated once the release spec lands.
 

--- a/docs/en/reference/environment-variables.md
+++ b/docs/en/reference/environment-variables.md
@@ -11,7 +11,7 @@
 |---|---|---|
 | `ST_EDITION` | `ce` (forced by compose/image) | Edition identifier. CE mode cannot be downgraded. |
 | `NOVELVIDEO_DATA_ROOT` | `.` (set to `/data` under Docker) | Data root directory; the three items below derive from it by default. |
-| `NOVELVIDEO_OUTPUT_DIR` | `$DATA_ROOT/output` | Output directory for finished videos and artifacts. Note: `.env.example` sets it explicitly to `output` (a relative path), which inside Docker lands at `/app/output` rather than the `/data` volume; to persist to the volume, set it to `/data/output` or leave it empty to use the default. |
+| `NOVELVIDEO_OUTPUT_DIR` | `$DATA_ROOT/output` | Output directory for finished videos and artifacts. Docker Compose pins it to `/data/output`, which is persisted in the `ce-data` volume. |
 | `NOVELVIDEO_STATE_DIR` | `$DATA_ROOT/state` | Local state. |
 | `NOVELVIDEO_RUNTIME_DIR` | `$DATA_ROOT/runtime` | Runtime temporary directory. |
 | `ST_CONTROL_PLANE_DSN` / `ST_REDIS_URL` / `ST_CELERY_BROKER_URL` / `ST_CELERY_RESULT_BACKEND` | Empty (forced empty in CE) | Used only by EE/distributed; CE runs tasks inline in-process, so leave empty. |

--- a/docs/zh/guides/self-hosting.md
+++ b/docs/zh/guides/self-hosting.md
@@ -28,7 +28,7 @@ cp .env.example .env
 | 服务 | `api` + `web` | 无 PG/Redis（自建网关版另起 `newapi`） |
 | 端口 | `8780:8780` | REST API |
 | 强制环境 | `ST_EDITION=ce`、清空 control-plane/Redis/Celery | CE 模式不可降级 |
-| 数据卷 | `ce-data:/data`（`NOVELVIDEO_DATA_ROOT=/data`） | 项目数据持久化 |
+| 数据卷 | `ce-data:/data`（输出为 `/data/output`） | 持久化项目数据库、设置和生成媒体 |
 
 ## 3. 配置 `.env`
 
@@ -56,7 +56,7 @@ docker compose down              # 停止（保留数据卷）
 
 ## 5. 数据在哪 / 备份、恢复与迁移
 
-- 项目数据在命名卷 `ce-data`（容器内 `/data`），输出在 `NOVELVIDEO_OUTPUT_DIR`（默认 `output`）。
+- 项目数据库、设置和生成媒体都在命名卷 `ce-data`（容器内 `/data`）；生成媒体固定写入 `/data/output`。删除或重建容器不会删除该卷，只有显式执行 `docker compose down -v` 才会删除。
 - 备份数据卷：
 
 ```bash
@@ -73,7 +73,7 @@ docker run --rm -v dramaclaw-ce_ce-data:/data -v "$PWD":/backup alpine \
   tar xzf /backup/ce-data-backup.tar.gz -C /data
 ```
 
-然后照常起服务（`docker compose -f docker-compose.selfhosted.yml up -d`）。若要一并带上已生成的媒体与配置，把 `output` 目录（`NOVELVIDEO_OUTPUT_DIR`）和 `.env` 也拷过去。
+然后照常起服务（`docker compose -f docker-compose.selfhosted.yml up -d`）。数据卷备份已包含生成媒体；`.env` 仍需单独备份。
 
 ## 6. 升级
 
@@ -83,6 +83,24 @@ docker run --rm -v dramaclaw-ce_ce-data:/data -v "$PWD":/backup alpine \
 git pull
 docker compose up -d --build
 ```
+
+如果旧版本曾将媒体写入容器内 `/app/output`，请在重建旧容器**之前**运行一次迁移：
+
+```bash
+git pull
+docker compose exec -T api python - < scripts/migrate_docker_output.py
+docker compose up -d --build
+```
+
+Windows PowerShell 使用：
+
+```powershell
+git pull
+Get-Content scripts/migrate_docker_output.py -Raw | docker compose exec -T api python -
+docker compose up -d --build
+```
+
+脚本只补拷缺失文件，不覆盖或删除源文件；修改项目前会备份 `projects.db`。如果旧容器已经被删除，原本仅存在于该容器层的文件无法由数据卷恢复。
 
 正式发布后改为**拉取钉版本的已发布镜像** + env-sync（升级保留你的自定义 `.env` 值）——见发行规格落地后更新本节。
 

--- a/docs/zh/reference/environment-variables.md
+++ b/docs/zh/reference/environment-variables.md
@@ -11,7 +11,7 @@
 |---|---|---|
 | `ST_EDITION` | `ce`(compose/镜像强制) | 版本标识。CE 模式不可降级。 |
 | `NOVELVIDEO_DATA_ROOT` | `.`(Docker 设为 `/data`) | 数据根目录,下面三项默认派生于此。 |
-| `NOVELVIDEO_OUTPUT_DIR` | `$DATA_ROOT/output` | 成片与产物输出目录。注:`.env.example` 显式设为 `output`(相对路径),Docker 内会落到 `/app/output` 而非 `/data` 卷;要持久化到卷请设为 `/data/output` 或留空用默认。 |
+| `NOVELVIDEO_OUTPUT_DIR` | `$DATA_ROOT/output` | 成片与产物输出目录。Docker Compose 固定为 `/data/output`，随 `ce-data` 卷持久化。 |
 | `NOVELVIDEO_STATE_DIR` | `$DATA_ROOT/state` | 本地状态。 |
 | `NOVELVIDEO_RUNTIME_DIR` | `$DATA_ROOT/runtime` | 运行时临时目录。 |
 | `ST_CONTROL_PLANE_DSN` / `ST_REDIS_URL` / `ST_CELERY_BROKER_URL` / `ST_CELERY_RESULT_BACKEND` | 空(CE 强制清空) | EE/分布式才用;CE 任务进程内 inline 执行,留空。 |

--- a/license-inventory.csv
+++ b/license-inventory.csv
@@ -1266,6 +1266,7 @@ scripts/compliance/generate_p0b_artifacts.py,Elastic-2.0,2026 SuperTale contribu
 scripts/lint_banned_words.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 scripts/lint_ce_imports.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 scripts/lint_ee_terms.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
+scripts/migrate_docker_output.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 scripts/start-ce.sh,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 src/novelvideo/__init__.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 src/novelvideo/agents/__init__.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
@@ -1728,6 +1729,7 @@ tests/test_detected_empty_markers.py,Elastic-2.0,2026 SuperTale contributors,REU
 tests/test_director_staging_shape_presets.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_director_world_service.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_director_world_staging_prop_ai.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
+tests/test_docker_persistence_config.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_ee_terms_lint.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_env_config_ratchet.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_episode_optimizer_colors.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
@@ -1775,6 +1777,7 @@ tests/test_manual_shots.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml ag
 tests/test_mcp_ce_owner.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_media_model_request_schema.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_media_relay.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
+tests/test_migrate_docker_output_script.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_model_gateway_settings.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_narrator_main_semantics.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_newapi_image_gateway.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation

--- a/sbom.spdx.json
+++ b/sbom.spdx.json
@@ -7,7 +7,7 @@
     ]
   },
   "dataLicense": "CC0-1.0",
-  "documentNamespace": "https://supertale.local/spdx/supertale-ce/a436188162946e8a",
+  "documentNamespace": "https://supertale.local/spdx/supertale-ce/1f85a35344c6d605",
   "name": "supertale-ce-p0b-sbom",
   "packages": [
     {
@@ -18,7 +18,7 @@
       "licenseConcluded": "Elastic-2.0",
       "licenseDeclared": "Elastic-2.0",
       "name": "supertale-ce",
-      "versionInfo": "1.1.5"
+      "versionInfo": "1.2.1"
     },
     {
       "SPDXID": "SPDXRef-Package-aiofiles",

--- a/scripts/migrate_docker_output.py
+++ b/scripts/migrate_docker_output.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""Move legacy Docker outputs into the persistent CE data volume."""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import sqlite3
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class MigrationResult:
+    copied_files: int
+    skipped_files: int
+    migrated_projects: int
+    backup_path: Path | None
+
+
+def _copy_missing_files(source_root: Path, target_root: Path) -> tuple[int, int]:
+    copied = 0
+    skipped = 0
+    if not source_root.is_dir():
+        return copied, skipped
+
+    for source in source_root.rglob("*"):
+        relative = source.relative_to(source_root)
+        target = target_root / relative
+        if source.is_dir():
+            target.mkdir(parents=True, exist_ok=True)
+            continue
+        if not source.is_file():
+            continue
+        target.parent.mkdir(parents=True, exist_ok=True)
+        if target.exists():
+            skipped += 1
+            continue
+        shutil.copy2(source, target)
+        copied += 1
+    return copied, skipped
+
+
+def _backup_registry(registry_db: Path) -> Path:
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S%fZ")
+    backup_path = registry_db.with_name(f"{registry_db.name}.backup-{timestamp}")
+    source = sqlite3.connect(registry_db)
+    target = sqlite3.connect(backup_path)
+    try:
+        source.backup(target)
+    finally:
+        target.close()
+        source.close()
+    return backup_path
+
+
+def _migrate_project_paths(
+    registry_db: Path,
+    *,
+    legacy_root: Path,
+    target_root: Path,
+) -> tuple[int, Path | None]:
+    if not registry_db.is_file():
+        return 0, None
+
+    legacy_prefix = legacy_root.as_posix().rstrip("/")
+    target_prefix = target_root.as_posix().rstrip("/")
+    connection = sqlite3.connect(registry_db)
+    try:
+        rows = connection.execute(
+            "SELECT id, output_dir FROM projects WHERE output_dir = ? OR output_dir LIKE ?",
+            (legacy_prefix, f"{legacy_prefix}/%"),
+        ).fetchall()
+        if not rows:
+            return 0, None
+
+        backup_path = _backup_registry(registry_db)
+        connection.execute("BEGIN IMMEDIATE")
+        for project_id, output_dir in rows:
+            suffix = str(output_dir)[len(legacy_prefix) :]
+            connection.execute(
+                "UPDATE projects SET output_dir = ? WHERE id = ?",
+                (f"{target_prefix}{suffix}", project_id),
+            )
+        connection.commit()
+    except Exception:
+        connection.rollback()
+        raise
+    finally:
+        connection.close()
+    return len(rows), backup_path
+
+
+def migrate_docker_output(
+    *,
+    legacy_root: Path,
+    target_root: Path,
+    registry_db: Path,
+) -> MigrationResult:
+    target_root.mkdir(parents=True, exist_ok=True)
+    copied, skipped = _copy_missing_files(legacy_root, target_root)
+    migrated_projects, backup_path = _migrate_project_paths(
+        registry_db,
+        legacy_root=legacy_root,
+        target_root=target_root,
+    )
+    return MigrationResult(
+        copied_files=copied,
+        skipped_files=skipped,
+        migrated_projects=migrated_projects,
+        backup_path=backup_path,
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Migrate legacy /app/output data into the CE /data volume."
+    )
+    parser.add_argument("--legacy-root", type=Path, default=Path("/app/output"))
+    parser.add_argument("--target-root", type=Path, default=Path("/data/output"))
+    parser.add_argument(
+        "--registry-db",
+        type=Path,
+        default=Path("/data/state/local/projects.db"),
+    )
+    args = parser.parse_args()
+
+    result = migrate_docker_output(
+        legacy_root=args.legacy_root,
+        target_root=args.target_root,
+        registry_db=args.registry_db,
+    )
+    print(f"copied_files={result.copied_files}")
+    print(f"skipped_existing_files={result.skipped_files}")
+    print(f"migrated_projects={result.migrated_projects}")
+    print(f"registry_backup={result.backup_path or '-'}")
+    print("Legacy files were preserved. You can now rebuild the API container.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/novelvideo/generators/video_generator.py
+++ b/src/novelvideo/generators/video_generator.py
@@ -32,7 +32,7 @@ from novelvideo.shared.provider_costs import is_definite_no_cost_http_rejection
 from novelvideo.storage.media_relay import (
     IMAGE_TRANSFORM_AI_REFERENCE_JPEG,
     media_relay_ttl_seconds,
-    upload_image_bytes,
+    upload_media_bytes,
 )
 from novelvideo.task_backend.cancel import TaskCancelled, TaskTimedOut
 from novelvideo.task_backend.subprocesses import run_project_subprocess
@@ -1947,6 +1947,7 @@ class NewApiVideoGenerator(VideoGeneratorBase):
         media_value: str,
         *,
         default_ext: str = "png",
+        resource_type: str = "image",
         image_transform: str | None = None,
     ) -> str:
         media_value = str(media_value or "").strip()
@@ -1964,24 +1965,26 @@ class NewApiVideoGenerator(VideoGeneratorBase):
             data = base64.b64decode(encoded)
             ext = cls._ext_from_data_url_header(header, default_ext)
             return await asyncio.to_thread(
-                upload_image_bytes,
+                upload_media_bytes,
                 data,
                 ext=ext,
                 ttl=media_relay_ttl_seconds(
                     minimum=NEWAPI_MEDIA_INPUT_MIN_TTL_SECONDS,
                 ),
+                resource_type=resource_type,
                 image_transform=image_transform,
             )
 
         media_path = Path(media_value)
         ext = media_path.suffix.lstrip(".") or default_ext
         return await asyncio.to_thread(
-            upload_image_bytes,
+            upload_media_bytes,
             media_path.read_bytes(),
             ext=ext,
             ttl=media_relay_ttl_seconds(
                 minimum=NEWAPI_MEDIA_INPUT_MIN_TTL_SECONDS,
             ),
+            resource_type=resource_type,
             image_transform=image_transform,
         )
 
@@ -2064,6 +2067,7 @@ class NewApiVideoGenerator(VideoGeneratorBase):
                 url = await self._relay_media_input(
                     path,
                     default_ext="mp4" if media_type == "video" else "mp3",
+                    resource_type="video",
                 )
             if not path.startswith(("http://", "https://")):
                 log(f"{media_type} 参考素材已上传到媒体中转")
@@ -2311,21 +2315,25 @@ class NewApiVideoGenerator(VideoGeneratorBase):
                 default_ext = "png"
                 label = "图片参考"
                 image_transform = IMAGE_TRANSFORM_AI_REFERENCE_JPEG
+                resource_type = "image"
             elif ref_type == "video":
                 key = "reference_videos"
                 default_ext = "mp4"
                 label = "视频参考"
                 image_transform = None
+                resource_type = "video"
             elif ref_type == "audio":
                 key = "reference_audios"
                 default_ext = "mp3"
                 label = "音频参考"
                 image_transform = None
+                resource_type = "video"
             else:
                 continue
             url = await self._relay_media_input(
                 path,
                 default_ext=default_ext,
+                resource_type=resource_type,
                 image_transform=image_transform,
             )
             if not path.startswith(("http://", "https://")):
@@ -2623,6 +2631,7 @@ class NewApiVideoGenerator(VideoGeneratorBase):
                     video_url = await self._relay_media_input(
                         video_reference_paths[0],
                         default_ext="mp4",
+                        resource_type="video",
                     )
                     if not video_reference_paths[0].startswith(("http://", "https://")):
                         log("视频参考已上传到媒体中转")

--- a/src/novelvideo/storage/media_relay.py
+++ b/src/novelvideo/storage/media_relay.py
@@ -61,7 +61,14 @@ class AliyunOSSRelay:
             bucket_name.strip(),
         )
 
-    def upload_bytes(self, data: bytes, *, ext: str = "png", ttl: int = 1800) -> str:
+    def upload_bytes(
+        self,
+        data: bytes,
+        *,
+        ext: str = "png",
+        ttl: int = 1800,
+        resource_type: str = "image",
+    ) -> str:
         if not data:
             raise ValueError("cannot relay empty media bytes")
         ext = _normalize_ext(ext)
@@ -108,17 +115,30 @@ class CloudinaryRelay:
         self._api_secret = api_secret.strip()
         self._folder = str(folder or "").strip().strip("/")
 
-    def upload_bytes(self, data: bytes, *, ext: str = "png", ttl: int = 1800) -> str:
+    def upload_bytes(
+        self,
+        data: bytes,
+        *,
+        ext: str = "png",
+        ttl: int = 1800,
+        resource_type: str = "image",
+    ) -> str:
         if not data:
             raise ValueError("cannot relay empty media bytes")
 
         import httpx
 
         ext = _normalize_ext(ext)
+        resource_type = str(resource_type or "image").strip().lower()
+        if resource_type not in {"image", "video"}:
+            raise ValueError(f"unsupported Cloudinary resource type: {resource_type}")
         filename = f"{uuid.uuid4().hex}.{ext}"
         content_type = mimetypes.types_map.get(f".{ext}", "application/octet-stream")
         payload = {"folder": self._folder} if self._folder else {}
-        url = f"https://api.cloudinary.com/v1_1/{self._cloud_name}/image/upload"
+        url = (
+            f"https://api.cloudinary.com/v1_1/{self._cloud_name}/"
+            f"{resource_type}/upload"
+        )
         try:
             with httpx.Client(timeout=60.0) as client:
                 response = client.post(
@@ -128,6 +148,13 @@ class CloudinaryRelay:
                     auth=(self._api_key, self._api_secret),
                 )
                 response.raise_for_status()
+        except httpx.HTTPStatusError as exc:
+            detail = _cloudinary_error_detail(exc.response)
+            suffix = f": {detail}" if detail else ""
+            raise MediaRelayConfigError(
+                "Cloudinary media relay upload failed "
+                f"(HTTP {exc.response.status_code}){suffix}"
+            ) from exc
         except httpx.HTTPError as exc:
             raise MediaRelayConfigError(f"Cloudinary media relay upload failed: {exc}") from exc
 
@@ -217,9 +244,31 @@ def upload_image_bytes(
     ttl: int | None = None,
     image_transform: str | None = None,
 ) -> str:
+    return upload_media_bytes(
+        data,
+        ext=ext,
+        ttl=ttl,
+        resource_type="image",
+        image_transform=image_transform,
+    )
+
+
+def upload_media_bytes(
+    data: bytes,
+    *,
+    ext: str = "png",
+    ttl: int | None = None,
+    resource_type: str = "image",
+    image_transform: str | None = None,
+) -> str:
     ttl_seconds = int(ttl if ttl is not None else _default_media_relay_ttl_seconds())
     data, ext = _apply_image_transform(data, ext=ext, image_transform=image_transform)
-    return get_media_relay().upload_bytes(data, ext=ext, ttl=ttl_seconds)
+    return get_media_relay().upload_bytes(
+        data,
+        ext=ext,
+        ttl=ttl_seconds,
+        resource_type=resource_type,
+    )
 
 
 def upload_image_file(path: str | Path, *, ttl: int | None = None) -> str:
@@ -344,3 +393,20 @@ def _normalize_ext(ext: str) -> str:
     if ext == "svg+xml":
         return "svg"
     return ext or "png"
+
+
+def _cloudinary_error_detail(response: object) -> str:
+    try:
+        payload = response.json()  # type: ignore[attr-defined]
+    except Exception:
+        payload = None
+    if isinstance(payload, dict):
+        error = payload.get("error")
+        if isinstance(error, dict):
+            message = str(error.get("message") or "").strip()
+            if message:
+                return message[:500]
+    try:
+        return str(response.text or "").strip()[:500]  # type: ignore[attr-defined]
+    except Exception:
+        return ""

--- a/tests/test_docker_persistence_config.py
+++ b/tests/test_docker_persistence_config.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import yaml
+
+
+REPOSITORY_ROOT = Path(__file__).parents[1]
+COMPOSE_FILES = (
+    "docker-compose.yml",
+    "docker-compose.release.yml",
+    "docker-compose.selfhosted.yml",
+    "docker-compose.selfhosted.release.yml",
+)
+
+
+def test_all_compose_variants_persist_generated_media_in_ce_data_volume() -> None:
+    for relative_path in COMPOSE_FILES:
+        compose = yaml.safe_load((REPOSITORY_ROOT / relative_path).read_text())
+        api = compose["services"]["api"]
+
+        assert api["environment"] | {
+            "NOVELVIDEO_DATA_ROOT": "/data",
+            "NOVELVIDEO_OUTPUT_DIR": "/data/output",
+            "NOVELVIDEO_STATE_DIR": "/data/state",
+            "NOVELVIDEO_RUNTIME_DIR": "/data/runtime",
+        } == api["environment"]
+        assert "ce-data:/data" in api["volumes"]
+
+
+def test_env_example_configures_data_root_instead_of_individual_directories() -> None:
+    env_example = (REPOSITORY_ROOT / ".env.example").read_text()
+
+    assert re.search(r"^NOVELVIDEO_OUTPUT_DIR=", env_example, re.MULTILINE) is None
+    assert "# NOVELVIDEO_DATA_ROOT=" in env_example

--- a/tests/test_media_relay.py
+++ b/tests/test_media_relay.py
@@ -148,7 +148,21 @@ def test_get_media_relay_uses_saved_runtime_cloudinary_config(monkeypatch, tmp_p
     assert relay._folder == "dramaclaw-relay"
 
 
-def test_cloudinary_relay_uploads_bytes_with_basic_auth(monkeypatch: pytest.MonkeyPatch) -> None:
+@pytest.mark.parametrize(
+    ("ext", "resource_type", "expected_path", "expected_content_type"),
+    [
+        ("PNG", "image", "/image/upload", "image/png"),
+        ("mp3", "video", "/video/upload", "audio/mpeg"),
+        ("mp4", "video", "/video/upload", "video/mp4"),
+    ],
+)
+def test_cloudinary_relay_uploads_bytes_with_basic_auth(
+    monkeypatch: pytest.MonkeyPatch,
+    ext: str,
+    resource_type: str,
+    expected_path: str,
+    expected_content_type: str,
+) -> None:
     calls: list[dict[str, object]] = []
 
     class FakeResponse:
@@ -182,16 +196,64 @@ def test_cloudinary_relay_uploads_bytes_with_basic_auth(monkeypatch: pytest.Monk
         folder="dramaclaw-relay",
     )
 
-    url = relay.upload_bytes(b"image-bytes", ext="PNG", ttl=900)
+    url = relay.upload_bytes(
+        b"image-bytes",
+        ext=ext,
+        ttl=900,
+        resource_type=resource_type,
+    )
 
     assert url == "https://res.cloudinary.com/demo/image/upload/abc.png"
-    assert calls[0]["url"] == "https://api.cloudinary.com/v1_1/demo-cloud/image/upload"
+    assert str(calls[0]["url"]).endswith(expected_path)
     assert calls[0]["data"] == {"folder": "dramaclaw-relay"}
     assert calls[0]["auth"] == ("api-key", "api-secret")
     filename, data, content_type = calls[0]["files"]["file"]
-    assert filename.endswith(".png")
+    assert filename.endswith(f".{ext.lower()}")
     assert data == b"image-bytes"
-    assert content_type == "image/png"
+    assert content_type == expected_content_type
+
+
+def test_cloudinary_relay_surfaces_safe_error_detail(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import httpx
+
+    request = httpx.Request(
+        "POST", "https://api.cloudinary.com/v1_1/demo-cloud/video/upload"
+    )
+    response = httpx.Response(
+        400,
+        request=request,
+        json={"error": {"message": "Invalid video file"}},
+    )
+
+    class FakeClient:
+        def __init__(self, *, timeout: float) -> None:
+            self.timeout = timeout
+
+        def __enter__(self) -> "FakeClient":
+            return self
+
+        def __exit__(self, *args) -> None:
+            return None
+
+        def post(self, *args, **kwargs):
+            return response
+
+    monkeypatch.setattr(httpx, "Client", FakeClient)
+    relay = media_relay.CloudinaryRelay(
+        cloud_name="demo-cloud",
+        api_key="api-key",
+        api_secret="api-secret",
+    )
+
+    with pytest.raises(media_relay.MediaRelayConfigError) as exc_info:
+        relay.upload_bytes(b"audio-bytes", ext="mp3", resource_type="video")
+
+    assert str(exc_info.value) == (
+        "Cloudinary media relay upload failed (HTTP 400): Invalid video file"
+    )
+    assert "api-secret" not in str(exc_info.value)
 
 
 class CaptureRelay:
@@ -199,7 +261,14 @@ class CaptureRelay:
         self.uploaded_bytes: list[tuple[bytes, str, int]] = []
         self.uploaded_files: list[tuple[Path, int]] = []
 
-    def upload_bytes(self, data: bytes, *, ext: str = "png", ttl: int = 1800) -> str:
+    def upload_bytes(
+        self,
+        data: bytes,
+        *,
+        ext: str = "png",
+        ttl: int = 1800,
+        resource_type: str = "image",
+    ) -> str:
         self.uploaded_bytes.append((data, ext, ttl))
         return f"https://relay.test/bytes.{ext}?ttl={ttl}"
 

--- a/tests/test_migrate_docker_output_script.py
+++ b/tests/test_migrate_docker_output_script.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import importlib.util
+import sqlite3
+import sys
+from pathlib import Path
+
+
+def _load_migration_module():
+    script_path = Path(__file__).parents[1] / "scripts" / "migrate_docker_output.py"
+    spec = importlib.util.spec_from_file_location("migrate_docker_output", script_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _create_registry(path: Path, *, legacy_root: Path) -> None:
+    connection = sqlite3.connect(path)
+    try:
+        connection.execute(
+            "CREATE TABLE projects (id TEXT PRIMARY KEY, output_dir TEXT NOT NULL)"
+        )
+        connection.executemany(
+            "INSERT INTO projects(id, output_dir) VALUES (?, ?)",
+            [
+                ("legacy", f"{legacy_root.as_posix()}/local/demo"),
+                ("persistent", "/data/output/local/other"),
+            ],
+        )
+        connection.commit()
+    finally:
+        connection.close()
+
+
+def test_migrate_docker_output_copies_without_overwrite_and_rebases_registry(
+    tmp_path: Path,
+) -> None:
+    module = _load_migration_module()
+    legacy_root = tmp_path / "app-output"
+    target_root = tmp_path / "data-output"
+    registry_db = tmp_path / "projects.db"
+    (legacy_root / "local" / "demo").mkdir(parents=True)
+    (target_root / "local" / "demo").mkdir(parents=True)
+    (legacy_root / "local" / "demo" / "missing.png").write_bytes(b"legacy")
+    (legacy_root / "local" / "demo" / "existing.png").write_bytes(b"old")
+    (target_root / "local" / "demo" / "existing.png").write_bytes(b"new")
+    _create_registry(registry_db, legacy_root=legacy_root)
+
+    result = module.migrate_docker_output(
+        legacy_root=legacy_root,
+        target_root=target_root,
+        registry_db=registry_db,
+    )
+
+    assert result.copied_files == 1
+    assert result.skipped_files == 1
+    assert result.migrated_projects == 1
+    assert result.backup_path is not None and result.backup_path.is_file()
+    assert (target_root / "local" / "demo" / "missing.png").read_bytes() == b"legacy"
+    assert (target_root / "local" / "demo" / "existing.png").read_bytes() == b"new"
+    assert (legacy_root / "local" / "demo" / "missing.png").is_file()
+
+    connection = sqlite3.connect(registry_db)
+    try:
+        rows = dict(connection.execute("SELECT id, output_dir FROM projects"))
+    finally:
+        connection.close()
+    assert rows == {
+        "legacy": f"{target_root.as_posix()}/local/demo",
+        "persistent": "/data/output/local/other",
+    }
+
+    second_result = module.migrate_docker_output(
+        legacy_root=legacy_root,
+        target_root=target_root,
+        registry_db=registry_db,
+    )
+
+    assert second_result.copied_files == 0
+    assert second_result.skipped_files == 2
+    assert second_result.migrated_projects == 0
+    assert second_result.backup_path is None
+    assert len(list(tmp_path.glob("projects.db.backup-*"))) == 1

--- a/tests/test_seedance2_request.py
+++ b/tests/test_seedance2_request.py
@@ -1136,24 +1136,33 @@ async def test_newapi_video_relay_frame_input_normalizes_local_image_refs(
     frame_path.write_bytes(b"fake-png")
     captured: dict[str, object] = {}
 
-    def fake_upload_image_bytes(data, *, ext="png", ttl=None, image_transform=None):
+    def fake_upload_media_bytes(
+        data,
+        *,
+        ext="png",
+        ttl=None,
+        resource_type="image",
+        image_transform=None,
+    ):
         captured.update(
             {
                 "data": data,
                 "ext": ext,
                 "ttl": ttl,
+                "resource_type": resource_type,
                 "image_transform": image_transform,
             }
         )
         return f"https://relay.example/frame.{ext}"
 
-    monkeypatch.setattr(video_module, "upload_image_bytes", fake_upload_image_bytes)
+    monkeypatch.setattr(video_module, "upload_media_bytes", fake_upload_media_bytes)
 
     result = await NewApiVideoGenerator._relay_frame_input(str(frame_path))
 
     assert result == "https://relay.example/frame.png"
     assert captured["data"] == b"fake-png"
     assert captured["ext"] == "png"
+    assert captured["resource_type"] == "image"
     assert captured["image_transform"] == video_module.IMAGE_TRANSFORM_AI_REFERENCE_JPEG
 
 
@@ -1171,18 +1180,26 @@ async def test_newapi_video_seedance2_references_normalize_only_image_refs(
     audio_path.write_bytes(b"fake-mp3")
     captured: list[dict[str, object]] = []
 
-    def fake_upload_image_bytes(data, *, ext="png", ttl=None, image_transform=None):
+    def fake_upload_media_bytes(
+        data,
+        *,
+        ext="png",
+        ttl=None,
+        resource_type="image",
+        image_transform=None,
+    ):
         captured.append(
             {
                 "data": data,
                 "ext": ext,
                 "ttl": ttl,
+                "resource_type": resource_type,
                 "image_transform": image_transform,
             }
         )
         return f"https://relay.example/{len(captured)}.{ext}"
 
-    monkeypatch.setattr(video_module, "upload_image_bytes", fake_upload_image_bytes)
+    monkeypatch.setattr(video_module, "upload_media_bytes", fake_upload_media_bytes)
     generator = NewApiVideoGenerator(
         api_key="test-key",
         endpoint="https://newapi.example",
@@ -1204,6 +1221,7 @@ async def test_newapi_video_seedance2_references_normalize_only_image_refs(
         "reference_audios": ["https://relay.example/3.mp3"],
     }
     assert captured[0]["image_transform"] == video_module.IMAGE_TRANSFORM_AI_REFERENCE_JPEG
+    assert [item["resource_type"] for item in captured] == ["image", "video", "video"]
     assert captured[1]["image_transform"] is None
     assert captured[2]["image_transform"] is None
     assert all(


### PR DESCRIPTION
## Summary

- persist CE project output, state, and runtime data under the `ce-data` volume in every Docker Compose variant
- route Cloudinary image uploads to `/image/upload` and audio/video uploads to `/video/upload`
- add an idempotent, non-destructive migration script for legacy `/app/output` projects
- document backup, upgrade, and manual recovery behavior in Chinese and English

## Root causes

1. `.env.example` set `NOVELVIDEO_OUTPUT_DIR=output`, so Docker resolved generated media to `/app/output` outside the `/data` volume.
2. the media relay sent all Seedance reference assets to Cloudinary's image resource endpoint, while Cloudinary handles both audio and video as `video` resources.

## Legacy Docker migration

Run this after pulling the fix but before rebuilding the old API container:

```bash
docker compose exec -T api python - < scripts/migrate_docker_output.py
```

PowerShell:

```powershell
Get-Content scripts/migrate_docker_output.py -Raw | docker compose exec -T api python -
```

The script copies only missing files, preserves the legacy source, backs up `projects.db` only when an old path needs updating, and is safe to run repeatedly.

## Verification

- `uv run pytest tests/test_migrate_docker_output_script.py tests/test_docker_persistence_config.py tests/test_media_relay.py tests/test_seedance2_request.py` (54 passed)
- `uv run ruff check src/novelvideo/storage/media_relay.py src/novelvideo/generators/video_generator.py scripts/migrate_docker_output.py tests/test_media_relay.py tests/test_seedance2_request.py tests/test_migrate_docker_output_script.py tests/test_docker_persistence_config.py`
- `uv run python scripts/check_env_config.py`
- `git diff --check`

## Impact

- Configuration: Docker-generated media now lives at `/data/output` in `ce-data`.
- Migration: manual and non-destructive; no automatic startup migration.
- Providers: Cloudinary only; Aliyun OSS behavior is unchanged.
- EE: the shared media relay fix applies when EE vendors this CE commit, while the CE Compose and SQLite migration remain CE-specific.

Fixes #246
