### PR TITLE
fix promotion product surface context

### DIFF
--- a/src/novelvideo/api/routes/generation.py
+++ b/src/novelvideo/api/routes/generation.py
@@ -2335,16 +2335,12 @@ async def audio_generation_billing_quote(
             billable_chars=billable_chars,
         ),
         "quantity": quantity,
+        "product_surface": "mainline",
     }
-    try:
-        quote = await get_credit_quote().generation_credit_quote(
-            **quote_args,
-            user_id=str(user.get("id") or user.get("user_id") or ""),
-        )
-    except TypeError as exc:
-        if "user_id" not in str(exc):
-            raise
-        quote = await get_credit_quote().generation_credit_quote(**quote_args)
+    quote = await get_credit_quote().generation_credit_quote(
+        **quote_args,
+        user_id=str(user.get("id") or user.get("user_id") or ""),
+    )
     return {
         "ok": True,
         "data": {
@@ -2510,16 +2506,12 @@ async def global_optimize_video_billing_quote(
             }
         },
         "quantity": quantity,
+        "product_surface": "mainline",
     }
-    try:
-        quote = await get_credit_quote().generation_credit_quote(
-            **quote_args,
-            user_id=str(user.get("id") or user.get("user_id") or ""),
-        )
-    except TypeError as exc:
-        if "user_id" not in str(exc):
-            raise
-        quote = await get_credit_quote().generation_credit_quote(**quote_args)
+    quote = await get_credit_quote().generation_credit_quote(
+        **quote_args,
+        user_id=str(user.get("id") or user.get("user_id") or ""),
+    )
     return {
         "ok": True,
         "data": {

--- a/src/novelvideo/api/routes/model_credits.py
+++ b/src/novelvideo/api/routes/model_credits.py
@@ -26,6 +26,11 @@ GenerationCreditCostKind = Literal[
 GenerationCreditSurface = Literal["supertale", "canvas"]
 
 
+def _credit_product_surface(surface: GenerationCreditSurface) -> str:
+    """Map quote rendering context to the product entry that owns the request."""
+    return "freezone" if surface == "canvas" else "mainline"
+
+
 def _display_credit_cost(cost: int) -> str:
     return str(cost)
 
@@ -921,18 +926,12 @@ async def get_generation_credit_cost(
             image_role=_clean_query_value(image_role),
         ),
         "quantity": _clean_quantity(quantity),
+        "product_surface": _credit_product_surface(surface),
     }
-    try:
-        quote = await get_credit_quote().generation_credit_quote(
-            **quote_args,
-            user_id=str(user.get("id") or user.get("user_id") or ""),
-        )
-    except TypeError as exc:
-        if "user_id" not in str(exc):
-            raise
-        # One-release compatibility for third-party quote ports compiled
-        # against the previous protocol.
-        quote = await get_credit_quote().generation_credit_quote(**quote_args)
+    quote = await get_credit_quote().generation_credit_quote(
+        **quote_args,
+        user_id=str(user.get("id") or user.get("user_id") or ""),
+    )
     original_cost = (
         quote.total_cost
         if quote.original_total_cost is None

--- a/src/novelvideo/ports/credit_quote.py
+++ b/src/novelvideo/ports/credit_quote.py
@@ -27,5 +27,6 @@ class CreditQuotePort(Protocol):
         model: str,
         params: dict,
         quantity: int,
+        product_surface: str,
         user_id: str = "",
     ) -> CreditQuote: ...

--- a/src/novelvideo/ports/local/credit_quote.py
+++ b/src/novelvideo/ports/local/credit_quote.py
@@ -13,7 +13,8 @@ class LocalCreditQuote:
         model: str,
         params: dict,
         quantity: int,
+        product_surface: str,
         user_id: str = "",
     ) -> CreditQuote:
-        del kind, model, params, quantity, user_id
+        del kind, model, params, quantity, product_surface, user_id
         return CreditQuote(total_cost=0, display="0", unit="call", unit_cost=0, quantity=1, params={})

--- a/tests/contract/test_m09_route_contracts.py
+++ b/tests/contract/test_m09_route_contracts.py
@@ -183,9 +183,20 @@ class _FakeTaskBackend:
 
 
 class _FakeCreditQuote:
-    async def generation_credit_quote(self, *, kind, model, params, quantity):
+    async def generation_credit_quote(
+        self,
+        *,
+        kind,
+        model,
+        params,
+        quantity,
+        product_surface,
+        user_id="",
+    ):
         assert kind == "feature"
         assert model == "mainline.beat_video_prompt"
+        assert product_surface == "mainline"
+        assert user_id == "local"
         assert params == {
             "pricing_metrics": {"call_count": quantity, "item_count": quantity}
         }

--- a/tests/ports/test_credit_quote.py
+++ b/tests/ports/test_credit_quote.py
@@ -11,6 +11,7 @@ async def test_local_credit_quote_returns_zero_display() -> None:
         model="gpt-image-2",
         params={"size": "2K"},
         quantity=3,
+        product_surface="mainline",
     )
 
     assert quote == CreditQuote(

--- a/tests/test_api_audio_indextts2_cutover.py
+++ b/tests/test_api_audio_indextts2_cutover.py
@@ -336,6 +336,7 @@ async def test_audio_billing_quote_uses_server_planned_quantity(monkeypatch, tmp
         "model": "mainline.beat_audio_generation",
         "params": generation._audio_billing_payload([2, 4], billable_chars=9),
         "quantity": 2,
+        "product_surface": "mainline",
         "user_id": "user_1",
     }
 

--- a/tests/test_api_model_credit_cost.py
+++ b/tests/test_api_model_credit_cost.py
@@ -16,8 +16,10 @@ def patch_quote(monkeypatch, model_credits, *, expected_model: str, cost: int) -
             model: str,
             params=None,
             quantity=1,
+            product_surface="mainline",
+            user_id="",
         ):
