### PR TITLE
fix(canvas): 视频节点素材模式纠偏 + 素材连线上限

### DIFF
--- a/frontend/src/__tests__/features/canvas/canvas-manual-connect.test.tsx
+++ b/frontend/src/__tests__/features/canvas/canvas-manual-connect.test.tsx
@@ -473,3 +473,108 @@ describe("Canvas 拖线落点校验与建边判定对齐", () => {
     }
   });
 });
+
+// 素材上限(videoReferenceLimits)是后加的一条规则,同样必须两处同源:只在 onConnect
+// 里拦,用户会看见落点高亮成合法、松手却什么也没建;只在 isValidConnection 里拦,
+// 其它建边路径(资产拖入、菜单新建)照样能把第 10 张图连上去。
+describe("Canvas 素材上限在落点校验与建边判定上对齐", () => {
+  const IMAGE_CAP = 9;
+
+  function setupSaturatedVideo() {
+    const images = Array.from({ length: IMAGE_CAP + 1 }, (_, index) => ({
+      id: `image-${index}`,
+      type: CANVAS_NODE_TYPES.imageGen,
+      data: { imageUrl: `/i-${index}.png` },
+      position: { x: index * 300, y: 0 },
+    }));
+    const video = {
+      id: "video",
+      type: CANVAS_NODE_TYPES.video,
+      data: { videoUrl: "/v.mp4" },
+      position: { x: 0, y: 800 },
+    };
+    // 前 9 张已连上,第 10 张(image-9)是这次要拖的。
+    useCanvasStore.getState().setCanvasData(
+      [...images, video],
+      images.slice(0, IMAGE_CAP).map((node) => ({
+        id: `e-${node.id}`,
+        source: node.id,
+        target: video.id,
+        sourceHandle: "source",
+        targetHandle: "target",
+      })),
+    );
+  }
+
+  beforeEach(() => {
+    capturedOnConnect = null;
+    capturedReactFlowProps = null;
+    vi.stubGlobal("ResizeObserver", ResizeObserverMock);
+    setupSaturatedVideo();
+  });
+
+  it(`已连满 ${IMAGE_CAP} 张图时,第 ${IMAGE_CAP + 1} 张两处都拒绝`, async () => {
+    renderCanvas();
+    await waitFor(() => expect(capturedOnConnect).toBeTruthy());
+
+    const connection: Connection = {
+      source: `image-${IMAGE_CAP}`,
+      sourceHandle: "source",
+      target: "video",
+      targetHandle: "target",
+    };
+    const isValidConnection = capturedReactFlowProps?.isValidConnection as
+      | ((connection: Connection | Edge) => boolean)
+      | undefined;
+    const highlightedAsValid = isValidConnection?.(connection);
+
+    act(() => {
+      capturedOnConnect?.(connection);
+    });
+    const edgeCreated = useCanvasStore
+      .getState()
+      .edges.some((edge) => edge.source === connection.source && edge.target === "video");
+
+    expect({ highlightedAsValid, edgeCreated }).toEqual({
+      highlightedAsValid: false,
+      edgeCreated: false,
+    });
+    // 已有的 9 条不能被这次拒绝顺手带走。
+    expect(
+      useCanvasStore.getState().edges.filter((edge) => edge.target === "video"),
+    ).toHaveLength(IMAGE_CAP);
+  });
+
+  it(`没连满时(${IMAGE_CAP - 1} 张)两处都放行`, async () => {
+    act(() => {
+      useCanvasStore.setState((state) => ({
+        edges: state.edges.filter((edge) => edge.source !== `image-${IMAGE_CAP - 1}`),
+      }));
+    });
+    renderCanvas();
+    await waitFor(() => expect(capturedOnConnect).toBeTruthy());
+
+    const connection: Connection = {
+      source: `image-${IMAGE_CAP}`,
+      sourceHandle: "source",
+      target: "video",
+      targetHandle: "target",
+    };
+    const isValidConnection = capturedReactFlowProps?.isValidConnection as
+      | ((connection: Connection | Edge) => boolean)
+      | undefined;
+    const highlightedAsValid = isValidConnection?.(connection);
+
+    act(() => {
+      capturedOnConnect?.(connection);
+    });
+    const edgeCreated = useCanvasStore
+      .getState()
+      .edges.some((edge) => edge.source === connection.source && edge.target === "video");
+
+    expect({ highlightedAsValid, edgeCreated }).toEqual({
+      highlightedAsValid: true,
+      edgeCreated: true,
+    });
+  });
+});

--- a/frontend/src/__tests__/features/canvas/video-model-capabilities.test.ts
+++ b/frontend/src/__tests__/features/canvas/video-model-capabilities.test.ts
@@ -16,6 +16,7 @@ import {
   videoEmptyStateCtaModes,
   videoModeRequiresPrompt,
   videoModelReferenceDisabledReason,
+  videoMultiImageAutoSwitchMode,
   videoReferenceAutoSwitchAction,
   type VideoReferenceAutoSwitchAction,
   videoSubmitMediaRejectionReason,
@@ -187,6 +188,130 @@ describe("videoSubmitMediaRejectionReason — 提交前素材守卫 (P1/P2)", ()
     expect(
       videoSubmitMediaRejectionReason("imageReference", HAPPYHORSE, { images: 5, videos: 0, audios: 0 }),
     ).toBeNull();
+  });
+});
+
+describe("videoMultiImageAutoSwitchMode — 首帧接多图时的自动改模式", () => {
+  // 这条是 bug 本体：i2v 端点按图片张数分流（1 张 = 图生视频，2-9 张 = 图片参考），
+  // 接上第二张图后做的其实已经是图片参考了，界面上模式却还写着「首帧生成视频」。
+  it("Seedance 2.0：首帧接到第 2 张图 → 切全能参考", () => {
+    expect(videoMultiImageAutoSwitchMode("imageToVideo", SEEDANCE2_FAST, 2)).toBe(
+      "allReference",
+    );
+    expect(videoMultiImageAutoSwitchMode("imageToVideo", SEEDANCE2_VALUE, 9)).toBe(
+      "allReference",
+    );
+  });
+
+  it("单图 / 无图不动 —— 那正是首帧本来的用法", () => {
+    for (const images of [0, 1]) {
+      expect(
+        videoMultiImageAutoSwitchMode("imageToVideo", SEEDANCE2_FAST, images),
+      ).toBeNull();
+    }
+  });
+
+  it("只管首帧模式，其它模式一律不插手", () => {
+    for (const mode of [
+      "textToVideo",
+      "imageReference",
+      "allReference",
+      "firstLastFrame",
+      "videoEdit",
+    ] as VideoGenMode[]) {
+      expect(videoMultiImageAutoSwitchMode(mode, SEEDANCE2_FAST, 5)).toBeNull();
+    }
+  });
+
+  // HappyHorse 自己那套状态机（videos>0→视频编辑 / images>1→图片参考）已经收口了，
+  // 这里再插一脚只会两处 updateNodeData 来回打架。
+  it("HappyHorse 不动，交给它自己的状态机", () => {
+    expect(videoMultiImageAutoSwitchMode("imageToVideo", HAPPYHORSE, 3)).toBeNull();
+  });
+
+  // 换模式救不了 1.x：它的 i2v 端点 >1 图直接 400，切到哪个模式都是 400。留在首帧上，
+  // 让提交守卫那句「该模型单次仅支持 1 张图片」把「该换模型」这个真问题说清楚。
+  it("Seedance 1.x 不动：它多图必 400，问题在模型不在模式", () => {
+    for (const id of [SEEDANCE10_PRO_FAST, SEEDANCE15_PRO]) {
+      expect(videoMultiImageAutoSwitchMode("imageToVideo", id, 2)).toBeNull();
+      expect(videoSubmitMediaRejectionReason("imageToVideo", id, {
+        images: 2,
+        videos: 0,
+        audios: 0,
+      })).toBeTruthy();
+    }
+  });
+
+  // 媒体目录声明的 supportedModes 优先级高于启发式（与可见 tab 同一口径）。
+  it("目录声明没有全能参考时退到图片参考；两个都没有则不动", () => {
+    expect(
+      videoMultiImageAutoSwitchMode(
+        "imageToVideo",
+        {
+          id: SEEDANCE2_FAST,
+          apiModel: SEEDANCE2_FAST,
+          supportedModes: ["text_to_video", "first_frame", "image_reference"],
+        },
+        2,
+      ),
+    ).toBe("imageReference");
+    expect(
+      videoMultiImageAutoSwitchMode(
+        "imageToVideo",
+        {
+          id: SEEDANCE2_FAST,
+          apiModel: SEEDANCE2_FAST,
+          supportedModes: ["text_to_video", "first_frame"],
+        },
+        2,
+      ),
+    ).toBeNull();
+  });
+
+  // 自动改模式与提交守卫必须闭合：切完之后那个模式得真能提交，否则等于把用户从
+  // 一个坑挪到另一个坑。
+  it("切过去的模式在提交守卫里放行", () => {
+    const counts = { images: 3, videos: 0, audios: 0 };
+    const target = videoMultiImageAutoSwitchMode("imageToVideo", SEEDANCE2_FAST, counts.images);
+    expect(target).not.toBeNull();
+    expect(
+      videoSubmitMediaRejectionReason(target as VideoGenMode, SEEDANCE2_FAST, counts),
+    ).toBeNull();
+  });
+
+  // 自动切模式只是把界面导对，真正兜底提交的是引用上限：万一模式没被切走（比如
+  // effect 还没跑、或将来又有人加了 bail 条件），提交也只能带 1 张图，绝不能靠
+  // 张数悄悄变成图片参考。这条上限是结构性的，不接受媒体目录 referenceImageMax 覆盖。
+  it("首帧的图片上限锁死在 1，且不被媒体目录配置覆盖", () => {
+    const source = readFileSync("src/features/canvas/nodes/VideoNode.tsx", "utf8");
+    expect(source).toContain("imageToVideo: { image: 1, video: 0, audio: 0 }");
+    expect(source).toContain("const FIXED_IMAGE_CAP_BY_MODE");
+    expect(source).toContain(
+      "image: FIXED_IMAGE_CAP_BY_MODE[mode] ?? model?.referenceImageMax ?? defaults.image",
+    );
+  });
+});
+
+describe("HappyHorse 单图默认模式", () => {
+  // 单张图时首帧和图片参考都可用（videoModeDisabledReason 两条都返回 null），默认必须
+  // 落在图片参考：它吃 1~9 张，用户接着连第二张图不用换模式；默认落首帧的话第二张一连
+  // 上来状态机就得把模式改掉，用户眼里就是「我选的模式自己变了」。
+  // 反过来用户主动点「首帧」要留得住 —— 所以是 imageToVideo 才保持 imageToVideo。
+  it("上游正好 1 张图时默认图片参考，只在用户主动选了首帧时才保持首帧", () => {
+    const source = readFileSync("src/features/canvas/nodes/VideoNode.tsx", "utf8");
+    expect(source).toContain(
+      'target = genMode === "imageToVideo" ? "imageToVideo" : "imageReference";',
+    );
+  });
+
+  // 默认值必须真的可用，否则一连图就顶进一个 hover 提示写着「不可用」的 tab。
+  it("图片参考在 1~9 张图时都可用", () => {
+    const source = readFileSync(
+      "src/features/canvas/nodes/VideoOperationsPanel.tsx",
+      "utf8",
+    );
+    expect(source).toContain('if (images === 0) return "需要连接图片节点（1~9个）";');
+    expect(source).toContain('if (images > 9) return "「图片参考」最多支持 9 张图片";');
   });
 });
 

