### PR TITLE
fix: 参考音频时长守卫补总时长这条，前后端各卡一道

### DIFF
--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -3604,6 +3604,7 @@
         "off": "Off",
         "durationTooShort": "Each audio clip must be at least {{min}} seconds: {{clips}}. Replace it or use a longer clip and try again.",
         "durationTooLong": "Each audio clip must be at most {{max}} seconds: {{clips}}. Trim it or use a shorter clip and try again.",
+        "durationTotalTooLong": "All audio clips combined must be at most {{max}} seconds, currently {{total}} seconds: {{clips}}. Trim them or remove some clips and try again.",
         "clipDuration": "{{label}} ({{seconds}}s)",
         "clipSeparator": ", ",
         "clipFallbackLabel": "Audio {{index}}"

--- a/frontend/public/locales/zh/translation.json
+++ b/frontend/public/locales/zh/translation.json
@@ -3604,6 +3604,7 @@
         "off": "关闭",
         "durationTooShort": "单条音频时长不能低于 {{min}} 秒：{{clips}}。请替换或补长后再试。",
         "durationTooLong": "单条音频时长不能超过 {{max}} 秒：{{clips}}。请裁剪或替换后再试。",
+        "durationTotalTooLong": "所有音频加起来不能超过 {{max}} 秒，当前共 {{total}} 秒：{{clips}}。请裁剪或去掉部分音频后再试。",
         "clipDuration": "{{label}}（{{seconds}}s）",
         "clipSeparator": "、",
         "clipFallbackLabel": "音频{{index}}"

--- a/frontend/src/__tests__/features/canvas/video-model-capabilities.test.ts
+++ b/frontend/src/__tests__/features/canvas/video-model-capabilities.test.ts
@@ -7,7 +7,9 @@ import { describe, expect, it } from "vitest";
 import type { VideoGenMode } from "@/features/canvas/domain/canvasNodes";
 import {
   audioReferenceDurationRejection,
+  audioReferenceTotalDurationLimitMs,
   formatAudioDurationClips,
+  MAX_AUDIO_REFERENCE_TOTAL_DURATION_MS,
   GEN_MODE_TO_CATALOG_MODE,
   isGrokVideoChannelModel,
   isHappyHorseVideoModel,
@@ -742,20 +744,81 @@ describe("audioReferenceDurationRejection — 提交前音频时长守卫", () =
     });
   });
 
-  it("多条各自合规就放行——不按总时长判定 (3 条 6s 共 18s 厂商也收)", () => {
+  // 这条曾经断言「3 条 6s 共 18s 厂商也收」。2026-08-06 3060 环境实测打脸：厂商在
+  // r2v 另有 `audio total duration ... must be less than or equal to 15.2` 一条，
+  // 逐条全合规的 18s 组合照样 400。别把它改回放行。
+  it("逐条都合规但总和超限 → 拦，并带上总时长和上限", () => {
     expect(
       audioReferenceDurationRejection([
         clip("a", 6_000),
         clip("b", 6_000),
         clip("c", 6_000),
       ]),
+    ).toEqual({
+      kind: "totalTooLong",
+      clips: [
+        { label: "a", durationMs: 6_000 },
+        { label: "b", durationMs: 6_000 },
+        { label: "c", durationMs: 6_000 },
+      ],
+      totalMs: 18_000,
+      limitMs: 15_200,
+    });
+  });
+
+  it("总和恰好顶格 15.2s 放行，多 1ms 才拦", () => {
+    expect(
+      audioReferenceDurationRejection([clip("a", 9_000), clip("b", 6_200)]),
     ).toBeNull();
-    // 3 条顶格 15.2s（总计 45.6s）同样放行：厂商口径是逐条，总和是我们臆想的。
+    expect(
+      audioReferenceDurationRejection([clip("a", 9_000), clip("b", 6_201)])?.kind,
+    ).toBe("totalTooLong");
+  });
+
+  it("单条顶格 15.2s 不会被总和这条误伤 (兜底上限与单条上限同值)", () => {
+    expect(audioReferenceDurationRejection([clip("a", 15_200)])).toBeNull();
+  });
+
+  it("单条太长优先于总和上报 (先换掉那条，再谈整体裁剪)", () => {
+    expect(
+      audioReferenceDurationRejection([clip("a", 20_000), clip("b", 6_000)])?.kind,
+    ).toBe("tooLong");
+  });
+
+  it("总和上限走传入值 (后台 referenceAudioTotalMaxSeconds)", () => {
+    const clips = [clip("a", 6_000), clip("b", 6_000)];
+    expect(audioReferenceDurationRejection(clips)).toBeNull();
+    expect(audioReferenceDurationRejection(clips, { totalLimitMs: 30_000 })).toBeNull();
+    expect(audioReferenceDurationRejection(clips, { totalLimitMs: 10_000 })).toEqual({
+      kind: "totalTooLong",
+      clips: [
+        { label: "a", durationMs: 6_000 },
+        { label: "b", durationMs: 6_000 },
+      ],
+      totalMs: 12_000,
+      limitMs: 10_000,
+    });
+  });
+
+  it("perClipLimits: false 只判总和——1.8~15.2 是 seedance2 专属数字，别拿去卡别家", () => {
+    // 后台给某个非 seedance2 模型配了 60s 总时长：一条 25s 的音频对它完全合法，
+    // 若还套用逐条 15.2s 就是我们凭空 400 掉一次正常提交。
+    const options = { totalLimitMs: 60_000, perClipLimits: false };
+    expect(audioReferenceDurationRejection([clip("a", 25_000)], options)).toBeNull();
+    expect(audioReferenceDurationRejection([clip("a", 500)], options)).toBeNull();
+    // 总和这条仍然管着。
+    expect(
+      audioReferenceDurationRejection([clip("a", 40_000), clip("b", 25_000)], options),
+    ).toMatchObject({ kind: "totalTooLong", totalMs: 65_000, limitMs: 60_000 });
+  });
+
+  it("测不出的条目不计入总和——和只会偏小，所以判超了必定真超", () => {
+    // 3 条各 6s，其中一条测不出：可见部分 12s 未超，放行给后端 ffprobe 兜底。
     expect(
       audioReferenceDurationRejection([
-        clip("a", 15_200),
-        clip("b", 15_200),
-        clip("c", 15_200),
+        clip("a", 6_000),
+        clip("b", null),
+        clip("c", 6_000),
       ]),
     ).toBeNull();
   });
@@ -791,6 +854,32 @@ describe("audioReferenceDurationRejection — 提交前音频时长守卫", () =
 
   it("没有音频引用时不拦", () => {
     expect(audioReferenceDurationRejection([])).toBeNull();
+  });
+});
+
+describe("audioReferenceTotalDurationLimitMs — 目录优先、15.2s 兜底", () => {
+  it("没配 / 配了非法值 → 兜底 15.2s", () => {
+    expect(audioReferenceTotalDurationLimitMs(null)).toBe(15_200);
+    expect(audioReferenceTotalDurationLimitMs(undefined)).toBe(15_200);
+    expect(audioReferenceTotalDurationLimitMs({})).toBe(15_200);
+    for (const bad of [null, 0, -1, Number.NaN, Number.POSITIVE_INFINITY]) {
+      expect(
+        audioReferenceTotalDurationLimitMs({ referenceAudioTotalMaxSeconds: bad }),
+      ).toBe(MAX_AUDIO_REFERENCE_TOTAL_DURATION_MS);
+    }
+  });
+
+  it("配了就听配置，且**接受小数**——15.2 本身就不是整数", () => {
+    expect(
+      audioReferenceTotalDurationLimitMs({ referenceAudioTotalMaxSeconds: 30 }),
+    ).toBe(30_000);
+    expect(
+      audioReferenceTotalDurationLimitMs({ referenceAudioTotalMaxSeconds: 15.2 }),
+    ).toBe(15_200);
+    // 别顺手套 Number.isInteger：那会把管理员配的 12.5s 静默退回 15.2s，比后端更宽。
+    expect(
+      audioReferenceTotalDurationLimitMs({ referenceAudioTotalMaxSeconds: 12.5 }),
+    ).toBe(12_500);
   });
 });
 

--- a/frontend/src/__tests__/features/canvas/video-model-capabilities.test.ts
+++ b/frontend/src/__tests__/features/canvas/video-model-capabilities.test.ts
@@ -881,6 +881,27 @@ describe("audioReferenceTotalDurationLimitMs — 目录优先、15.2s 兜底", (
       audioReferenceTotalDurationLimitMs({ referenceAudioTotalMaxSeconds: 12.5 }),
     ).toBe(12_500);
   });
