### PR TITLE
fix(style): keep official presets content-neutral

### DIFF
--- a/src/novelvideo/styles/presets/STYLE_DESIGN.md
+++ b/src/novelvideo/styles/presets/STYLE_DESIGN.md
@@ -15,9 +15,9 @@ A preset must not override the concrete content of the story. Exact era, locatio
 
 ## Field Semantics
 
-`label` is the product-facing name. It may describe the intended look in user language, but it should be precise enough that users understand the content bias. For example, the built-in `guoman_fantasy` preset is labeled `3D玄幻国漫` because its instructions intentionally include xianxia, Dunhuang, and fantasy-drama traits; it is not a generic Guoman preset.
+`label` is the product-facing name. It may describe the intended look in familiar user language, but it is not injected into generation prompts and must not act as a hidden content fallback. For example, the built-in `guoman_fantasy` preset keeps the familiar `3D玄幻国漫` label while its prompt controls only the 3D Guoman rendering medium and finish.
 
-Content bias inside a preset is a default flavor, not a hard rule. For `guoman_fantasy`, fantasy-drama rendering traits, Dunhuang-inspired garments, xianxia robes, and black-gold luxury accents apply only when character descriptions, identity references, scene context, and wardrobe do not specify a stronger choice. Exact facial traits, expression, temperament, ethnicity, age, costume, and identity details belong to character/scene/prop content, not the preset. Explicit character or reference-image details always win.
+Content bias inside a preset may only be conditional genre tone, never a hard rule or a fallback source for concrete entities. Exact facial traits, expression, temperament, ethnicity, age, costume, identity, props, and environment details belong to character/scene/prop content. Explicit descriptions and reference images always win.
 
 `style_tag` is the short, high-signal anchor injected near every generated panel. It should describe medium and grade, not era or story content. Avoid words like `PERIOD`, `REPUBLICAN`, `ERA`, `DYNASTY`, `MODERN`, `ANCIENT`, `DRAMA`, `民国`, or `古装` in `style_tag`.
 

--- a/src/novelvideo/styles/presets/anime.json
+++ b/src/novelvideo/styles/presets/anime.json
@@ -1,7 +1,7 @@
 {
   "id": "anime",
   "name": "Anime Style",
-  "style_instructions": "Create a high-quality Japanese anime key visual illustration. Style: 2D cel animation with crisp black outlines (medium weight), flat color fills with 2-layer cel shading (base color + single shadow tone). Eyes: large, detailed with multi-layer reflections and catchlights. Hair: flowing strands with distinct highlight bands. Background: painted watercolor-style environment with softer detail than foreground characters. Color palette: vibrant and saturated with high contrast between light and shadow areas. Render at anime production key frame quality.",
+  "style_instructions": "Create a high-quality stylized 2D anime cel-animation render with crisp medium-weight outlines, flat color fills, controlled two-layer cel shading, clean color separation, and a polished anime production key-frame finish. Apply this style only to the rendering medium, linework, color treatment, shading, and finish; do not infer or change facial features, eye proportions, hairstyles, body proportions, clothing, props, environments, or backgrounds from the style preset. Always follow explicit character descriptions, reference images, beat, scene, and prop descriptions; do not override them with the style preset.",
   "avoid_instructions": "FORBIDDEN: photorealistic rendering, 3D CGI, photograph textures. NOT realistic skin pores or film grain. No gradient shading or soft blending — use FLAT cel-shading only. No watermarks, signatures, or text overlays. No bad anatomy, extra limbs, or mutated hands.",
   "style_tag": "ANIME",
   "label": "动漫风格",

--- a/src/novelvideo/styles/presets/guoman_fantasy.json
+++ b/src/novelvideo/styles/presets/guoman_fantasy.json
@@ -2,8 +2,8 @@
   "id": "guoman_fantasy",
   "name": "3D Xianxia Guoman",
   "style_instructions": "Create a premium stylized 3D Chinese animation render with high-precision PBR materials, refined 3D edge lighting, clean high-definition rendering, and a polished Unreal Engine / Octane-style finish. Apply this style only to the rendering medium, materials, lighting, and finish; do not infer or change faces, ages, genders, body proportions, clothing, accessories, social status, props, environments, or transparency from the style preset. Always follow explicit character descriptions, reference images, beat, scene, and prop descriptions; do not override them with the style preset.",
-  "avoid_instructions": "FORBIDDEN: live-action photography, Western comic style, flat 2D cel anime, chibi, childish face, influencer face, oily vulgar glamour, cheap web-novel cover look, low-poly game asset, plastic toy texture, wax figure appearance, over-smoothed skin, excessive HDR, messy ornament overload, deformed hands, extra limbs, broken anatomy, text, labels, watermarks.",
-  "style_tag": "3D GUOMAN FANTASY",
+  "avoid_instructions": "FORBIDDEN: live-action photography, Western comic style, flat 2D cel anime, chibi, unintended age drift, influencer face, oily vulgar glamour, cheap web-novel cover look, low-poly game asset, plastic toy texture, wax figure appearance, over-smoothed skin, excessive HDR, messy ornament overload, deformed hands, extra limbs, broken anatomy, text, labels, watermarks.",
+  "style_tag": "PREMIUM 3D GUOMAN CG",
   "label": "3D玄幻国漫",
   "style_family": "animation",
   "animation_subtype": "3d"

--- a/src/novelvideo/styles/presets/post_apocalyptic.json
+++ b/src/novelvideo/styles/presets/post_apocalyptic.json
@@ -1,8 +1,8 @@
 {
   "id": "post_apocalyptic",
   "name": "Post-Apocalyptic",
-  "style_instructions": "Create in PHOTOREALISTIC live-action film style. REAL WORLD scene with REAL PEOPLE — NOT animation, NOT illustration, NOT CGI. When the beat or scene context calls for a post-apocalyptic setting, use desaturated muted tones, dusty grays and browns, harsh natural light, weathering, dirt, sweat, cracked concrete, rusted metal, peeling paint, overgrown vegetation, and practical survival detail. Follow the beat, scene, character, and prop descriptions for exact era, location, wardrobe, technology, and materials; do not override explicit non-apocalyptic, modern, ancient, foreign, or traversal-story details. Maintain gritty realism with documentary-like authenticity.",
-  "avoid_instructions": "ABSOLUTELY FORBIDDEN: anime, manga, cartoon, illustrated, or painted styles. NOT CGI, NOT 3D animated. No smooth flawless skin — must show natural texture and weathering. No text, watermarks, or labels on image.",
+  "style_instructions": "Create a photorealistic live-action film render — not animation, illustration, or CGI. When the beat or scene context calls for a post-apocalyptic setting, use desaturated muted tones, dusty grays and browns, harsh natural light, weathering, dirt, sweat, cracked concrete, rusted metal, peeling paint, overgrown vegetation, and practical survival detail. Follow the beat, scene, character, and prop descriptions for exact character type, era, location, wardrobe, technology, and materials; do not override explicit non-apocalyptic, modern, ancient, foreign, traversal-story, or non-human details. Maintain gritty realism with documentary-like authenticity.",
+  "avoid_instructions": "ABSOLUTELY FORBIDDEN: anime, manga, cartoon, illustrated, or painted styles. NOT CGI, NOT 3D animated. For visible human skin, avoid artificial smoothing; apply dirt and weathering only when supported by the character and scene context. No text, watermarks, or labels on image.",
   "style_tag": "DESATURATED GRITTY REALISM, HARSH LIGHT",
   "label": "写实末日风格",
   "style_family": "live_action",

--- a/tests/test_prompt_style_ethnicity_layering.py
+++ b/tests/test_prompt_style_ethnicity_layering.py
@@ -59,6 +59,7 @@ def test_style_presets_do_not_use_hard_negative_content_constraints():
         "business suit",
         "foreign person",
         "western person",
+        "childish face",
     ]
 
     for path in preset_dir.glob("*.json"):
@@ -89,6 +90,7 @@ def test_style_tags_do_not_encode_era_content():
         "MODERN",
         "ANCIENT",
         "DRAMA",
+        "FANTASY",
         "民国",
         "古装",
     }