--- a/frontend/src/__tests__/features/canvas/video-reference-limits.test.ts
+++ b/frontend/src/__tests__/features/canvas/video-reference-limits.test.ts
@@ -10,6 +10,7 @@ import {
 import {
   VIDEO_REFERENCE_ENVELOPE,
   classifyVideoReferenceMedia,
+  overflowingVideoReferenceEdgeIds,
   videoReferenceConnectionRejection,
 } from "@/features/canvas/domain/videoReferenceLimits";
 
@@ -149,5 +150,60 @@ describe("videoReferenceConnectionRejection — 建边时的素材上限", () =>
     // 同样这批 upload 节点没占图片额度，图片还能继续连。
     const extraImage = node("extra-image", CANVAS_NODE_TYPES.imageGen);
     expect(connect([...nodes, extraImage], edges, extraImage.id)).toBeNull();
+  });
+});
+
+// 建边时的校验挡不住「先连边、后变类型」：外部文件导入先落空 Upload 并连边（按图片
+// 计数），再按 MIME 转成 video/audio。类型定下来之后必须能重算出溢出的那几条。
+describe("overflowingVideoReferenceEdgeIds — 类型变了之后的重算", () => {
+  function graph(kinds: readonly CanvasNodeType[]) {
+    const target = node("video-target", CANVAS_NODE_TYPES.video);
+    const sources = kinds.map((type, index) => node(`src-${index}`, type));
+    return {
+      nodes: [target, ...sources],
+      edges: sources.map((source) => ({
+        id: `e-${source.id}`,
+        source: source.id,
+        target: target.id,
+      })),
+    };
+  }
+
+  it("没超时返回空", () => {
+    const { nodes, edges } = graph(fill(CANVAS_NODE_TYPES.video, VIDEO_REFERENCE_ENVELOPE.video));
+    expect(overflowingVideoReferenceEdgeIds(nodes, edges, "video-target")).toEqual([]);
+  });
+
+  it("超出的按先来后到只溢出最后几条", () => {
+    const { nodes, edges } = graph(
+      fill(CANVAS_NODE_TYPES.video, VIDEO_REFERENCE_ENVELOPE.video + 2),
+    );
+    expect(overflowingVideoReferenceEdgeIds(nodes, edges, "video-target")).toEqual([
+      `e-src-${VIDEO_REFERENCE_ENVELOPE.video}`,
+      `e-src-${VIDEO_REFERENCE_ENVELOPE.video + 1}`,
+    ]);
+  });
+
+  it("逐项没超但总数超 12 时也算溢出", () => {
+    const { nodes, edges } = graph([
+      ...fill(CANVAS_NODE_TYPES.imageGen, VIDEO_REFERENCE_ENVELOPE.image),
+      ...fill(CANVAS_NODE_TYPES.video, VIDEO_REFERENCE_ENVELOPE.video),
+      CANVAS_NODE_TYPES.audio,
+    ]);
+    expect(overflowingVideoReferenceEdgeIds(nodes, edges, "video-target")).toEqual([
+      `e-src-${VIDEO_REFERENCE_ENVELOPE.total}`,
+    ]);
+  });
+
+  it("目标不是视频节点时不管", () => {
+    const { nodes, edges } = graph(fill(CANVAS_NODE_TYPES.video, VIDEO_REFERENCE_ENVELOPE.video + 2));
+    const imageTarget = node("image-target", CANVAS_NODE_TYPES.imageGen);
+    expect(
+      overflowingVideoReferenceEdgeIds(
+        [...nodes, imageTarget],
+        edges.map((edge) => ({ ...edge, target: imageTarget.id })),
+        imageTarget.id,
+      ),
+    ).toEqual([]);
   });
 });

--- a/frontend/src/__tests__/features/canvas/video-reference-limits.test.ts
+++ b/frontend/src/__tests__/features/canvas/video-reference-limits.test.ts
@@ -1,0 +1,153 @@
+// SPDX-License-Identifier: Elastic-2.0
+// Copyright (c) 2026 ClaymoreLab
+import { describe, expect, it } from "vitest";
+
+import {
+  CANVAS_NODE_TYPES,
+  type CanvasNode,
+  type CanvasNodeType,
+} from "@/features/canvas/domain/canvasNodes";
+import {
+  VIDEO_REFERENCE_ENVELOPE,
+  classifyVideoReferenceMedia,
+  videoReferenceConnectionRejection,
+} from "@/features/canvas/domain/videoReferenceLimits";
+
+function node(
+  id: string,
+  type: CanvasNodeType,
+  data: Record<string, unknown> = {},
+): CanvasNode {
+  return { id, type, position: { x: 0, y: 0 }, data } as CanvasNode;
+}
+
+/** 目标视频节点 + n 个已连上的某类素材节点，返回 (nodes, edges) 供守卫查。 */
+function scene(kinds: readonly CanvasNodeType[], datas: readonly Record<string, unknown>[] = []) {
+  const target = node("video-target", CANVAS_NODE_TYPES.video);
+  const sources = kinds.map((type, index) => node(`src-${index}`, type, datas[index] ?? {}));
+  return {
+    nodes: [target, ...sources],
+    edges: sources.map((source) => ({ source: source.id, target: target.id })),
+  };
+}
+
+function fill(type: CanvasNodeType, count: number): CanvasNodeType[] {
+  return Array.from({ length: count }, () => type);
+}
+
+describe("classifyVideoReferenceMedia — 素材归类", () => {
+  it("按节点类型归类，空节点也算（先连节点后填素材是正常顺序）", () => {
+    expect(classifyVideoReferenceMedia(node("a", CANVAS_NODE_TYPES.imageGen))).toBe("image");
+    expect(classifyVideoReferenceMedia(node("a", CANVAS_NODE_TYPES.upload))).toBe("image");
+    expect(classifyVideoReferenceMedia(node("a", CANVAS_NODE_TYPES.video))).toBe("video");
+    expect(classifyVideoReferenceMedia(node("a", CANVAS_NODE_TYPES.audio))).toBe("audio");
+  });
+
+  // 资产库选入的视频是 upload 节点，地址写在 data.videoUrl —— 只看类型会被误当图片。
+  it("带 videoUrl 的 upload 节点算视频，不算图片", () => {
+    expect(
+      classifyVideoReferenceMedia(
+        node("a", CANVAS_NODE_TYPES.upload, { videoUrl: "/a.mp4" }),
+      ),
+    ).toBe("video");
+  });
+
+  it("非素材节点（文本 / 空）不计数", () => {
+    expect(classifyVideoReferenceMedia(node("a", CANVAS_NODE_TYPES.textAnnotation))).toBeNull();
+    expect(classifyVideoReferenceMedia(null)).toBeNull();
+  });
+});
+
+describe("videoReferenceConnectionRejection — 建边时的素材上限", () => {
+  const connect = (nodes: CanvasNode[], edges: { source: string; target: string }[], sourceId: string) =>
+    videoReferenceConnectionRejection(nodes, edges, {
+      source: sourceId,
+      target: "video-target",
+    });
+
+  it(`图片满 ${VIDEO_REFERENCE_ENVELOPE.image} 张后拒绝第 ${VIDEO_REFERENCE_ENVELOPE.image + 1} 张`, () => {
+    const { nodes, edges } = scene(fill(CANVAS_NODE_TYPES.imageGen, VIDEO_REFERENCE_ENVELOPE.image));
+    const extra = node("extra", CANVAS_NODE_TYPES.imageGen);
+    expect(connect([...nodes, extra], edges, extra.id)).toContain(
+      String(VIDEO_REFERENCE_ENVELOPE.image),
+    );
+  });
+
+  it("没满就放行", () => {
+    const { nodes, edges } = scene(
+      fill(CANVAS_NODE_TYPES.imageGen, VIDEO_REFERENCE_ENVELOPE.image - 1),
+    );
+    const extra = node("extra", CANVAS_NODE_TYPES.imageGen);
+    expect(connect([...nodes, extra], edges, extra.id)).toBeNull();
+  });
+
+  // 这是「按能力包络拦」而不是「按当前模式那格拦」的核心用例：首帧只吃 1 张图，
+  // 但第 2 张必须连得上，否则 VideoNode 里「首帧 → 全能参考」的自动切换永远
+  // 触发不了，用户会被卡在单图状态。
+  it("首帧模式下第 2 张图仍放行 —— 留给自动切模式去纠正", () => {
+    const { nodes, edges } = scene([CANVAS_NODE_TYPES.imageGen]);
+    const second = node("second", CANVAS_NODE_TYPES.imageGen);
+    expect(connect([...nodes, second], edges, second.id)).toBeNull();
+  });
+
+  it(`视频 / 音频各自满 ${VIDEO_REFERENCE_ENVELOPE.video} 个后拒绝`, () => {
+    for (const [type, cap] of [
+      [CANVAS_NODE_TYPES.video, VIDEO_REFERENCE_ENVELOPE.video],
+      [CANVAS_NODE_TYPES.audio, VIDEO_REFERENCE_ENVELOPE.audio],
+    ] as const) {
+      const { nodes, edges } = scene(fill(type, cap));
+      const extra = node("extra", type);
+      expect(connect([...nodes, extra], edges, extra.id)).toContain(String(cap));
+    }
+  });
+
+  // 后端 validate_omni_reference_limits 除了逐项还有 total_max=12：图 9 + 视频 3
+  // 已经顶满总数，再连音频逐项没超、总数超了。
+  it("逐项都没超但总数超 12 → 也拒绝", () => {
+    const { nodes, edges } = scene([
+      ...fill(CANVAS_NODE_TYPES.imageGen, VIDEO_REFERENCE_ENVELOPE.image),
+      ...fill(CANVAS_NODE_TYPES.video, VIDEO_REFERENCE_ENVELOPE.video),
+    ]);
+    const extra = node("extra", CANVAS_NODE_TYPES.audio);
+    expect(connect([...nodes, extra], edges, extra.id)).toContain(
+      String(VIDEO_REFERENCE_ENVELOPE.total),
+    );
+  });
+
+  it("目标不是视频节点 / 源不是素材节点 → 不管", () => {
+    const { nodes, edges } = scene(fill(CANVAS_NODE_TYPES.imageGen, VIDEO_REFERENCE_ENVELOPE.image));
+    const text = node("text", CANVAS_NODE_TYPES.textAnnotation);
+    // 满 9 张图，但连进来的是文本节点：不占素材位。
+    expect(connect([...nodes, text], edges, text.id)).toBeNull();
+    // 同样 9 张图，目标换成图片节点：这条上限只管视频节点。
+    const imageTarget = node("image-target", CANVAS_NODE_TYPES.imageGen);
+    const extra = node("extra", CANVAS_NODE_TYPES.imageGen);
+    expect(
+      videoReferenceConnectionRejection(
+        [...nodes, imageTarget, extra],
+        edges.map((edge) => ({ ...edge, target: imageTarget.id })),
+        { source: extra.id, target: imageTarget.id },
+      ),
+    ).toBeNull();
+  });
+
+  // 重连一条已存在的边不该被自己挡住（它本来也建不出第二条边）。
+  it("同一个源重复连线放行", () => {
+    const { nodes, edges } = scene(fill(CANVAS_NODE_TYPES.imageGen, VIDEO_REFERENCE_ENVELOPE.image));
+    expect(connect(nodes, edges, "src-0")).toBeNull();
+  });
+
+  it("上游是带 videoUrl 的 upload 节点时按视频计数，不占图片额度", () => {
+    const { nodes, edges } = scene(
+      fill(CANVAS_NODE_TYPES.upload, VIDEO_REFERENCE_ENVELOPE.video),
+      Array.from({ length: VIDEO_REFERENCE_ENVELOPE.video }, () => ({ videoUrl: "/a.mp4" })),
+    );
+    const extraVideo = node("extra-video", CANVAS_NODE_TYPES.video);
+    expect(connect([...nodes, extraVideo], edges, extraVideo.id)).toContain(
+      String(VIDEO_REFERENCE_ENVELOPE.video),
+    );
+    // 同样这批 upload 节点没占图片额度，图片还能继续连。
+    const extraImage = node("extra-image", CANVAS_NODE_TYPES.imageGen);
+    expect(connect([...nodes, extraImage], edges, extraImage.id)).toBeNull();
+  });
+});

