### PR TITLE
fix(audio): guard narrator voice prerequisites

### DIFF
--- a/frontend/src/__tests__/components/episode/beat-workbench/audio-pane.test.tsx
+++ b/frontend/src/__tests__/components/episode/beat-workbench/audio-pane.test.tsx
@@ -15,6 +15,7 @@ const i18n = i18next.createInstance();
 const mutateRegenerate = vi.hoisted(() => vi.fn());
 const toastError = vi.hoisted(() => vi.fn());
 const navigateMock = vi.hoisted(() => vi.fn());
+const audioPrereqErrors = vi.hoisted(() => ({ current: [] as string[] }));
 
 beforeAll(async () => {
   await i18n.use(initReactI18next).init({
@@ -66,7 +67,12 @@ beforeAll(async () => {
 });
 
 vi.mock("@/lib/queries/audio", () => ({
-  useAudioBillingQuote: () => ({ data: { ok: true, data: { display: "" } } }),
+  useAudioBillingQuote: () => ({
+    data: {
+      ok: true,
+      data: { display: "", prereq_errors: audioPrereqErrors.current },
+    },
+  }),
   useRegenerateBeatAudio: () => ({
     mutateAsync: mutateRegenerate,
     isPending: false,
@@ -142,6 +148,7 @@ function makeBeat(overrides: Partial<Beat> = {}): Beat {
 beforeEach(() => {
   vi.clearAllMocks();
   window.localStorage.clear();
+  audioPrereqErrors.current = [];
   mutateRegenerate.mockResolvedValue({
     ok: true,
     scope: "ep001:beat_01:__narrator__",
@@ -149,6 +156,36 @@ beforeEach(() => {
 });
 
 describe("AudioPane", () => {
+  it("uses quote prerequisite errors to avoid submitting an invalid audio task", async () => {
+    audioPrereqErrors.current = [
+      "Beat 01 解说声线缺失：项目解说人声线已配置，但声线文件无法读取，请重新上传或检查项目存储",
+    ];
+    const user = userEvent.setup();
+
+    render(
+      <Wrapper>
+        <AudioPane
+          beat={makeBeat()}
+          project="demo"
+          episode={1}
+          state="missing"
+          spineTemplate="narrated"
+        />
+      </Wrapper>,
+    );
+
+    await user.click(screen.getByRole("button", { name: "去配置" }));
+
+    expect(mutateRegenerate).not.toHaveBeenCalled();
+    expect(screen.queryByRole("button", { name: "确认" })).not.toBeInTheDocument();
+    expect(toastError).toHaveBeenCalledWith(
+      "Beat 01 解说声线缺失：项目解说人声线已配置，但声线文件无法读取，请重新上传或检查项目存储。请到「资产 > 声线」上传或裁剪默认解说声线。",
+      expect.objectContaining({
+        action: expect.objectContaining({ label: "去配置" }),
+      }),
+    );
+  });
+
   it("keeps beat voice upload and project narrator voice controls out of drama narration", () => {
     render(
       <Wrapper>
@@ -226,7 +263,7 @@ describe("AudioPane", () => {
     mutateRegenerate.mockResolvedValueOnce({
       ok: false,
       code: "voice_prereq_required",
-      error: "Beat 01 解说声线缺失：项目解说人声线缺失，请上传或录制解说人音频",
+      error: "Beat 01 解说声线缺失：项目解说人声线未配置，请上传或录制解说人音频",
     });
     const user = userEvent.setup();
 
@@ -246,7 +283,7 @@ describe("AudioPane", () => {
     await user.click(screen.getByRole("button", { name: "确认" }));
 
     expect(toastError).toHaveBeenCalledWith(
-      "Beat 01 解说声线缺失：项目解说人声线缺失，请上传或录制解说人音频。请到「资产 > 声线」上传或裁剪默认解说声线。",
+      "Beat 01 解说声线缺失：项目解说人声线未配置，请上传或录制解说人音频。请到「资产 > 声线」上传或裁剪默认解说声线。",
       expect.objectContaining({
         action: expect.objectContaining({ label: "去配置" }),
       }),

--- a/frontend/src/__tests__/components/episode/beat-workbench/batch-bar.test.tsx
+++ b/frontend/src/__tests__/components/episode/beat-workbench/batch-bar.test.tsx
@@ -122,6 +122,7 @@ const {
   regenerateSketchesMock,
   sketchStartMock,
   toastSuccessMock,
+  audioQuoteState,
 } = vi.hoisted(() => ({
   assignColorsMock: vi.fn(),
   detectIdentitiesMock: vi.fn(),
@@ -129,6 +130,7 @@ const {
   regenerateSketchesMock: vi.fn(),
   sketchStartMock: vi.fn(),
   toastSuccessMock: vi.fn(),
+  audioQuoteState: { prereqErrors: [] as string[] },
 }));
 
 vi.mock("@/lib/queries/sketches", () => ({
@@ -164,7 +166,7 @@ vi.mock("@/lib/queries/audio", () => ({
         unit_cost: 6,
         cost: 18,
         display: "18",
-        prereq_errors: [],
+        prereq_errors: audioQuoteState.prereqErrors,
       },
     },
     error: null,
@@ -390,6 +392,10 @@ const DEFAULT_BEATS = [
 ];
 
 describe("BatchBar", () => {
+  beforeEach(() => {
+    audioQuoteState.prereqErrors = [];
+  });
+
   it("hides whole-episode script rewrite from the batch toolbar", () => {
     render(
       <I18nextProvider i18n={i18n}>
@@ -543,6 +549,35 @@ describe("BatchBar", () => {
 
     expect(screen.getByRole("button", { name: "确认执行" })).toBeInTheDocument();
     expect(screen.getAllByText("18").length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("stops whole-episode audio before confirmation when the quote reports a voice prerequisite", async () => {
+    audioQuoteState.prereqErrors = [
+      "Beat 01 解说声线缺失：项目解说人声线未配置，请上传或录制解说人音频",
+    ];
+    const user = userEvent.setup();
+    render(
+      <I18nextProvider i18n={i18n}>
+        <BatchBar
+          project="demo"
+          episode={1}
+          beats={DEFAULT_BEATS}
+          videoBackend="seedance"
+          spineTemplate="narrated"
+          sketchAspectRatio="2:3"
+          onSketchAspectRatioChange={vi.fn()}
+        />
+      </I18nextProvider>,
+    );
+
+    await user.click(screen.getByRole("button", { name: "生成音频" }));
+
+    expect(screen.queryByRole("button", { name: "确认执行" })).not.toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Beat 01 解说声线缺失：项目解说人声线未配置，请上传或录制解说人音频",
+      ),
+    ).toBeInTheDocument();
   });
 
   it("keeps whole-episode TTS generation visible but unavailable when Seedance2 is selected", async () => {

--- a/frontend/src/__tests__/lib/queries/character-voice-samples.test.tsx
+++ b/frontend/src/__tests__/lib/queries/character-voice-samples.test.tsx
@@ -171,6 +171,35 @@ describe("character voice sample query hooks", () => {
     });
   });
 
+  it("invalidates audio billing quotes after a character voice changes", async () => {
+    server.use(
+      http.post(
+        "http://localhost:3000/api/v1/projects/demo/characters/%E7%A7%A6/voice-samples/default/upload",
+        () =>
+          HttpResponse.json({
+            ok: true,
+            data: { slot: "default", path: "voice_default.wav" },
+          }),
+      ),
+    );
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const invalidateSpy = vi.spyOn(qc, "invalidateQueries");
+    const { result } = renderHook(
+      () => useUploadCharacterVoiceSample("demo", "秦"),
+      { wrapper: wrapperWithClient(qc) },
+    );
+
+    result.current.mutate({
+      slot: "default",
+      file: new File(["voice"], "voice.wav"),
+    });
+
+    await waitFor(() => expect(result.current.data).toBeDefined());
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: queryKeys.audioBillingQuotes("demo"),
+    });
+  });
+
   it("posts recorded data URLs to the record endpoint", async () => {
     let body: unknown = null;
     server.use(

--- a/frontend/src/__tests__/lib/queries/narrator-voice.test.tsx
+++ b/frontend/src/__tests__/lib/queries/narrator-voice.test.tsx
@@ -187,7 +187,7 @@ describe("narrator voice query hooks", () => {
     expect(called).toBe(true);
   });
 
-  it("invalidates Seedance2 beat status after narrator voice changes", async () => {
+  it("invalidates dependent generation state after narrator voice changes", async () => {
     server.use(
       http.post(
         "http://localhost:3000/api/v1/projects/demo/narrator-voice/delete",
@@ -205,6 +205,9 @@ describe("narrator voice query hooks", () => {
     await waitFor(() => expect(result.current.data).toBeDefined());
     expect(invalidateSpy).toHaveBeenCalledWith({
       queryKey: ["seedance2-beat-status", "demo"],
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ["audio-billing-quote", "demo"],
     });
   });
 });

--- a/frontend/src/components/episode/beat-workbench/audio-pane.tsx
+++ b/frontend/src/components/episode/beat-workbench/audio-pane.tsx
@@ -87,6 +87,7 @@ export function AudioPane({
     (audioCost.error instanceof BillingRuleNotConfiguredError
       ? t("common.billingRuleNotConfiguredShort")
       : null);
+  const audioPrereqError = audioCost.data?.data.prereq_errors?.[0] ?? "";
   const audioTask = useTaskController({
     key: { taskType: TASK_TYPES.AUDIO_GENERATION_INDEXTTS2, project, episode },
     alsoReconcile: [TASK_TYPES.AUDIO_GENERATION],
@@ -163,7 +164,13 @@ export function AudioPane({
           <Button
             size="xs"
             variant="outline"
-            onClick={() => setRegenConfirm(true)}
+            onClick={() => {
+              if (audioPrereqError) {
+                showAudioError(audioPrereqError);
+                return;
+              }
+              setRegenConfirm(true);
+            }}
             disabled={regenerate.isPending || audioTask.started}
             className={MEDIA_PRIMARY_ACTION_BUTTON_CLASS}
           >
@@ -172,11 +179,15 @@ export function AudioPane({
             ) : (
               <RefreshCw className="size-3" />
             )}
-            {t("common.regenerate")}
-            <CreditCostInline
-              display={audioCostDisplay}
-              promotion={audioCost.data?.data.promotion}
-            />
+            {audioPrereqError
+              ? t("episode.workbench.audio.configureVoiceAction")
+              : t("common.regenerate")}
+            {!audioPrereqError && (
+              <CreditCostInline
+                display={audioCostDisplay}
+                promotion={audioCost.data?.data.promotion}
+              />
+            )}
           </Button>
         </div>
       )}

--- a/frontend/src/components/episode/beat-workbench/batch-bar.tsx
+++ b/frontend/src/components/episode/beat-workbench/batch-bar.tsx
@@ -157,6 +157,8 @@ export function BatchBar({
     (episodeAudioBillingQuote.error instanceof BillingRuleNotConfiguredError
       ? t("common.billingRuleNotConfiguredShort")
       : "");
+  const episodeAudioPrereqErrors =
+    episodeAudioBillingQuote.data?.data.prereq_errors ?? [];
   const detectIdentitiesCostDisplay =
     detectIdentitiesCost.data?.data.display ??
     (detectIdentitiesCost.error instanceof BillingRuleNotConfiguredError
@@ -356,6 +358,13 @@ export function BatchBar({
                   variant="ghost"
                   onClick={() => {
                     if (audioUnavailableForVideoBackend) return;
+                    if (episodeAudioPrereqErrors.length > 0) {
+                      showError(
+                        t("episode.workbench.batch.genAudioTitle"),
+                        episodeAudioPrereqErrors.join("\n"),
+                      );
+                      return;
+                    }
                     askConfirm(
                       t("episode.workbench.batch.genAudioTitle"),
                       t("episode.workbench.batch.genAudioDesc"),
@@ -380,12 +389,14 @@ export function BatchBar({
               )}
               {t("episode.workbench.batch.genAudio")}
               <span aria-hidden="true" className="inline-flex min-w-7 justify-start">
-                <CreditCostPill
-                  display={episodeAudioCostDisplay}
-                  promotion={episodeAudioBillingQuote.data?.data.promotion}
-                  disabled={audioUnavailableForVideoBackend}
-                  className="h-4 bg-transparent px-0 text-[11px]"
-                />
+                {episodeAudioPrereqErrors.length === 0 && (
+                  <CreditCostPill
+                    display={episodeAudioCostDisplay}
+                    promotion={episodeAudioBillingQuote.data?.data.promotion}
+                    disabled={audioUnavailableForVideoBackend}
+                    className="h-4 bg-transparent px-0 text-[11px]"
+                  />
+                )}
               </span>
             </TooltipTrigger>
             {audioUnavailableForVideoBackend && (

--- a/frontend/src/components/episode/beat-workbench/batch-panel.tsx
+++ b/frontend/src/components/episode/beat-workbench/batch-panel.tsx
@@ -489,6 +489,7 @@ export function BatchPanel({
     (audioBillingQuote.error instanceof BillingRuleNotConfiguredError
       ? t("common.billingRuleNotConfiguredShort")
       : "");
+  const audioPrereqErrors = audioBillingQuote.data?.data.prereq_errors ?? [];
   const sketchPlanItems = useMemo(
     () => createSketchRegenPlanItems(
       beats,
@@ -911,21 +912,31 @@ export function BatchPanel({
                 variant="outline"
                 size="sm"
                 disabled={actionDisabled.audio}
-                onClick={() => askConfirm(
-                  t("episode.workbench.batch.genBatchAudioTitle", { count }),
-                  t("episode.workbench.batch.genBatchAudioDesc", { beats: beatList.join(", #") }),
-                  handleBatchAudio,
-                )}
+                onClick={() => {
+                  if (audioPrereqErrors.length > 0) {
+                    toast.error(audioPrereqErrors.join("\n"));
+                    return;
+                  }
+                  askConfirm(
+                    t("episode.workbench.batch.genBatchAudioTitle", { count }),
+                    t("episode.workbench.batch.genBatchAudioDesc", {
+                      beats: beatList.join(", #"),
+                    }),
+                    handleBatchAudio,
+                  );
+                }}
                 className="h-7 gap-1 px-2 text-[11px]"
               >
                 {generateAudio.isPending || audioTask.started ? (
                   <Loader2 className="size-3 animate-spin" />
                 ) : null}
                 {t("episode.workbench.batch.genBatchAudio", { count })}
-                <CreditCostInline
-                  display={audioCostDisplay}
-                  promotion={audioBillingQuote.data?.data.promotion}
-                />
+                {audioPrereqErrors.length === 0 && (
+                  <CreditCostInline
+                    display={audioCostDisplay}
+                    promotion={audioBillingQuote.data?.data.promotion}
+                  />
+                )}
               </Button>
             </div>
           )}

--- a/frontend/src/lib/queries/audio.ts
+++ b/frontend/src/lib/queries/audio.ts
@@ -4,6 +4,7 @@ import { useMutation, useQuery } from "@tanstack/react-query";
 import { api } from "@/lib/api";
 import { jsonWithBackendError } from "@/lib/api-errors";
 import { p } from "@/lib/api-path";
+import { queryKeys } from "@/lib/query-keys";
 import type { ErrorResponse, OkResponse, TaskResponse } from "@/types/api";
 import type { GenerationCreditCost } from "@/lib/queries/generation-credit-cost";
 
@@ -34,8 +35,7 @@ export function useAudioBillingQuote(
   const mode = params.mode ?? "sync_changed";
   return useQuery({
     queryKey: [
-      "audio-billing-quote",
-      project,
+      ...queryKeys.audioBillingQuotes(project),
       episode,
       mode,
       beatNumbers.join(","),

--- a/frontend/src/lib/queries/characters.ts
+++ b/frontend/src/lib/queries/characters.ts
@@ -217,6 +217,7 @@ function invalidateCharacterVoiceQueries(
 ) {
   qc.invalidateQueries({ queryKey: queryKeys.characters(project) });
   qc.invalidateQueries({ queryKey: queryKeys.characterVoiceSamples(project, name) });
+  qc.invalidateQueries({ queryKey: queryKeys.audioBillingQuotes(project) });
 }
 
 function updateCharacterVoiceCache(

--- a/frontend/src/lib/queries/video.ts
+++ b/frontend/src/lib/queries/video.ts
@@ -76,6 +76,7 @@ function invalidateNarratorVoiceQueries(
 ) {
   qc.invalidateQueries({ queryKey: queryKeys.narratorVoice(project) });
   qc.invalidateQueries({ queryKey: queryKeys.narratorVoiceSources(project) });
+  qc.invalidateQueries({ queryKey: queryKeys.audioBillingQuotes(project) });
   qc.invalidateQueries({ queryKey: seedance2BeatStatusProjectKey(project) });
 }
 

--- a/frontend/src/lib/query-keys.ts
+++ b/frontend/src/lib/query-keys.ts
@@ -93,6 +93,7 @@ export const queryKeys = {
   narratorVoice: (p: string) => ["projects", p, "narrator-voice"] as const,
   narratorVoiceSources: (p: string) =>
     ["projects", p, "narrator-voice", "sources"] as const,
+  audioBillingQuotes: (p: string) => ["audio-billing-quote", p] as const,
   finalVideo: (p: string, ep: number) =>
     ["projects", p, "episodes", ep, "final-video"] as const,
   tasks: (p?: string) => (p ? (["projects", p, "tasks"] as const) : (["tasks"] as const)),

--- a/src/novelvideo/seedance2_i2v/voice_clone.py
+++ b/src/novelvideo/seedance2_i2v/voice_clone.py
@@ -197,7 +197,7 @@ def narrator_reference_audio_path(project_dir: str | Path, stored_path: str) -> 
     path = Path(stored)
     if not path.is_absolute():
         path = Path(project_dir) / path
-    return path if path.exists() else None
+    return path if path.is_file() else None
 
 
 def file_sha256(path: Path) -> str:
@@ -334,11 +334,21 @@ def resolve_narrator_source(
             sha256="",
             error="项目解说人声线已配置，但声线文件无法读取，请重新上传或检查项目存储",
         )
+    try:
+        sha256 = file_sha256(audio_path)
+    except OSError:
+        return NarratorResolution(
+            style=style,
+            source="project_narrator",
+            audio_path=None,
+            sha256="",
+            error="项目解说人声线已配置，但声线文件无法读取，请重新上传或检查项目存储",
+        )
     return NarratorResolution(
         style=style,
         source="project_narrator",
         audio_path=audio_path,
-        sha256=file_sha256(audio_path),
+        sha256=sha256,
     )
 
 

--- a/src/novelvideo/seedance2_i2v/voice_clone.py
+++ b/src/novelvideo/seedance2_i2v/voice_clone.py
@@ -315,14 +315,24 @@ def resolve_narrator_source(
             identity_name=identity_name,
         )
 
-    audio_path = narrator_reference_audio_path(project_dir, project_narrator_stored_path)
+    stored_narrator_path = str(project_narrator_stored_path or "").strip()
+    if not stored_narrator_path:
+        return NarratorResolution(
+            style=style,
+            source="project_narrator",
+            audio_path=None,
+            sha256="",
+            error="项目解说人声线未配置，请上传或录制解说人音频",
+        )
+
+    audio_path = narrator_reference_audio_path(project_dir, stored_narrator_path)
     if audio_path is None:
         return NarratorResolution(
             style=style,
             source="project_narrator",
             audio_path=None,
             sha256="",
-            error="项目解说人声线缺失，请上传或录制解说人音频",
+            error="项目解说人声线已配置，但声线文件无法读取，请重新上传或检查项目存储",
         )
     return NarratorResolution(
         style=style,

--- a/tests/test_api_audio_indextts2_cutover.py
+++ b/tests/test_api_audio_indextts2_cutover.py
@@ -196,6 +196,51 @@ async def test_audio_generate_route_dispatches_indextts2(monkeypatch, tmp_path):
     ]
 
 
+@pytest.mark.asyncio
+async def test_audio_generate_route_does_not_enqueue_when_voice_file_is_missing(
+    monkeypatch, tmp_path
+):
+    from novelvideo.api.routes import generation
+    from novelvideo.api.schemas import TTSGenerateRequest
+
+    calls = []
+    _patch_generation_celery(monkeypatch, generation, tmp_path, _FakeStore())
+
+    async def fake_plan(**_kwargs):
+        return (
+            [],
+            [
+                "Beat 02 解说声线缺失：项目解说人声线已配置，"
+                "但声线文件无法读取，请重新上传或检查项目存储"
+            ],
+            0,
+        )
+
+    monkeypatch.setattr(generation, "_audio_generation_plan", fake_plan)
+    monkeypatch.setattr(
+        generation,
+        "get_task_backend",
+        lambda: SimpleNamespace(enqueue_project_task=_fake_enqueue(calls)),
+    )
+
+    response = await generation.generate_audio(
+        project="demo",
+        episode_num=3,
+        body=TTSGenerateRequest(mode="redo_selected", beat_numbers=[2]),
+        user={"username": "alice"},
+    )
+
+    assert response == {
+        "ok": False,
+        "code": "voice_prereq_required",
+        "error": (
+            "Beat 02 解说声线缺失：项目解说人声线已配置，"
+            "但声线文件无法读取，请重新上传或检查项目存储"
+        ),
+    }
+    assert calls == []
+
+
 def test_audio_generate_http_route_dispatches_indextts2(monkeypatch, tmp_path):
     from novelvideo.api.routes import generation
 

--- a/tests/test_hermes_dramaclaw_plugin.py
+++ b/tests/test_hermes_dramaclaw_plugin.py
@@ -48,7 +48,7 @@ def test_dramaclaw_plugin_adds_chat_error_without_replacing_task_error():
 
 def test_dramaclaw_plugin_adds_voice_prereq_chat_error():
     plugin = _load_plugin_module()
-    raw_error = "Beat 03 解说声线缺失：项目解说人声线缺失，请上传或录制解说人音频"
+    raw_error = "Beat 03 解说声线缺失：项目解说人声线未配置，请上传或录制解说人音频"
 
     result = plugin._with_chat_error_hints(
         {

--- a/tests/test_indextts2_beat_audio_task.py
+++ b/tests/test_indextts2_beat_audio_task.py
@@ -463,7 +463,7 @@ async def test_indextts2_narrated_project_ignores_beat_uploaded_narration_voice(
     )
 
     assert errors == [
-        "Beat 01 解说声线缺失：项目解说人声线缺失，请上传或录制解说人音频"
+        "Beat 01 解说声线缺失：项目解说人声线未配置，请上传或录制解说人音频"
     ]
 
 
@@ -926,7 +926,7 @@ async def test_indextts2_voice_prereq_check_reports_missing_narrator_before_task
     )
 
     assert errors == [
-        "Beat 01 解说声线缺失：项目解说人声线缺失，请上传或录制解说人音频"
+        "Beat 01 解说声线缺失：项目解说人声线未配置，请上传或录制解说人音频"
     ]
 
 

--- a/tests/test_seedance2_voice_clone.py
+++ b/tests/test_seedance2_voice_clone.py
@@ -601,3 +601,39 @@ def test_resolve_narrator_source_third_person_uses_project_narrator(tmp_path):
     assert resolution.audio_path == narrator_audio
     assert resolution.sha256
     assert resolution.character_name == ""
+
+
+def test_resolve_narrator_source_third_person_reports_unconfigured_voice(tmp_path):
+    from novelvideo.seedance2_i2v.voice_clone import resolve_narrator_source
+
+    project_dir = tmp_path / "proj"
+    project_dir.mkdir()
+    store = _FakeStore(project_dir, [])
+
+    resolution = resolve_narrator_source(
+        store=store,
+        narration_style="third_person",
+        project_narrator_stored_path="",
+    )
+
+    assert resolution.audio_path is None
+    assert resolution.error == "项目解说人声线未配置，请上传或录制解说人音频"
+
+
+def test_resolve_narrator_source_third_person_reports_missing_configured_file(tmp_path):
+    from novelvideo.seedance2_i2v.voice_clone import resolve_narrator_source
+
+    project_dir = tmp_path / "proj"
+    project_dir.mkdir()
+    store = _FakeStore(project_dir, [])
+
+    resolution = resolve_narrator_source(
+        store=store,
+        narration_style="third_person",
+        project_narrator_stored_path="assets/narrator/voice.wav",
+    )
+
+    assert resolution.audio_path is None
+    assert resolution.error == (
+        "项目解说人声线已配置，但声线文件无法读取，请重新上传或检查项目存储"
+    )

--- a/tests/test_seedance2_voice_clone.py
+++ b/tests/test_seedance2_voice_clone.py
@@ -637,3 +637,47 @@ def test_resolve_narrator_source_third_person_reports_missing_configured_file(tm
     assert resolution.error == (
         "项目解说人声线已配置，但声线文件无法读取，请重新上传或检查项目存储"
     )
+
+
+def test_resolve_narrator_source_third_person_rejects_configured_directory(tmp_path):
+    from novelvideo.seedance2_i2v.voice_clone import resolve_narrator_source
+
+    project_dir = tmp_path / "proj"
+    narrator_directory = project_dir / "assets" / "narrator" / "voice.wav"
+    narrator_directory.mkdir(parents=True)
+    store = _FakeStore(project_dir, [])
+
+    resolution = resolve_narrator_source(
+        store=store,
+        narration_style="third_person",
+        project_narrator_stored_path="assets/narrator/voice.wav",
+    )
+
+    assert resolution.audio_path is None
+    assert "声线文件无法读取" in resolution.error
+
+
+def test_resolve_narrator_source_third_person_reports_hash_read_failure(
+    tmp_path, monkeypatch
+):
+    import novelvideo.seedance2_i2v.voice_clone as voice_clone
+
+    project_dir = tmp_path / "proj"
+    narrator_audio = project_dir / "assets" / "narrator" / "voice.wav"
+    narrator_audio.parent.mkdir(parents=True)
+    narrator_audio.write_bytes(b"project-narrator")
+    store = _FakeStore(project_dir, [])
+
+    def fail_to_read(_path):
+        raise PermissionError("denied")
+
+    monkeypatch.setattr(voice_clone, "file_sha256", fail_to_read)
+
+    resolution = voice_clone.resolve_narrator_source(
+        store=store,
+        narration_style="third_person",
+        project_narrator_stored_path="assets/narrator/voice.wav",
+    )
+
+    assert resolution.audio_path is None
+    assert "声线文件无法读取" in resolution.error


### PR DESCRIPTION
## What changed

- distinguish an unconfigured narrator voice from a configured but unreadable voice file
- block single-Beat, selected-Beat, and whole-episode audio submission when narrator prerequisites are missing
- hide misleading credit quotes and guide users to configure the required voice
- add backend and frontend regression coverage ensuring invalid requests are not enqueued

## Why

Narrated projects require a usable narrator voice source. Previously, missing configuration and missing storage files produced the same error, making deployment/storage faults look like user input errors. Some frontend audio entry points could also continue toward confirmation even when the quote API had already reported the missing prerequisite.

## User impact

- users receive an actionable configuration message before task creation or credit reservation
- configured-but-missing files now point operators toward project storage instead of asking users to configure the voice again
- first-person narration behavior remains unchanged and continues to use the protagonist identity voice

## Verification

- `uv run pytest tests/test_api_audio_prereq.py tests/test_api_audio_indextts2_cutover.py tests/test_indextts2_beat_audio_task.py tests/test_seedance2_voice_clone.py tests/test_project_config_narration.py tests/test_narrator_main_semantics.py tests/test_hermes_dramaclaw_plugin.py -q` — 89 passed
- focused frontend tests — 38 passed
- `npm run build`
- Ruff checks for changed Python files
- `git diff --check`
- `npx @google/design.md lint DESIGN.md` — 0 errors
