### PR TITLE
support video-input-aware pricing

### DIFF
--- a/frontend/src/__tests__/features/canvas/video-node-credit-contract.test.ts
+++ b/frontend/src/__tests__/features/canvas/video-node-credit-contract.test.ts
@@ -13,18 +13,24 @@ const nodeSource = readFileSync(
 );
 
 describe("canvas video generation credit contract", () => {
-  it("quotes the product feature with backend, resolution, count, and duration", () => {
+  it("quotes the product feature with output and input-video duration", () => {
     // feature key 在主体定义并导出，面板 import——两个提交入口必须同一口径。
     expect(nodeSource).toContain(
       'export const VIDEO_GENERATE_FEATURE_KEY = "freezone.video_generate"',
     );
     expect(panelSource).toContain(
-      'debouncedBackend ? VIDEO_GENERATE_FEATURE_KEY : null',
+      "debouncedBackend && videoInputBillingReady\n        ? VIDEO_GENERATE_FEATURE_KEY\n        : null",
     );
     expect(panelSource).toContain("video_backend: debouncedBackend");
     expect(panelSource).toContain("pricing_quantity: videoPricingQuantity");
     expect(panelSource).toContain("quantity: videoCount");
     expect(panelSource).toContain("operation: genMode");
+    expect(panelSource).toContain(
+      "video_input_present: debouncedVideoInputPresent",
+    );
+    expect(panelSource).toContain(
+      "input_video_duration_seconds: debouncedInputVideoDuration",
+    );
     expect(panelSource).not.toContain(
       'useGenerationCreditCost(\n      "video_backend"',
     );
@@ -53,7 +59,13 @@ describe("canvas video generation credit contract", () => {
     // 未选中且无错误的节点保持零估价开销），且 submitDisabled 包含该闸门——
     // handleSubmit 开头的 submitDisabled 早退由此同时覆盖两个提交入口。
     expect(nodeSource).toContain(
-      "hasGenerationError && videoBackendForCost\n        ? VIDEO_GENERATE_FEATURE_KEY\n        : null",
+      "hasGenerationError && videoBackendForCost && videoInputBilling.ready\n        ? VIDEO_GENERATE_FEATURE_KEY\n        : null",
+    );
+    expect(nodeSource).toContain(
+      "video_input_present: videoInputBilling.present",
+    );
+    expect(nodeSource).toContain(
+      "input_video_duration_seconds: videoInputBilling.durationSeconds",
     );
     expect(nodeSource).toContain(
       "retryBillingProbe.error instanceof BillingRuleNotConfiguredError",

--- a/frontend/src/features/canvas/nodes/VideoNode.tsx
+++ b/frontend/src/features/canvas/nodes/VideoNode.tsx
@@ -588,6 +588,10 @@ export const VideoNode = memo(
 
     const prompt = typeof data.prompt === "string" ? data.prompt : "";
     const genMode: VideoGenMode = data.genMode ?? "textToVideo";
+    // Billing and submission must inspect the same one-hop inputs. Keeping the
+    // subscription here also lets the displayed quote react when a source
+    // video's browser-probed duration becomes available.
+    const upstreamNodes = useUpstreamNodes(id);
     const {
       models: availableVideoModels,
       isLoading: videoModelsLoading,
@@ -673,6 +677,36 @@ export const VideoNode = memo(
     const supportsHumanReview = selectedVideoModel?.humanReview === true;
     const humanReview = Boolean(data.humanReview);
     const count: VideoGenCount = (data.count ?? 1) as VideoGenCount;
+    const videoInputBilling = useMemo(() => {
+      if (genMode !== "allReference" && genMode !== "videoEdit") {
+        return { present: false, ready: true, durationSeconds: 0 };
+      }
+      const ordered = sortUpstreamByReferenceOrder(
+        upstreamNodes,
+        data.referenceOrder,
+      ).filter((node) => Boolean(referenceVideoUrl(node)));
+      const limit =
+        genMode === "videoEdit"
+          ? 1
+          : (selectedVideoModel?.referenceVideoMax ?? 3);
+      const videos = ordered.slice(0, Math.max(limit, 0));
+      if (videos.length === 0) {
+        return { present: false, ready: true, durationSeconds: 0 };
+      }
+      const durations = videos.map((node) =>
+        typeof node.data.durationMs === "number" && node.data.durationMs > 0
+          ? node.data.durationMs
+          : null,
+      );
+      const ready = durations.every((duration) => duration != null);
+      return {
+        present: true,
+        ready,
+        durationSeconds: ready
+          ? durations.reduce((sum, duration) => sum + (duration ?? 0), 0) / 1000
+          : 0,
+      };
+    }, [data.referenceOrder, genMode, selectedVideoModel, upstreamNodes]);
     useEffect(() => {
       const patch: Partial<VideoNodeData> = {};
       if (data.quality !== quality) {
@@ -763,7 +797,6 @@ export const VideoNode = memo(
     // referenceOrder taking precedence — see sortUpstreamByReferenceOrder.
     // Subscribe to ONLY this node's one-hop upstream (not the whole nodes array)
     // so dragging unrelated nodes doesn't re-render this node. See useUpstreamGraph.
-    const upstreamNodes = useUpstreamNodes(id);
     // 节点被连线（存在入边）后：隐藏「试试」CTA，只在节点中间显示一个图标（对齐 libtv）。
     const isConnected = useCanvasStore((state) =>
       state.edges.some((edge) => edge.target === id)
@@ -1772,7 +1805,7 @@ export const VideoNode = memo(
     // 零估价开销；错误态与面板同时活跃时参数一致、查询同 key，由 react-query 去重。
     const retryBillingProbe = useGenerationCreditCost(
       "feature",
-      hasGenerationError && videoBackendForCost
+      hasGenerationError && videoBackendForCost && videoInputBilling.ready
         ? VIDEO_GENERATE_FEATURE_KEY
         : null,
       {
@@ -1786,6 +1819,8 @@ export const VideoNode = memo(
           pricing_quantity: Math.min(Math.max(count, 1), 4) * durationSec,
           operation: genMode,
           generate_audio: generateAudio,
+          video_input_present: videoInputBilling.present,
+          input_video_duration_seconds: videoInputBilling.durationSeconds,
         },
         quantity: Math.min(Math.max(count, 1), 4),
       },
@@ -3018,6 +3053,9 @@ export const VideoNode = memo(
             prompt={prompt}
             isGenerating={isGenerating}
             videoBackendForCost={videoBackendForCost}
+            videoInputPresent={videoInputBilling.present}
+            videoInputBillingReady={videoInputBilling.ready}
+            inputVideoDurationSeconds={videoInputBilling.durationSeconds}
             submitDisabled={submitDisabled}
             selectedModelReferenceError={selectedModelReferenceError}
             mediaRejectionReason={mediaRejectionReason}

--- a/frontend/src/features/canvas/nodes/VideoOperationsPanel.tsx
+++ b/frontend/src/features/canvas/nodes/VideoOperationsPanel.tsx
@@ -215,6 +215,9 @@ interface VideoOperationsPanelProps {
   isGenerating: boolean;
   /** 估价用的后端模型 ID；模型目录加载中 / fallback 时为 null（暂不发估价请求）。 */
   videoBackendForCost: string | null;
+  videoInputPresent: boolean;
+  videoInputBillingReady: boolean;
+  inputVideoDurationSeconds: number;
   submitDisabled: boolean;
   selectedModelReferenceError: string | null;
   mediaRejectionReason: string | null;
@@ -254,6 +257,9 @@ export function VideoOperationsPanel({
   prompt,
   isGenerating,
   videoBackendForCost,
+  videoInputPresent,
+  videoInputBillingReady,
+  inputVideoDurationSeconds,
   submitDisabled,
   selectedModelReferenceError,
   mediaRejectionReason,
@@ -325,12 +331,22 @@ export function VideoOperationsPanel({
     const debouncedQuality = useDebouncedValue(quality, 350);
     const debouncedCount = useDebouncedValue(count, 350);
     const debouncedDurationSec = useDebouncedValue(durationSec, 350);
+    const debouncedVideoInputPresent = useDebouncedValue(
+      videoInputPresent,
+      350,
+    );
+    const debouncedInputVideoDuration = useDebouncedValue(
+      inputVideoDurationSeconds,
+      350,
+    );
     const videoCount = Math.min(Math.max(debouncedCount, 1), 4);
     const videoPricingQuantity =
       videoCount * debouncedDurationSec;
     const videoCreditCost = useGenerationCreditCost(
       "feature",
-      debouncedBackend ? VIDEO_GENERATE_FEATURE_KEY : null,
+      debouncedBackend && videoInputBillingReady
+        ? VIDEO_GENERATE_FEATURE_KEY
+        : null,
       {
         surface: "canvas",
         params: {
@@ -340,6 +356,8 @@ export function VideoOperationsPanel({
           pricing_quantity: videoPricingQuantity,
           operation: genMode,
           generate_audio: generateAudio,
+          video_input_present: debouncedVideoInputPresent,
+          input_video_duration_seconds: debouncedInputVideoDuration,
         },
         quantity: videoCount,
       },

--- a/license-inventory.csv
+++ b/license-inventory.csv
@@ -1635,6 +1635,7 @@ src/novelvideo/verification/trace_ids.py,Elastic-2.0,2026 SuperTale contributors
 src/novelvideo/verification/training_db.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 src/novelvideo/verification/utils.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 src/novelvideo/verification/version_hash.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
+src/novelvideo/video_billing.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 src/novelvideo/video_duration.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 src/novelvideo/video_request_usage.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 src/novelvideo/workflows/__init__.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
@@ -1865,6 +1866,7 @@ tests/test_task_video_global_optimizer_lifecycle.py,Elastic-2.0,2026 SuperTale c
 tests/test_task_video_runner_returned_last_frame.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_tasks_stream_list.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_upload_sanitization.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
+tests/test_video_billing.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_video_composer_result_contract.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_video_pool_static_urls.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_wysiwyg_consistency.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation

--- a/src/novelvideo/api/routes/freezone.py
+++ b/src/novelvideo/api/routes/freezone.py
@@ -279,6 +279,7 @@ from novelvideo.task_identity import (
     task_config_scope,
     task_state_key,
 )
+from novelvideo.video_billing import probe_total_video_duration_seconds
 from novelvideo.task_state import get_task_manager
 from novelvideo.utils.background_anchor import copy_to_beat_selected_background
 from novelvideo.utils.document_parsers import count_billable_text_chars
@@ -367,6 +368,20 @@ async def _start_or_enqueue_freezone_video_gen(
         freezone_video_generate_task_billing,
     )
 
+    video_input_paths = [
+        str(item.get("path") or "").strip()
+        for item in reference_items
+        if str(item.get("type") or "").strip().lower() == "video"
+        and str(item.get("path") or "").strip()
+    ]
+    try:
+        input_video_duration_seconds = await probe_total_video_duration_seconds(
+            video_input_paths
+        )
+    except (OSError, ValueError) as exc:
+        raise HTTPException(
+            400, f"unable to read reference video duration: {exc}"
+        ) from exc
     billing = freezone_video_generate_task_billing(
         {
             "video_backend": backend,
@@ -374,6 +389,8 @@ async def _start_or_enqueue_freezone_video_gen(
             "pricing_quantity": duration_seconds,
             "operation": gen_mode or "textToVideo",
             "generate_audio": generate_audio,
+            "video_input_present": bool(video_input_paths),
+            "input_video_duration_seconds": input_video_duration_seconds,
             **({"catalog_id": catalog_id} if catalog_id else {}),
         }
     )

--- a/src/novelvideo/api/routes/model_credits.py
+++ b/src/novelvideo/api/routes/model_credits.py
@@ -1,6 +1,7 @@
 """Generation credit cost lookup for the main application."""
 
 import json
+import math
 import os
 from typing import Literal
 
@@ -354,7 +355,11 @@ def _image_selection_billing_params(
 
 def _video_backend_billing_params(params: dict) -> dict:
     resolution = str(params.get("resolution") or "").strip()
-    return {"resolution": resolution} if resolution else {}
+    has_video_input = params.get("video_input_present") is True
+    result = {"video_input": "present" if has_video_input else "none"}
+    if resolution:
+        result["resolution"] = resolution
+    return result
 
 
 def _video_backend_feature_billing_params(params: dict) -> dict:
@@ -367,12 +372,26 @@ def _video_backend_feature_billing_params(params: dict) -> dict:
     # resolved server-side so callers cannot pair cheap pricing with another
     # provider model.
     pricing_model = _video_backend_cost_model(video_backend)
-    pricing_quantity = normalize_video_duration_for_backend(
+    output_duration = normalize_video_duration_for_backend(
         video_backend,
         params.get("pricing_quantity"),
     )
+    has_video_input = params.get("video_input_present") is True
+    try:
+        input_video_duration = max(
+            float(params.get("input_video_duration_seconds") or 0),
+            0.0,
+        )
+    except (TypeError, ValueError):
+        input_video_duration = 0.0
+    input_video_billed_seconds = (
+        math.floor(input_video_duration) if has_video_input else 0
+    )
+    pricing_quantity = output_duration + input_video_billed_seconds
     return {
         **params,
+        "video_input_present": has_video_input,
+        "input_video_duration_seconds": input_video_duration,
         "pricing_kind": "video",
         "pricing_model": pricing_model,
         "pricing_params": _video_backend_billing_params(params),
@@ -381,6 +400,9 @@ def _video_backend_feature_billing_params(params: dict) -> dict:
             "call_count": 1,
             "item_count": 1,
             "duration_seconds": pricing_quantity,
+            "output_duration_seconds": output_duration,
+            "input_video_duration_ms": round(input_video_duration * 1000),
+            "input_video_billed_seconds": input_video_billed_seconds,
         },
         "pricing_model_selection": video_backend,
     }
@@ -831,6 +853,12 @@ def _default_billing_params(
             if str(resolved.get("pricing_kind") or "").strip() == "video":
                 per_call_duration = max(int(metrics.get("duration_seconds") or 0), 1)
                 metrics["duration_seconds"] = per_call_duration * action_count
+                for key in (
+                    "output_duration_seconds",
+                    "input_video_duration_ms",
+                    "input_video_billed_seconds",
+                ):
+                    metrics[key] = max(int(metrics.get(key) or 0), 0) * action_count
         return {**resolved, "pricing_metrics": metrics}
 
     if surface == "canvas":

--- a/src/novelvideo/media_model_request_schema.py
+++ b/src/novelvideo/media_model_request_schema.py
@@ -286,6 +286,18 @@ def validate_media_model_catalog_config(
         if value is not None and (type(value) is not int or value < 0):
             raise MediaModelSchemaError(f"{field} must be a non-negative integer")
 
+    if media_type == "video":
+        video_limit = config.get("referenceVideoMax")
+        configured_modes = set(modes or [])
+        if (
+            type(video_limit) is int
+            and video_limit > 0
+            and not configured_modes.intersection({"all_reference", "video_edit"})
+        ):
+            raise MediaModelSchemaError(
+                "referenceVideoMax requires all_reference or video_edit mode"
+            )
+
     min_pixels = config.get("minPixels")
     if min_pixels is not None and (
         type(min_pixels) is not int

--- a/src/novelvideo/video_billing.py
+++ b/src/novelvideo/video_billing.py
@@ -1,0 +1,56 @@
+"""Server-authoritative billing metrics for reference-video generation."""
+
+from __future__ import annotations
+
+import asyncio
+import math
+import subprocess
+from collections.abc import Iterable
+
+
+async def probe_video_duration_seconds(path: str) -> float:
+    """Read one input video's real duration with ffprobe.
+
+    Billing must not trust a duration supplied by the browser. The API resolves
+    project-local URLs first and calls this helper before reserving credits.
+    """
+
+    def _probe() -> float:
+        result = subprocess.run(
+            [
+                "ffprobe",
+                "-v",
+                "error",
+                "-show_entries",
+                "format=duration",
+                "-of",
+                "default=noprint_wrappers=1:nokey=1",
+                path,
+            ],
+            capture_output=True,
+            text=True,
+            timeout=120,
+            check=False,
+        )
+        if result.returncode != 0:
+            detail = (result.stderr or "").strip()[-500:]
+            raise ValueError(detail or "ffprobe could not read video duration")
+        try:
+            duration = float((result.stdout or "").strip())
+        except ValueError as exc:
+            raise ValueError("ffprobe returned an invalid video duration") from exc
+        if not math.isfinite(duration) or duration <= 0:
+            raise ValueError("video duration must be positive")
+        return duration
+
+    return await asyncio.to_thread(_probe)
+
+
+async def probe_total_video_duration_seconds(paths: Iterable[str]) -> float:
+    clean_paths = [str(path or "").strip() for path in paths if str(path or "").strip()]
+    if not clean_paths:
+        return 0.0
+    durations = await asyncio.gather(
+        *(probe_video_duration_seconds(path) for path in clean_paths)
+    )
+    return sum(durations)

--- a/tests/test_api_audio_indextts2_cutover.py
+++ b/tests/test_api_audio_indextts2_cutover.py
@@ -472,15 +472,20 @@ async def test_seedance2_single_video_passes_prepared_config_and_duration(
         "pricing_kind": "video",
         "pricing_model": "seedance-2.0-fast",
         "pricing_model_selection": "huimeng_seedance-2.0-fast",
-        "pricing_params": {"resolution": "720p"},
+        "pricing_params": {"resolution": "720p", "video_input": "none"},
         "pricing_quantity": 11,
         "pricing_metrics": {
             "call_count": 1,
             "item_count": 1,
             "duration_seconds": 11,
+            "output_duration_seconds": 11,
+            "input_video_duration_ms": 0,
+            "input_video_billed_seconds": 0,
         },
         "resolution": "720p",
         "video_backend": "huimeng_seedance-2.0-fast",
+        "video_input_present": False,
+        "input_video_duration_seconds": 0.0,
     }
 
 

--- a/tests/test_api_model_credit_cost.py
+++ b/tests/test_api_model_credit_cost.py
@@ -42,10 +42,23 @@ def patch_quote_expect(
         pricing_kind = expected_params.get("pricing_kind")
         pricing_quantity = int(expected_params.get("pricing_quantity") or 1)
         if pricing_kind == "video":
+            input_video_duration = float(
+                expected_params.get("input_video_duration_seconds") or 0
+            )
+            input_video_billed_seconds = (
+                int(input_video_duration)
+                if expected_params.get("video_input_present")
+                else 0
+            )
             metrics = {
                 "call_count": 1,
                 "item_count": 1,
                 "duration_seconds": pricing_quantity,
+                "output_duration_seconds": (
+                    pricing_quantity - input_video_billed_seconds
+                ),
+                "input_video_duration_ms": round(input_video_duration * 1000),
+                "input_video_billed_seconds": input_video_billed_seconds,
             }
         elif pricing_kind == "audio" and "billable_chars" in expected_params:
             metrics = {
@@ -921,7 +934,7 @@ async def test_generation_credit_cost_route_keeps_video_params_and_quantity(
         model_credits,
         expected_kind="video",
         expected_model="seedance-1.0-pro-fast",
-        expected_params={"resolution": "720p"},
+        expected_params={"resolution": "720p", "video_input": "none"},
         expected_quantity=5,
         cost=25,
     )
@@ -952,8 +965,10 @@ async def test_generation_credit_cost_route_prices_video_feature_by_backend_and_
             "pricing_kind": "video",
             "pricing_model": "seedance-1.0-pro-fast",
             "pricing_model_selection": "newapi_seedance-1.0-pro-fast",
-            "pricing_params": {"resolution": "720p"},
+            "pricing_params": {"resolution": "720p", "video_input": "none"},
             "pricing_quantity": 5,
+            "video_input_present": False,
+            "input_video_duration_seconds": 0.0,
             "resolution": "720p",
             "video_backend": "newapi_seedance-1.0-pro-fast",
         },
@@ -1010,6 +1025,36 @@ def test_video_feature_billing_ignores_client_pricing_model_override():
     assert billing["pricing_quantity"] == 12
 
 
+def test_video_feature_billing_combines_output_with_total_input_duration():
+    from novelvideo.api.routes.model_credits import (
+        _video_backend_feature_billing_params,
+    )
+
+    billing = _video_backend_feature_billing_params(
+        {
+            "video_backend": "newapi_seedance-2.0",
+            "resolution": "720p",
+            "pricing_quantity": 12,
+            "video_input_present": True,
+            "input_video_duration_seconds": 11.95,
+        }
+    )
+
+    assert billing["pricing_params"] == {
+        "resolution": "720p",
+        "video_input": "present",
+    }
+    assert billing["pricing_quantity"] == 23
+    assert billing["pricing_metrics"] == {
+        "call_count": 1,
+        "item_count": 1,
+        "duration_seconds": 23,
+        "output_duration_seconds": 12,
+        "input_video_duration_ms": 11950,
+        "input_video_billed_seconds": 11,
+    }
+
+
 @pytest.mark.asyncio
 async def test_generation_credit_cost_route_prices_freezone_video_generate_by_feature(
     monkeypatch,
@@ -1029,8 +1074,10 @@ async def test_generation_credit_cost_route_prices_freezone_video_generate_by_fe
             "generate_audio": True,
             "pricing_kind": "video",
             "pricing_model": "seedance-1.0-pro-fast",
-            "pricing_params": {"resolution": "1080p"},
+            "pricing_params": {"resolution": "1080p", "video_input": "none"},
             "pricing_model_selection": "newapi_seedance-1.0-pro-fast",
+            "video_input_present": False,
+            "input_video_duration_seconds": 0.0,
         },
         expected_quantity=1,
         cost=48,
@@ -1088,6 +1135,9 @@ async def test_generation_credit_cost_route_prices_video_batch_by_calls_and_tota
         "call_count": 3,
         "item_count": 3,
         "duration_seconds": 15,
+        "output_duration_seconds": 15,
+        "input_video_duration_ms": 0,
+        "input_video_billed_seconds": 0,
     }
     assert captured["quantity"] == 3
 

--- a/tests/test_freezone_image_backend.py
+++ b/tests/test_freezone_image_backend.py
@@ -419,14 +419,80 @@ async def test_freezone_video_generation_enqueues_feature_billing(
         "generate_audio": True,
         "pricing_kind": "video",
         "pricing_model": "seedance-1.0-pro-fast",
-        "pricing_params": {"resolution": "1080p"},
+        "pricing_params": {"resolution": "1080p", "video_input": "none"},
         "pricing_metrics": {
             "call_count": 1,
             "item_count": 1,
             "duration_seconds": 8,
+            "output_duration_seconds": 8,
+            "input_video_duration_ms": 0,
+            "input_video_billed_seconds": 0,
         },
         "pricing_model_selection": "newapi_seedance-1.0-pro-fast",
+        "video_input_present": False,
+        "input_video_duration_seconds": 0.0,
     }
+
+
+@pytest.mark.asyncio
+async def test_freezone_video_generation_probes_reference_duration_before_billing(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    captured: dict[str, object] = {}
+
+    async def fake_enqueue_project_task(_ctx: ProjectContext, **kwargs):
+        captured.update(kwargs)
+        return SimpleNamespace(
+            task_state=SimpleNamespace(task_id="task_video_ref"),
+            backend="celery",
+            queue="node.node_a.video",
+        )
+
+    async def fake_probe(paths):
+        assert list(paths) == ["/project/a.mp4", "/project/b.mp4"]
+        return 11.95
+
+    monkeypatch.setattr(
+        freezone_routes,
+        "get_task_backend",
+        lambda: SimpleNamespace(enqueue_project_task=fake_enqueue_project_task),
+    )
+    monkeypatch.setattr(
+        freezone_routes,
+        "probe_total_video_duration_seconds",
+        fake_probe,
+    )
+
+    await freezone_routes._start_or_enqueue_freezone_video_gen(
+        ctx=_project_ctx(tmp_path),
+        username="admin",
+        project="demo",
+        project_dir=tmp_path / "project",
+        output_dir=str(tmp_path / "output"),
+        job_id="job_video_ref",
+        prompt="参考视频生成",
+        reference_items=[
+            {"type": "video", "path": "/project/a.mp4"},
+            {"type": "video", "path": "/project/b.mp4"},
+        ],
+        aspect_ratio="16:9",
+        resolution="720p",
+        duration_seconds=12,
+        generate_audio=False,
+        human_review=False,
+        scene_optimize=None,
+        backend="newapi_seedance-2.0",
+        gen_mode="allReference",
+    )
+
+    billing = captured["payload"]["billing"]
+    assert billing["pricing_params"] == {
+        "resolution": "720p",
+        "video_input": "present",
+    }
+    assert billing["pricing_quantity"] == 23
+    assert billing["pricing_metrics"]["input_video_billed_seconds"] == 11
 
 
 @pytest.mark.asyncio

--- a/tests/test_media_model_request_schema.py
+++ b/tests/test_media_model_request_schema.py
@@ -213,6 +213,11 @@ def test_validates_media_catalog_capabilities():
             {**valid, "supportedModes": ["unknown_mode"]},
             "video",
         )
+    with pytest.raises(MediaModelSchemaError, match="referenceVideoMax requires"):
+        validate_media_model_catalog_config(
+            {**valid, "supportedModes": ["text_to_video"]},
+            "video",
+        )
 
 
 def test_catalog_config_rejects_endpoint_for_other_media_type():

--- a/tests/test_video_billing.py
+++ b/tests/test_video_billing.py
@@ -1,0 +1,39 @@
+from types import SimpleNamespace
+
+import pytest
+
+from novelvideo import video_billing
+
+
+@pytest.mark.asyncio
+async def test_probe_total_video_duration_sums_raw_durations_before_billing_rounding(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    durations = {"a.mp4": 7.05, "b.mp4": 4.9}
+
+    async def fake_probe(path: str) -> float:
+        return durations[path]
+
+    monkeypatch.setattr(video_billing, "probe_video_duration_seconds", fake_probe)
+
+    assert await video_billing.probe_total_video_duration_seconds(
+        ["a.mp4", "b.mp4"]
+    ) == pytest.approx(11.95)
+
+
+@pytest.mark.asyncio
+async def test_probe_video_duration_rejects_non_finite_value(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        video_billing.subprocess,
+        "run",
+        lambda *_args, **_kwargs: SimpleNamespace(
+            returncode=0,
+            stdout="Infinity\n",
+            stderr="",
+        ),
+    )
+
+    with pytest.raises(ValueError, match="positive"):
+        await video_billing.probe_video_duration_seconds("broken.mp4")


### PR DESCRIPTION
## 背景

支持视频参考/视频编辑的模型会产生输入视频成本，但此前报价只携带输出时长，前端展示与实际成本无法区分。

## 改动

- 服务端统一识别视频输入模式，规范化输出时长和输入视频计费时长。
- Freezone 报价和任务提交携带相同的视频输入计费参数。
- 画布视频节点汇总实际连接的视频时长；时长未就绪时不发送误导性报价。
- 适配最新 `VideoOperationsPanel` 架构，并同步错误态重试的计费闸门。
- 补充视频计费、请求协议和画布计费契约回归测试。

## 配套依赖

- 依赖 SuperTale 同名分支提供 `0032_video_input_pricing` 与新报价契约。

## 验证

- Python 定向测试：`270 passed`
- 画布视频计费契约：`3 passed`
- CE 前端生产构建通过
- Ruff 与 DCO 本地检查通过

