### PR TITLE
test(canvas): align scene 360 viewer contract

### DIFF
--- a/frontend/src/__tests__/features/viewer-kit/freezone-viewer-contract.test.ts
+++ b/frontend/src/__tests__/features/viewer-kit/freezone-viewer-contract.test.ts
@@ -355,7 +355,8 @@ describe("freezone viewer contracts", () => {
     expect(overlay).not.toContain("activeSourceId");
     expect(overlay).toContain("output_role: 'scene_360_candidate'");
     expect(overlay).toContain("media_kind: 'pano360'");
-    expect(overlay).toContain("aspectRatio,");
+    expect(overlay).toContain("const SCENE_360_OUTPUT_ASPECT_RATIO = '2:1' as const;");
+    expect(overlay).toContain("aspectRatio: SCENE_360_OUTPUT_ASPECT_RATIO");
   });
 
   it("lets canvas ThreeDWorldNode open pano360 image sources when explicitly connected", () => {


### PR DESCRIPTION
## 修复

同步 360 全景 viewer 契约测试与当前固定输出合同：

- 明确断言最终输出比例常量为 2:1
- 断言生成节点使用 SCENE_360_OUTPUT_ASPECT_RATIO
- 不改运行时逻辑

修复主线 frontend CI 唯一失败：旧测试仍查找对象简写 aspectRatio，而 #251 已改成显式固定比例常量。

## 验证

- npm test -- --run src/__tests__/features/viewer-kit/freezone-viewer-contract.test.ts — 25 passed
- npm test -- --run — 2143 passed
- npm run build — passed
- git diff --check — passed