### PR TITLE
fix(canvas): 模型选择器按媒体目录判定视频素材可用性

### DIFF
--- a/frontend/src/__tests__/features/canvas/video-model-capabilities.test.ts
+++ b/frontend/src/__tests__/features/canvas/video-model-capabilities.test.ts
@@ -465,6 +465,45 @@ describe("videoModelReferenceDisabledReason — 模型选择器置灰守卫", ()
     ).toBeTruthy();
   });
 
+  // 后台把某个模型的「视频编辑」下掉后，启发式那套「HappyHorse 天生能吃视频」的假设
+  // 就不成立了 —— 目录声明才是事实。
+  it("HappyHorse：目录里没有 video_edit 时，接入视频 → 置灰", () => {
+    const withoutVideoEdit = {
+      apiModel: HAPPYHORSE,
+      supportedModes: [
+        "text_to_video",
+        "first_frame",
+        "image_reference",
+        "first_last_frame",
+      ],
+    };
+    expect(
+      videoModelReferenceDisabledReason(withoutVideoEdit, { ...none, videos: 1 }),
+    ).toBe("该模型不支持视频素材");
+    // 目录里还留着 video_edit 的话照旧放行，别把整个模型误伤掉。
+    expect(
+      videoModelReferenceDisabledReason(
+        { apiModel: HAPPYHORSE, supportedModes: [...withoutVideoEdit.supportedModes, "video_edit"] },
+        { ...none, videos: 1 },
+      ),
+    ).toBeNull();
+  });
+
+  // 回归：选择器曾把模型塌成 `model.apiModel ?? model.id` 再传进来，目录声明的
+  // supportedModes 在这条路径上整个丢掉，只剩启发式 —— 后台下掉 HappyHorse 的视频
+  // 编辑后，它在选择器里依然可选，用户选进去后所有模式都是灰的、提交也被拦，成了
+  // 死胡同。这里锁住「传整个 ModelOption」，与 VideoNode 的提交守卫同源。
+  it("模型选择器必须把整个 ModelOption 传给置灰守卫（而非只传 id）", () => {
+    const source = readFileSync(
+      "src/features/canvas/nodes/VideoOperationsPanel.tsx",
+      "utf8",
+    );
+    expect(source).toContain("videoModelReferenceDisabledReason(model, {");
+    expect(source).not.toContain(
+      "videoModelReferenceDisabledReason(model.apiModel ?? model.id",
+    );
+  });
+
   it("Grok Video Channel：仅图片、且最多 8 张", () => {
     const GROK = "newapi_grok-video-channel";
     expect(videoModelReferenceDisabledReason(GROK, { ...none, images: 8 })).toBeNull();

--- a/frontend/src/features/canvas/nodes/VideoOperationsPanel.tsx
+++ b/frontend/src/features/canvas/nodes/VideoOperationsPanel.tsx
@@ -732,7 +732,12 @@ export function VideoOperationsPanel({
                     domain="video"
                     popoverPlacement="top"
                     getOptionDisabledReason={(model) =>
-                      videoModelReferenceDisabledReason(model.apiModel ?? model.id, {
+                      // 传整个 ModelOption,不要塌成 id —— 能力口径以后台「媒体模型」
+                      // 声明的 supportedModes 为准,只传 id 会退到启发式,把目录里的
+                      // 改动整个丢掉(例如后台下掉 HappyHorse 的视频编辑后,它在这里
+                      // 依然可选,选进去所有模式都是灰的、提交也被拦)。与 VideoNode
+                      // 的提交守卫同源。
+                      videoModelReferenceDisabledReason(model, {
                         images: upstreamCounts.images,
                         // 视频 / 音频必须和自动切模型的 effect 同一口径（按节点类型，
                         // 空节点也算）。若这里用「已解析 URL」口径，连着空视频节点时


### PR DESCRIPTION
## 问题

视频节点引用了视频素材时，后台已经下掉「视频编辑」的 HappyHorse 1.0 在模型选择器里依然可选。选进去之后模式下拉里所有模式都是灰的、提交也被拦 —— 用户进了一个死胡同。

Seedance 1.5 Pro / 1.0 Pro Fast 表现正常。

## 根因

`videoModelReferenceDisabledReason()` 有两条分支：模型对象带 `supportedModes`（后台「媒体模型」的能力声明）时以目录为准，否则退到按模型名的启发式。

模型选择器的调用点把模型塌成了字符串：

```ts
// VideoOperationsPanel.tsx:735
videoModelReferenceDisabledReason(model.apiModel ?? model.id, {…})
```

`supportedModes` 在这条路径上整个丢掉，永远走启发式。而启发式里 HappyHorse 那段硬编码着「r2v 吃多图、视频编辑吃视频」，只拦音频 —— 目录里怎么改它都不知道。

Seedance 1.x 之所以「碰巧对」，是启发式里 `isSeedance1xVideoModel` 本就写死了「接入视频/音频 → 置灰」，与目录声明无关。

同一个节点里模式下拉走的是 `supportedModes`（正确），提交守卫 `VideoNode` 传的也是整个对象（正确），只有选择器这一处口径不同源，于是出现「模式全灰但模型可选」的自相矛盾。

## 改动

- `getOptionDisabledReason` 改传整个 `ModelOption`，与 `VideoNode` 的提交守卫同源
- 补 2 个用例：目录去掉 `video_edit` 后接入视频必须置灰（留着则放行，别误伤整个模型）；一条锁调用点的回归断言，改动前是红的

## 验证

- `tsc -b` 通过
- `vitest run` 全量 324 文件 / 2171 用例通过
- `pnpm build` 通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)