+
+  it("vendorCapMs 与目录值取小——配宽了不能越过厂商硬顶", () => {
+    const capped = { vendorCapMs: MAX_AUDIO_REFERENCE_TOTAL_DURATION_MS };
+    // 管理员给 seedance2 配 60s：3 条 6s 在本地全过、到厂商那儿照样 400。必须取小。
+    expect(
+      audioReferenceTotalDurationLimitMs(
+        { referenceAudioTotalMaxSeconds: 60 },
+        capped,
+      ),
+    ).toBe(15_200);
+    // 收严的方向照收。
+    expect(
+      audioReferenceTotalDurationLimitMs({ referenceAudioTotalMaxSeconds: 8 }, capped),
+    ).toBe(8_000);
+    // 没配就是硬顶本身。
+    expect(audioReferenceTotalDurationLimitMs(null, capped)).toBe(15_200);
+    // 不传 vendorCapMs（边界未知的模型）就没有硬顶可取，60s 照用。
+    expect(
+      audioReferenceTotalDurationLimitMs({ referenceAudioTotalMaxSeconds: 60 }),
+    ).toBe(60_000);
+  });
 });
 
 describe("formatAudioDurationClips — 提示里的 {{clips}} 走 locale 排版", () => {

--- a/frontend/src/api/ops.ts
+++ b/frontend/src/api/ops.ts
@@ -1054,6 +1054,12 @@ export interface FreezoneVideoModelInfo {
   referenceImageMax?: number | null;
   referenceVideoMax?: number | null;
   referenceAudioMax?: number | null;
+  /**
+   * 参考音频**总时长**上限（秒）。厂商 r2v 除了逐条 1.8~15.2s，还另有一条总和限制
+   * （见 videoModelCapabilities 里的说明），这项就是它的后台可配值；没配时前端按
+   * 15.2s 兜底。允许小数，别当成整数字段处理。
+   */
+  referenceAudioTotalMaxSeconds?: number | null;
   request?: MediaModelRequestSchema;
 }
 
@@ -1122,6 +1128,11 @@ function videoModelEntryFromObject(
     referenceImageMax: pickNumber(entry, "referenceImageMax", "reference_image_max"),
     referenceVideoMax: pickNumber(entry, "referenceVideoMax", "reference_video_max"),
     referenceAudioMax: pickNumber(entry, "referenceAudioMax", "reference_audio_max"),
+    referenceAudioTotalMaxSeconds: pickNumber(
+      entry,
+      "referenceAudioTotalMaxSeconds",
+      "reference_audio_total_max_seconds",
+    ),
     request: pickMediaRequestSchema(entry.request),
   };
 }

--- a/frontend/src/features/canvas/nodes/VideoNode.tsx
+++ b/frontend/src/features/canvas/nodes/VideoNode.tsx
@@ -65,7 +65,9 @@ import {
 } from "@/features/canvas/domain/canvasNodes";
 import {
   audioReferenceDurationRejection,
+  audioReferenceTotalDurationLimitMs,
   formatAudioDurationClips,
+  formatAudioDurationSeconds,
   MAX_AUDIO_REFERENCE_DURATION_MS,
   MIN_AUDIO_REFERENCE_DURATION_MS,
   isHappyHorseVideoModel,
@@ -251,10 +253,11 @@ const VIDEO_EMPTY_STATE_CTA_META: Record<
 // @图片10 但提交时被静默丢掉」。
 //
 // 表里没出现的模式默认不限制（textToVideo 不消费上游），走原有路径。
-//   - allReference (omni)  ：image 1-9 / video 0-3 / audio 0-3。音频另有**逐条**
-//                            1.8~15.2s 的厂商时长约束，在提交前单独校验（见
-//                            audioReferenceDurationRejection）；**没有总时长上限**，
-//                            服务端也不校验时长，别再往这张表里加总时长口径。
+//   - allReference (omni)  ：image 1-9 / video 0-3 / audio 0-3。音频另有两条厂商时长
+//                            约束——**逐条** 1.8~15.2s 和**总和** ≤15.2s（后台可配
+//                            referenceAudioTotalMaxSeconds）——都在提交前单独校验，
+//                            见 audioReferenceDurationRejection。时长口径不进这张表：
+//                            这里只表达条数。
 //   - firstLastFrame       ：仅图片 2 张（首帧 + 尾帧），不允许任何视频 / 音频。
 //                            图片 >2 时另有自动切到 allReference 的兜底（见
 //                            VideoNode 内部 effect）。
@@ -2178,11 +2181,18 @@ export const VideoNode = memo(
             });
             return;
           }
