### PR TITLE
chore: release v1.3.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "supertale-ce"
-version = "1.3.0"
+version = "1.3.1"
 description = "SuperTale Community Edition API and video pipeline"
 readme = "README.md"
 requires-python = ">=3.11,<3.13"

--- a/src/novelvideo/release-notes.md
+++ b/src/novelvideo/release-notes.md
@@ -1,55 +1,27 @@
 ---
-version: 1.3.0
+version: 1.3.1
 attention: low
 ---
-# v1.3.0
+# v1.3.1
 
 ## User-facing Highlights (zh)
 
-- **模型能力统一管理**: CE 新增模型渠道与能力配置,图片和视频模型、参数及素材连线上限统一由后台下发,不再依赖前端内置清单。
-- **官方配置内置 MiniMax-H3**: 使用官方配置时可直接选择 MiniMax-H3 视频模型,支持文生视频、首帧、首尾帧、图片参考和全能参考等生成模式。
-- **接入本地 ComfyUI**: 自定义与本地加官方混合模式均可连接本地 ComfyUI,配置 API Format Workflow,并让指定视频模型走本地生成而其他模型继续使用 RelayClaw。
-- **部署本地 MiniMax H3 视频模型**: 提供 MiniMax H3 文生视频、图生视频和参考生视频 Workflow 初始模板,可按本机 ComfyUI 节点与模型文件调整后接入画布。
-- **视频素材与计费更准确**: 修正视频生成模式语义和参考素材限制,补齐参考音频总时长校验,支持按视频输入量计费,并让主线与画布应用各自正确的促销报价。
-- **画布与任务体验升级**: 大型画布平移采用轻量 LOD,视频节点面板完成拆分,同时修复小地图拖动、任务进度卡住、等待超时和主动终止提示。
-- **自托管数据更可靠**: Docker 部署持久化生成媒体并中转远程资产,备份同步前先快照可变状态,降低重启、外链失效或同步竞争造成的数据风险。
-- **生成结果更稳定**: 优化结构化输出、视频 Beat、角色身份和官方风格提示,单行脚本失败时继续处理其余内容,并补充旁白与参考音频前置校验。
+- **官方媒体模型目录可更新**: CE 设置页现在可手动检查官方媒体模型目录更新，也可开启进入设置页时自动检查；新目录生效后，虾画图片和视频模型选项会立即刷新。
+- **视频能力与素材限制更准确**: 图生视频能力可独立配置，参考音频和视频支持单条及合计时长限制；前后端会在计费和任务投递前拦截不符合要求的素材。
+- **画布创建与模型选择更顺畅**: 低缩放下通过快捷栏、技能入口或拖线菜单创建节点时会自动聚焦，同时模型选择器会依据媒体目录准确判断视频素材是否可用。
 
 ## User-facing Highlights (en)
 
-- **Unified model capability management**: CE now manages model channels and capabilities, with image/video models, parameters, and reference limits delivered by the backend instead of a hard-coded frontend catalog.
-- **MiniMax-H3 built into the official profile**: MiniMax-H3 is directly selectable with the official configuration, supporting text-to-video, first-frame, first/last-frame, image-reference, and all-reference generation modes.
-- **Connect local ComfyUI**: Custom and Local + Official Hybrid modes can connect to a local ComfyUI service, configure API Format workflows, and route selected video models locally while other models continue through RelayClaw.
-- **Deploy a local MiniMax H3 video model**: Starter workflows are provided for MiniMax H3 text-to-video, image-to-video, and reference-to-video, ready to adapt to locally installed ComfyUI nodes and model files.
-- **More accurate video references and billing**: Video generation modes and reference limits are corrected, total reference-audio duration is validated, pricing can account for video input, and promotional quotes use the correct mainline or canvas context.
-- **Upgraded canvas and task experience**: Large canvases use lightweight LOD while panning, the video node panel is split out, and minimap dragging, stuck progress, timeout, and cancellation feedback are fixed.
-- **More reliable self-hosted data**: Docker deployments persist generated media and relay remote assets, while backup sync snapshots mutable state first to reduce restart, expired-link, and synchronization risks.
-- **More stable generation results**: Structured output, video beat, character identity, and official style prompts are refined; isolated script-line failures no longer abort the rest, with stronger narrator and reference-audio validation.
+- **Updatable official media catalog**: CE settings can now check for official media model catalog updates manually or automatically when the settings panel opens; image and video model options refresh immediately after an update.
+- **More accurate video capabilities and reference limits**: Image-to-video can be configured independently, with per-item and total duration limits for reference audio and video; invalid media is rejected before billing or task dispatch.
+- **Smoother canvas creation and model selection**: Nodes created from quick-add, skill, or connection menus are focused automatically at low zoom, while the model picker now uses the media catalog to determine video-reference compatibility.
 
 ## New Features
 