--- a/frontend/src/__tests__/features/canvas/video-reference-limits.test.ts
+++ b/frontend/src/__tests__/features/canvas/video-reference-limits.test.ts
@@ -12,7 +12,10 @@ import {
   classifyVideoReferenceMedia,
   overflowingVideoReferenceEdgeIds,
   videoReferenceConnectionRejection,
+  videoReferenceEnvelopeForModel,
 } from "@/features/canvas/domain/videoReferenceLimits";
+import { videoReferenceEnvelopeForNode } from "@/features/canvas/application/videoReferenceEnvelope";
+import type { ModelOption } from "@/features/canvas/ui/ProviderModelPicker";
 
 function node(
   id: string,
@@ -56,6 +59,84 @@ describe("classifyVideoReferenceMedia — 素材归类", () => {
   it("非素材节点（文本 / 空）不计数", () => {
     expect(classifyVideoReferenceMedia(node("a", CANVAS_NODE_TYPES.textAnnotation))).toBeNull();
     expect(classifyVideoReferenceMedia(null)).toBeNull();
+  });
+});
+
+// 9/3/3/12 只是「目录没配」时的默认值。媒体目录允许把 referenceImageMax 等配成任意
+// 非负整数，后端 _catalog_reference_limits（api/routes/freezone.py:7004）会采用它们；
+// 前端要是把默认值当硬上限，一个配了 image=10 的合法模型会在第 10 张被拦掉，请求永远
+// 到不了本来会接受它的后端 —— 前端比后端严 = 把管理员配出来的能力吞掉。
+describe("videoReferenceEnvelopeForModel — 目录配置优先", () => {
+  it("没配任何目录值时用默认包络", () => {
+    expect(videoReferenceEnvelopeForModel(undefined)).toEqual(VIDEO_REFERENCE_ENVELOPE);
+    expect(videoReferenceEnvelopeForModel({})).toEqual(VIDEO_REFERENCE_ENVELOPE);
+  });
+
+  // total 的算法与后端 omni 调用点（freezone.py:7857-7868）一致：三项里只要有任意
+  // 一项来自目录，总数就取三项之和；一项都没配才回落到 12。
+  it("配了任意一项就按三项之和算总数", () => {
+    expect(videoReferenceEnvelopeForModel({ referenceImageMax: 10 })).toEqual({
+      image: 10,
+      video: VIDEO_REFERENCE_ENVELOPE.video,
+      audio: VIDEO_REFERENCE_ENVELOPE.audio,
+      total: 10 + VIDEO_REFERENCE_ENVELOPE.video + VIDEO_REFERENCE_ENVELOPE.audio,
+    });
+    expect(
+      videoReferenceEnvelopeForModel({
+        referenceImageMax: 4,
+        referenceVideoMax: 1,
+        referenceAudioMax: 0,
+      }),
+    ).toEqual({ image: 4, video: 1, audio: 0, total: 5 });
+  });
+
+  // 与后端 `type(value) is int and value >= 0` 同一口径。
+  it("null / 负数 / 小数一律当作没配", () => {
+    expect(
+      videoReferenceEnvelopeForModel({
+        referenceImageMax: null,
+        referenceVideoMax: -1,
+        referenceAudioMax: 2.5,
+      }),
+    ).toEqual(VIDEO_REFERENCE_ENVELOPE);
+  });
+});
+
+describe("videoReferenceEnvelopeForNode — 从节点解析出所选模型的包络", () => {
+  const catalog: ModelOption[] = [
+    { id: 'first', providerId: 'seedance', apiModel: 'first', label: 'First' },
+    {
+      id: 'wide',
+      providerId: 'seedance',
+      apiModel: 'wide',
+      label: 'Wide',
+      referenceImageMax: 10,
+    },
+  ];
+
+  it("按 data.model 在目录里查", () => {
+    const videoNode = node("v", CANVAS_NODE_TYPES.video, { model: 'wide' });
+    expect(videoReferenceEnvelopeForNode(videoNode, catalog).image).toBe(10);
+  });
+
+  // 兜底必须和 VideoNode 的 selectedVideoModel 一致（没存 model 时显示列表第一个），
+  // 否则会出现「界面按 A 模型显示上限、建边按 B 模型拦」。
+  it("没存 model / 目录里查不到时回落到列表第一个", () => {
+    expect(videoReferenceEnvelopeForNode(node("v", CANVAS_NODE_TYPES.video), catalog).image).toBe(
+      VIDEO_REFERENCE_ENVELOPE.image,
+    );
+    expect(
+      videoReferenceEnvelopeForNode(
+        node("v", CANVAS_NODE_TYPES.video, { model: 'gone' }),
+        catalog,
+      ).image,
+    ).toBe(VIDEO_REFERENCE_ENVELOPE.image);
+  });
+
+  it("目录还没加载出来（空列表）时退回默认包络", () => {
+    expect(videoReferenceEnvelopeForNode(node("v", CANVAS_NODE_TYPES.video), [])).toEqual(
+      VIDEO_REFERENCE_ENVELOPE,
+    );
   });
 });
 
@@ -138,6 +219,20 @@ describe("videoReferenceConnectionRejection — 建边时的素材上限", () =>
     expect(connect(nodes, edges, "src-0")).toBeNull();
   });
 