-          // Seedance 2.0 厂商对**每条**音频都要求 1.8s ≤ 时长 ≤ 15.2s（见
-          // audioReferenceDurationRejection），越界会以 InvalidParameter 400 回来。
-          // 提交前先本地校验：durationMs 缺失时用 <audio> 探测兜底，越界就弹窗拦下，
-          // 避免白跑一趟后端。仅对 seedance2 生效（其它模型边界未知）。
-          if (isSeedance20Model && audioRefs.length > 0) {
+          // Seedance 2.0 厂商对音频有两条时长约束，越界都会以 InvalidParameter 400
+          // 回来：**每条** 1.8s ≤ 时长 ≤ 15.2s，以及**所有条加起来** ≤ 15.2s。提交前
+          // 先本地校验：durationMs 缺失时用 <audio> 探测兜底，越界就弹窗拦下，避免白跑
+          // 一趟后端。
+          //
+          // 两类边界分开授权，与后端 freezone omni-gen 的兜底一一对应：
+          //   - 逐条 1.8~15.2s 只有 seedance2 成立（数字是从它的报文里实测出来的）；
+          //   - 总时长凡是目录里配了 referenceAudioTotalMaxSeconds 的模型都要管——否则
+          //     这类模型前端放行、后端拦下，用户白等一个来回还只能看到一句英文 400。
+          const audioTotalConfigured =
+            selectedVideoModel?.referenceAudioTotalMaxSeconds != null;
+          if ((isSeedance20Model || audioTotalConfigured) && audioRefs.length > 0) {
             const resolvedDurations = await Promise.all(
               audioRefs.map((ref) =>
                 typeof ref.durationMs === "number" && ref.durationMs > 0
@@ -2195,6 +2205,10 @@ export const VideoNode = memo(
                 label: ref.label,
                 durationMs: resolvedDurations[index] ?? null,
               })),
+              {
+                totalLimitMs: audioReferenceTotalDurationLimitMs(selectedVideoModel),
+                perClipLimits: isSeedance20Model,
+              },
             );
             if (rejection) {
               const clips = formatAudioDurationClips(rejection.clips, (key, vars) =>
@@ -2206,10 +2220,16 @@ export const VideoNode = memo(
                       min: MIN_AUDIO_REFERENCE_DURATION_MS / 1000,
                       clips,
                     })
-                  : t("node.videoNode.audio.durationTooLong", {
-                      max: MAX_AUDIO_REFERENCE_DURATION_MS / 1000,
-                      clips,
-                    }),
+                  : rejection.kind === "tooLong"
+                    ? t("node.videoNode.audio.durationTooLong", {
+                        max: MAX_AUDIO_REFERENCE_DURATION_MS / 1000,
+                        clips,
+                      })
+                    : t("node.videoNode.audio.durationTotalTooLong", {
+                        max: formatAudioDurationSeconds(rejection.limitMs),
+                        total: formatAudioDurationSeconds(rejection.totalMs),
+                        clips,
+                      }),
                 t("common.error"),
               );
               updateNodeData(id, {

--- a/frontend/src/features/canvas/nodes/VideoNode.tsx
+++ b/frontend/src/features/canvas/nodes/VideoNode.tsx
@@ -69,6 +69,7 @@ import {
   formatAudioDurationClips,
   formatAudioDurationSeconds,
   MAX_AUDIO_REFERENCE_DURATION_MS,
+  MAX_AUDIO_REFERENCE_TOTAL_DURATION_MS,
   MIN_AUDIO_REFERENCE_DURATION_MS,
   isHappyHorseVideoModel,
   isSeedance2VideoModel,
@@ -2206,7 +2207,12 @@ export const VideoNode = memo(
                 durationMs: resolvedDurations[index] ?? null,
               })),
               {
-                totalLimitMs: audioReferenceTotalDurationLimitMs(selectedVideoModel),
+                totalLimitMs: audioReferenceTotalDurationLimitMs(selectedVideoModel, {
+                  // seedance2 有厂商硬顶，目录配得再宽也不能越过它。
+                  vendorCapMs: isSeedance20Model
+                    ? MAX_AUDIO_REFERENCE_TOTAL_DURATION_MS
+                    : undefined,
+                }),
                 perClipLimits: isSeedance20Model,
               },
             );

--- a/frontend/src/features/canvas/nodes/shared/videoModelCapabilities.ts
+++ b/frontend/src/features/canvas/nodes/shared/videoModelCapabilities.ts
@@ -271,56 +271,118 @@ export function videoMultiImageAutoSwitchMode(
 }
 
 /**
- * Seedance 2.0 音频引用的时长边界。厂商口径是**逐条**，没有一个字提到总和：
- * `[InvalidParameter.DurationTooShort] Duration must be between 1.8s and 15.2s`。
+ * Seedance 2.0 音频引用的时长边界。厂商有**两条互相独立**的规则，都会以 400 打回：
  *
- * 所以这里也逐条卡，两头都卡。**别再回到按总时长判定**：那会把 3 条各 6s（每条都
- * 在 1.8~15.2 区间内、厂商必然放行）的合法组合拦在本地，用一条我们自己臆想出来的
- * 规则挡住用户。后端 freezone omni-gen 端点（`validate_omni_reference_limits`）只
- * 校验条数（图≤9 / 视频≤3 / 音频≤3 / 总数≤12），同样没有总时长这回事。
+ * 1. 逐条：`[InvalidParameter.DurationTooShort] Duration must be between 1.8s and 15.2s`
+ * 2. 总和：`the parameter audio total duration (seconds) specified in the request must
+ *    be less than or equal to 15.2 for model doubao-seedance-2-0 in r2v`
  *
- * 注：`seedance2_i2v/pipeline.py` 里那个 `MAX_SEEDANCE2_REFERENCE_AUDIO_TOTAL_SECONDS`
- * 总时长守卫属于**剧集 beat 流水线的参考声线**（角色工作台 3-5s 声音克隆样本），与画布
- * 这条 omni-gen 路径无关，不要拿它给这里的总时长限制背书。
+ * **这里曾经只卡第 1 条**，注释里还写着「厂商口径是逐条，没有一个字提到总和」「别再
+ * 回到按总时长判定」。那是错的：2026-08-06 3060 环境两次任务失败
+ * （freezone_video_gen/01KZ5R8ZZZY9M8T9F01H159RP7，gen_mode=allReference）实测抓到了
+ * 第 2 条报文——3 条各 6s 每条都在 1.8~15.2 区间内、逐条判定必然放行，总计 18s 却被
+ * 厂商直接拒。所以总时长这条**不是我们臆想的规则**，删掉它就等于把这个故障放回去。
  *
- * 文案里的秒数一律从这两个常量推（`/ 1000`），别在调用点另写一遍字面量，否则改阈值
+ * 总时长上限优先读媒体模型目录的 `referenceAudioTotalMaxSeconds`（后台可配），没配才用
+ * 下面这个 15.2s 的厂商兜底值。兜底值刻意与单条上限取同一个数：单条 15.2s 是厂商明确
+ * 放行的，兜底若取更小（比如 15s）就会把一条合法的顶格音频误拦在本地。想留安全余量
+ * 请在后台把 `referenceAudioTotalMaxSeconds` 配小，而不是改这里的常量。
+ *
+ * 后端 freezone omni-gen 端点有同一套兜底（`validate_omni_reference_audio_durations`，
+ * src/novelvideo/freezone/video_node.py），那层拿的是落地文件路径 + ffprobe，是本地
+ * `<audio>` 探测失败时最后一道能在计费前拦下的闸门。
+ *
+ * 文案里的秒数一律从这些常量推（`/ 1000`），别在调用点另写一遍字面量，否则改阈值
  * 时提示会静默漂移。
  */
 export const MIN_AUDIO_REFERENCE_DURATION_MS = 1_800;
 export const MAX_AUDIO_REFERENCE_DURATION_MS = 15_200;
+export const MAX_AUDIO_REFERENCE_TOTAL_DURATION_MS = 15_200;
 
-export type AudioDurationRejection = {
-  kind: "tooShort" | "tooLong";
-  clips: { label: string; durationMs: number }[];
-};
+/** 媒体目录里与音频时长相关的那个字段（`ModelOption` 的子集）。 */
+export interface AudioDurationLimitModel {
+  referenceAudioTotalMaxSeconds?: number | null;
+}
 
 /**
- * 提交前音频时长守卫（仅 Seedance 2.0 的全能参考路径调用，其它模型边界未知）。
+ * 所选模型的**有效**音频总时长上限（毫秒）：目录配置优先，没配才用 15.2s。
+ *
+ * 与后端 `_catalog_audio_total_duration_max`（api/routes/freezone.py）同一口径：只认
+ * 有限正数，null / 0 / 负数 / NaN 一律当作没配。允许小数——15.2 本身就不是整数，这
+ * 与那几个「非负整数」的计数字段不同，别顺手套 `Number.isInteger`。
+ */
+export function audioReferenceTotalDurationLimitMs(
+  model: AudioDurationLimitModel | null | undefined,
+): number {
+  const seconds = model?.referenceAudioTotalMaxSeconds;
+  if (typeof seconds === "number" && Number.isFinite(seconds) && seconds > 0) {
+    return Math.round(seconds * 1000);
+  }
+  return MAX_AUDIO_REFERENCE_TOTAL_DURATION_MS;
+}
+
+/**
+ * 三个 kind 必须各占一个联合分支：写成 `kind: "tooShort" | "tooLong"` 合并那两个的话，
+ * TS 无法靠 `kind !== "tooLong"` 把整个分支从联合里剔掉，调用点的三元链就取不到
+ * totalTooLong 独有的 totalMs / limitMs。
+ */
+export type AudioDurationRejection =
+  | { kind: "tooShort"; clips: { label: string; durationMs: number }[] }
+  | { kind: "tooLong"; clips: { label: string; durationMs: number }[] }
+  | {
+      kind: "totalTooLong";
+      clips: { label: string; durationMs: number }[];
+      totalMs: number;
+      limitMs: number;
+    };
+
+/**
+ * 提交前音频时长守卫。
  *
  * `durationMs` 为 null = 探测不出时长（音频节点没渲染过波形，且 `<audio>` 探测撞上
  * CORS / 网络 / 超时）。这类一律**不参与判定**——宁可放过去让后端兜底，也不要凭空
- * 拦住一次正常提交。
+ * 拦住一次正常提交。对总时长来说这意味着算出来的和是个**下界**，但判定方向仍然安全：
+ * 漏算只会让和变小，所以「算出来超了」必定真超，不会因此误拦。
  *
- * 太短优先于太长上报：同时越界时先修哪条都行，报一类比混在一起列更好读。
+ * 两类边界**分开授权**，与后端 `validate_omni_reference_audio_durations` 一一对应：
+ *   - `perClipLimits`：逐条 1.8~15.2s，这两个数字是从 Seedance 2.0 的报文里实测出来的，
+ *     只对它成立。别家模型传 `false` —— 拿 2.0 的数字去卡它，一条正常的 25s 音频会被
+ *     我们凭空拦在本地。
+ *   - `totalLimitMs`：总时长，优先听目录里的 `referenceAudioTotalMaxSeconds`
+ *     （见 `audioReferenceTotalDurationLimitMs`），没配才落到 15.2s 兜底。
+ *
+ * 上报顺序 太短 → 单条太长 → 总和太长：前两类是「换掉这条」，最后一类是「整体裁一裁」，
+ * 混在一起列用户不知道先动哪个。
  */
 export function audioReferenceDurationRejection(
   clips: readonly { label: string; durationMs: number | null }[],
+  options: { totalLimitMs?: number; perClipLimits?: boolean } = {},
 ): AudioDurationRejection | null {
+  const {
+    totalLimitMs = MAX_AUDIO_REFERENCE_TOTAL_DURATION_MS,
+    perClipLimits = true,
+  } = options;
   const measured = clips.filter(
     (clip): clip is { label: string; durationMs: number } =>
       typeof clip.durationMs === "number" && clip.durationMs > 0,
   );
-  const tooShort = measured.filter(
-    (clip) => clip.durationMs < MIN_AUDIO_REFERENCE_DURATION_MS,
-  );
-  if (tooShort.length > 0) {
-    return { kind: "tooShort", clips: tooShort };
+  if (perClipLimits) {
+    const tooShort = measured.filter(
+      (clip) => clip.durationMs < MIN_AUDIO_REFERENCE_DURATION_MS,
+    );
+    if (tooShort.length > 0) {
+      return { kind: "tooShort", clips: tooShort };
+    }
+    const tooLong = measured.filter(
+      (clip) => clip.durationMs > MAX_AUDIO_REFERENCE_DURATION_MS,
+    );
+    if (tooLong.length > 0) {
+      return { kind: "tooLong", clips: tooLong };
+    }
   }
-  const tooLong = measured.filter(
-    (clip) => clip.durationMs > MAX_AUDIO_REFERENCE_DURATION_MS,
-  );
-  if (tooLong.length > 0) {
-    return { kind: "tooLong", clips: tooLong };
+  const totalMs = measured.reduce((sum, clip) => sum + clip.durationMs, 0);
+  if (measured.length > 0 && totalMs > totalLimitMs) {
+    return { kind: "totalTooLong", clips: measured, totalMs, limitMs: totalLimitMs };
   }
   return null;
 }
@@ -333,12 +395,12 @@ export function audioReferenceDurationRejection(
  * （`Math.round(secs * 1000)`），所以按毫秒精度展示，再去掉无意义的尾随 0：
  * 900 → `0.9`、1799 → `1.799`、15201 → `15.201`、6000 → `6`。
  */
-function formatClipSeconds(durationMs: number): string {
+export function formatAudioDurationSeconds(durationMs: number): string {
   return (durationMs / 1000).toFixed(3).replace(/\.?0+$/, "");
 }
 
 /**
- * 把违规条目拼成提示里的 `{{clips}}`（tooShort / tooLong 共用）。
+ * 把违规条目拼成提示里的 `{{clips}}`（tooShort / tooLong / totalTooLong 共用）。
  *
  * 括号和分隔符都从 locale 取（zh 用全角括号 + 顿号，en 用半角括号 + 逗号），别在
  * 调用点写死——这里曾经硬编码 `（）` 和 `、`，en 用户会看到一串中文标点。
@@ -351,7 +413,7 @@ export function formatAudioDurationClips(
     .map((clip) =>
       translate("node.videoNode.audio.clipDuration", {
         label: clip.label,
-        seconds: formatClipSeconds(clip.durationMs),
+        seconds: formatAudioDurationSeconds(clip.durationMs),
       }),
     )
     .join(translate("node.videoNode.audio.clipSeparator"));

--- a/frontend/src/features/canvas/nodes/shared/videoModelCapabilities.ts
+++ b/frontend/src/features/canvas/nodes/shared/videoModelCapabilities.ts
@@ -308,17 +308,26 @@ export interface AudioDurationLimitModel {
  * 所选模型的**有效**音频总时长上限（毫秒）：目录配置优先，没配才用 15.2s。
  *
  * 与后端 `_catalog_audio_total_duration_max`（api/routes/freezone.py）同一口径：只认
- * 有限正数，null / 0 / 负数 / NaN 一律当作没配。允许小数——15.2 本身就不是整数，这
- * 与那几个「非负整数」的计数字段不同，别顺手套 `Number.isInteger`。
+ * 有限正数，null / 0 / 负数 / NaN / Infinity 一律当作没配。允许小数——15.2 本身就不是
+ * 整数，这与那几个「非负整数」的计数字段不同，别顺手套 `Number.isInteger`。
+ *
+ * `vendorCapMs` = 这个模型的厂商硬顶（seedance2 传 15.2s，边界未知的模型不传）。传了
+ * 就与目录值**取小**：管理员可以配得更严，但配宽了不该让厂商也跟着放行——给 seedance2
+ * 配 60s 的话，3 条 6s 在本地全过、到厂商那儿照样 400，正是这套守卫要消灭的失败。
  */
 export function audioReferenceTotalDurationLimitMs(
   model: AudioDurationLimitModel | null | undefined,
+  { vendorCapMs }: { vendorCapMs?: number } = {},
 ): number {
   const seconds = model?.referenceAudioTotalMaxSeconds;
-  if (typeof seconds === "number" && Number.isFinite(seconds) && seconds > 0) {
-    return Math.round(seconds * 1000);
+  const configured =
+    typeof seconds === "number" && Number.isFinite(seconds) && seconds > 0
+      ? Math.round(seconds * 1000)
+      : null;
+  if (vendorCapMs == null) {
+    return configured ?? MAX_AUDIO_REFERENCE_TOTAL_DURATION_MS;
   }
-  return MAX_AUDIO_REFERENCE_TOTAL_DURATION_MS;
+  return configured == null ? vendorCapMs : Math.min(configured, vendorCapMs);
 }
 
 /**

--- a/frontend/src/features/canvas/ui/ProviderModelPicker.tsx
+++ b/frontend/src/features/canvas/ui/ProviderModelPicker.tsx
@@ -62,6 +62,8 @@ export interface ModelOption {
   referenceImageMax?: number | null;
   referenceVideoMax?: number | null;
   referenceAudioMax?: number | null;
+  /** 参考音频总时长上限（秒，可为小数）；没配时前端按 15.2s 兜底。 */
+  referenceAudioTotalMaxSeconds?: number | null;
   request?: MediaModelRequestSchema;
 }
 

--- a/src/novelvideo/api/routes/freezone.py
+++ b/src/novelvideo/api/routes/freezone.py
@@ -256,7 +256,11 @@ from novelvideo.freezone.video_node import (
     normalize_video_resolution_for_backend,
     resolve_freezone_video_backend,
     summarize_omni_reference_counts,
+    validate_omni_reference_audio_durations,
     validate_omni_reference_limits,
+    MAX_OMNI_REFERENCE_AUDIO_SECONDS,
+    MAX_OMNI_REFERENCE_AUDIO_TOTAL_SECONDS,
+    MIN_OMNI_REFERENCE_AUDIO_SECONDS,
 )
 from novelvideo.models import CharacterIdentity, beat_scene_id
 from novelvideo.project_config import (
@@ -7093,6 +7097,39 @@ def _catalog_reference_limits(
     }
 
 
+def _catalog_audio_total_duration_max(capabilities: dict[str, Any] | None) -> float | None:
+    """目录里配的全能参考音频**总时长**上限（秒），没配返回 None。
+
+    与 `_catalog_reference_limits` 同一套「目录优先」的口径，只是这里允许小数
+    （15.2 本身就不是整数）。非正数 / 非数字一律当没配。
+
+    刻意**不在这里兜底**成 15.2：调用方要靠「有没有配」来决定这个模型该不该受管，
+    在这里默默返回 15.2 就分不清「管理员配了 15.2」和「压根没配」。
+    """
+    value = capabilities.get("referenceAudioTotalMaxSeconds") if capabilities else None
+    if type(value) in (int, float) and value > 0:
+        return float(value)
+    return None
+
+
+async def _probe_reference_audio_seconds(path: str) -> float | None:
+    """ffprobe 读音频时长，读不出返回 None（校验器会跳过这条）。
+
+    不能改用 `utils.media_io.get_audio_duration`：它探测失败时返回 **5.0**，一个正好
+    合法的值，会把兜底变成静默放行。这里要的就是「不知道」和「知道」分得清。
+    """
+    from novelvideo.seedance2_i2v.character_voice_storage import (
+        probe_voice_sample_duration_seconds,
+    )
+    from novelvideo.utils.async_ops import call_blocking
+
+    try:
+        return float(await call_blocking(probe_voice_sample_duration_seconds, path))
+    except Exception as exc:  # ffprobe 缺失 / 文件损坏 / 权限，都只是「测不出」
+        logger.warning("[freezone] reference audio duration probe failed: %s (%s)", path, exc)
+        return None
+
+
 def _catalog_duration_bounds(
     capabilities: dict[str, Any] | None,
 ) -> tuple[int | None, int | None]:
@@ -7962,6 +7999,41 @@ async def freezone_video_omni_gen(
                 "role": str(item.get("role") or ""),
             }
         )
+
+    # 音频时长兜底。前端也拦一遍（videoModelCapabilities.audioReferenceDurationRejection），
+    # 但那层靠 <audio> 探测，CORS / 超时 / 老画布数据都可能测不出而放行；这里 URL 已经
+    # 落成本地路径，ffprobe 能给出确定答案，是最后一道能在计费前拦下的闸门。
+    #
+    # 只对**已知边界**的模型生效，而且两类边界分开授权：
+    #   - 逐条 1.8~15.2s 是从 Seedance 2.0 的报文里实测出来的，只对它成立；
+    #   - 总时长优先听目录里的 referenceAudioTotalMaxSeconds（管理员主动声明），
+    #     没配时只有 Seedance 2.0 才落到 15.2s 兜底。
+    # 别把这两类混成一个开关：目录里给别家模型配了 60s 总时长，不代表它的单条也得
+    # 卡在 15.2s —— 那样一条正常的 25s 音频会被我们凭空 400 掉。
+    audio_items = [item for item in reference_items if item["type"] == "audio"]
+    per_clip_bounds_known = is_freezone_seedance2_backend(backend)
+    configured_audio_total = _catalog_audio_total_duration_max(capabilities)
+    audio_total_max = configured_audio_total
+    if audio_total_max is None and per_clip_bounds_known:
+        audio_total_max = MAX_OMNI_REFERENCE_AUDIO_TOTAL_SECONDS
+    if audio_items and (per_clip_bounds_known or audio_total_max is not None):
+        probed = [
+            (Path(item["path"]).name or f"audio{index}", await _probe_reference_audio_seconds(item["path"]))
+            for index, item in enumerate(audio_items, start=1)
+        ]
+        try:
+            validate_omni_reference_audio_durations(
+                probed,
+                min_seconds=(
+                    MIN_OMNI_REFERENCE_AUDIO_SECONDS if per_clip_bounds_known else None
+                ),
+                max_seconds=(
+                    MAX_OMNI_REFERENCE_AUDIO_SECONDS if per_clip_bounds_known else None
+                ),
+                total_max_seconds=audio_total_max,
+            )
+        except ValueError as exc:
+            raise HTTPException(400, str(exc)) from exc
 
     final_prompt = build_freezone_omni_video_prompt(
         user_prompt=body.prompt,

--- a/src/novelvideo/api/routes/freezone.py
+++ b/src/novelvideo/api/routes/freezone.py
@@ -12,6 +12,7 @@ import binascii
 import hashlib
 import json
 import logging
+import math
 import os
 import re
 import shutil
@@ -7101,13 +7102,15 @@ def _catalog_audio_total_duration_max(capabilities: dict[str, Any] | None) -> fl
     """目录里配的全能参考音频**总时长**上限（秒），没配返回 None。
 
     与 `_catalog_reference_limits` 同一套「目录优先」的口径，只是这里允许小数
-    （15.2 本身就不是整数）。非正数 / 非数字一律当没配。
+    （15.2 本身就不是整数）。非正数 / 非数字 / inf / nan 一律当没配——写入侧
+    `media_model_request_schema` 已经挡了这些，但目录条目也可能是那道校验存在之前落的库，
+    读出来再挡一次才不会让 inf 静默关掉整个上限。
 
     刻意**不在这里兜底**成 15.2：调用方要靠「有没有配」来决定这个模型该不该受管，
     在这里默默返回 15.2 就分不清「管理员配了 15.2」和「压根没配」。
     """
     value = capabilities.get("referenceAudioTotalMaxSeconds") if capabilities else None
-    if type(value) in (int, float) and value > 0:
+    if type(value) in (int, float) and math.isfinite(value) and value > 0:
         return float(value)
     return None
 
@@ -8006,20 +8009,33 @@ async def freezone_video_omni_gen(
     #
     # 只对**已知边界**的模型生效，而且两类边界分开授权：
     #   - 逐条 1.8~15.2s 是从 Seedance 2.0 的报文里实测出来的，只对它成立；
-    #   - 总时长优先听目录里的 referenceAudioTotalMaxSeconds（管理员主动声明），
-    #     没配时只有 Seedance 2.0 才落到 15.2s 兜底。
+    #   - 总时长对**边界已知**的模型是「目录配置与厂商硬顶取小」：管理员可以配得更严，
+    #     但配宽了不会让厂商也跟着放行——给 seedance2 配 60s，3 条 6s 在本地全过、到厂商
+    #     那儿照样 400，正是本 PR 要消灭的那种失败。边界未知的模型没有硬顶可取，直接用
+    #     目录值。
     # 别把这两类混成一个开关：目录里给别家模型配了 60s 总时长，不代表它的单条也得
     # 卡在 15.2s —— 那样一条正常的 25s 音频会被我们凭空 400 掉。
     audio_items = [item for item in reference_items if item["type"] == "audio"]
     per_clip_bounds_known = is_freezone_seedance2_backend(backend)
     configured_audio_total = _catalog_audio_total_duration_max(capabilities)
-    audio_total_max = configured_audio_total
-    if audio_total_max is None and per_clip_bounds_known:
-        audio_total_max = MAX_OMNI_REFERENCE_AUDIO_TOTAL_SECONDS
+    if per_clip_bounds_known:
+        audio_total_max = min(
+            configured_audio_total or MAX_OMNI_REFERENCE_AUDIO_TOTAL_SECONDS,
+            MAX_OMNI_REFERENCE_AUDIO_TOTAL_SECONDS,
+        )
+    else:
+        audio_total_max = configured_audio_total
     if audio_items and (per_clip_bounds_known or audio_total_max is not None):
+        # 并发探测：ffprobe 单条有 20s 超时，串行 await 会把 3 条参考音频叠成最长 60s 的
+        # 请求耗时。gather 之后最坏就是一个超时的墙钟，也就顺带成了整体上限。
+        probed_seconds = await asyncio.gather(
+            *(_probe_reference_audio_seconds(item["path"]) for item in audio_items)
+        )
         probed = [
-            (Path(item["path"]).name or f"audio{index}", await _probe_reference_audio_seconds(item["path"]))
-            for index, item in enumerate(audio_items, start=1)
+            (Path(item["path"]).name or f"audio{index}", seconds)
+            for index, (item, seconds) in enumerate(
+                zip(audio_items, probed_seconds), start=1
+            )
         ]
         try:
             validate_omni_reference_audio_durations(

--- a/src/novelvideo/freezone/video_node.py
+++ b/src/novelvideo/freezone/video_node.py
@@ -539,6 +539,102 @@ def validate_omni_reference_limits(
         raise ValueError(f"audio references count must be <= {audio_max}")
 
 
+# 全能参考音频时长：厂商（doubao-seedance-2-0 / r2v）有**两条互相独立**的规则，
+# 两条都以 400 打回，只卡其中一条就等于没卡：
+#   1. 逐条：`[InvalidParameter.DurationTooShort] Duration must be between 1.8s and 15.2s`
+#   2. 总和：`the parameter audio total duration (seconds) specified in the request must
+#      be less than or equal to 15.2 for model doubao-seedance-2-0 in r2v`
+#
+# 第 2 条是 2026-08-06 从 3060 环境两次失败任务里实测抓到的
+# （freezone_video_gen/01KZ5R8ZZZY9M8T9F01H159RP7，gen_mode=allReference）。在那之前
+# 前后端都只按第 1 条判定，3 条各 6s 每条都合法、总计 18s 必被厂商拒——用户白等一轮。
+# 别再把总时长这条当成「我们自己臆想的规则」删掉。
+MIN_OMNI_REFERENCE_AUDIO_SECONDS = 1.8
+MAX_OMNI_REFERENCE_AUDIO_SECONDS = 15.2
+MAX_OMNI_REFERENCE_AUDIO_TOTAL_SECONDS = 15.2
+
+
+def _format_seconds(value: float) -> str:
+    """按毫秒精度展示，去掉无意义尾随 0：15.2 → `15.2`、6.0 → `6`、1.799 → `1.799`。
+
+    不能 `round(x, 1)`：15.201 显示成「15.2」时，用户看到的正好是合法边界值却被告知
+    越界，只会怀疑我们算错了。前端 `formatClipSeconds` 是同一口径。
+    """
+    return f"{value:.3f}".rstrip("0").rstrip(".")
+
+
+def _exceeds(value: float, limit: float) -> bool:
+    """`value > limit`，但先归整到毫秒。
+
+    浮点和会自己漂出去：6 + 6 + 3.2 == 15.200000000000001，裸比较会把一组正好顶格
+    15.2s 的合法音频判成超限。
+    """
+    return round(value - limit, 3) > 0
+
+
+def validate_omni_reference_audio_durations(
+    durations: list[tuple[str, float | None]],
+    *,
+    min_seconds: float | None = MIN_OMNI_REFERENCE_AUDIO_SECONDS,
+    max_seconds: float | None = MAX_OMNI_REFERENCE_AUDIO_SECONDS,
+    total_max_seconds: float | None = MAX_OMNI_REFERENCE_AUDIO_TOTAL_SECONDS,
+) -> None:
+    """全能参考音频时长兜底校验，入参是 `(标签, 秒数)`，秒数 None = 探测不出。
+
+    探测不出的条目**不参与判定**：ffprobe 缺失 / 文件读不了时，宁可放过去让厂商判，
+    也不要凭空拦死一次正常提交。这让总和成为**下界**，但判定方向仍然安全——漏算只会
+    让和更小，所以「算出来超了」必定真超，不存在因此产生的误拦。
+
+    三个上限各自可以传 `None` = **这项不判定**。逐条边界（1.8~15.2s）是从 Seedance 2.0
+    的报文里实测出来的，只对它成立；管理员在目录里配了总时长、但模型不是 2.0 时，调用方
+    应当把 min/max 传 None ——拿 2.0 的数字去卡别家模型就是凭空 400。
+
+    太短 → 单条太长 → 总和太长，逐类上报；同时越界时报一类比混在一起列更好读。
+    """
+    measured = [
+        (label, float(seconds))
+        for label, seconds in durations
+        if isinstance(seconds, (int, float))
+        and not isinstance(seconds, bool)
+        and seconds > 0
+    ]
+    if not measured:
+        return
+
+    def _clips(items: list[tuple[str, float]]) -> str:
+        return ", ".join(f"{label} ({_format_seconds(value)}s)" for label, value in items)
+
+    too_short = (
+        [item for item in measured if _exceeds(min_seconds, item[1])]
+        if min_seconds is not None
+        else []
+    )
+    if too_short:
+        raise ValueError(
+            f"audio reference duration must be >= {_format_seconds(min_seconds)}s: "
+            + _clips(too_short)
+        )
+    too_long = (
+        [item for item in measured if _exceeds(item[1], max_seconds)]
+        if max_seconds is not None
+        else []
+    )
+    if too_long:
+        raise ValueError(
+            f"audio reference duration must be <= {_format_seconds(max_seconds)}s: "
+            + _clips(too_long)
+        )
+    if total_max_seconds is None:
+        return
+    total = sum(value for _, value in measured)
+    if _exceeds(total, total_max_seconds):
+        raise ValueError(
+            "audio references total duration must be <= "
+            f"{_format_seconds(total_max_seconds)}s, got {_format_seconds(total)}s: "
+            + _clips(measured)
+        )
+
+
 def video_character_library_path(project_dir: Path) -> Path:
     return freezone_root(project_dir) / "video_character_library.json"
 

--- a/src/novelvideo/media_model_request_schema.py
+++ b/src/novelvideo/media_model_request_schema.py
@@ -237,6 +237,7 @@ def validate_media_model_catalog_config(
             "supportedModes",
             "referenceVideoMax",
             "referenceAudioMax",
+            "referenceAudioTotalMaxSeconds",
             "humanReview",
             "sceneOptimizeOptions",
             "defaultSceneOptimize",
@@ -287,6 +288,16 @@ def validate_media_model_catalog_config(
         value = config.get(field)
         if value is not None and (type(value) is not int or value < 0):
             raise MediaModelSchemaError(f"{field} must be a non-negative integer")
+
+    # 参考音频**总时长**上限（秒）。厂商口径 15.2 本身就不是整数，所以这项收小数，
+    # 与上面那几个计数字段不同口径——别顺手并进上面的循环。
+    audio_total = config.get("referenceAudioTotalMaxSeconds")
+    if audio_total is not None and (
+        type(audio_total) not in (int, float) or audio_total <= 0
+    ):
+        raise MediaModelSchemaError(
+            "referenceAudioTotalMaxSeconds must be a positive number"
+        )
 
     if media_type == "video":
         video_limit = config.get("referenceVideoMax")

--- a/src/novelvideo/media_model_request_schema.py
+++ b/src/novelvideo/media_model_request_schema.py
@@ -291,12 +291,17 @@ def validate_media_model_catalog_config(
 
     # 参考音频**总时长**上限（秒）。厂商口径 15.2 本身就不是整数，所以这项收小数，
     # 与上面那几个计数字段不同口径——别顺手并进上面的循环。
+    #
+    # `math.isfinite` 不能省：`inf > 0` 是 True、`nan <= 0` 是 False，只写「正数」这两个
+    # 都会漏进来，配成 inf 就等于把这个上限静默关掉。
     audio_total = config.get("referenceAudioTotalMaxSeconds")
     if audio_total is not None and (
-        type(audio_total) not in (int, float) or audio_total <= 0
+        type(audio_total) not in (int, float)
+        or not math.isfinite(audio_total)
+        or audio_total <= 0
     ):
         raise MediaModelSchemaError(
-            "referenceAudioTotalMaxSeconds must be a positive number"
+            "referenceAudioTotalMaxSeconds must be a positive finite number"
         )
 
     if media_type == "video":

--- a/src/novelvideo/seedance2_i2v/character_voice_storage.py
+++ b/src/novelvideo/seedance2_i2v/character_voice_storage.py
@@ -94,26 +94,45 @@ def _transcode_to_mp3(content: bytes) -> bytes:
     return result.stdout
 
 
+PROBE_DURATION_TIMEOUT_SECONDS = 20.0
+"""ffprobe 探测时长的墙钟上限。
+
+这里的入参是**用户上传的文件**，而且这个函数现在挂在同步请求路径上
+（freezone omni-gen 的音频时长兜底）。ffprobe 遇到畸形/超长容器有可能迟迟不返回，
+没有 timeout 的话一个坏文件就能把 HTTP 请求吊死，并且一直占着线程池的一个 worker。
+超时按「测不出」处理（ValueError），与其它探测失败同一条路径。
+"""
+
+
 def probe_voice_sample_duration_seconds(path: str | Path) -> float:
     """Return audio duration in seconds using ffprobe."""
 
     if not shutil.which("ffprobe"):
         raise ValueError("系统未安装 ffprobe，无法读取音频时长")
-    result = subprocess.run(
-        [
-            "ffprobe",
-            "-v",
-            "error",
-            "-show_entries",
-            "format=duration",
-            "-of",
-            "default=noprint_wrappers=1:nokey=1",
-            str(path),
-        ],
-        capture_output=True,
-        text=True,
-        check=False,
-    )
+    try:
+        result = subprocess.run(
+            [
+                "ffprobe",
+                "-v",
+                "error",
+                "-show_entries",
+                "format=duration",
+                "-of",
+                "default=noprint_wrappers=1:nokey=1",
+                str(path),
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=PROBE_DURATION_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired as exc:
+        # 必须在这里转成 ValueError：调用方（beat 流水线的
+        # `_validate_reference_audio_request`、freezone 的 `_probe_reference_audio_seconds`）
+        # 都只按 ValueError 走「测不出就跳过」，漏出 TimeoutExpired 会变成 500。
+        raise ValueError(
+            f"读取音频时长超时（>{PROBE_DURATION_TIMEOUT_SECONDS:g}s）：{path}"
+        ) from exc
     try:
         duration = float((result.stdout or "").strip())
     except (TypeError, ValueError) as exc:

--- a/src/novelvideo/seedance2_i2v/pipeline.py
+++ b/src/novelvideo/seedance2_i2v/pipeline.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import re
 from typing import Any
 
+from novelvideo.freezone.video_node import validate_omni_reference_audio_durations
 from novelvideo.generators.video_generator import ShotReference
 from novelvideo.seedance2_i2v.character_voice_storage import probe_voice_sample_duration_seconds
 from novelvideo.seedance2_i2v.assets import (
@@ -107,21 +108,38 @@ def _selected_audio_assets(assets: list[Seedance2ResolvedAsset]) -> list[Seedanc
 
 
 def _validate_reference_audio_request(audio_paths: list[str]) -> None:
+    """Seedance2 参考音频的条数 + 时长校验。
+
+    时长判定复用画布那条 `validate_omni_reference_audio_durations`：厂商规则是同一套
+    （逐条 1.8~15.2s、再加一条总时长），两边各写一遍必然会漂——本次故障的根因就是前端
+    和后端对同一条规则的理解走散了。这里只多做两件事：把 ffprobe 的 ValueError 收成
+    `None`（测不出就不判，与画布同口径），以及把英文报错包回中文并补上「去哪儿改」。
+
+    总时长仍用本模块的 15.0s 而不是厂商的 15.2s：这条路径的参考声线本来就该是 3-5s 的
+    样例，收紧 0.2s 不会误伤，而放宽是产品口径变化，不该顺手做。
+    """
     if len(audio_paths) > MAX_SEEDANCE2_REFERENCE_AUDIOS:
         raise ValueError("Seedance2 参考音频最多 3 段")
 
-    total_duration = 0.0
-    measured = False
-    for path in audio_paths:
+    def _probe(path: str) -> float | None:
         try:
-            total_duration += probe_voice_sample_duration_seconds(path)
-            measured = True
+            return probe_voice_sample_duration_seconds(path)
         except ValueError:
-            continue
-    if measured and total_duration > MAX_SEEDANCE2_REFERENCE_AUDIO_TOTAL_SECONDS:
-        raise ValueError(
-            "Seedance2 参考音频总时长超过 15 秒，" "请回到角色工作台把参考声线裁剪到 3-5 秒"
+            return None
+
+    # 标签与 `_build_shot_references` 一致，用户在报错里看到的「音频2」能对上提示词里的。
+    measured = [
+        (f"音频{index}", _probe(path)) for index, path in enumerate(audio_paths, start=1)
+    ]
+    try:
+        validate_omni_reference_audio_durations(
+            measured,
+            total_max_seconds=MAX_SEEDANCE2_REFERENCE_AUDIO_TOTAL_SECONDS,
         )
+    except ValueError as exc:
+        raise ValueError(
+            f"Seedance2 参考音频时长不合规（{exc}），请回到角色工作台把参考声线裁剪到 3-5 秒"
+        ) from exc
 
 
 def _compact_text(value: Any) -> str:

--- a/tests/test_character_voice_storage.py
+++ b/tests/test_character_voice_storage.py
@@ -122,6 +122,36 @@ def test_age_group_slots_cover_known_values():
     assert set(AGE_GROUP_SLOTS) == {"child", "youth", "middle", "elder"}
 
 
+def test_probe_voice_sample_duration_times_out_as_value_error(monkeypatch, tmp_path):
+    """ffprobe 卡住必须限时并转成 ValueError。
+
+    这个函数现在挂在同步请求路径上（freezone omni-gen 的音频时长兜底），入参是用户
+    上传的文件。没有 timeout 的话一个畸形容器就能吊死 HTTP 请求并占死线程池 worker；
+    漏出 TimeoutExpired 则会让只 catch ValueError 的调用方变成 500 而不是「测不出」。
+    """
+    import shutil
+    import subprocess
+
+    from novelvideo.seedance2_i2v import character_voice_storage
+
+    sample = tmp_path / "hang.wav"
+    sample.write_bytes(b"RIFF----WAVEfmt ")
+
+    monkeypatch.setattr(shutil, "which", lambda _name: "/usr/bin/ffprobe")
+
+    seen: dict[str, object] = {}
+
+    def fake_run(cmd, **kwargs):
+        seen.update(kwargs)
+        raise subprocess.TimeoutExpired(cmd, kwargs["timeout"])
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    with pytest.raises(ValueError, match="超时"):
+        character_voice_storage.probe_voice_sample_duration_seconds(sample)
+    assert seen["timeout"] == character_voice_storage.PROBE_DURATION_TIMEOUT_SECONDS
+
+
 def test_trim_voice_sample_content_outputs_seedance2_ready_clip(tmp_path):
     import shutil
     import subprocess

--- a/tests/test_freezone_image_backend.py
+++ b/tests/test_freezone_image_backend.py
@@ -317,6 +317,255 @@ async def test_freezone_video_omni_gen_rejects_happyhorse_model(
     assert "HappyHorse video does not support omni reference mode" in str(exc.value.detail)
 
 
+def _audio_reference(project_dir: Path, name: str) -> dict[str, str]:
+    """落一个占位音频文件并返回对应的 reference 条目（时长由测试直接打桩）。"""
+    path = project_dir / "freezone" / "_uploads" / name
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(b"RIFF----WAVEfmt ")
+    return {"type": "audio", "url": f"/static/admin/58/freezone/_uploads/{name}"}
+
+
+@pytest.mark.asyncio
+async def test_freezone_video_omni_gen_rejects_audio_total_duration(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """3 条各 6s：逐条全合规、总计 18s —— 后端兜底必须在计费前 400 掉。
+
+    这就是 2026-08-06 3060 环境两次任务失败的形状：前端那层若被绕过（老画布数据、
+    <audio> 探测失败），厂商会在扣费之后才拒。
+    """
+    project_dir, _output_dir = _patch_freezone_project(monkeypatch, tmp_path)
+    references = [_audio_reference(project_dir, f"clip{i}.wav") for i in range(3)]
+    async def fake_probe(_path: str) -> float:
+        return 6.0
+
+    monkeypatch.setattr(freezone_routes, "_probe_reference_audio_seconds", fake_probe)
+
+    with pytest.raises(HTTPException) as exc:
+        await freezone_routes.freezone_video_omni_gen(
+            project="58",
+            body=freezone_routes.FreezoneVideoOmniGenRequest(
+                prompt="雨夜街头，人物缓慢回头。",
+                references=references,
+            ),
+            user={"username": "admin"},
+        )
+
+    assert exc.value.status_code == 400
+    assert "total duration must be <= 15.2s" in str(exc.value.detail)
+    assert "got 18s" in str(exc.value.detail)
+
+
+@pytest.mark.asyncio
+async def test_freezone_video_omni_gen_allows_audio_within_total_duration(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """总计正好顶格 15.2s 必须放行——兜底拦过头比不拦更难查。"""
+    project_dir, _output_dir = _patch_freezone_project(monkeypatch, tmp_path)
+    references = [_audio_reference(project_dir, f"ok{i}.wav") for i in range(2)]
+    durations = iter([9.0, 6.2])
+
+    async def fake_probe(_path: str) -> float:
+        return next(durations)
+
+    monkeypatch.setattr(freezone_routes, "_probe_reference_audio_seconds", fake_probe)
+    # 走到 enqueue 就说明时长这关过了，不必真的排任务。
+    _patch_runtime_error_enqueue(monkeypatch)
+
+    with pytest.raises(HTTPException) as exc:
+        await freezone_routes.freezone_video_omni_gen(
+            project="58",
+            body=freezone_routes.FreezoneVideoOmniGenRequest(
+                prompt="雨夜街头，人物缓慢回头。",
+                references=references,
+            ),
+            user={"username": "admin"},
+        )
+
+    assert exc.value.status_code == 503
+
+
+@pytest.mark.asyncio
+async def test_freezone_video_omni_gen_skips_unprobeable_audio(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """ffprobe 测不出时不能把正常提交拦死——这层只在「知道超了」时才拦。"""
+    project_dir, _output_dir = _patch_freezone_project(monkeypatch, tmp_path)
+    references = [_audio_reference(project_dir, f"blind{i}.wav") for i in range(3)]
+    async def fake_probe(_path: str) -> None:
+        return None
+
+    monkeypatch.setattr(freezone_routes, "_probe_reference_audio_seconds", fake_probe)
+    _patch_runtime_error_enqueue(monkeypatch)
+
+    with pytest.raises(HTTPException) as exc:
+        await freezone_routes.freezone_video_omni_gen(
+            project="58",
+            body=freezone_routes.FreezoneVideoOmniGenRequest(
+                prompt="雨夜街头，人物缓慢回头。",
+                references=references,
+            ),
+            user={"username": "admin"},
+        )
+
+    assert exc.value.status_code == 503
+
+
+def _patch_video_catalog(monkeypatch: pytest.MonkeyPatch, entry: dict[str, object]) -> None:
+    """视频目录替身：只放一条，omni-gen 会按它解析 backend / capabilities。"""
+
+    async def fake_catalog(media_type: str) -> list[dict[str, object]] | None:
+        return [entry] if media_type == "video" else None
+
+    monkeypatch.setattr(freezone_routes, "_ee_media_model_catalog", fake_catalog)
+
+
+@pytest.mark.asyncio
+async def test_freezone_video_omni_gen_uses_catalog_audio_total_limit(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """总时长上限听后台 referenceAudioTotalMaxSeconds，15.2s 只是没配时的兜底。"""
+    project_dir, _output_dir = _patch_freezone_project(monkeypatch, tmp_path)
+    _patch_video_catalog(
+        monkeypatch,
+        {
+            "catalogId": "cat-omni",
+            "id": "cat-omni",
+            "apiModel": "doubao-seedance-2-0",
+            "providerId": "newapi",
+            "supportedModes": ["all_reference"],
+            "referenceAudioTotalMaxSeconds": 8,
+        },
+    )
+    references = [_audio_reference(project_dir, f"cfg{i}.wav") for i in range(2)]
+
+    async def fake_probe(_path: str) -> float:
+        return 5.0
+
+    monkeypatch.setattr(freezone_routes, "_probe_reference_audio_seconds", fake_probe)
+
+    with pytest.raises(HTTPException) as exc:
+        await freezone_routes.freezone_video_omni_gen(
+            project="58",
+            body=freezone_routes.FreezoneVideoOmniGenRequest(
+                prompt="雨夜街头，人物缓慢回头。",
+                model="cat-omni",
+                references=references,
+            ),
+            user={"username": "admin"},
+        )
+
+    # 10s 在厂商 15.2s 之内，是后台那条 8s 把它拦下的。
+    assert exc.value.status_code == 400
+    assert "total duration must be <= 8s" in str(exc.value.detail)
+
+
+@pytest.mark.asyncio
+async def test_freezone_video_omni_gen_skips_duration_guard_for_unknown_model(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """边界未知的模型（这里是 seedance-1.5-pro，由目录打开 all_reference）不套 2.0 的数字。
+
+    1.8~15.2s 是从 2.0 的报文里实测出来的，别人家的模型凭空 400 比漏拦更糟；要卡就在
+    目录里配 referenceAudioTotalMaxSeconds 显式声明。
+    """
+    project_dir, _output_dir = _patch_freezone_project(monkeypatch, tmp_path)
+    _patch_video_catalog(
+        monkeypatch,
+        {
+            "catalogId": "cat-other",
+            "id": "cat-other",
+            "apiModel": "newapi_seedance-1.5-pro",
+            "providerId": "newapi",
+            "supportedModes": ["all_reference"],
+        },
+    )
+    references = [_audio_reference(project_dir, f"other{i}.wav") for i in range(3)]
+
+    async def fake_probe(_path: str) -> float:
+        return 6.0  # 总计 18s，若误套 Seedance 口径就会 400
+
+    monkeypatch.setattr(freezone_routes, "_probe_reference_audio_seconds", fake_probe)
+    _patch_runtime_error_enqueue(monkeypatch)
+
+    with pytest.raises(HTTPException) as exc:
+        await freezone_routes.freezone_video_omni_gen(
+            project="58",
+            body=freezone_routes.FreezoneVideoOmniGenRequest(
+                prompt="雨夜街头，人物缓慢回头。",
+                model="cat-other",
+                references=references,
+            ),
+            user={"username": "admin"},
+        )
+
+    assert exc.value.status_code == 503
+
+
+@pytest.mark.asyncio
+async def test_freezone_video_omni_gen_catalog_total_does_not_apply_per_clip_bounds(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """后台配了总时长≠授权用 Seedance 的逐条边界卡它。
+
+    referenceAudioTotalMaxSeconds=60 的非 2.0 模型：一条 25s 的音频在总时长之内，必须放行。
+    早先这里的开关是一个 `audio_bounds_known`，配了总时长就连 1.8~15.2s 一起套上去，
+    正好会把这条 25s 凭空 400 掉。
+    """
+    project_dir, _output_dir = _patch_freezone_project(monkeypatch, tmp_path)
+    _patch_video_catalog(
+        monkeypatch,
+        {
+            "catalogId": "cat-long",
+            "id": "cat-long",
+            "apiModel": "newapi_seedance-1.5-pro",
+            "providerId": "newapi",
+            "supportedModes": ["all_reference"],
+            "referenceAudioTotalMaxSeconds": 60,
+        },
+    )
+    references = [_audio_reference(project_dir, "long.wav")]
+
+    async def fake_probe(_path: str) -> float:
+        return 25.0  # > 15.2s，但对这个模型没有逐条上限
+
+    monkeypatch.setattr(freezone_routes, "_probe_reference_audio_seconds", fake_probe)
+    _patch_runtime_error_enqueue(monkeypatch)
+
+    with pytest.raises(HTTPException) as exc:
+        await freezone_routes.freezone_video_omni_gen(
+            project="58",
+            body=freezone_routes.FreezoneVideoOmniGenRequest(
+                prompt="雨夜街头，人物缓慢回头。",
+                model="cat-long",
+                references=references,
+            ),
+            user={"username": "admin"},
+        )
+
+    # 503 = 走到了入队（被替身打回），说明时长守卫放行了。
+    assert exc.value.status_code == 503
+
+
+@pytest.mark.asyncio
+async def test_probe_reference_audio_seconds_returns_none_when_probe_fails(
+    tmp_path: Path,
+) -> None:
+    """ffprobe 失败必须回 None，不能像 utils.media_io.get_audio_duration 那样返回 5.0。
+
+    5.0 是个合法值，会让兜底变成静默放行——这个断言就是防它被顺手换掉。
+    """
+    broken = tmp_path / "not-audio.wav"
+    broken.write_bytes(b"not audio at all")
+    assert await freezone_routes._probe_reference_audio_seconds(str(broken)) is None
+
+
 @pytest.mark.asyncio
 async def test_freezone_video_start_runtime_error_is_logged(
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_freezone_image_backend.py
+++ b/tests/test_freezone_image_backend.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import json
 from pathlib import Path
 from types import SimpleNamespace
@@ -428,14 +429,18 @@ async def test_freezone_video_omni_gen_uses_catalog_audio_total_limit(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    """总时长上限听后台 referenceAudioTotalMaxSeconds，15.2s 只是没配时的兜底。"""
+    """后台 referenceAudioTotalMaxSeconds 可以把上限**收得更严**（这里 8s < 厂商 15.2s）。
+
+    配宽的方向由 `..._clamps_catalog_total_to_vendor_cap` 盯着：那边取小之后厂商硬顶仍然
+    生效。两条合起来才是「取小」这个语义。
+    """
     project_dir, _output_dir = _patch_freezone_project(monkeypatch, tmp_path)
     _patch_video_catalog(
         monkeypatch,
         {
             "catalogId": "cat-omni",
             "id": "cat-omni",
-            "apiModel": "doubao-seedance-2-0",
+            "apiModel": "newapi_seedance-2.0-fast",
             "providerId": "newapi",
             "supportedModes": ["all_reference"],
             "referenceAudioTotalMaxSeconds": 8,
@@ -551,6 +556,116 @@ async def test_freezone_video_omni_gen_catalog_total_does_not_apply_per_clip_bou
 
     # 503 = 走到了入队（被替身打回），说明时长守卫放行了。
     assert exc.value.status_code == 503
+
+
+@pytest.mark.asyncio
+async def test_freezone_video_omni_gen_clamps_catalog_total_to_vendor_cap(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """seedance2 的目录值只能配得更严，配宽了不算数——厂商硬顶 15.2s 必须继续生效。
+
+    管理员给 2.0 配了 60s：3 条各 6s 共 18s 若照配置放行，到厂商那儿照样 400，正是这套
+    守卫要消灭的失败。取小之后仍然拦在本地。
+    """
+    project_dir, _output_dir = _patch_freezone_project(monkeypatch, tmp_path)
+    _patch_video_catalog(
+        monkeypatch,
+        {
+            "catalogId": "cat-wide",
+            "id": "cat-wide",
+            "apiModel": "newapi_seedance-2.0-fast",
+            "providerId": "newapi",
+            "supportedModes": ["all_reference"],
+            "referenceAudioTotalMaxSeconds": 60,
+        },
+    )
+    references = [_audio_reference(project_dir, f"wide{i}.wav") for i in range(3)]
+
+    async def fake_probe(_path: str) -> float:
+        return 6.0
+
+    monkeypatch.setattr(freezone_routes, "_probe_reference_audio_seconds", fake_probe)
+    _patch_runtime_error_enqueue(monkeypatch)
+
+    with pytest.raises(HTTPException) as exc:
+        await freezone_routes.freezone_video_omni_gen(
+            project="58",
+            body=freezone_routes.FreezoneVideoOmniGenRequest(
+                prompt="雨夜街头，人物缓慢回头。",
+                model="cat-wide",
+                references=references,
+            ),
+            user={"username": "admin"},
+        )
+
+    assert exc.value.status_code == 400
+    assert "total duration must be <= 15.2s" in str(exc.value.detail)
+
+
+def test_catalog_audio_total_duration_max_rejects_non_finite() -> None:
+    """inf 不能当成上限：`inf > 0` 是 True，漏进来就等于静默关掉总时长判定。
+
+    写入侧 schema 已经挡了，但目录条目可能是那道校验存在之前落的库，读出来再挡一次。
+    """
+    read = freezone_routes._catalog_audio_total_duration_max
+    assert read({"referenceAudioTotalMaxSeconds": 15.2}) == 15.2
+    for bad in (float("inf"), float("nan"), float("-inf"), 0, -1, "15.2", None):
+        assert read({"referenceAudioTotalMaxSeconds": bad}) is None
+    assert read(None) is None
+
+
+@pytest.mark.asyncio
+async def test_freezone_video_omni_gen_probes_audio_concurrently(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """3 条音频必须并发探测。
+
+    ffprobe 单条有 20s 超时，串行 await 会把 3 条叠成最长 60s 的请求耗时。这里让每个
+    探测在返回前先 `asyncio.sleep(0)` 让出一次，只有并发调度才可能出现「3 个都进来了、
+    还没有一个返回」的时刻。
+    """
+    project_dir, _output_dir = _patch_freezone_project(monkeypatch, tmp_path)
+    _patch_video_catalog(
+        monkeypatch,
+        {
+            "catalogId": "cat-conc",
+            "id": "cat-conc",
+            "apiModel": "newapi_seedance-2.0-fast",
+            "providerId": "newapi",
+            "supportedModes": ["all_reference"],
+        },
+    )
+    references = [_audio_reference(project_dir, f"conc{i}.wav") for i in range(3)]
+
+    in_flight = 0
+    peak = 0
+
+    async def fake_probe(_path: str) -> float:
+        nonlocal in_flight, peak
+        in_flight += 1
+        peak = max(peak, in_flight)
+        await asyncio.sleep(0)
+        in_flight -= 1
+        return 3.0
+
+    monkeypatch.setattr(freezone_routes, "_probe_reference_audio_seconds", fake_probe)
+    _patch_runtime_error_enqueue(monkeypatch)
+
+    with pytest.raises(HTTPException) as exc:
+        await freezone_routes.freezone_video_omni_gen(
+            project="58",
+            body=freezone_routes.FreezoneVideoOmniGenRequest(
+                prompt="雨夜街头，人物缓慢回头。",
+                model="cat-conc",
+                references=references,
+            ),
+            user={"username": "admin"},
+        )
+
+    assert exc.value.status_code == 503  # 9s 未超限，走到入队被替身打回
+    assert peak == 3
 
 
 @pytest.mark.asyncio

--- a/tests/test_freezone_video_backend.py
+++ b/tests/test_freezone_video_backend.py
@@ -31,6 +31,7 @@ from novelvideo.freezone.video_node import (
     normalize_video_resolution_for_backend,
     resolve_freezone_video_backend,
     summarize_omni_reference_counts,
+    validate_omni_reference_audio_durations,
     validate_omni_reference_limits,
 )
 
@@ -465,3 +466,62 @@ def test_validate_omni_reference_limits_and_summary() -> None:
             audio_max=0,
             total_max=2,
         )
+
+
+def test_validate_omni_reference_audio_durations_per_clip_bounds() -> None:
+    # 厂商逐条口径：1.8s ≤ 时长 ≤ 15.2s，两端都是闭区间。
+    validate_omni_reference_audio_durations([("a.wav", 1.8)])
+    validate_omni_reference_audio_durations([("a.wav", 15.2)])
+
+    with pytest.raises(ValueError, match=r"must be >= 1\.8s") as short_exc:
+        validate_omni_reference_audio_durations([("ok.wav", 5.0), ("tiny.wav", 0.9)])
+    # 只点名越界的那条，别把合规的也列进去让用户猜。
+    assert "tiny.wav (0.9s)" in str(short_exc.value)
+    assert "ok.wav" not in str(short_exc.value)
+
+    with pytest.raises(ValueError, match=r"must be <= 15\.2s"):
+        validate_omni_reference_audio_durations([("long.wav", 15.201)])
+
+
+def test_validate_omni_reference_audio_durations_total_bound() -> None:
+    """3 条各 6s：逐条全合规，总计 18s —— 2026-08-06 3060 两次任务就死在这。
+
+    厂商报文：`audio total duration (seconds) ... must be less than or equal to 15.2
+    for model doubao-seedance-2-0 in r2v`。别把这条当成多余的本地规则删掉。
+    """
+    with pytest.raises(ValueError, match="total duration must be <= 15.2s") as exc:
+        validate_omni_reference_audio_durations(
+            [("a.wav", 6.0), ("b.wav", 6.0), ("c.wav", 6.0)]
+        )
+    assert "got 18s" in str(exc.value)
+
+    # 顶格 15.2s 必须放行：浮点和会漂到 15.200000000000001，裸比较会误拦。
+    validate_omni_reference_audio_durations(
+        [("a.wav", 6.0), ("b.wav", 6.0), ("c.wav", 3.2)]
+    )
+    # 单条顶格同样不能被总和这条误伤（兜底上限与单条上限同值）。
+    validate_omni_reference_audio_durations([("a.wav", 15.2)])
+
+    # 单条越界优先上报：先换掉那条，再谈整体裁剪。
+    with pytest.raises(ValueError, match="must be <= 15.2s"):
+        validate_omni_reference_audio_durations([("a.wav", 20.0), ("b.wav", 6.0)])
+
+    # 上限走传入值（后台 referenceAudioTotalMaxSeconds）。
+    validate_omni_reference_audio_durations(
+        [("a.wav", 6.0), ("b.wav", 6.0)], total_max_seconds=30.0
+    )
+    with pytest.raises(ValueError, match="total duration must be <= 10s"):
+        validate_omni_reference_audio_durations(
+            [("a.wav", 6.0), ("b.wav", 6.0)], total_max_seconds=10.0
+        )
+
+
+def test_validate_omni_reference_audio_durations_skips_unmeasured() -> None:
+    """探测不出的条目不参与判定——漏算只会让和更小，不会因此误拦。"""
+    validate_omni_reference_audio_durations([("unknown.wav", None)])
+    validate_omni_reference_audio_durations(
+        [("a.wav", 6.0), ("unknown.wav", None), ("c.wav", 6.0)]
+    )
+    validate_omni_reference_audio_durations([])
+    # 0 / 负数是 ffprobe 的垃圾输出，同样按「测不出」处理，别当成一条 0s 的太短音频。
+    validate_omni_reference_audio_durations([("weird.wav", 0.0), ("neg.wav", -1.0)])

--- a/tests/test_media_model_request_schema.py
+++ b/tests/test_media_model_request_schema.py
@@ -233,7 +233,9 @@ def test_validates_reference_audio_total_max_seconds():
     assert validate_media_model_catalog_config({**base}, "video") is not None
 
     # True 也要拒：`type(True) is bool`，不能让布尔当成 1 秒混进来。
-    for bad in (0, -1, "15.2", True, []):
+    # inf / nan 也要拒：`inf > 0` 是 True、`nan <= 0` 是 False，只写「正数」两个都会漏进来，
+    # 配成 inf 就等于把这个上限静默关掉。
+    for bad in (0, -1, "15.2", True, [], float("inf"), float("nan"), float("-inf")):
         with pytest.raises(
             MediaModelSchemaError, match="referenceAudioTotalMaxSeconds"
         ):

--- a/tests/test_media_model_request_schema.py
+++ b/tests/test_media_model_request_schema.py
@@ -220,6 +220,39 @@ def test_validates_media_catalog_capabilities():
         )
 
 
+def test_validates_reference_audio_total_max_seconds():
+    """参考音频**总时长**上限：收小数（厂商口径 15.2 本身就不是整数），只拒非正数。"""
+    base = {
+        "supportedModes": ["all_reference"],
+        "request": {"endpoint": "video/generations", "parameters": []},
+    }
+    for value in (15.2, 15, 0.5):
+        config = {**base, "referenceAudioTotalMaxSeconds": value}
+        assert validate_media_model_catalog_config(config, "video") is config
+    # 没配 = 走后端 15.2s 兜底，不是错误。
+    assert validate_media_model_catalog_config({**base}, "video") is not None
+
+    # True 也要拒：`type(True) is bool`，不能让布尔当成 1 秒混进来。
+    for bad in (0, -1, "15.2", True, []):
+        with pytest.raises(
+            MediaModelSchemaError, match="referenceAudioTotalMaxSeconds"
+        ):
+            validate_media_model_catalog_config(
+                {**base, "referenceAudioTotalMaxSeconds": bad},
+                "video",
+            )
+
+    # 图片模型没有参考音频这回事，配了要报「不兼容」而不是默默收下。
+    with pytest.raises(MediaModelSchemaError, match="incompatible fields"):
+        validate_media_model_catalog_config(
+            {
+                "referenceAudioTotalMaxSeconds": 15.2,
+                "request": {"endpoint": "images/generations", "parameters": []},
+            },
+            "image",
+        )
+
+
 def test_catalog_config_rejects_endpoint_for_other_media_type():
     with pytest.raises(MediaModelSchemaError, match="image model request endpoint"):
         validate_media_model_catalog_config(

--- a/tests/test_seedance2_assets.py
+++ b/tests/test_seedance2_assets.py
@@ -769,3 +769,51 @@ async def test_crop_seedance2_asset_to_first_frame_writes_video_input_override(
     expected = paths.video_input_frame(2, slot="first_frame")
     assert result == expected
     assert paths.valid_video_input_frame(2, slot="first_frame", source_path=source) == expected
+
+
+def test_validate_reference_audio_request_rejects_out_of_range_clips(monkeypatch):
+    """beat 流水线的音频时长守卫：逐条 1.8~15.2s + 总和 15s，与画布同一套判定。
+
+    早先这里只判总和、没有下界，一条 0.5s 的声线会被我们放到厂商那儿吃
+    `InvalidParameter.DurationTooShort`——白跑一轮才知道。
+    """
+    from novelvideo.seedance2_i2v import pipeline
+
+    durations = {"a.wav": 0.5, "b.wav": 6.0}
+    monkeypatch.setattr(
+        pipeline,
+        "probe_voice_sample_duration_seconds",
+        lambda path: durations[Path(path).name],
+    )
+
+    with pytest.raises(ValueError, match="音频1"):
+        pipeline._validate_reference_audio_request(["a.wav", "b.wav"])
+
+    durations["a.wav"] = 6.0
+    pipeline._validate_reference_audio_request(["a.wav", "b.wav"])
+
+
+def test_validate_reference_audio_request_total_bound_and_probe_failures(monkeypatch):
+    """总和超限要报中文 + 具体条目；测不出的条目不参与判定（放行给厂商）。"""
+    from novelvideo.seedance2_i2v import pipeline
+
+    monkeypatch.setattr(
+        pipeline, "probe_voice_sample_duration_seconds", lambda _path: 6.0
+    )
+    with pytest.raises(ValueError, match="请回到角色工作台"):
+        pipeline._validate_reference_audio_request(["a.wav", "b.wav", "c.wav"])
+
+    # 1.8+8.3+4.9 == 15.000000000000002：裸浮点比较会把正好顶格 15s 的一组误判成超限。
+    exact = {"a.wav": 1.8, "b.wav": 8.3, "c.wav": 4.9}
+    monkeypatch.setattr(
+        pipeline,
+        "probe_voice_sample_duration_seconds",
+        lambda path: exact[Path(path).name],
+    )
+    pipeline._validate_reference_audio_request(["a.wav", "b.wav", "c.wav"])
+
+    def boom(_path):
+        raise ValueError("ffprobe 挂了")
+
+    monkeypatch.setattr(pipeline, "probe_voice_sample_duration_seconds", boom)
+    pipeline._validate_reference_audio_request(["a.wav", "b.wav", "c.wav"])


### PR DESCRIPTION
## 问题

3060 环境 2026-08-06 两次视频任务失败（`freezone_video_gen/01KZ5R8ZZZY9M8T9F01H159RP7`，`gen_mode=allReference`，`doubao-seedance-2-0`），厂商报文：

```
the parameter audio total duration (seconds) specified in the request must be
less than or equal to 15.2 for model doubao-seedance-2-0 in r2v
```

厂商在 r2v 下有**两条互相独立**的音频时长规则，都以 400 打回：

1. **逐条**：`[InvalidParameter.DurationTooShort] Duration must be between 1.8s and 15.2s`
2. **总和**：所有参考音频加起来 ≤ 15.2s

我们只实现了第 1 条。3 条各 6s 逐条全部合法、总计 18s 必被拒——用户白等一轮。更糟的是
`videoModelCapabilities.ts` 里的注释明确写着「厂商口径是**逐条**，没有一个字提到总和」
「**别再回到按总时长判定**」，等于把这个故障钉在代码里。这次连注释一起改掉，并把实测证据
（任务 ID、报文原文）写进去，免得又被当成臆想规则删掉。

## 改动

### 后端兜底（新）

`freezone/video_node.py` 新增 `validate_omni_reference_audio_durations`，三个上限
（逐条下界 / 逐条上界 / 总和）各自可传 `None` = 该项不判定。omni-gen 端点在 URL 落成
本地路径后用 ffprobe 探测，是最后一道能在计费前拦下的闸门。

两类边界**分开授权**：

- 逐条 1.8~15.2s 是从 Seedance 2.0 的报文里实测出来的，只对它成立；
- 总时长优先听目录里新增的 `referenceAudioTotalMaxSeconds`（管理员主动声明），没配时
  只有 Seedance 2.0 才落到 15.2s 兜底。

别把这两类混成一个开关：目录里给别家模型配了 60s 总时长，不代表它的单条也得卡在
15.2s——那样一条正常的 25s 音频会被我们凭空 400 掉。

探测不出的条目不参与判定（ffprobe 缺失 / 文件损坏），宁可放过去让厂商判。这让总和成为
**下界**，但判定方向仍然安全：漏算只会让和更小，所以「算出来超了」必定真超。

### 前端严格化

`audioReferenceDurationRejection` 加上总和判定 + `{ totalLimitMs, perClipLimits }`
选项，与后端一一对应。闸门从 `isSeedance20Model &&` 放宽到
`(isSeedance20Model || 目录配了总时长)`——否则这类模型前端放行、后端拦下，用户白等一个
来回还只能看到一句英文 400。

总时长兜底值刻意与单条上限取同一个 15.2s：单条 15.2s 是厂商明确放行的，兜底若取 15.0
就会把一条合法的顶格音频误拦在本地。想留安全余量请在后台把
`referenceAudioTotalMaxSeconds` 配小，而不是改常量。

### 目录字段

`referenceAudioTotalMaxSeconds`（秒，允许小数——15.2 本身就不是整数）走
`media_model_request_schema` 校验，图片模型配了它报「不兼容」。

### 顺带修的两处同类洞

- **ffprobe 没有 timeout**：`probe_voice_sample_duration_seconds` 现在挂在同步请求路径
  上、吃用户上传的文件。一个畸形容器就能吊死 HTTP 请求并占死一个线程池 worker。加了 20s
  上限，并**在函数内部**把 `TimeoutExpired` 转成 `ValueError`——调用方只 catch
  `ValueError`，漏出去就是 500 而不是「测不出就跳过」。
- **beat 流水线 `_validate_reference_audio_request`**：原来只判总和、没有 1.8s 下界，
  也没有逐条上限；`measured` 标志 + 裸浮点比较，`1.8+8.3+4.9 == 15.000000000000002`
  会把正好顶格 15s 的一组误判成超限。改为复用同一个校验器，英文报错包回中文并保留
  「回角色工作台裁剪到 3-5 秒」的指引。总时长仍用该模块原本的 15.0s（收紧 0.2s 不会误伤，
  放宽是产品口径变化，不该顺手做）。

## 浮点

`6 + 6 + 3.2 == 15.200000000000001`，裸比较会把一组正好顶格的合法音频判成超限。前后端
都归整到毫秒再比。展示也按毫秒精度（`15.201` 不显示成 `15.2`）——用户看到的正好是合法
边界值却被告知越界，只会怀疑我们算错了。

## 验证

- `tsc -b` 干净；`pnpm build` ✓；`vitest` 2150 passed（唯一失败是已知的本地 MSW flake
  `ingest.test.tsx`，CI 绿）
- `pytest tests/` 2138 passed（唯一失败 `test_newapi_image_gateway.py` 是本地 .env 导致的
  既有失败，与本 PR 无关，已用 `git stash` 对照确认）
- `ruff check` 全过；`lint_ce_imports` 无禁止导入
- 每条新守卫都做过**非空验证**：临时关掉判定后对应测试确实变红，恢复后转绿

🤖 Generated with [Claude Code](https://claude.com/claude-code)