-- CE 新增模型渠道与能力管理,并由后台统一下发图片/视频模型配置、参数和素材上限 (#251, #254).
-- 官方配置内置 MiniMax-H3 视频模型及常用生成模式,无需额外创建媒体模型配置 (#254).
-- 自定义与本地加官方混合模式支持接入本地 ComfyUI,并提供 MiniMax H3 文生视频、图生视频和参考生视频 Workflow 初始模板 (#254).
-- 支持依据视频输入量计算生成费用,并补充产品功能可见性与计费上下文 (#249, #258).
+- CE 支持查看并更新官方媒体模型目录，并可选择在打开设置页时自动检查更新 (#271).
+- 视频模型支持独立声明图生视频能力，并配置参考音频、参考视频的单条及合计时长限制 (#268).
 
 ## Bug Fixes
 
-- 修复 EE 下全能参考被错误拦截及节点进度停在 96% 的问题 (#245).
-- 修复前端任务等待预算与后端上限不一致导致的过早超时 (#242).
-- 修复主动终止任务成功后仍显示错误提示的问题 (#243).
-- 修复换图后图片节点继续显示旧失败横幅的问题 (#224).
-- 修复结构化输出启用推理模式导致的兼容性问题 (#248).
-- 单行模型输出失败时继续处理其余脚本内容,避免整批任务中断 (#244).
-- 修正视频生成模式语义、素材模式和素材连线上限 (#253, #255).
-- 修复参考音频总时长与旁白音色前置条件缺少校验的问题 (#260, #262).
-- 修复小地图拖动增益随视口偏移持续放大的问题 (#259).
-- 修复备份同步期间可变状态不一致的问题 (#261).
-- 修正视频 Beat、国漫角色身份及官方风格提示的内容污染问题 (#263, #264, #265).
-- 修复主线与画布生成报价缺少产品入口上下文,导致促销价格应用不准确的问题 (#266).
-
-## Improvements
-
-- 为大型画布增加平移 LOD 外壳,并拆分视频节点操作面板以降低渲染开销 (#241).
-- Docker 部署持久化生成媒体,并支持中转保存 Cloudinary 等远程资产 (#247).
-- 按实际交付结果结算积分并发送带类型的计费数量,提高计费记录准确性 (#239, #240).
+- 修复模型选择器未按媒体目录判断视频素材能力，导致可选模型进入无可用模式状态的问题 (#269).
+- 修复低缩放下通过快捷栏、技能入口或拖线菜单创建节点后，新节点不在可见区域的问题 (#270).

--- a/tests/test_release_feed.py
+++ b/tests/test_release_feed.py
@@ -114,7 +114,7 @@ def test_built_wheel_contains_parseable_release_notes_artifact(tmp_path: Path) -
 def test_project_version_is_single_source_of_truth() -> None:
     pyproject = tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))
 
-    assert pyproject["project"]["version"] == "1.3.0"
+    assert pyproject["project"]["version"] == "1.3.1"
     assert importlib.metadata.version("supertale-ce") == pyproject["project"]["version"]
     assert "__version__" not in Path("src/novelvideo/__init__.py").read_text(encoding="utf-8")
 

--- a/uv.lock
+++ b/uv.lock
@@ -3419,7 +3419,7 @@ wheels = [
 
 [[package]]
 name = "supertale-ce"
-version = "1.3.0"
+version = "1.3.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## PR 类型 / Type of PR
- [ ] 🐞 Bug 修复 / Bug fix
- [ ] ✨ 新功能 / Feature
- [x] 📝 文档 / Documentation
- [ ] 🧹 重构 / 清理 / Refactor or cleanup
- [x] ⚙️ 构建 / CI / Build or CI
- [ ] ⚠️ 破坏性变更 / Breaking change

## 改动说明 / What this PR does and why

- 将项目版本从 `1.3.0` 更新为 `1.3.1`，同步版本单源测试与 `uv.lock`。
- 基于 `main` 在 v1.3.0 后合入的 #268、#269、#270、#271 重写包内双语 release notes。
- Highlights 覆盖官方媒体模型目录更新、独立视频能力与素材时长限制，以及画布创建和模型选择修复。

## 关联 issue / Linked issues

N/A

## 给 reviewer 的说明 / Notes for the reviewer

- 此 PR 仅准备 v1.3.1 发布元数据；审核合入前不会创建 tag 或 GitHub Release。
- 发布基准节点为 `95439559fea2752b7dde1a2c7df1685078168ee6`。
- 包内 release notes 使用 `attention: low`，不会主动点亮旧版本用户的通知红点。

## 面向用户的变更 / User-facing change
```release-note
CE 支持更新官方媒体模型目录，视频能力与参考素材限制更加准确，并修复低缩放创建节点和视频素材模型选择问题。
```

## 自检 / Checklist
- [x] 已自测，`uv run pytest` 通过 / Self-tested, `uv run pytest` passes
- [x] 必要的文档已更新 / Docs updated where needed
- [x] 提交信息清晰（建议 Conventional Commits）/ Clear commits (Conventional Commits suggested)
- [x] 每个 commit 都已 `git commit -s` 附 DCO 签署 / Every commit signed off with DCO
- [ ] 我已阅读并同意[贡献者协议](../CONTRIBUTING.md#贡献者协议) / I've read and agree to the [contributor terms](../CONTRIBUTING.md#贡献者协议)

## 验证 / Verification

- `UV_CACHE_DIR=/Users/newyue/claymorelab/.uv-cache uv lock --check`
- `UV_CACHE_DIR=/Users/newyue/claymorelab/.uv-cache uv sync`
- `UV_CACHE_DIR=/Users/newyue/claymorelab/.uv-cache uv run pytest tests/test_release_feed.py` (`12 passed`)
- `git diff --check`
