### PR TITLE
refactor(seedance2): return prompt as plain text

### DIFF
--- a/src/novelvideo/seedance2_i2v/pipeline.py
+++ b/src/novelvideo/seedance2_i2v/pipeline.py
@@ -21,7 +21,7 @@ from novelvideo.seedance2_i2v.models import (
     dump_seedance2_config,
     parse_seedance2_config,
 )
-from novelvideo.seedance2_i2v.spoken_dialogue import parse_seedance2_spoken_lines
+from novelvideo.seedance2_i2v.spoken_dialogue import required_seedance2_dialogue_texts
 from novelvideo.seedance2_i2v.voice_clone import normalize_seedance2_audio_type
 
 SEEDANCE2_HUIMENG_BACKEND = "huimeng_seedance-2.0-fast"
@@ -137,15 +137,12 @@ def _validate_dialogue_final_prompt(
     if normalize_seedance2_audio_type(beat) != "dialogue":
         return
 
-    lines = parse_seedance2_spoken_lines(beat)
-    if not lines:
-        return
-
+    required_texts = required_seedance2_dialogue_texts(beat)
     prompt_text = _compact_text(final_prompt)
     missing_lines = [
-        line.text
-        for line in lines
-        if _compact_text(line.text) and _compact_text(line.text) not in prompt_text
+        text
+        for text in required_texts
+        if _compact_text(text) and _compact_text(text) not in prompt_text
     ]
     if missing_lines:
         raise ValueError(

--- a/src/novelvideo/seedance2_i2v/prompt.py
+++ b/src/novelvideo/seedance2_i2v/prompt.py
@@ -8,20 +8,9 @@ import re
 from dataclasses import dataclass
 from typing import Any, Awaitable, Callable
 
-from pydantic import BaseModel, Field
-
 from novelvideo.models import beat_scene_ref, real_detected_identities, real_detected_props
 from novelvideo.seedance2_i2v.models import Seedance2I2VMode
-from novelvideo.seedance2_i2v.spoken_dialogue import (
-    parse_seedance2_spoken_lines,
-    speaker_display_name,
-)
-
-
-class Seedance2PromptComposerOutput(BaseModel):
-    """Structured output returned by the prompt composer agent."""
-
-    prompt: str = Field(default="", description="最终 Seedance 2.0 prompt")
+from novelvideo.seedance2_i2v.spoken_dialogue import speaker_display_name
 
 
 @dataclass(frozen=True)
@@ -245,46 +234,33 @@ def _prop_prompt_fallbacks(assets: list[Any] | None) -> dict[str, str]:
     return fallbacks
 
 
-def _voice_reference_labels(assets: list[Any] | None) -> dict[str, str]:
-    labels: dict[str, str] = {}
+def _beat_spoken_prompt_fragment(beat: dict[str, Any], assets: list[Any] | None) -> str:
+    spoken = _beat_spoken_text(beat)
+    if not spoken:
+        return ""
+
+    voice_references: list[str] = []
     for asset in _selected_assets(assets):
-        media_type = _text(_asset_value(asset, "media_type"))
-        reference_label = _text(_asset_value(asset, "reference_label"))
-        if media_type != "audio" or not reference_label.startswith("音频"):
+        label = _text(_asset_value(asset, "reference_label"))
+        if not label.startswith("音频"):
             continue
         identity_id = _text(_asset_value(asset, "identity_id"))
-        key = _text(_asset_value(asset, "key"))
-        if identity_id:
-            labels.setdefault(identity_id, reference_label)
-            labels.setdefault(speaker_display_name(identity_id), reference_label)
-        if key.startswith("voice:"):
-            key_id = key.split(":", 1)[1]
-            labels.setdefault(key_id, reference_label)
-            labels.setdefault(speaker_display_name(key_id), reference_label)
-    return labels
+        title = speaker_display_name(identity_id) or _text(_asset_value(asset, "label"))
+        voice_references.append(f"{title}参考{label}声线" if title else f"参考{label}声线")
 
-
-def _beat_spoken_prompt_fragment(beat: dict[str, Any], assets: list[Any] | None) -> str:
-    lines = parse_seedance2_spoken_lines(beat)
-    if not lines:
-        return _beat_spoken_text(beat)
-
-    voice_labels = _voice_reference_labels(assets)
-    fragments: list[str] = []
-    for line in lines:
-        speaker = speaker_display_name(line.speaker)
-        label = voice_labels.get(line.speaker) or voice_labels.get(speaker)
-        action = _sentence_text(line.action)
-        if action and label:
-            action_part = f"（{action}，参考{label}声线）"
-        elif action:
-            action_part = f"（{action}）"
-        elif label:
-            action_part = f"（参考{label}声线）"
-        else:
-            action_part = ""
-        fragments.append(f"{speaker}{action_part}说：“{_sentence_text(line.text)}”")
-    return "；".join(fragments)
+    speaker = speaker_display_name(_text(beat.get("speaker")))
+    context: list[str] = []
+    if speaker:
+        context.append(f"本 Beat 说话角色为{speaker}")
+    if voice_references:
+        context.append("声线对应：" + "、".join(dict.fromkeys(voice_references)))
+    context_text = "；".join(context)
+    if context_text:
+        context_text = f"；{context_text}"
+    return (
+        "原始对白与表演文本（请语义区分动作说明和实际说出的台词，"
+        f"实际台词必须逐字完整保留{context_text}）：{spoken}"
+    )
 
 
 def _text_with_identity_references(text: Any, assets: list[Any] | None) -> str:
@@ -555,7 +531,9 @@ def build_seedance2_prompt_composer_task(
         "- duration、resolution、ratio、generate_audio、return_last_frame、human_review "
         "只作为 API 请求参数，不要写进 prompt。\n"
         "- 如果用户写作要求和资产清单、道具 fallback 冲突，以资产清单和 fallback 为准。\n"
-        "- 输出字段 prompt 只放最终 prompt，不要解释。\n\n"
+        "- dialogue 或 narration_segment 属于对白时，请根据语义区分动作说明和实际说出的台词；"
+        "动作可自然改写，但实际台词必须逐字完整保留，不能删减或概括。\n"
+        "- 只输出最终 prompt，不要解释。\n\n"
         f"{json.dumps(payload, ensure_ascii=False, indent=2, default=str)}"
     )
 
@@ -563,10 +541,7 @@ def build_seedance2_prompt_composer_task(
 def create_seedance2_prompt_composer_agent():
     from pydantic_ai import Agent
 
-    from novelvideo.config import (
-        get_newapi_structured_output_model_settings,
-        get_newapi_text_pydantic_model,
-    )
+    from novelvideo.config import get_newapi_text_pydantic_model
 
     return Agent(
         get_newapi_text_pydantic_model(
@@ -574,9 +549,7 @@ def create_seedance2_prompt_composer_agent():
             "gemini-3.5-flash",
         ),
         system_prompt=SEEDANCE2_COMPOSER_SYSTEM_PROMPT,
-        model_settings=get_newapi_structured_output_model_settings(),
-        output_type=Seedance2PromptComposerOutput,
-        output_retries=2,
+        output_type=str,
         name="Seedance 2.0 Prompt Composer",
     )
 
@@ -605,7 +578,7 @@ async def compose_seedance2_prompt_with_agent(
             manual_prompt_reference=manual_prompt_reference,
         )
     )
-    prompt = normalize_seedance2_editor_prompt(result.output.prompt)
+    prompt = normalize_seedance2_editor_prompt(result.output)
     if not prompt:
         raise ValueError("AI composer returned an empty prompt")
     return prompt

--- a/src/novelvideo/seedance2_i2v/spoken_dialogue.py
+++ b/src/novelvideo/seedance2_i2v/spoken_dialogue.py
@@ -14,6 +14,9 @@ _SPEAKER_PREFIX_RE = re.compile(
     r"(?:（(?P<action>[^）]{0,120})）|\((?P<action_ascii>[^)]{0,120})\))?"
     r"\s*[：:]"
 )
+_LEADING_PERFORMANCE_NOTE_RE = re.compile(
+    r"^\s*(?:（[^）]{1,120}）|\([^)]{1,120}\))\s*"
+)
 
 
 @dataclass(frozen=True)
@@ -36,8 +39,8 @@ def _spoken_source(beat: dict[str, Any]) -> str:
 def parse_seedance2_spoken_lines(beat: dict[str, Any]) -> list[Seedance2SpokenLine]:
     """Parse dialogue text into speaker/action/text lines.
 
-    Supports literal script lines such as ``角色（动作）：台词``. Falls back to the
-    beat-level ``speaker`` when the text is plain dialogue.
+    Only parses explicit literal-script lines such as ``角色（动作）：台词``.
+    Ambiguous beat-level prose is left intact for the AI prompt composer.
     """
 
     if normalize_seedance2_audio_type(beat) != "dialogue":
@@ -65,11 +68,30 @@ def parse_seedance2_spoken_lines(beat: dict[str, Any]) -> list[Seedance2SpokenLi
     if lines:
         return lines
 
-    speaker = _text(beat.get("speaker"))
-    text = dialogue_text(beat)
-    if speaker and text:
-        return [Seedance2SpokenLine(speaker=speaker, text=text)]
     return []
+
+
+def required_seedance2_dialogue_texts(beat: dict[str, Any]) -> list[str]:
+    """Return the minimum verbatim dialogue required in the final prompt.
+
+    The AI composer still receives the untouched source and decides how to express
+    performance directions. This helper only unwraps one explicit leading
+    parenthetical note so validation does not confuse it with spoken dialogue.
+    """
+
+    lines = parse_seedance2_spoken_lines(beat)
+    if lines:
+        return [line.text for line in lines if line.text]
+
+    text = dialogue_text(beat).strip(" \t\r\n，,。；;")
+    if not text:
+        return []
+    leading_note = _LEADING_PERFORMANCE_NOTE_RE.match(text)
+    if leading_note:
+        spoken_text = text[leading_note.end() :].strip(" \t\r\n，,。；;")
+        if spoken_text:
+            text = spoken_text
+    return [text]
 
 
 def unique_seedance2_dialogue_speakers(beat: dict[str, Any]) -> list[str]:

--- a/tests/test_newapi_text_gateway.py
+++ b/tests/test_newapi_text_gateway.py
@@ -461,16 +461,11 @@ def test_seedance2_prompt_composer_uses_newapi_composer_model_env(monkeypatch):
     import novelvideo.seedance2_i2v.prompt as seedance2_prompt
 
     model_calls = []
-    settings_calls = []
     agent_kwargs = {}
 
     def fake_newapi_model(model_env, default_model):
         model_calls.append((model_env, default_model))
         return "composer-model"
-
-    def fake_settings():
-        settings_calls.append(())
-        return {"openai_reasoning_effort": "none"}
 
     class FakeAgent:
         def __init__(self, model, **kwargs):
@@ -478,18 +473,16 @@ def test_seedance2_prompt_composer_uses_newapi_composer_model_env(monkeypatch):
             agent_kwargs.update(kwargs)
 
     monkeypatch.setattr(config, "get_newapi_text_pydantic_model", fake_newapi_model)
-    monkeypatch.setattr(config, "get_newapi_structured_output_model_settings", fake_settings)
     monkeypatch.setattr("pydantic_ai.Agent", FakeAgent)
 
     seedance2_prompt.create_seedance2_prompt_composer_agent()
 
     assert model_calls == [("SEEDANCE2_PROMPT_COMPOSER_MODEL", "gemini-3.5-flash")]
-    assert settings_calls == [()]
     assert agent_kwargs["model"] == "composer-model"
-    assert agent_kwargs["model_settings"] == {"openai_reasoning_effort": "none"}
+    assert "model_settings" not in agent_kwargs
     assert agent_kwargs["name"] == "Seedance 2.0 Prompt Composer"
-    assert agent_kwargs["output_type"] is seedance2_prompt.Seedance2PromptComposerOutput
-    assert agent_kwargs["output_retries"] == 2
+    assert agent_kwargs["output_type"] is str
+    assert "output_retries" not in agent_kwargs
 
 
 def test_ai_identity_detector_keeps_legacy_global_video_model_fallback(monkeypatch):

--- a/tests/test_seedance2_prompt.py
+++ b/tests/test_seedance2_prompt.py
@@ -207,6 +207,129 @@ def test_seedance2_prompt_draft_binds_multi_speaker_dialogue_to_audio_labels():
     assert "你知道研发部的主管杜晨吗？" in prompt
 
 
+def test_seedance2_dialogue_draft_delegates_ambiguous_prose_to_ai():
+    from novelvideo.seedance2_i2v.assets import Seedance2ResolvedAsset
+    from novelvideo.seedance2_i2v.models import Seedance2I2VMode
+    from novelvideo.seedance2_i2v.prompt import build_seedance2_prompt_draft
+
+    beat = {
+        "audio_type": "dialogue",
+        "speaker": "丫鬟_青年时期",
+        "narration_segment": "（清脆出声，探头打趣）说起来你和赵小王爷长得一模一样。",
+    }
+    assets = [
+        Seedance2ResolvedAsset(
+            key="voice:丫鬟_青年时期",
+            label="丫鬟 · 青年时期声线",
+            media_type="audio",
+            path=Path("maid.mp3"),
+            exists=True,
+            selected=True,
+            request_field="reference_audios",
+            reference_label="音频1",
+            identity_id="丫鬟_青年时期",
+            audio_number=1,
+        )
+    ]
+
+    prompt = build_seedance2_prompt_draft(
+        mode=Seedance2I2VMode.MULTIMODAL_REFERENCE,
+        beat=beat,
+        assets=assets,
+        text_overlay={},
+        prompt_guidance="",
+    )
+
+    assert "请语义区分动作说明和实际说出的台词" in prompt
+    assert "实际台词必须逐字完整保留" in prompt
+    assert "本 Beat 说话角色为丫鬟" in prompt
+    assert "丫鬟参考音频1声线" in prompt
+    assert "（清脆出声，探头打趣）说起来你和赵小王爷长得一模一样。" in prompt
+
+
+def test_seedance2_dialogue_validation_checks_explicit_lines_and_audio_labels():
+    from novelvideo.seedance2_i2v.assets import Seedance2ResolvedAsset
+    from novelvideo.seedance2_i2v.pipeline import _validate_dialogue_final_prompt
+
+    beat = {
+        "audio_type": "dialogue",
+        "narration_segment": "丫鬟（清脆出声，探头打趣）：说起来你和赵小王爷长得一模一样。",
+    }
+    assets = [
+        Seedance2ResolvedAsset(
+            key="voice:丫鬟_青年时期",
+            label="丫鬟 · 青年时期声线",
+            media_type="audio",
+            path=Path("maid.mp3"),
+            exists=True,
+            selected=True,
+            request_field="reference_audios",
+            reference_label="音频1",
+            identity_id="丫鬟_青年时期",
+            audio_number=1,
+        )
+    ]
+
+    with pytest.raises(ValueError, match="Seedance2 最终提示词缺少台词内容"):
+        _validate_dialogue_final_prompt(
+            beat=beat,
+            final_prompt="丫鬟（清脆出声，探头打趣，参考音频1声线）看向对方。",
+            assets=assets,
+        )
+
+    with pytest.raises(ValueError, match="Seedance2 最终提示词缺少参考声线"):
+        _validate_dialogue_final_prompt(
+            beat={
+                "audio_type": "dialogue",
+                "speaker": "丫鬟_青年时期",
+                "narration_segment": "（清脆出声，探头打趣）说起来你和赵小王爷长得一模一样。",
+            },
+            final_prompt="丫鬟说：“说起来你和赵小王爷长得一模一样。”",
+            assets=assets,
+        )
+
+
+def test_seedance2_dialogue_validation_keeps_plain_beat_dialogue_required():
+    from novelvideo.seedance2_i2v.assets import Seedance2ResolvedAsset
+    from novelvideo.seedance2_i2v.pipeline import _validate_dialogue_final_prompt
+
+    beat = {
+        "audio_type": "dialogue",
+        "speaker": "丫鬟_青年时期",
+        "narration_segment": "（清脆出声，探头打趣）说起来你和赵小王爷长得一模一样。",
+    }
+    assets = [
+        Seedance2ResolvedAsset(
+            key="voice:丫鬟_青年时期",
+            label="丫鬟 · 青年时期声线",
+            media_type="audio",
+            path=Path("maid.mp3"),
+            exists=True,
+            selected=True,
+            request_field="reference_audios",
+            reference_label="音频1",
+            identity_id="丫鬟_青年时期",
+            audio_number=1,
+        )
+    ]
+
+    _validate_dialogue_final_prompt(
+        beat=beat,
+        final_prompt=(
+            "丫鬟（清脆出声，探头打趣，参考音频1声线）说："
+            "“说起来你和赵小王爷长得一模一样。”"
+        ),
+        assets=assets,
+    )
+
+    with pytest.raises(ValueError, match="Seedance2 最终提示词缺少台词内容"):
+        _validate_dialogue_final_prompt(
+            beat=beat,
+            final_prompt="丫鬟（清脆出声，探头打趣，参考音频1声线）看向对方。",
+            assets=assets,
+        )
+
+
 def test_seedance2_prompt_draft_can_use_narration_voice_reference():
     from novelvideo.seedance2_i2v.assets import Seedance2ResolvedAsset
     from novelvideo.seedance2_i2v.models import Seedance2I2VMode
@@ -509,6 +632,7 @@ def test_seedance2_prompt_composer_task_includes_scene_ref_and_dialogue_text():
     assert '"variant_id"' not in task
     assert '"dialogue": "谢铮低声说：' in task
     assert "别回头，跟我走" in task
+    assert "实际台词必须逐字完整保留" in task
 
 
 def test_seedance2_prompt_hash_ignores_request_only_video_params():
@@ -598,3 +722,32 @@ async def test_generate_seedance2_prompt_uses_ai_composer_before_fallback():
     assert result.prompt == "根据图片1生成官方风格视频。"
     assert result.used_ai is True
     assert result.error == ""
+
+
+async def test_seedance2_prompt_composer_accepts_plain_text_output(monkeypatch):
+    from types import SimpleNamespace
+
+    import novelvideo.seedance2_i2v.prompt as prompt_module
+    from novelvideo.seedance2_i2v.models import Seedance2I2VMode
+
+    class FakeAgent:
+        async def run(self, task):
+            assert "只输出最终 prompt" in task
+            return SimpleNamespace(output="  根据图片1生成一段电影感视频。  ")
+
+    monkeypatch.setattr(
+        prompt_module,
+        "create_seedance2_prompt_composer_agent",
+        lambda: FakeAgent(),
+    )
+
+    result = await prompt_module.compose_seedance2_prompt_with_agent(
+        mode=Seedance2I2VMode.MULTIMODAL_REFERENCE,
+        beat={"visual_description": "人物转身。"},
+        assets=[],
+        text_overlay={},
+        prompt_guidance="",
+        draft_prompt="人物转身。",
+    )
+
+    assert result == "根据图片1生成一段电影感视频。"


### PR DESCRIPTION
## 变更
- 将 Seedance 2.0 Prompt Composer 从单字段结构化输出改为普通文本
- 不再为该纯文本任务关闭推理或强制 tool call
- 保留 prompt 规范化、空结果失败与规则草稿回退

## 验证
- uv run ruff check src/novelvideo/seedance2_i2v/prompt.py tests/test_newapi_text_gateway.py tests/test_seedance2_prompt.py
- uv run pytest -q tests/test_newapi_text_gateway.py tests/test_seedance2_prompt.py tests/test_api_seedance2_prompt_route.py tests/test_seedance2_panel_service_narration_audio.py
- 43 passed

## 影响
只调整 Seedance 2.0 提示词生成的 LLM 输出协议，不修改视频生成、计费或前端 API 合同。