+  // 包络由调用方解析后喂进来：目录里配了 image=10 的模型，第 10 张必须放行。
+  it("按模型包络放行 —— 目录配 image=10 时第 10 张连得上", () => {
+    const { nodes, edges } = scene(fill(CANVAS_NODE_TYPES.imageGen, VIDEO_REFERENCE_ENVELOPE.image));
+    const extra = node("extra", CANVAS_NODE_TYPES.imageGen);
+    expect(
+      videoReferenceConnectionRejection(
+        [...nodes, extra],
+        edges,
+        { source: extra.id, target: "video-target" },
+        () => videoReferenceEnvelopeForModel({ referenceImageMax: 10 }),
+      ),
+    ).toBeNull();
+  });
+
   it("上游是带 videoUrl 的 upload 节点时按视频计数，不占图片额度", () => {
     const { nodes, edges } = scene(
       fill(CANVAS_NODE_TYPES.upload, VIDEO_REFERENCE_ENVELOPE.video),
@@ -193,6 +288,16 @@ describe("overflowingVideoReferenceEdgeIds — 类型变了之后的重算", () 
     expect(overflowingVideoReferenceEdgeIds(nodes, edges, "video-target")).toEqual([
       `e-src-${VIDEO_REFERENCE_ENVELOPE.total}`,
     ]);
+  });
+
+  // 重算同样按模型包络走：目录配了 video=5 的模型，5 条视频引用一条都不该被清掉。
+  it("按模型包络重算 —— 目录配 video=5 时 5 条视频都留下", () => {
+    const { nodes, edges } = graph(fill(CANVAS_NODE_TYPES.video, 5));
+    expect(
+      overflowingVideoReferenceEdgeIds(nodes, edges, "video-target", () =>
+        videoReferenceEnvelopeForModel({ referenceVideoMax: 5 }),
+      ),
+    ).toEqual([]);
   });
 
   it("目标不是视频节点时不管", () => {

--- a/frontend/src/__tests__/stores/canvas-store-video-reference-limits.test.ts
+++ b/frontend/src/__tests__/stores/canvas-store-video-reference-limits.test.ts
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: Elastic-2.0
+// Copyright (c) 2026 ClaymoreLab
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { useCanvasStore } from "@/stores/canvasStore";
+import { CANVAS_NODE_TYPES } from "@/features/canvas/domain/canvasNodes";
+import { VIDEO_REFERENCE_ENVELOPE } from "@/features/canvas/domain/videoReferenceLimits";
+
+function incomingEdges(target: string) {
+  return useCanvasStore.getState().edges.filter((edge) => edge.target === target);
+}
+
+describe("canvasStore 建边入口的素材上限", () => {
+  beforeEach(() => {
+    useCanvasStore.getState().setCanvasData([], []);
+  });
+
+  // onConnect 只覆盖手动拖线。资产库选参考、外部文件导入(spawnExternalAssetNodes)
+  // 走的是 addEdge —— 它同样是「往一个已存在的视频节点上接素材」，漏掉就等于这条
+  // 上限只在拖线时成立，正常产品入口能直接绕过去。
+  it("addEdge 也受上限约束：满 9 张图后第 10 张连不上", () => {
+    const store = useCanvasStore.getState();
+    const video = store.addNode(CANVAS_NODE_TYPES.video, { x: 900, y: 0 }, {});
+    const images = Array.from({ length: VIDEO_REFERENCE_ENVELOPE.image + 1 }, (_, index) =>
+      useCanvasStore
+        .getState()
+        .addNode(CANVAS_NODE_TYPES.imageGen, { x: index * 100, y: 0 }, {}),
+    );
+
+    for (const image of images.slice(0, VIDEO_REFERENCE_ENVELOPE.image)) {
+      expect(useCanvasStore.getState().addEdge(image, video)).not.toBeNull();
+    }
+    expect(incomingEdges(video)).toHaveLength(VIDEO_REFERENCE_ENVELOPE.image);
+
+    const overflow = images[VIDEO_REFERENCE_ENVELOPE.image];
+    expect(useCanvasStore.getState().addEdge(overflow, video)).toBeNull();
+    expect(incomingEdges(video)).toHaveLength(VIDEO_REFERENCE_ENVELOPE.image);
+  });
+
+  // 外部文件导入的顺序是「先建空 Upload 并连边、再按 MIME 转成 video/audio」。
+  // 建边那一刻空 Upload 只能按图片计数，4 个视频文件因此全落在图片上限(9)内 ——
+  // 等转换完成就变成 4 条视频引用，超出视频上限(3)。所以类型确定之后必须重算。
+  it("Upload 转成视频后超出视频上限的那条边被清掉", () => {
+    const store = useCanvasStore.getState();
+    const video = store.addNode(CANVAS_NODE_TYPES.video, { x: 900, y: 0 }, {});
+    const uploads = Array.from({ length: VIDEO_REFERENCE_ENVELOPE.video + 1 }, (_, index) =>
+      useCanvasStore
+        .getState()
+        .addNode(CANVAS_NODE_TYPES.upload, { x: index * 100, y: 0 }, {}),
+    );
+    for (const upload of uploads) {
+      expect(useCanvasStore.getState().addEdge(upload, video)).not.toBeNull();
+    }
+    expect(incomingEdges(video)).toHaveLength(VIDEO_REFERENCE_ENVELOPE.video + 1);
+
+    uploads.forEach((upload, index) => {
+      useCanvasStore
+        .getState()
+        .convertNodeType(upload, CANVAS_NODE_TYPES.video, { videoUrl: `/v-${index}.mp4` });
+    });
+
+    expect(incomingEdges(video)).toHaveLength(VIDEO_REFERENCE_ENVELOPE.video);
+    // 先来的留下、后来的被清掉，用户看到的是「最后那个没接上」而不是随机少一个。
+    expect(incomingEdges(video).map((edge) => edge.source)).toEqual(
+      uploads.slice(0, VIDEO_REFERENCE_ENVELOPE.video),
+    );
+  });
+
+  it("没超上限时转换不误伤任何边", () => {
+    const store = useCanvasStore.getState();
+    const video = store.addNode(CANVAS_NODE_TYPES.video, { x: 900, y: 0 }, {});
+    const uploads = Array.from({ length: VIDEO_REFERENCE_ENVELOPE.video }, (_, index) =>
+      useCanvasStore
+        .getState()
+        .addNode(CANVAS_NODE_TYPES.upload, { x: index * 100, y: 0 }, {}),
+    );
+    for (const upload of uploads) {
+      useCanvasStore.getState().addEdge(upload, video);
+    }
+
+    uploads.forEach((upload, index) => {
+      useCanvasStore
+        .getState()
+        .convertNodeType(upload, CANVAS_NODE_TYPES.video, { videoUrl: `/v-${index}.mp4` });
+    });
+
+    expect(incomingEdges(video)).toHaveLength(VIDEO_REFERENCE_ENVELOPE.video);
+  });
+});

--- a/frontend/src/__tests__/stores/canvas-store-video-reference-limits.test.ts
+++ b/frontend/src/__tests__/stores/canvas-store-video-reference-limits.test.ts
@@ -1,10 +1,26 @@
 // SPDX-License-Identifier: Elastic-2.0
 // Copyright (c) 2026 ClaymoreLab
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { useCanvasStore } from "@/stores/canvasStore";
 import { CANVAS_NODE_TYPES } from "@/features/canvas/domain/canvasNodes";
 import { VIDEO_REFERENCE_ENVELOPE } from "@/features/canvas/domain/videoReferenceLimits";
+import type { ModelOption } from "@/features/canvas/ui/ProviderModelPicker";
+
+// 建边校验跑在 React 之外，模型目录从 useFreezoneVideoModels 的 module-level store 读。
+// 这里替掉那个读取口就能喂进任意目录；默认空列表 = 目录还没加载，行为回落到默认包络，
+// 下面前几个用例仍按 9/3/3/12 断言。
+let catalog: ModelOption[] = [];
+vi.mock("@/features/canvas/hooks/useFreezoneVideoModels", () => ({
+  readFreezoneVideoModels: () => catalog,
+  prefetchFreezoneVideoModels: () => {},
+  useFreezoneVideoModels: () => ({
+    models: catalog,
+    isLoading: false,
+    isFallback: true,
+    error: null,
+  }),
+}));
 
 function incomingEdges(target: string) {
   return useCanvasStore.getState().edges.filter((edge) => edge.target === target);
@@ -12,6 +28,7 @@ function incomingEdges(target: string) {
 
 describe("canvasStore 建边入口的素材上限", () => {
   beforeEach(() => {
+    catalog = [];
     useCanvasStore.getState().setCanvasData([], []);
   });
 
@@ -64,6 +81,90 @@ describe("canvasStore 建边入口的素材上限", () => {
     expect(incomingEdges(video).map((edge) => edge.source)).toEqual(
       uploads.slice(0, VIDEO_REFERENCE_ENVELOPE.video),
     );
+  });
+
+  // 媒体目录允许把 referenceImageMax 配成任意非负整数，后端会照配置放行。前端要是把
+  // 默认的 9 当成所有模型的硬上限，配了 image=10 的模型在第 10 张就被本地拦掉，请求永远
+  // 到不了本来会接受它的后端。建边校验必须按**所选模型**的有效包络走。
+  it("目录配了 image=10 的模型：第 10 张图连得上", () => {
+    catalog = [
+      {
+        id: "wide-model",
+        providerId: "seedance",
+        apiModel: "wide-model",
+        label: "Wide",
+        referenceImageMax: 10,
+      },
+    ];
+    const store = useCanvasStore.getState();
+    const video = store.addNode(CANVAS_NODE_TYPES.video, { x: 900, y: 0 }, { model: "wide-model" });
+    const images = Array.from({ length: 10 }, (_, index) =>
+      useCanvasStore
+        .getState()
+        .addNode(CANVAS_NODE_TYPES.imageGen, { x: index * 100, y: 0 }, {}),
+    );
+    for (const image of images) {
+      expect(useCanvasStore.getState().addEdge(image, video)).not.toBeNull();
+    }
+    expect(incomingEdges(video)).toHaveLength(10);
+  });
+
+  // 反过来也要成立：目录把上限配得比默认更小时，前端不能放行到 9。
+  it("目录配了 image=2 的模型：第 3 张图就拦住", () => {
+    catalog = [
+      {
+        id: "narrow-model",
+        providerId: "seedance",
+        apiModel: "narrow-model",
+        label: "Narrow",
+        referenceImageMax: 2,
+      },
+    ];
+    const store = useCanvasStore.getState();
+    const video = store.addNode(
+      CANVAS_NODE_TYPES.video,
+      { x: 900, y: 0 },
+      { model: "narrow-model" },
+    );
+    const images = Array.from({ length: 3 }, (_, index) =>
+      useCanvasStore
+        .getState()
+        .addNode(CANVAS_NODE_TYPES.imageGen, { x: index * 100, y: 0 }, {}),
+    );
+    expect(useCanvasStore.getState().addEdge(images[0], video)).not.toBeNull();
+    expect(useCanvasStore.getState().addEdge(images[1], video)).not.toBeNull();
+    expect(useCanvasStore.getState().addEdge(images[2], video)).toBeNull();
+    expect(incomingEdges(video)).toHaveLength(2);
+  });
+
+  // 类型转换后的重算走的是同一把尺子：目录配 video=5 时，5 条视频引用一条都不该被清掉。
+  it("目录配了 video=5 的模型：Upload 全转成视频后 5 条边都留下", () => {
+    catalog = [
+      {
+        id: "many-video",
+        providerId: "seedance",
+        apiModel: "many-video",
+        label: "ManyVideo",
+        referenceVideoMax: 5,
+      },
+    ];
+    const store = useCanvasStore.getState();
+    const video = store.addNode(CANVAS_NODE_TYPES.video, { x: 900, y: 0 }, { model: "many-video" });
+    const uploads = Array.from({ length: 5 }, (_, index) =>
+      useCanvasStore
+        .getState()
+        .addNode(CANVAS_NODE_TYPES.upload, { x: index * 100, y: 0 }, {}),
+    );
+    for (const upload of uploads) {
+      useCanvasStore.getState().addEdge(upload, video);
+    }
+    uploads.forEach((upload, index) => {
+      useCanvasStore
+        .getState()
+        .convertNodeType(upload, CANVAS_NODE_TYPES.video, { videoUrl: `/v-${index}.mp4` });
+    });
+
+    expect(incomingEdges(video)).toHaveLength(5);
   });
 
   it("没超上限时转换不误伤任何边", () => {

--- a/frontend/src/features/canvas/Canvas.tsx
+++ b/frontend/src/features/canvas/Canvas.tsx
@@ -109,6 +109,7 @@ import {
 import { nodeCatalog } from '@/features/canvas/application/nodeCatalog';
 import { applySkillRoleBindingConnection } from '@/features/canvas/domain/skillConnectionEdges';
 import { videoReferenceConnectionRejection } from '@/features/canvas/domain/videoReferenceLimits';
+import { videoReferenceEnvelopeForNode } from '@/features/canvas/application/videoReferenceEnvelope';
 import { embedStoryboardImageMetadata } from '@/commands/image';
 import { nodeTypes as canvasNodeTypes } from './nodes';
 import { edgeTypes as canvasEdgeTypes } from './edges';
@@ -1808,7 +1809,14 @@ export function Canvas({
       }
       // 视频节点的素材已经满到能力包络（图 9 / 视频 3 / 音频 3 / 总数 12）时，
       // 拖线落点变灰、不成边。与 store 的 onConnect 收口同一把尺子。
-      if (videoReferenceConnectionRejection(nodes, edges, connection) != null) {
+      if (
+        videoReferenceConnectionRejection(
+          nodes,
+          edges,
+          connection,
+          videoReferenceEnvelopeForNode,
+        ) != null
+      ) {
         return false;
       }
       if (targetNode.type !== CANVAS_NODE_TYPES.threeDWorld) return true;
@@ -3906,10 +3914,12 @@ export function Canvas({
       if (!dropNodeId || dropNodeId === pending.nodeId) return null;
       const sourceId = pending.handleType === 'source' ? pending.nodeId : dropNodeId;
       const targetId = pending.handleType === 'source' ? dropNodeId : pending.nodeId;
-      return videoReferenceConnectionRejection(nodes, edges, {
-        source: sourceId,
-        target: targetId,
-      });
+      return videoReferenceConnectionRejection(
+        nodes,
+        edges,
+        { source: sourceId, target: targetId },
+        videoReferenceEnvelopeForNode,
+      );
     },
     [edges, nodes],
   );

--- a/frontend/src/features/canvas/Canvas.tsx
+++ b/frontend/src/features/canvas/Canvas.tsx
@@ -108,6 +108,7 @@ import {
 } from '@/features/canvas/domain/nodeRegistry';
 import { nodeCatalog } from '@/features/canvas/application/nodeCatalog';
 import { applySkillRoleBindingConnection } from '@/features/canvas/domain/skillConnectionEdges';
+import { videoReferenceConnectionRejection } from '@/features/canvas/domain/videoReferenceLimits';
 import { embedStoryboardImageMetadata } from '@/commands/image';
 import { nodeTypes as canvasNodeTypes } from './nodes';
 import { edgeTypes as canvasEdgeTypes } from './edges';
@@ -1803,6 +1804,11 @@ export function Canvas({
         ? nodes.find((node) => node.id === connection.source)
         : undefined;
       if (sourceNode && !canNodeTypeBeManualConnectionSource(sourceNode.type, targetNode.type)) {
+        return false;
+      }
+      // 视频节点的素材已经满到能力包络（图 9 / 视频 3 / 音频 3 / 总数 12）时，
+      // 拖线落点变灰、不成边。与 store 的 onConnect 收口同一把尺子。
+      if (videoReferenceConnectionRejection(nodes, edges, connection) != null) {
         return false;
       }
       if (targetNode.type !== CANVAS_NODE_TYPES.threeDWorld) return true;
@@ -3892,6 +3898,22 @@ export function Canvas({
     }
   }, []);
 
+  // 手动建边落到某个节点上时，这条边会不会把视频节点的素材撑过能力包络？非空即拒绝。
+  // 三条手动路径（React Flow 拖线松手、"+" 拖拽的落点高亮、"+" 松手建边）共用同一把
+  // 尺子——少一处就会出现「拖过去高亮成合法、一松手什么也没有」。
+  const manualDropReferenceRejection = useCallback(
+    (pending: PendingConnectStart, dropNodeId: string | null): string | null => {
+      if (!dropNodeId || dropNodeId === pending.nodeId) return null;
+      const sourceId = pending.handleType === 'source' ? pending.nodeId : dropNodeId;
+      const targetId = pending.handleType === 'source' ? dropNodeId : pending.nodeId;
+      return videoReferenceConnectionRejection(nodes, edges, {
+        source: sourceId,
+        target: targetId,
+      });
+    },
+    [edges, nodes],
+  );
+
   const handleConnectEnd = useCallback(
     (event: MouseEvent | TouchEvent, connectionState: FinalConnectionState) => {
       if (connectionState.isValid || !pendingConnectStart) {
@@ -3916,6 +3938,21 @@ export function Canvas({
       const dropNodeId = dropNodeElement?.dataset?.id ?? null;
 
       if (dropNodeId && dropNodeId !== pendingConnectStart.nodeId) {
+        // 素材撑过能力包络：这条分支是 connectionState.isValid 为 false 才走到的
+        // 补救路径，**不看** isValidConnection，必须自己拦。不拦就会一路掉进下面
+        // 「拖到空白处 → 弹新建节点菜单」，用户明明松手在节点上却弹出个菜单。
+        // 顺带 toast 出原因——落点变灰本身不解释「为什么」。
+        const referenceRejection = manualDropReferenceRejection(
+          pendingConnectStart,
+          dropNodeId,
+        );
+        if (referenceRejection) {
+          toast.warning(referenceRejection);
+          setPendingConnectStart(null);
+          setPreviewConnectionVisual(null);
+          return;
+        }
+
         const sourceNode =
           pendingConnectStart.handleType === 'source'
             ? nodes.find((node) => node.id === pendingConnectStart.nodeId)
@@ -4036,6 +4073,7 @@ export function Canvas({
     },
     [
       connectGraphNodes,
+      manualDropReferenceRejection,
       nodes,
       pendingConnectStart,
       reactFlowInstance,
@@ -4110,6 +4148,9 @@ export function Canvas({
       const validate = (el: HTMLElement | null): HTMLElement | null => {
         const dropNodeId = el?.dataset?.id ?? null;
         if (!el || !dropNodeId || dropNodeId === pending.nodeId) return null;
+        // 素材已满的视频节点不高亮成落点（与拖线时落点变灰同一口径）；松手那一下
+        // 由 handlePlusConnectDragEnd 再 toast 出原因。
+        if (manualDropReferenceRejection(pending, dropNodeId)) return null;
         const sourceNode =
           pending.handleType === 'source'
             ? nodes.find((node) => node.id === pending.nodeId)
@@ -4168,7 +4209,7 @@ export function Canvas({
         });
       return best;
     },
-    [nodes],
+    [manualDropReferenceRejection, nodes],
   );
 
   const handlePlusConnectDragStart = useCallback((params: PlusConnectDragParams) => {
@@ -4258,6 +4299,23 @@ export function Canvas({
 
       const containerRect = wrapperRef.current?.getBoundingClientRect();
       if (!pending || !containerRect) {
+        setPendingConnectStart(null);
+        setPreviewConnectionVisual(null);
+        return;
+      }
+
+      // 素材已满的视频节点上面 resolveManualDropTargetEl 不会认作落点（不高亮），
+      // 松手就会掉进「拖到空白处 → 弹新建节点菜单」。所以先单独看光标正下方压着
+      // 谁：确实是被素材上限挡下的，就 toast 出原因并收工，别弹那个菜单。
+      const hoveredNodeId =
+        (
+          document
+            .elementFromPoint(params.clientPosition.x, params.clientPosition.y)
+            ?.closest?.('.react-flow__node[data-id]') as HTMLElement | null
+        )?.dataset?.id ?? null;
+      const hoveredRejection = manualDropReferenceRejection(pending, hoveredNodeId);
+      if (hoveredRejection) {
+        toast.warning(hoveredRejection);
         setPendingConnectStart(null);
         setPreviewConnectionVisual(null);
         return;
@@ -4355,6 +4413,7 @@ export function Canvas({
     },
     [
       connectGraphNodes,
+      manualDropReferenceRejection,
       nodes,
       reactFlowInstance,
       scheduleCanvasPersist,

--- a/frontend/src/features/canvas/application/videoReferenceEnvelope.ts
+++ b/frontend/src/features/canvas/application/videoReferenceEnvelope.ts
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: Elastic-2.0
+// Copyright (c) 2026 ClaymoreLab
+import type { CanvasNode } from '@/features/canvas/domain/canvasNodes';
+import {
+  videoReferenceEnvelopeForModel,
+  type VideoReferenceEnvelope,
+} from '@/features/canvas/domain/videoReferenceLimits';
+import { readFreezoneVideoModels } from '@/features/canvas/hooks/useFreezoneVideoModels';
+import type { ModelOption } from '@/features/canvas/ui/ProviderModelPicker';
+
+/**
+ * 把一个视频节点解析成它**当前所选模型**的引用上限包络。
+ *
+ * 建边校验（Canvas 的 isValidConnection、canvasStore 的 onConnect/addEdge）跑在 React
+ * 之外，拿不到 useFreezoneVideoModels 的返回值，所以这里从同一个 module-level store
+ * 直接读目录。domain 层保持纯函数、只接受算好的包络，解析这件事放在 application 层。
+ *
+ * 兜底口径必须和 VideoNode 的 `selectedVideoModel` 一致：`data.model` 没存或在目录里
+ * 找不到时，用列表第一个模型 —— 那正是 ProviderModelPicker 显示、提交时也会用的那个。
+ * 两边不一致的话，会出现「界面显示 A 模型的上限、建边按 B 模型拦」。
+ *
+ * models 参数只为测试注入目录用，生产代码不要传。
+ */
+export function videoReferenceEnvelopeForNode(
+  videoNode: CanvasNode,
+  models: ModelOption[] = readFreezoneVideoModels(),
+): VideoReferenceEnvelope {
+  const persisted =
+    typeof videoNode.data?.model === 'string' && videoNode.data.model.length > 0
+      ? videoNode.data.model
+      : null;
+  const model =
+    (persisted ? models.find((entry) => entry.id === persisted) : undefined) ??
+    models[0];
+  return videoReferenceEnvelopeForModel(model);
+}

--- a/frontend/src/features/canvas/domain/videoReferenceLimits.ts
+++ b/frontend/src/features/canvas/domain/videoReferenceLimits.ts
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: Elastic-2.0
+// Copyright (c) 2026 ClaymoreLab
+import {
+  isAudioNode,
+  isExportImageNode,
+  isImageEditNode,
+  isImageGenNode,
+  isStoryboardGenNode,
+  isUploadNode,
+  isVideoNode,
+  type CanvasNode,
+} from '@/features/canvas/domain/canvasNodes';
+
+/**
+ * 视频节点的**素材连线上限**——建边时就拦，而不是等到提交才报错。
+ *
+ * 这里卡的是「任何模型 / 任何模式都消费不了」的硬顶，不是当前模式那一格：
+ * 首帧只吃 1 张图、首尾帧只吃 2 张，但接上第 2 / 第 3 张图时 VideoNode 的 effect
+ * 会自动把模式切到全能参考 / 图片参考；同理连音频到 Seedance 1.x 会自动把模型换成
+ * 2.0。按当前模式那格拦，等于把这些自动救场全部拦死 —— 用户连不上第二张图，也就
+ * 永远触发不了「首帧 → 全能参考」的自动切换。
+ *
+ * 所以口径取**能力包络**：图 9 / 视频 3 / 音频 3 / 总数 12，与后端 omni-gen 的
+ * `validate_omni_reference_limits`（src/novelvideo/freezone/video_node.py:522）
+ * 逐项一致。越过这条线不存在任何可切换的模式或模型能消费，拦掉才是帮用户。
+ *
+ * 表里更小的那些数字（首帧 1 / 首尾帧 2 / 视频编辑 5 张参考图）继续由「自动切模式」
+ * 和提交守卫负责，不在建边这层拦。
+ */
+export const VIDEO_REFERENCE_ENVELOPE = {
+  image: 9,
+  video: 3,
+  audio: 3,
+  total: 12,
+} as const;
+
+export type VideoReferenceMediaKind = 'image' | 'video' | 'audio';
+
+/**
+ * 把一个上游节点归类成图片 / 视频 / 音频素材，非素材节点（文本、脚本…）返回 null。
+ *
+ * 与 VideoNode 里 `upstreamTypeCounts` 同一口径：**按节点类型算，空节点也算**
+ * （先连节点后填素材是正常顺序）。唯一的例外是 `data.videoUrl` 优先——资产库选入
+ * 的视频是 upload 节点，只看类型会被误当图片。
+ */
+export function classifyVideoReferenceMedia(
+  node: CanvasNode | null | undefined,
+): VideoReferenceMediaKind | null {
+  if (!node) return null;
+  const videoUrl = (node.data as { videoUrl?: unknown }).videoUrl;
+  if (isVideoNode(node) || (typeof videoUrl === 'string' && videoUrl.length > 0)) {
+    return 'video';
+  }
+  if (isAudioNode(node)) return 'audio';
+  if (
+    isImageGenNode(node) ||
+    isUploadNode(node) ||
+    isImageEditNode(node) ||
+    isExportImageNode(node) ||
+    isStoryboardGenNode(node)
+  ) {
+    return 'image';
+  }
+  return null;
+}
+
+const KIND_LABEL: Record<VideoReferenceMediaKind, string> = {
+  image: '张图片',
+  video: '个视频',
+  audio: '个音频',
+};
+
+/**
+ * 这条连线会不会把视频节点的素材撑过能力包络？返回非空理由则应拒绝建边。
+ *
+ * 所有建边路径共用（手动拖线的 `isValidConnection` 让落点变灰、store 的 `onConnect`
+ * 兜底其余路径），口径必须同源：只在一处拦会表现成「拖过去高亮成合法、一松手什么
+ * 也没有」。
+ *
+ * 目标不是视频节点、源不是素材节点、或源已经连着了（重复连线）一律放行。
+ */
+export function videoReferenceConnectionRejection(
+  nodes: readonly CanvasNode[],
+  edges: readonly { source: string; target: string }[],
+  connection: { source?: string | null; target?: string | null },
+): string | null {
+  const { source, target } = connection;
+  if (!source || !target) return null;
+  const targetNode = nodes.find((node) => node.id === target);
+  if (!isVideoNode(targetNode)) return null;
+  const incoming = classifyVideoReferenceMedia(
+    nodes.find((node) => node.id === source),
+  );
+  if (!incoming) return null;
+
+  const counted = new Set<string>();
+  const counts = { image: 0, video: 0, audio: 0 };
+  for (const edge of edges) {
+    if (edge.target !== target) continue;
+    // 同一个源重复连线不叠加计数；它本来也建不出第二条边。
+    if (edge.source === source) return null;
+    if (counted.has(edge.source)) continue;
+    counted.add(edge.source);
+    const kind = classifyVideoReferenceMedia(
+      nodes.find((node) => node.id === edge.source),
+    );
+    if (kind) counts[kind] += 1;
+  }
+
+  if (counts[incoming] + 1 > VIDEO_REFERENCE_ENVELOPE[incoming]) {
+    return `视频节点最多引用 ${VIDEO_REFERENCE_ENVELOPE[incoming]} ${KIND_LABEL[incoming]}`;
+  }
+  const total = counts.image + counts.video + counts.audio;
+  if (total + 1 > VIDEO_REFERENCE_ENVELOPE.total) {
+    return `视频节点最多引用 ${VIDEO_REFERENCE_ENVELOPE.total} 个素材`;
+  }
+  return null;
+}

--- a/frontend/src/features/canvas/domain/videoReferenceLimits.ts
+++ b/frontend/src/features/canvas/domain/videoReferenceLimits.ts
@@ -116,3 +116,48 @@ export function videoReferenceConnectionRejection(
   }
   return null;
 }
+
+/**
+ * 某个视频节点当前**已经**超出包络的入边（返回要清掉的边 id）。
+ *
+ * 建边时校验挡不住类型后变的情况：外部文件导入是「先建空 Upload 并连边、再按 MIME
+ * 转成 video/audio 节点」，连边那一刻空 Upload 只能按图片计数，4 个视频文件因此全落
+ * 在图片上限(9)以内 —— 等转换完成就成了 4 条视频引用，超出视频上限(3)。所以
+ * `convertNodeType` 这类会改变素材类型的操作之后必须拿这个函数重算一遍。
+ *
+ * 保留策略是**先来后到**：按边的插入顺序装桶，装不下的才算溢出。刚转换完的那条边是
+ * 最新的，于是被清掉的就是它 —— 用户看到的是「最后拖进来的那个没接上」，而不是
+ * 随机少一条老连线。
+ */
+export function overflowingVideoReferenceEdgeIds(
+  nodes: readonly CanvasNode[],
+  edges: readonly { id: string; source: string; target: string }[],
+  videoTargetId: string,
+): string[] {
+  const targetNode = nodes.find((node) => node.id === videoTargetId);
+  if (!isVideoNode(targetNode)) return [];
+
+  const counts = { image: 0, video: 0, audio: 0 };
+  let total = 0;
+  const counted = new Set<string>();
+  const overflow: string[] = [];
+  for (const edge of edges) {
+    if (edge.target !== videoTargetId) continue;
+    if (counted.has(edge.source)) continue;
+    counted.add(edge.source);
+    const kind = classifyVideoReferenceMedia(
+      nodes.find((node) => node.id === edge.source),
+    );
+    if (!kind) continue;
+    if (
+      counts[kind] + 1 > VIDEO_REFERENCE_ENVELOPE[kind] ||
+      total + 1 > VIDEO_REFERENCE_ENVELOPE.total
+    ) {
+      overflow.push(edge.id);
+      continue;
+    }
+    counts[kind] += 1;
+    total += 1;
+  }
+  return overflow;
+}

--- a/frontend/src/features/canvas/domain/videoReferenceLimits.ts
+++ b/frontend/src/features/canvas/domain/videoReferenceLimits.ts
@@ -26,6 +26,9 @@ import {
  *
  * 表里更小的那些数字（首帧 1 / 首尾帧 2 / 视频编辑 5 张参考图）继续由「自动切模式」
  * 和提交守卫负责，不在建边这层拦。
+ *
+ * 9/3/3/12 只是**没有媒体目录配置时的默认值**，不是所有模型的硬上限 ——
+ * 见 `videoReferenceEnvelopeForModel`。
  */
 export const VIDEO_REFERENCE_ENVELOPE = {
   image: 9,
@@ -33,6 +36,66 @@ export const VIDEO_REFERENCE_ENVELOPE = {
   audio: 3,
   total: 12,
 } as const;
+
+export interface VideoReferenceEnvelope {
+  image: number;
+  video: number;
+  audio: number;
+  total: number;
+}
+
+/** 媒体目录里与引用上限相关的那几个字段（`ModelOption` 的子集）。 */
+export interface VideoReferenceLimitModel {
+  referenceImageMax?: number | null;
+  referenceVideoMax?: number | null;
+  referenceAudioMax?: number | null;
+}
+
+/**
+ * 所选模型的**有效**包络：媒体目录配置优先，没配才用 9/3/3/12。
+ *
+ * 与后端 `_catalog_reference_limits`（api/routes/freezone.py:7004）逐条对齐，包括
+ * total 的算法：三项里只要有任意一项来自目录，总数就取三项之和；一项都没配才是 12。
+ * 不这么算的话，一个目录里配了 image=10 的合法模型会在第 10 张被前端拦掉，请求永远
+ * 到不了本来会接受它的后端 —— 上限比后端严等于把管理员配出来的能力吞掉。
+ *
+ * 只认非负整数，与后端 `type(value) is int and value >= 0` 同一口径：null / 负数 /
+ * 小数一律当作没配。
+ */
+export function videoReferenceEnvelopeForModel(
+  model: VideoReferenceLimitModel | null | undefined,
+): VideoReferenceEnvelope {
+  const fromCatalog = (value: number | null | undefined): number | null =>
+    typeof value === 'number' && Number.isInteger(value) && value >= 0 ? value : null;
+
+  const image = fromCatalog(model?.referenceImageMax);
+  const video = fromCatalog(model?.referenceVideoMax);
+  const audio = fromCatalog(model?.referenceAudioMax);
+  const resolved = {
+    image: image ?? VIDEO_REFERENCE_ENVELOPE.image,
+    video: video ?? VIDEO_REFERENCE_ENVELOPE.video,
+    audio: audio ?? VIDEO_REFERENCE_ENVELOPE.audio,
+  };
+  const hasCatalogValue = image !== null || video !== null || audio !== null;
+  return {
+    ...resolved,
+    total: hasCatalogValue
+      ? resolved.image + resolved.video + resolved.audio
+      : VIDEO_REFERENCE_ENVELOPE.total,
+  };
+}
+
+/**
+ * 建边校验拿不到 React 上下文，模型只能由调用方解析后喂进来。默认值保持 9/3/3/12：
+ * 传不进模型时（测试、还没加载出目录）行为与改动之前一致。
+ */
+export type VideoReferenceEnvelopeResolver = (
+  videoNode: CanvasNode,
+) => VideoReferenceEnvelope;
+
+const DEFAULT_ENVELOPE_RESOLVER: VideoReferenceEnvelopeResolver = () => ({
+  ...VIDEO_REFERENCE_ENVELOPE,
+});
 
 export type VideoReferenceMediaKind = 'image' | 'video' | 'audio';
 
@@ -83,11 +146,13 @@ export function videoReferenceConnectionRejection(
   nodes: readonly CanvasNode[],
   edges: readonly { source: string; target: string }[],
   connection: { source?: string | null; target?: string | null },
+  resolveEnvelope: VideoReferenceEnvelopeResolver = DEFAULT_ENVELOPE_RESOLVER,
 ): string | null {
   const { source, target } = connection;
   if (!source || !target) return null;
   const targetNode = nodes.find((node) => node.id === target);
   if (!isVideoNode(targetNode)) return null;
+  const envelope = resolveEnvelope(targetNode);
   const incoming = classifyVideoReferenceMedia(
     nodes.find((node) => node.id === source),
   );
@@ -107,12 +172,12 @@ export function videoReferenceConnectionRejection(
     if (kind) counts[kind] += 1;
   }
 
-  if (counts[incoming] + 1 > VIDEO_REFERENCE_ENVELOPE[incoming]) {
-    return `视频节点最多引用 ${VIDEO_REFERENCE_ENVELOPE[incoming]} ${KIND_LABEL[incoming]}`;
+  if (counts[incoming] + 1 > envelope[incoming]) {
+    return `视频节点最多引用 ${envelope[incoming]} ${KIND_LABEL[incoming]}`;
   }
   const total = counts.image + counts.video + counts.audio;
-  if (total + 1 > VIDEO_REFERENCE_ENVELOPE.total) {
-    return `视频节点最多引用 ${VIDEO_REFERENCE_ENVELOPE.total} 个素材`;
+  if (total + 1 > envelope.total) {
+    return `视频节点最多引用 ${envelope.total} 个素材`;
   }
   return null;
 }
@@ -133,9 +198,11 @@ export function overflowingVideoReferenceEdgeIds(
   nodes: readonly CanvasNode[],
   edges: readonly { id: string; source: string; target: string }[],
   videoTargetId: string,
+  resolveEnvelope: VideoReferenceEnvelopeResolver = DEFAULT_ENVELOPE_RESOLVER,
 ): string[] {
   const targetNode = nodes.find((node) => node.id === videoTargetId);
   if (!isVideoNode(targetNode)) return [];
+  const envelope = resolveEnvelope(targetNode);
 
   const counts = { image: 0, video: 0, audio: 0 };
   let total = 0;
@@ -149,10 +216,7 @@ export function overflowingVideoReferenceEdgeIds(
       nodes.find((node) => node.id === edge.source),
     );
     if (!kind) continue;
-    if (
-      counts[kind] + 1 > VIDEO_REFERENCE_ENVELOPE[kind] ||
-      total + 1 > VIDEO_REFERENCE_ENVELOPE.total
-    ) {
+    if (counts[kind] + 1 > envelope[kind] || total + 1 > envelope.total) {
       overflow.push(edge.id);
       continue;
     }

--- a/frontend/src/features/canvas/hooks/useFreezoneVideoModels.ts
+++ b/frontend/src/features/canvas/hooks/useFreezoneVideoModels.ts
@@ -104,6 +104,23 @@ export function prefetchFreezoneVideoModels(project: string): void {
   ensureLoaded(project);
 }
 
+/**
+ * 非 hook 的读取口：store / 建边校验这类跑在 React 之外的代码要按当前模型算能力
+ * （比如引用上限）时用。读的是同一个 module-level store，所以和组件看到的是同一份
+ * 目录；还没加载出来时回落到硬编码的 VIDEO_MODELS，与 hook 的初始状态一致。
+ *
+ * 不在这里触发 ensureLoaded —— 建边是同步路径，等不到网络回来，而且这个函数会被
+ * 高频调用。目录的加载由 FreezoneShell 的 prefetch 和各视频节点的 hook 负责。
+ */
+export function readFreezoneVideoModels(
+  projectOverride?: string | null,
+): ModelOption[] {
+  const project =
+    projectOverride !== undefined ? projectOverride : readUrl().project;
+  const state = project ? states.get(project) : undefined;
+  return state?.models ?? getNoProjectState().models;
+}
+
 function subscribe(project: string | null, callback: () => void) {
   if (!project) return () => {};
   let bucket = listeners.get(project);

--- a/frontend/src/features/canvas/nodes/VideoNode.tsx
+++ b/frontend/src/features/canvas/nodes/VideoNode.tsx
@@ -73,6 +73,7 @@ import {
   videoEmptyStateCtaModes,
   videoModeRequiresPrompt,
   videoModelReferenceDisabledReason,
+  videoMultiImageAutoSwitchMode,
   videoReferenceAutoSwitchAction,
   videoSubmitMediaRejectionReason,
   videoUpstreamImageDefaultMode,
@@ -242,8 +243,7 @@ const VIDEO_EMPTY_STATE_CTA_META: Record<
 // 场景下）显式表达出来：超额 chip 标灰 + 从 @ 候选剔除，避免「prompt 引用了
 // @图片10 但提交时被静默丢掉」。
 //
-// 表里没出现的模式默认不限制（textToVideo 不消费上游、imageToVideo 走
-// `.slice(0, 9)` 自带兜底），各自走原有路径。
+// 表里没出现的模式默认不限制（textToVideo 不消费上游），走原有路径。
 //   - allReference (omni)  ：image 1-9 / video 0-3 / audio 0-3。音频另有**逐条**
 //                            1.8~15.2s 的厂商时长约束，在提交前单独校验（见
 //                            audioReferenceDurationRejection）；**没有总时长上限**，
@@ -251,10 +251,13 @@ const VIDEO_EMPTY_STATE_CTA_META: Record<
 //   - firstLastFrame       ：仅图片 2 张（首帧 + 尾帧），不允许任何视频 / 音频。
 //                            图片 >2 时另有自动切到 allReference 的兜底（见
 //                            VideoNode 内部 effect）。
+//   - imageToVideo         ：仅图片 1 张。i2v 端点按张数分流（1 张 = 图生视频，
+//                            2-9 张 = 图片参考），多给一张就悄悄换了种生成方式。
+//                            图片 >1 时同样有自动切模式的兜底（见内部 effect）。
 const REFERENCE_CAPS_BY_MODE: Partial<
   Record<VideoGenMode, { image: number; video: number; audio: number }>
 > = {
-  imageToVideo: { image: 9, video: 0, audio: 0 },
+  imageToVideo: { image: 1, video: 0, audio: 0 },
   imageReference: { image: 9, video: 0, audio: 0 },
   videoEdit: { image: 5, video: 1, audio: 0 },
   allReference: { image: 9, video: 3, audio: 3 },
@@ -383,6 +386,14 @@ function selectedVideoModelReferenceDisabledReason(
   return null;
 }
 
+// 「首帧生成视频」的 1 张图是**结构性**的，不是模型容量：i2v 端点按图片张数分流
+// （1 张 = 图生视频，2-9 张 = 图片参考），第二张一进去做的就已经不是首帧生成了。
+// 所以这条不接受媒体目录 referenceImageMax 的覆盖——那个字段表达的是「这个模型最多
+// 能吃几张参考图」，管的是参考类模式；让它盖住这里等于允许配置把首帧悄悄变成参考。
+const FIXED_IMAGE_CAP_BY_MODE: Partial<Record<VideoGenMode, number>> = {
+  imageToVideo: 1,
+};
+
 function referenceCapsForMode(
   model: ModelOption | null | undefined,
   mode: VideoGenMode,
@@ -390,7 +401,7 @@ function referenceCapsForMode(
   const defaults = REFERENCE_CAPS_BY_MODE[mode];
   if (!defaults) return null;
   return {
-    image: model?.referenceImageMax ?? defaults.image,
+    image: FIXED_IMAGE_CAP_BY_MODE[mode] ?? model?.referenceImageMax ?? defaults.image,
     video: model?.referenceVideoMax ?? defaults.video,
     audio: model?.referenceAudioMax ?? defaults.audio,
   };
@@ -1388,8 +1399,9 @@ export const VideoNode = memo(
     // 一条统一状态机替代分散的兜底 effect，避免多个 effect 互相打架：
     //   - 上游有视频            → 视频编辑 (videoEdit / video_url)
     //   - 上游图片 >1 张        → 图片参考 (imageReference / reference_images 1-9)
-    //   - 上游图片 == 1 张      → 默认首帧 (imageToVideo / image_url)，但尊重用户
-    //                             主动切到的「图片参考」
+    //   - 上游图片 == 1 张      → 默认图片参考，但尊重用户主动切到的「首帧」
+    //     （单张图两种模式都可用，默认给图片参考：它 1~9 张都吃，再连一张不用换模式；
+    //      首帧只吃 1 张，默认落在那儿等于让用户接着连第二张时被迫改模式。）
     //   - 无上游                → 文生视频 (textToVideo)
     // 每次都纠正，确保 genMode 不会卡在与当前上游不匹配的模式（否则 submit 时会被
     // 静默截断 / 触发上游互斥报错）。
@@ -1402,7 +1414,7 @@ export const VideoNode = memo(
       } else if (images > 1) {
         target = "imageReference";
       } else if (images === 1) {
-        target = genMode === "imageReference" ? "imageReference" : "imageToVideo";
+        target = genMode === "imageToVideo" ? "imageToVideo" : "imageReference";
       } else {
         target = "textToVideo";
       }
@@ -1552,6 +1564,29 @@ export const VideoNode = memo(
       if (upstreamCounts.images <= 2) return;
       updateNodeData(id, { genMode: "allReference" });
     }, [genMode, isHappyHorseModel, upstreamCounts.images, id, updateNodeData]);
+
+    // 「首帧生成视频」只承载一张图。i2v 端点按图片张数分流（1 张 = 图生视频，
+    // 2-9 张 = 图片参考），接上第二张后做的其实已经是图片参考了，模式却还停在
+    // 首帧上——所以直接把模式导到它真正在做的事情：全能参考 / 图片参考。
+    // 跟上面首尾帧 >2 图那条是同一类兜底，每次都纠正（不做一次性闩锁），
+    // 免得用户在多图状态下停在首帧、提交时被静默截断成一张。
+    // 该切到哪个、哪些情况不该动，全部收在 videoMultiImageAutoSwitchMode 里。
+    useEffect(() => {
+      const target = videoMultiImageAutoSwitchMode(
+        genMode,
+        selectedVideoModel ?? selectedVideoModelId,
+        upstreamCounts.images,
+      );
+      if (!target || target === genMode) return;
+      updateNodeData(id, { genMode: target });
+    }, [
+      genMode,
+      selectedVideoModel,
+      selectedVideoModelId,
+      upstreamCounts.images,
+      id,
+      updateNodeData,
+    ]);
 
     useEffect(
       () => () => {

--- a/frontend/src/features/canvas/nodes/shared/videoModelCapabilities.ts
+++ b/frontend/src/features/canvas/nodes/shared/videoModelCapabilities.ts
@@ -51,6 +51,25 @@ function isBaseSeedance2VideoModel(modelId: string | null | undefined): boolean 
 }
 
 /**
+ * 模型入参的统一形态：既可以只给一个 id 字符串，也可以给媒体目录下发的模型对象
+ * （`supportedModes` 存在时以它为准，那是 Admin 显式配置的能力声明）。
+ */
+export type VideoModelRef =
+  | string
+  | {
+      id?: string;
+      apiModel?: string;
+      supportedModes?: string[];
+    }
+  | null
+  | undefined;
+
+/** 从模型入参里取出用于能力启发式判定的 id（优先 apiModel，它才是打给上游的名字）。 */
+function videoModelIdOf(model: VideoModelRef): string | null | undefined {
+  return typeof model === "string" ? model : (model?.apiModel ?? model?.id);
+}
+
+/**
  * 指定模型是否支持某 genMode（与可见 tab / 切模型时是否重置残留模式口径一致）。
  * - HappyHorse：文生 / 首帧(i2v) / 图片参考(r2v) / 视频编辑。
  * - 非 HappyHorse：视频编辑是 HappyHorse 专属；全能参考与「真尾帧」首尾帧只有
@@ -59,15 +78,7 @@ function isBaseSeedance2VideoModel(modelId: string | null | undefined): boolean 
  */
 export function isVideoModeSupportedByModel(
   mode: VideoGenMode,
-  model:
-    | string
-    | {
-        id?: string;
-        apiModel?: string;
-        supportedModes?: string[];
-      }
-    | null
-    | undefined,
+  model: VideoModelRef,
 ): boolean {
   if (typeof model === "object" && model !== null && (model.supportedModes?.length ?? 0) > 0) {
     const modeKey: Record<VideoGenMode, string> = {
@@ -80,7 +91,7 @@ export function isVideoModeSupportedByModel(
     };
     return model.supportedModes?.includes(modeKey[mode]) ?? false;
   }
-  const modelId = typeof model === "string" ? model : (model?.apiModel ?? model?.id);
+  const modelId = videoModelIdOf(model);
   if (isHappyHorseVideoModel(modelId)) {
     return (
       mode === "textToVideo" ||
@@ -142,6 +153,47 @@ export function videoUpstreamImageDefaultMode(
  */
 export function videoModeRequiresPrompt(mode: VideoGenMode): boolean {
   return mode === "textToVideo" || mode === "allReference";
+}
+
+/**
+ * 该模型的 i2v 端点是否放行多图（>1）。后端只在「非 2.0 且非 HappyHorse」时对
+ * `len(source_paths) > 1` 直接 400（freezone.py），所以这两族之外的模型（Seedance
+ * 1.x 等）一次只能吃一张图 —— 对它们来说换模式救不了，得换模型。
+ */
+export function videoModelAcceptsMultipleImages(
+  modelId: string | null | undefined,
+): boolean {
+  return isSeedance2VideoModel(modelId) || isHappyHorseVideoModel(modelId);
+}
+
+/**
+ * 「首帧生成视频」(imageToVideo / i2v) 接了多图时该切到哪个模式，null = 不动。
+ *
+ * 为什么必须切：后端 i2v 端点按**图片张数**分流（1 张 = 图生视频，2-9 张 = 图片
+ * 参考视频），多连一张不会报错，而是悄悄变成另一种生成方式 —— 界面上模式却还写着
+ * 「首帧生成视频」。用户把第二张图连上来这个动作本身就是明确意图，直接把模式导到
+ * 真正在做的事情上：优先「全能参考」(omni，还能继续接视频 / 音频)，模型不支持
+ * omni 时退「图片参考」。
+ *
+ * 三种情况**不动**：
+ * - HappyHorse 有自己那套完整状态机（videos>0→视频编辑 / images>1→图片参考 /
+ *   images===1→首帧），在那儿统一收口，这里再插一脚只会两处来回打架；
+ * - 模型压根消费不了多图（Seedance 1.x：i2v 端点 >1 图直接 400），换到哪个模式都是
+ *   400。留在首帧上，让提交守卫那句「该模型单次仅支持 1 张图片」把话说清楚，别用
+ *   一次模式跳变把真正的问题（该换模型）盖掉；
+ * - 两个候选模式该模型都不支持 —— 宁可不动，也不要顶进一个提交必 400 的模式。
+ */
+export function videoMultiImageAutoSwitchMode(
+  mode: VideoGenMode,
+  model: VideoModelRef,
+  imageCount: number,
+): VideoGenMode | null {
+  if (mode !== "imageToVideo" || imageCount <= 1) return null;
+  const modelId = videoModelIdOf(model);
+  if (isHappyHorseVideoModel(modelId)) return null;
+  if (!videoModelAcceptsMultipleImages(modelId)) return null;
+  const candidates: VideoGenMode[] = ["allReference", "imageReference"];
+  return candidates.find((candidate) => isVideoModeSupportedByModel(candidate, model)) ?? null;
 }
 
 /**
@@ -257,11 +309,7 @@ export function videoSubmitMediaRejectionReason(
   if (counts.audios > 0 && mode !== "allReference") {
     return "该模型不支持音频素材";
   }
-  if (
-    counts.images > 1 &&
-    !isSeedance2VideoModel(modelId) &&
-    !isHappyHorseVideoModel(modelId)
-  ) {
+  if (counts.images > 1 && !videoModelAcceptsMultipleImages(modelId)) {
     return "该模型单次仅支持 1 张图片";
   }
   return null;

--- a/frontend/src/stores/canvasStore.ts
+++ b/frontend/src/stores/canvasStore.ts
@@ -51,6 +51,7 @@ import {
   overflowingVideoReferenceEdgeIds,
   videoReferenceConnectionRejection,
 } from '@/features/canvas/domain/videoReferenceLimits';
+import { videoReferenceEnvelopeForNode } from '@/features/canvas/application/videoReferenceEnvelope';
 import {
   type ViewportBookmark,
   type ViewportBookmarks,
@@ -1407,7 +1408,14 @@ export const useCanvasStore = create<CanvasState>((set, get) => ({
       // 视频节点素材上限收口：素材已满到能力包络（图 9 / 视频 3 / 音频 3 /
       // 总数 12）时拒绝新连接。手动拖线在 isValidConnection 就变灰了，这里兜住
       // 拖到空白生成节点等其它建边路径。
-      if (videoReferenceConnectionRejection(state.nodes, state.edges, connection) != null) {
+      if (
+        videoReferenceConnectionRejection(
+          state.nodes,
+          state.edges,
+          connection,
+          videoReferenceEnvelopeForNode,
+        ) != null
+      ) {
         return {};
       }
       return {
@@ -1957,7 +1965,14 @@ export const useCanvasStore = create<CanvasState>((set, get) => ({
     // 素材上限同样要收口在这里：资产库选参考、外部文件导入
     // （spawnExternalAssetNodes）都是往一个**已存在**的视频节点上接素材，走的正是
     // addEdge。只在 onConnect 拦等于这条上限只在手动拖线时成立。
-    if (videoReferenceConnectionRejection(state.nodes, state.edges, { source, target }) != null) {
+    if (
+      videoReferenceConnectionRejection(
+        state.nodes,
+        state.edges,
+        { source, target },
+        videoReferenceEnvelopeForNode,
+      ) != null
+    ) {
       return null;
     }
 
@@ -2001,7 +2016,14 @@ export const useCanvasStore = create<CanvasState>((set, get) => ({
     // 与 addEdge 同一把尺子：目前这条路径的 target 都是刚建出来的新节点（技能输出、
     // 背景候选），够不到上限；放在这里是为了「所有公开建边入口口径一致」，将来谁把
     // 带数据的边接到已有视频节点上也不会漏。
-    if (videoReferenceConnectionRejection(state.nodes, state.edges, { source, target }) != null) {
+    if (
+      videoReferenceConnectionRejection(
+        state.nodes,
+        state.edges,
+        { source, target },
+        videoReferenceEnvelopeForNode,
+      ) != null
+    ) {
       return null;
     }
 
@@ -2392,6 +2414,7 @@ export const useCanvasStore = create<CanvasState>((set, get) => ({
         nextNodes,
         nextEdges,
         videoTargetId,
+        videoReferenceEnvelopeForNode,
       )) {
         overflowEdgeIds.add(edgeId);
       }

--- a/frontend/src/stores/canvasStore.ts
+++ b/frontend/src/stores/canvasStore.ts
@@ -47,6 +47,7 @@ import {
   isUpstreamConnectionAllowed,
 } from '@/features/canvas/domain/nodeRegistry';
 import { EXPORT_RESULT_DISPLAY_NAME } from '@/features/canvas/domain/nodeDisplay';
+import { videoReferenceConnectionRejection } from '@/features/canvas/domain/videoReferenceLimits';
 import {
   type ViewportBookmark,
   type ViewportBookmarks,
@@ -1398,6 +1399,12 @@ export const useCanvasStore = create<CanvasState>((set, get) => ({
         targetNode &&
         !isUpstreamConnectionAllowed(sourceNode.type, targetNode.type)
       ) {
+        return {};
+      }
+      // 视频节点素材上限收口：素材已满到能力包络（图 9 / 视频 3 / 音频 3 /
+      // 总数 12）时拒绝新连接。手动拖线在 isValidConnection 就变灰了，这里兜住
+      // 拖到空白生成节点等其它建边路径。
+      if (videoReferenceConnectionRejection(state.nodes, state.edges, connection) != null) {
         return {};
       }
       return {

--- a/frontend/src/stores/canvasStore.ts
+++ b/frontend/src/stores/canvasStore.ts
@@ -47,7 +47,10 @@ import {
   isUpstreamConnectionAllowed,
 } from '@/features/canvas/domain/nodeRegistry';
 import { EXPORT_RESULT_DISPLAY_NAME } from '@/features/canvas/domain/nodeDisplay';
-import { videoReferenceConnectionRejection } from '@/features/canvas/domain/videoReferenceLimits';
+import {
+  overflowingVideoReferenceEdgeIds,
+  videoReferenceConnectionRejection,
+} from '@/features/canvas/domain/videoReferenceLimits';
 import {
   type ViewportBookmark,
   type ViewportBookmarks,
@@ -1951,6 +1954,12 @@ export const useCanvasStore = create<CanvasState>((set, get) => ({
     if (!isUpstreamConnectionAllowed(sourceNode.type, targetNode.type)) {
       return null;
     }
+    // 素材上限同样要收口在这里：资产库选参考、外部文件导入
+    // （spawnExternalAssetNodes）都是往一个**已存在**的视频节点上接素材，走的正是
+    // addEdge。只在 onConnect 拦等于这条上限只在手动拖线时成立。
+    if (videoReferenceConnectionRejection(state.nodes, state.edges, { source, target }) != null) {
+      return null;
+    }
 
     const edgeId = `e-${source}-${target}`;
     // Check if edge already exists
@@ -1987,6 +1996,12 @@ export const useCanvasStore = create<CanvasState>((set, get) => ({
     }
     // 上游类型规则收口（如音频←非文本）。
     if (!isUpstreamConnectionAllowed(sourceNode.type, targetNode.type)) {
+      return null;
+    }
+    // 与 addEdge 同一把尺子：目前这条路径的 target 都是刚建出来的新节点（技能输出、
+    // 背景候选），够不到上限；放在这里是为了「所有公开建边入口口径一致」，将来谁把
+    // 带数据的边接到已有视频节点上也不会漏。
+    if (videoReferenceConnectionRejection(state.nodes, state.edges, { source, target }) != null) {
       return null;
     }
 
@@ -2365,9 +2380,29 @@ export const useCanvasStore = create<CanvasState>((set, get) => ({
       return isUpstreamConnectionAllowed(sourceType, targetType);
     });
 
+    // 类型变了，素材归类也跟着变：空 Upload 建边时按图片算，转成 video/audio 之后
+    // 可能把下游视频节点顶出视频/音频上限（外部文件导入正是「先连边、后按 MIME
+    // 转换」）。建边时的校验管不到这一刻，只能在类型确定之后重算一遍。
+    const affectedVideoTargets = new Set(
+      nextEdges.filter((edge) => edge.source === nodeId).map((edge) => edge.target),
+    );
+    const overflowEdgeIds = new Set<string>();
+    for (const videoTargetId of affectedVideoTargets) {
+      for (const edgeId of overflowingVideoReferenceEdgeIds(
+        nextNodes,
+        nextEdges,
+        videoTargetId,
+      )) {
+        overflowEdgeIds.add(edgeId);
+      }
+    }
+    const finalEdges = overflowEdgeIds.size
+      ? nextEdges.filter((edge) => !overflowEdgeIds.has(edge.id))
+      : nextEdges;
+
     set({
       nodes: nextNodes,
-      edges: nextEdges,
+      edges: finalEdges,
       history: {
         past: pushSnapshot(state.history.past, createSnapshot(state.nodes, state.edges)),
         future: [],

--- a/license-inventory.csv
+++ b/license-inventory.csv
@@ -396,6 +396,7 @@ frontend/src/__tests__/features/canvas/video-error-notification.test.ts,Elastic-
 frontend/src/__tests__/features/canvas/video-model-capabilities.test.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/__tests__/features/canvas/video-model-identity-contract.test.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/__tests__/features/canvas/video-node-credit-contract.test.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
+frontend/src/__tests__/features/canvas/video-reference-limits.test.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/__tests__/features/canvas/viewport-bookmarks-domain.test.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/__tests__/features/companion/petdex-pets.test.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/__tests__/features/freezone/asset-library-panel-beat-context.test.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
@@ -826,6 +827,7 @@ frontend/src/features/canvas/domain/nodeRegistry.ts,Elastic-2.0,2026 SuperTale c
 frontend/src/features/canvas/domain/skillConnectionEdges.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/features/canvas/domain/storyboardCellPreview.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/features/canvas/domain/storyboardGroup.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
+frontend/src/features/canvas/domain/videoReferenceLimits.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/features/canvas/domain/viewportBookmarks.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/features/canvas/edges/DisconnectableEdge.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/features/canvas/edges/edgeRouting.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation

--- a/license-inventory.csv
+++ b/license-inventory.csv
@@ -799,6 +799,7 @@ frontend/src/features/canvas/application/useUpstreamGraph.ts,Elastic-2.0,2026 Su
 frontend/src/features/canvas/application/videoFileTypes.test.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/features/canvas/application/videoFileTypes.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/features/canvas/application/videoFrameCapture.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
+frontend/src/features/canvas/application/videoReferenceEnvelope.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/features/canvas/application/videoStoryNormalizer.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/features/canvas/application/videoTranscode.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/features/canvas/application/videoTranscodeFfmpeg.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation

--- a/license-inventory.csv
+++ b/license-inventory.csv
@@ -543,6 +543,7 @@ frontend/src/__tests__/stores/auth-store.test.ts,Elastic-2.0,2026 SuperTale cont
 frontend/src/__tests__/stores/canvas-store-3d-upstream.test.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/__tests__/stores/canvas-store-auto-group-spawn.test.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/__tests__/stores/canvas-store-convert-node-type.test.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
+frontend/src/__tests__/stores/canvas-store-video-reference-limits.test.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/__tests__/stores/canvas-store-draft-hydrate.test.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/__tests__/stores/canvas-store-group-grow.test.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/__tests__/stores/canvas-store-image-resize-aspect.test.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation


### PR DESCRIPTION
## 问题

后端 i2v 端点按**图片张数**分流（1 张 = 图生视频，2-9 张 = 图片参考视频）。首帧模式下多连一张图不会报错，而是悄悄变成另一种生成方式 —— 界面上模式却还写着「首帧生成视频」，用户拿到的结果和他以为在做的事对不上。

顺带把「连了图片默认选中图生视频」和「素材连多少个都没人拦、等提交才 400」一起收了。

## 改动

**1. 首帧接多图 → 自动切模式**（`videoMultiImageAutoSwitchMode`）
优先「全能参考」（omni，还能继续接视频/音频），模型不支持时退「图片参考」。HappyHorse 有自己那套完整状态机、Seedance 1.x 多图必 400（换模式救不了，得换模型），这两族不插手。

**2. 首帧的图片上限锁到 1**
且不接受媒体目录 `referenceImageMax` 覆盖 —— 这条是结构性的，不是模型容量：第二张一进去做的就已经不是首帧生成了。万一 effect 没跑到，提交也只带 1 张，绝不靠张数悄悄变成图片参考。

**3. HappyHorse 单图默认改为「图片参考」**
图片参考吃 1~9 张，用户接着连第二张不用换模式；默认落首帧的话第二张一连上来状态机就得改模式，用户看到的是「我选的模式自己变了」。用户主动点过「首帧」的仍然保留。

**4. 素材连线上限（新）**
图 9 / 视频 3 / 音频 3 / 总数 12，与后端 `validate_omni_reference_limits`（`freezone/video_node.py:522`）逐项对齐，超出直接不让建边、落点变灰 + toast。

口径取**能力包络**而不是当前模式那一格：按模式拦会把上面的自动切模式（连不上第二张图就永远触发不了）和「1.x 接音频自动换 2.0」两个救场一起拦死。

判定收在 `videoReferenceLimits.ts` 一处，所有建边入口共用同一把尺子：
- `isValidConnection`（拖线落点变灰）
- `canvasStore.onConnect` / `addEdge` / `addEdgeWithData`
- `Canvas.tsx` 三条手动拖放路径

`addEdge` 这条是 review 指出的绕过（P1）：资产库选参考、外部文件导入（`spawnExternalAssets.ts:119`）都是往一个**已存在**的视频节点上接素材，走的正是 `addEdge` 而不是 `onConnect`。

**5. 类型转换后重算**（review 指出的第二个 P1）
外部文件导入的顺序是「先建空 Upload 并连边 → 再按 MIME `convertNodeType` 转成 video/audio」。连边那一刻空 Upload 只能按图片计数，4 个视频文件因此全落在图片上限（9）内，转换完成后就成了 4 条视频引用、超出视频上限（3）。

新增 `overflowingVideoReferenceEdgeIds`，`convertNodeType` 在类型确定之后重算并清掉溢出的入边。保留策略是**先来后到**（按边插入顺序装桶），被清掉的是刚转换完的那条 —— 用户看到的是「最后拖进来的那个没接上」，而不是随机少一条老连线。

**故意没动** `normalizeEdgesWithNodes`：在那里加张数规则会在加载旧画布时静默删掉用户已有的边。

## 测试

- `video-reference-limits.test.ts`（15 条）：逐项上限、总数 12、素材归类（带 `videoUrl` 的 upload 算视频）、重复连线、非视频目标不管、溢出重算的先来后到顺序。
- `canvas-store-video-reference-limits.test.ts`（新，3 条）：两个 P1 的最小回归 —— `addEdge` 满 9 张后第 10 张返回 null；4 个 Upload 转成 video 后只剩最先连的 3 条；没超上限时转换不误伤。两条都验证过「改之前失败、改之后通过」。
- `canvas-manual-connect.test.tsx` 加两条对齐用例：满 9 张时落点校验与建边判定都拒绝且不误删已有边；没满时两处都放行。
- `video-model-capabilities.test.ts` 加自动切模式 8 条 + 两条源码棘轮（上限锁死、单图默认）。
- `tsc -b` 通过、canvas + stores 591/591、`pnpm build` 成功。

🤖 Generated with [Claude Code](https://claude.com/claude-code)