-            del kind, params, quantity
+            del kind, params, quantity, product_surface, user_id
             assert model == expected_model
             return CreditQuote(total_cost=cost, display=str(cost))
 
@@ -96,7 +98,10 @@ def patch_quote_expect(
             model: str,
             params=None,
             quantity=1,
+            product_surface="mainline",
+            user_id="",
         ):
+            del user_id
             assert kind == expected_kind
             assert model == expected_model
             assert params == expected_with_metrics
@@ -118,7 +123,10 @@ def patch_quote_display_mismatch(cost: int, display: str) -> None:
             model: str,
             params=None,
             quantity=1,
+            product_surface="mainline",
+            user_id="",
         ):
+            del product_surface, user_id
             return CreditQuote(total_cost=cost, display=display)
 
     register_port("credit_quote", FakeCreditQuotePort())
@@ -165,6 +173,7 @@ async def test_generation_credit_cost_route_returns_promotion_display(monkeypatc
     class DiscountQuotePort:
         async def generation_credit_quote(self, **kwargs):
             assert kwargs["user_id"] == "usr_1"
+            assert kwargs["product_surface"] == "mainline"
             return CreditQuote(
                 total_cost=9,
                 display="9",
@@ -189,6 +198,29 @@ async def test_generation_credit_cost_route_returns_promotion_display(monkeypatc
         "discount_amount": 3,
         "promotion": {"id": "promo_1", "name": "模型七五折"},
     }
+
+
+@pytest.mark.asyncio
+async def test_canvas_quote_passes_freezone_product_surface():
+    from novelvideo.api.routes import model_credits
+    from novelvideo.ports.credit_quote import CreditQuote
+    from novelvideo.ports.registry import register_port
+
+    class CapturingQuotePort:
+        async def generation_credit_quote(self, **kwargs):
+            assert kwargs["product_surface"] == "freezone"
+            return CreditQuote(total_cost=12, display="12")
+
+    register_port("credit_quote", CapturingQuotePort())
+
+    result = await model_credits.get_generation_credit_cost(
+        kind="feature",
+        surface="canvas",
+        value="mainline.sketch_regen",
+        user={"user_id": "usr_1"},
+    )
+
+    assert result["data"]["cost"] == 12
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## 背景

功能 key 只标识计费规则，不能用来判断请求来自主线还是 Freezone。共享 `mainline.*` 功能在 Freezone 报价时，原逻辑会按主线促销区域匹配，导致展示报价与实际产品入口不一致。

## 改动

- 报价端口显式传递 `product_surface`
- 主线报价固定传递 `mainline`
- 画布报价根据 `surface=canvas` 传递 `freezone`
- 移除旧报价端口的 TypeError 兼容回退，保持新合同唯一
- 增加主线与 Freezone 报价归属回归测试

## 影响

基础价格仍只由功能 key、模型目录和计费参数决定；`product_surface` 仅用于运行时产品入口归属和促销区域选择。

## 验证

- `uv run pytest tests/test_api_model_credit_cost.py tests/ports/test_credit_quote.py tests/contract/test_m09_route_contracts.py -q`：62 passed
- 相关 Ruff 检查通过
- `git diff --check` 通过
