### PR TITLE
chore: release v1.3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "supertale-ce"
-version = "1.2.1"
+version = "1.3.0"
 description = "SuperTale Community Edition API and video pipeline"
 readme = "README.md"
 requires-python = ">=3.11,<3.13"

--- a/src/novelvideo/release-notes.md
+++ b/src/novelvideo/release-notes.md
@@ -1,33 +1,55 @@
 ---
-version: 1.2.1
+version: 1.3.0
 attention: low
 ---
-# v1.2.1
+# v1.3.0
 
 ## User-facing Highlights (zh)
 
-- **媒体生成参数更可靠**: 视频比例、分辨率和模型专用参数会完整传递,并修正 2K、4K 等尺寸换算及积分不足提示。
-- **小说导入进度更清晰**: 构建知识图谱时持续展示当前阶段、完成比例和已用时间,长时间导入不再像卡住一样。
-- **旧项目规划兼容性提升**: 无标准场景标题的历史剧本也可重新规划场景,Beat 生成与资产规划统一使用当前制作正文。
-- **任务与积分界面更稳定**: 修复草图编辑进度回退,积分中心改为更清晰的中性配色并让记录表格独立滚动。
+- **模型能力统一管理**: CE 新增模型渠道与能力配置,图片和视频模型、参数及素材连线上限统一由后台下发,不再依赖前端内置清单。
+- **官方配置内置 MiniMax-H3**: 使用官方配置时可直接选择 MiniMax-H3 视频模型,支持文生视频、首帧、首尾帧、图片参考和全能参考等生成模式。
+- **接入本地 ComfyUI**: 自定义与本地加官方混合模式均可连接本地 ComfyUI,配置 API Format Workflow,并让指定视频模型走本地生成而其他模型继续使用 RelayClaw。
+- **部署本地 MiniMax H3 视频模型**: 提供 MiniMax H3 文生视频、图生视频和参考生视频 Workflow 初始模板,可按本机 ComfyUI 节点与模型文件调整后接入画布。
+- **视频素材与计费更准确**: 修正视频生成模式语义和参考素材限制,补齐参考音频总时长校验,支持按视频输入量计费,并让主线与画布应用各自正确的促销报价。
+- **画布与任务体验升级**: 大型画布平移采用轻量 LOD,视频节点面板完成拆分,同时修复小地图拖动、任务进度卡住、等待超时和主动终止提示。
+- **自托管数据更可靠**: Docker 部署持久化生成媒体并中转远程资产,备份同步前先快照可变状态,降低重启、外链失效或同步竞争造成的数据风险。
+- **生成结果更稳定**: 优化结构化输出、视频 Beat、角色身份和官方风格提示,单行脚本失败时继续处理其余内容,并补充旁白与参考音频前置校验。
 
 ## User-facing Highlights (en)
 