@@ -150,6 +152,33 @@ def test_guoman_fantasy_preset_contains_only_rendering_style():
     assert "black-gold" not in lowered
     assert "when wardrobe is unspecified" not in lowered
     assert "keep the image transparent" not in lowered
+    assert data["style_tag"] == "PREMIUM 3D GUOMAN CG"
+
+
+def test_anime_preset_contains_only_rendering_style():
+    path = Path("src/novelvideo/styles/presets/anime.json")
+    data = json.loads(path.read_text())
+    instructions = data["style_instructions"].lower()
+
+    assert "apply this style only to the rendering medium" in instructions
+    assert "do not infer or change facial features" in instructions
+    assert "reference images" in instructions
+    assert "do not override them with the style preset" in instructions
+    assert "eyes: large" not in instructions
+    assert "hair: flowing" not in instructions
+    assert "watercolor-style environment" not in instructions
+
+
+def test_post_apocalyptic_preset_does_not_force_human_or_weathered_subjects():
+    path = Path("src/novelvideo/styles/presets/post_apocalyptic.json")
+    data = json.loads(path.read_text())
+    instructions = data["style_instructions"].lower()
+    avoid = data["avoid_instructions"].lower()
+
+    assert "real people" not in instructions
+    assert "non-human details" in instructions
+    assert "only when supported by the character and scene context" in avoid
+    assert "must show natural texture and weathering" not in avoid
 
 
 def test_topic_flavored_presets_defer_to_explicit_story_content():


### PR DESCRIPTION
## What changed

- make the built-in anime preset control only 2D cel rendering, linework, shading, and finish instead of forcing large eyes, flowing hair, or a watercolor environment
- remove the remaining age/content bias from the Guoman negative prompt and replace its per-panel `FANTASY` tag with a medium/grade-only tag
- keep the post-apocalyptic preset from forcing every subject to be human or weathered
- update the preset design contract to match the JSON source of truth
- add regression coverage for preset content boundaries

## Why

Built-in style prompts are reused across identity sheets, props, scenes, and storyboard panels. Concrete face, age, hairstyle, clothing, subject type, and background defaults inside a style preset can override reference images and business prompts. The presets should control the rendering medium and finish while explicit entity and scene inputs remain authoritative.

## User impact

New generations using the affected built-in presets preserve reference identity and story content more reliably. Existing generated assets are unchanged. Custom project styles still take precedence over built-in presets.

## Validation

- `jq empty src/novelvideo/styles/presets/*.json`
- `uv run pytest tests/test_prompt_style_ethnicity_layering.py tests/test_api_styles.py` — 28 passed
- `uv run ruff check tests/test_prompt_style_ethnicity_layering.py`
- `git diff --check`

## Operational impact

No migration or API/configuration changes. Updated built-in presets take effect for new generations after deploying and restarting API/worker processes because presets are cached in process memory.
