### PR TITLE
fix(canvas): 低缩放档下所有新建节点入口都自动聚焦

### DIFF
--- a/frontend/src/__tests__/features/canvas/canvas-lod.test.ts
+++ b/frontend/src/__tests__/features/canvas/canvas-lod.test.ts
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Elastic-2.0
 // Copyright (c) 2026 ClaymoreLab
+import { readFileSync } from 'node:fs';
+
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
@@ -191,6 +193,43 @@ describe('shell 升级队列', () => {
     tick();
     expect(a).not.toHaveBeenCalled();
     expect(b).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('低缩放档新建节点自动聚焦', () => {
+  const CANVAS_SOURCE = readFileSync('src/features/canvas/Canvas.tsx', 'utf8');
+
+  /**
+   * 截出某个组件内 handler 的函数体：从声明锚点到下一个组件作用域（两空格缩进）
+   * 的 `const` 声明为止。内层 `const` 缩进更深，不会误截。
+   */
+  const bodyAfter = (marker: string): string => {
+    const start = CANVAS_SOURCE.indexOf(marker);
+    expect(start, `Canvas.tsx 里找不到锚点：${marker}`).toBeGreaterThan(-1);
+    const rest = CANVAS_SOURCE.slice(start + marker.length);
+    const end = rest.indexOf('\n  const ');
+    return end === -1 ? rest : rest.slice(0, end);
+  };
+
+  it('所有「凭空新建节点」的入口都要过 focusNewNodeIfLowZoom', () => {
+    // 10% 缩放下新节点在屏幕上只有几十像素、深色面板贴深色背景，用户会以为
+    // 「没创建上」。之前只有拖放式落点补了聚焦，底部「+」快捷栏与拖线菜单
+    // 漏掉了 —— 这份清单就是为了锁住所有入口，新增入口必须一起补。
+    for (const marker of [
+      'const commitNodePlacementAtClientPosition = useCallback(',
+      'const finalizeNodeSpawn = useCallback(',
+      'const handleQuickAddNode = useCallback(',
+      'const handleQuickAddSkill = useCallback(',
+    ]) {
+      expect(bodyAfter(marker), marker).toContain('focusNewNodeIfLowZoom(');
+    }
+  });
+
+  it('聚焦门槛走 isLowDetailZoom，且把 zoom 拉到 ≥0.6', () => {
+    expect(bodyAfter('const focusNewNodeIfLowZoom = useCallback(')).toContain(
+      'isLowDetailZoom(reactFlowInstance.getZoom())'
+    );
+    expect(CANVAS_SOURCE).toContain('zoom: Math.max(currentZoom, 0.6)');
   });
 });
 

--- a/frontend/src/features/canvas/Canvas.tsx
+++ b/frontend/src/features/canvas/Canvas.tsx
@@ -1342,6 +1342,19 @@ export function Canvas({
     clearPendingFocus();
   }, [pendingFocusNodeId, nodes, reactFlowInstance, clearPendingFocus]);
 
+  // 低缩放档（10% 之类）下新节点在屏幕上只有几十像素、深色面板贴深色背景，
+  // 创建成功也近乎不可见，用户会以为「没创建上」。所有「凭空新建节点」的入口
+  // 都复用上面的聚焦机制：视口动画拉近到新节点（zoom 提到 ≥0.6），创建即所见、
+  // 且直接可编辑。常用工作缩放下不聚焦，避免打断用户的构图视角。
+  const focusNewNodeIfLowZoom = useCallback(
+    (nodeId: string) => {
+      if (isLowDetailZoom(reactFlowInstance.getZoom())) {
+        requestFocusNode(nodeId);
+      }
+    },
+    [reactFlowInstance, requestFocusNode],
+  );
+
   useEffect(() => {
     const sleep = (delayMs: number) =>
       new Promise<void>((resolve) => {
@@ -2136,13 +2149,7 @@ export function Canvas({
         pendingNodePlacement.initialData,
       );
       setSelectedNode(newNodeId);
-      // 低缩放档下新节点在屏幕上只有几十像素、深色面板贴深色背景，放置成功也
-      // 近乎不可见（用户会以为「没创建上」）。复用资产拖入的聚焦机制：视口动画
-      // 拉近到新节点（zoom 提到 ≥0.6），落点即所见、且直接可编辑。常用工作缩放
-      // 下不聚焦，避免打断用户的构图视角。
-      if (isLowDetailZoom(reactFlowInstance.getZoom())) {
-        requestFocusNode(newNodeId);
-      }
+      focusNewNodeIfLowZoom(newNodeId);
       if (pendingNodePlacement.skill) {
         bindSingleBeatContextInput(newNodeId, pendingNodePlacement.skill);
       }
@@ -2156,9 +2163,9 @@ export function Canvas({
     [
       addNode,
       bindSingleBeatContextInput,
+      focusNewNodeIfLowZoom,
       pendingNodePlacement,
       reactFlowInstance,
-      requestFocusNode,
       scheduleCanvasPersist,
       setSelectedNode,
       triggerPlacementConfirm,
@@ -3140,6 +3147,7 @@ export function Canvas({
         }
       }
 
+      focusNewNodeIfLowZoom(newNodeId);
       scheduleCanvasPersist(0);
       setShowNodeMenu(false);
       setMenuAllowedTypes(undefined);
@@ -3149,6 +3157,7 @@ export function Canvas({
     },
     [
       connectGraphNodes,
+      focusNewNodeIfLowZoom,
       pendingBatchConnectIds,
       pendingConnectStart,
       scheduleCanvasPersist,
@@ -3268,9 +3277,10 @@ export function Canvas({
     (type: CanvasNodeType) => {
       const newNodeId = addNode(type, spawnAtViewportCenter());
       setSelectedNode(newNodeId);
+      focusNewNodeIfLowZoom(newNodeId);
       scheduleCanvasPersist(0);
     },
-    [addNode, scheduleCanvasPersist, setSelectedNode, spawnAtViewportCenter],
+    [addNode, focusNewNodeIfLowZoom, scheduleCanvasPersist, setSelectedNode, spawnAtViewportCenter],
   );
 
   const handleQuickAddSkill = useCallback(
@@ -3281,10 +3291,18 @@ export function Canvas({
         displayName: skill.display_name,
       } as Partial<CanvasNodeData>);
       setSelectedNode(newNodeId);
+      focusNewNodeIfLowZoom(newNodeId);
       bindSingleBeatContextInput(newNodeId, skill);
       scheduleCanvasPersist(0);
     },
-    [addNode, bindSingleBeatContextInput, scheduleCanvasPersist, setSelectedNode, spawnAtViewportCenter],
+    [
+      addNode,
+      bindSingleBeatContextInput,
+      focusNewNodeIfLowZoom,
+      scheduleCanvasPersist,
+      setSelectedNode,
+      spawnAtViewportCenter,
+    ],
   );
 
   // 历史资产弹窗「使用」：把该资产作为新节点生成到视口中心（复用素材落点的 spawnAssetNode）。


### PR DESCRIPTION
## 问题

画布缩放到 10% 时，通过**底部「+」快捷栏**创建节点，画布上看不到新节点，必须手动放大缩放比例才能找到——用户会以为「没创建上」。

## 根因

低缩放聚焦守卫此前是内联写在 `commitNodePlacementAtClientPosition`（双击 / 右键菜单的落点路径）里的，没有被复用。其余「凭空新建节点」的入口都漏掉了：

- `handleQuickAddNode` —— 底部「+」建普通节点（**用户报的就是这条**）
- `handleQuickAddSkill` —— 底部「+」建技能节点
- `finalizeNodeSpawn` —— 从节点 handle 拖线松手弹菜单建节点（同病，一并修）

## 改法

把守卫提成一个 helper，四个入口统一调用：

```ts
const focusNewNodeIfLowZoom = useCallback(
  (nodeId: string) => {
    if (isLowDetailZoom(reactFlowInstance.getZoom())) {
      requestFocusNode(nodeId);
    }
  },
  [reactFlowInstance, requestFocusNode],
);
```

它驱动已有的 focus effect 做 `setCenter(..., { zoom: Math.max(currentZoom, 0.6), duration: 320 })`。只在 `zoom < 0.35`（`LOW_DETAIL_ZOOM_THRESHOLD`）时触发，常用工作缩放区间不聚焦，避免打断用户的构图视角。

文件拖入 / 粘贴那两条路径不在本次范围内：它们按光标位置成批落点，语义与「凭空新建一个空节点」不同。

## 测试

`canvas-lod.test.ts` 加了两个源断言用例，把四个入口列成清单锁住，以后新增建节点入口漏补聚焦会直接挂测试。先跑红再改绿。

本地：`tsc -b` 干净、`pnpm build` 通过、2172/2173 测试通过（唯一失败是 `ingest.test.tsx` 的本地 MSW 环境问题，与本改动无关）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)