-- **More reliable media parameters**: Video ratios, resolutions, and model-specific options are preserved, with corrected 2K/4K sizing and clearer insufficient-credit errors.
-- **Clearer novel import progress**: Knowledge-graph imports now show live stages, percentage, and elapsed time so long-running work no longer appears stalled.
-- **Better compatibility for existing projects**: Legacy scripts without standard scene headings can be planned again, while Beat generation and asset planning use the same production text.
-- **More stable task and credit screens**: Sketch-edit progress no longer jumps backward, and the credit center gains clearer neutral styling with an independently scrolling history table.
+- **Unified model capability management**: CE now manages model channels and capabilities, with image/video models, parameters, and reference limits delivered by the backend instead of a hard-coded frontend catalog.
+- **MiniMax-H3 built into the official profile**: MiniMax-H3 is directly selectable with the official configuration, supporting text-to-video, first-frame, first/last-frame, image-reference, and all-reference generation modes.
+- **Connect local ComfyUI**: Custom and Local + Official Hybrid modes can connect to a local ComfyUI service, configure API Format workflows, and route selected video models locally while other models continue through RelayClaw.
+- **Deploy a local MiniMax H3 video model**: Starter workflows are provided for MiniMax H3 text-to-video, image-to-video, and reference-to-video, ready to adapt to locally installed ComfyUI nodes and model files.
+- **More accurate video references and billing**: Video generation modes and reference limits are corrected, total reference-audio duration is validated, pricing can account for video input, and promotional quotes use the correct mainline or canvas context.
+- **Upgraded canvas and task experience**: Large canvases use lightweight LOD while panning, the video node panel is split out, and minimap dragging, stuck progress, timeout, and cancellation feedback are fixed.
+- **More reliable self-hosted data**: Docker deployments persist generated media and relay remote assets, while backup sync snapshots mutable state first to reduce restart, expired-link, and synchronization risks.
+- **More stable generation results**: Structured output, video beat, character identity, and official style prompts are refined; isolated script-line failures no longer abort the rest, with stronger narrator and reference-audio validation.
+
+## New Features
+
+- CE 新增模型渠道与能力管理,并由后台统一下发图片/视频模型配置、参数和素材上限 (#251, #254).
+- 官方配置内置 MiniMax-H3 视频模型及常用生成模式,无需额外创建媒体模型配置 (#254).
+- 自定义与本地加官方混合模式支持接入本地 ComfyUI,并提供 MiniMax H3 文生视频、图生视频和参考生视频 Workflow 初始模板 (#254).
+- 支持依据视频输入量计算生成费用,并补充产品功能可见性与计费上下文 (#249, #258).
 
 ## Bug Fixes
 
-- 修复 NewAPI 视频请求丢失比例、分辨率和模型专用参数的问题,并修正 2K、4K 尺寸换算及积分不足提示 (#235).
-- 修复知识图谱导入期间普通日志导致进度归零的问题,新增实时阶段和计时展示 (#232).
-- 修复历史剧本缺少标准场景标题时无法重新规划场景的问题 (#230).
-- 统一 Beat 生成与资产规划的制作正文来源,避免跳过改编稿 (#231).
-- 修复草图编辑任务在输出日志时进度条回退到零的问题 (#233).
+- 修复 EE 下全能参考被错误拦截及节点进度停在 96% 的问题 (#245).
+- 修复前端任务等待预算与后端上限不一致导致的过早超时 (#242).
+- 修复主动终止任务成功后仍显示错误提示的问题 (#243).
+- 修复换图后图片节点继续显示旧失败横幅的问题 (#224).
+- 修复结构化输出启用推理模式导致的兼容性问题 (#248).
+- 单行模型输出失败时继续处理其余脚本内容,避免整批任务中断 (#244).
+- 修正视频生成模式语义、素材模式和素材连线上限 (#253, #255).
+- 修复参考音频总时长与旁白音色前置条件缺少校验的问题 (#260, #262).
+- 修复小地图拖动增益随视口偏移持续放大的问题 (#259).
+- 修复备份同步期间可变状态不一致的问题 (#261).
+- 修正视频 Beat、国漫角色身份及官方风格提示的内容污染问题 (#263, #264, #265).
+- 修复主线与画布生成报价缺少产品入口上下文,导致促销价格应用不准确的问题 (#266).
 
 ## Improvements
 
-- 移除 Beat 脚本流程中未使用的旧图谱工具和重复状态加载,保持现有生成行为不变 (#234).
-- 优化积分中心配色、筛选控件及长列表滚动体验 (#237).
-- 虾导入口暂时显示升级提示,避免用户进入尚未完成的功能 (#216).
+- 为大型画布增加平移 LOD 外壳,并拆分视频节点操作面板以降低渲染开销 (#241).
+- Docker 部署持久化生成媒体,并支持中转保存 Cloudinary 等远程资产 (#247).
+- 按实际交付结果结算积分并发送带类型的计费数量,提高计费记录准确性 (#239, #240).

--- a/tests/test_release_feed.py
+++ b/tests/test_release_feed.py
@@ -114,7 +114,7 @@ def test_built_wheel_contains_parseable_release_notes_artifact(tmp_path: Path) -
 def test_project_version_is_single_source_of_truth() -> None:
     pyproject = tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))
 
-    assert pyproject["project"]["version"] == "1.2.1"
+    assert pyproject["project"]["version"] == "1.3.0"
     assert importlib.metadata.version("supertale-ce") == pyproject["project"]["version"]
     assert "__version__" not in Path("src/novelvideo/__init__.py").read_text(encoding="utf-8")
 

--- a/uv.lock
+++ b/uv.lock
@@ -3419,7 +3419,7 @@ wheels = [
 
 [[package]]
 name = "supertale-ce"
-version = "1.2.1"
+version = "1.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## PR 类型 / Type of PR
- [ ] 🐞 Bug 修复 / Bug fix
- [x] ✨ 新功能 / Feature
- [x] 📝 文档 / Documentation
- [ ] 🧹 重构 / 清理 / Refactor or cleanup
- [x] ⚙️ 构建 / CI / Build or CI
- [ ] ⚠️ 破坏性变更 / Breaking change

## 改动说明 / What this PR does and why
准备 Dramaclaw v1.3.0 发布元数据。由于本版本引入官方配置内置 MiniMax-H3、本地 ComfyUI 接入、MiniMax H3 本地视频生成模板、模型渠道与能力管理、后台驱动的媒体模型配置和视频输入计费等较多新特性，版本由原计划的 v1.2.2 调整为 v1.3.0。

- 将项目版本从 `1.2.1` 更新为 `1.3.0`
- 同步版本单源测试与 `uv.lock`
- 按发布规范重写中英文包内 release notes
- release notes 汇总 `v1.2.1..268d6035` 的 27 个已合入提交

本 PR 仅准备发布版本，审核合入后再单独创建 `v1.3.0` tag 和 GitHub Release。

## 关联 issue / Linked issues
N/A

## 给 reviewer 的说明 / Notes for the reviewer
请重点审核中英文 Highlights 是否准确区分以下 MiniMax-H3 使用方式：

- 官方配置已经内置 MiniMax-H3，可直接选择官方模型及其常用生成模式
- 自定义与本地加官方混合模式可以接入本地 ComfyUI
- 本地 MiniMax H3 提供文生视频、图生视频和参考生视频 Workflow 初始模板，但用户仍需自行安装 ComfyUI 节点和模型文件

其他 Highlights 覆盖模型能力管理、视频素材与计费、画布与任务体验、自托管可靠性和生成质量。最新基线还包含主线与画布促销报价产品上下文修复 (#266)。

发布分支已 rebase 到远端 `main` 的 `268d6035`。分支名保留历史名称 `agent/release-v1.2.2` 以维持现有 PR 审核记录；实际项目版本、提交、PR 标题及后续 tag 均为 v1.3.0。

本 PR 不包含 tag、GitHub Release 或镜像发布操作。

## 面向用户的变更 / User-facing change
```release-note
v1.3.0 includes MiniMax-H3 in the official profile and adds local ComfyUI integration with MiniMax H3 starter workflows, alongside unified model capability management and major canvas, task, self-hosting, billing, and generation reliability improvements.
```

## 自检 / Checklist
- [ ] 已自测，`uv run pytest` 通过 / Self-tested, `uv run pytest` passes
- [x] 必要的文档已更新 / Docs updated where needed
- [x] 提交信息清晰（建议 Conventional Commits）/ Clear commits (Conventional Commits suggested)
- [x] 每个 commit 都已 `git commit -s` 附 DCO 签署 / Every commit signed off with `git commit -s` (DCO)
- [ ] 我已阅读并同意[贡献者协议](../CONTRIBUTING.md#贡献者协议) / I've read and agree to the [contributor terms](../CONTRIBUTING.md#贡献者协议)

## Verification
- `UV_CACHE_DIR=/Users/newyue/claymorelab/.uv-cache uv lock --check`
- `git diff --check`
- `UV_CACHE_DIR=/Users/newyue/claymorelab/.uv-cache uv run pytest tests/test_release_feed.py` — 12 passed, 16 warnings
