### PR TITLE
fix video generation mode contract

### DIFF
--- a/frontend/src/api/ops.ts
+++ b/frontend/src/api/ops.ts
@@ -195,8 +195,8 @@ export interface FreezoneVideoGenPayload extends FreezoneNodeContext {
   generateAudio?: boolean;
   /** Backend model id, e.g. huimeng_seedance20_fast / seedance_pro. */
   model?: string;
-  /** 生成模式（还原用）：textToVideo / imageToVideo / firstLastFrame / imageReference / allReference。 */
-  genMode?: string;
+  /** 文生视频入口的固定业务模式。 */
+  genMode: "textToVideo";
   /**
    * Real-person material review. Set `true` when the input contains real
    * human faces so the backend routes the job through the human-review path
@@ -234,7 +234,7 @@ export async function submitFreezoneVideoGen(
         duration_seconds: Math.max(payload.durationSeconds ?? 5, 1),
         generate_audio: payload.generateAudio ?? false,
         ...(payload.model ? { model: payload.model, model_id: payload.model } : {}),
-        ...(payload.genMode ? { gen_mode: payload.genMode } : {}),
+        gen_mode: payload.genMode,
         human_review: payload.humanReview ?? false,
         scene_optimize: payload.sceneOptimize ?? null,
         ...nodeContextBody(payload),
@@ -291,6 +291,8 @@ export interface FreezoneVideoKeyframesPayload extends FreezoneNodeContext {
   durationSeconds?: number;
   generateAudio?: boolean;
   model?: string;
+  /** 关键帧业务模式。首尾帧可只提供首帧、只提供尾帧或同时提供。 */
+  genMode: "firstFrame" | "firstLastFrame";
   /** See {@link FreezoneVideoGenPayload.humanReview}. */
   humanReview?: boolean;
   sceneOptimize?: "anime" | "realistic" | null;
@@ -325,6 +327,7 @@ export async function submitFreezoneVideoKeyframes(
         duration_seconds: Math.max(payload.durationSeconds ?? 5, 1),
         generate_audio: payload.generateAudio ?? false,
         ...(payload.model ? { model: payload.model, model_id: payload.model } : {}),
+        gen_mode: payload.genMode,
         human_review: payload.humanReview ?? false,
         scene_optimize: payload.sceneOptimize ?? null,
         ...nodeContextBody(payload),
@@ -414,8 +417,8 @@ export interface FreezoneVideoEditPayload extends FreezoneNodeContext {
   generateAudio?: boolean;
   /** default newapi_happyhorse-1.0. */
   model?: string;
-  /** 生成模式（还原用）：videoEdit。 */
-  genMode?: string;
+  /** 视频编辑入口的固定业务模式。 */
+  genMode: "videoEdit";
   humanReview?: boolean;
 }
 
@@ -449,7 +452,7 @@ export async function submitFreezoneVideoEdit(
         audio_setting: payload.audioSetting ?? "auto",
         generate_audio: payload.generateAudio ?? false,
         ...(payload.model ? { model: payload.model, model_id: payload.model } : {}),
-        ...(payload.genMode ? { gen_mode: payload.genMode } : {}),
+        gen_mode: payload.genMode,
         human_review: payload.humanReview ?? false,
         ...nodeContextBody(payload),
       },
@@ -481,8 +484,8 @@ export interface FreezoneVideoOmniGenPayload extends FreezoneNodeContext {
   generateAudio?: boolean;
   /** default huimeng_seedance20_fast per backend default. */
   model?: string;
-  /** 生成模式（还原用）：textToVideo / imageToVideo / firstLastFrame / imageReference / allReference。 */
-  genMode?: string;
+  /** 全能参考入口的固定业务模式。 */
+  genMode: "allReference";
   /** See {@link FreezoneVideoGenPayload.humanReview}. */
   humanReview?: boolean;
   sceneOptimize?: "anime" | "realistic" | null;
@@ -522,7 +525,7 @@ export async function submitFreezoneVideoOmniGen(
         duration_seconds: Math.max(payload.durationSeconds ?? 5, 1),
         generate_audio: payload.generateAudio ?? false,
         ...(payload.model ? { model: payload.model, model_id: payload.model } : {}),
-        ...(payload.genMode ? { gen_mode: payload.genMode } : {}),
+        gen_mode: payload.genMode,
         human_review: payload.humanReview ?? false,
         scene_optimize: payload.sceneOptimize ?? null,
         ...nodeContextBody(payload),

--- a/frontend/src/features/canvas/nodes/TextAnnotationNode.tsx
+++ b/frontend/src/features/canvas/nodes/TextAnnotationNode.tsx
@@ -461,6 +461,7 @@ export const TextAnnotationNode = memo(({
           durationSeconds: durationSec,
           generateAudio,
           model: videoModel,
+          genMode: "textToVideo",
           canvasId: readUrl().canvas ?? 'default',
           nodeId: videoNodeId,
         });

--- a/frontend/src/features/canvas/nodes/VideoNode.tsx
+++ b/frontend/src/features/canvas/nodes/VideoNode.tsx
@@ -2022,6 +2022,7 @@ export const VideoNode = memo(
             submitFreezoneVideoKeyframes(projectId, {
               firstFrameUrl,
               lastFrameUrl,
+              genMode,
               prompt: composedPrompt,
               cameraTemplateId,
               aspectRatio: submitAspectRatio,

--- a/src/novelvideo/api/routes/freezone.py
+++ b/src/novelvideo/api/routes/freezone.py
@@ -369,6 +369,7 @@ async def _start_or_enqueue_freezone_video_gen(
     model_id: str | None = None,
     catalog_id: str | None = None,
     gen_mode: str | None = None,
+    requested_gen_mode: str | None = None,
     model_params: dict[str, Any] | None = None,
     request_schema: dict[str, Any] | None = None,
     capabilities: dict[str, Any] | None = None,
@@ -422,7 +423,7 @@ async def _start_or_enqueue_freezone_video_gen(
             "video_backend": backend,
             "resolution": resolution,
             "pricing_quantity": duration_seconds,
-            "operation": gen_mode or "textToVideo",
+            "operation": requested_gen_mode or gen_mode or "textToVideo",
             "generate_audio": generate_audio,
             "video_input_present": bool(video_input_paths),
             "input_video_duration_seconds": input_video_duration_seconds,
@@ -436,6 +437,7 @@ async def _start_or_enqueue_freezone_video_gen(
         "model_id": model_id or "",
         "catalog_id": catalog_id or "",
         "gen_mode": gen_mode or "",
+        "requested_gen_mode": requested_gen_mode or gen_mode or "",
         "prompt": prompt,
         "reference_items": reference_items,
         "aspect_ratio": aspect_ratio,
@@ -7748,11 +7750,11 @@ async def freezone_video_gen(
         "video",
         body.model,
         body.model_params,
-        mode=body.gen_mode or "text_to_video",
+        mode=body.gen_mode,
     )
     _require_catalog_video_mode(
         capabilities,
-        body.gen_mode or "text_to_video",
+        body.gen_mode,
     )
     character_items = _load_video_character_items_by_ids(project_dir, body.character_ids)
     character_names = [str(item.get("name") or "") for item in character_items]
@@ -7803,7 +7805,8 @@ async def freezone_video_gen(
             node_id=body.node_id or None,
             model_id=body.model,
             catalog_id=_catalog_entry_id(capabilities) or None,
-            gen_mode=body.gen_mode or "text_to_video",
+            gen_mode="text_to_video",
+            requested_gen_mode=body.gen_mode,
             model_params=model_params,
             request_schema=request_schema,
             capabilities=capabilities,
@@ -7922,6 +7925,7 @@ async def freezone_video_i2v(
             model_id=body.model,
             catalog_id=_catalog_entry_id(capabilities) or None,
             gen_mode=execution_mode,
+            requested_gen_mode=requested_mode,
             model_params=model_params,
             request_schema=request_schema,
             capabilities=capabilities,
@@ -7951,29 +7955,30 @@ async def freezone_video_keyframes(
 
     if body.camera_template_id and not get_video_camera_template(body.camera_template_id):
         raise HTTPException(400, f"unknown camera_template_id: {body.camera_template_id}")
-    if not (body.first_frame_url or body.last_frame_url):
-        raise HTTPException(400, "first_frame_url or last_frame_url is required")
+    if body.gen_mode == "firstFrame":
+        if not body.first_frame_url:
+            raise HTTPException(400, "firstFrame requires first_frame_url")
+        if body.last_frame_url:
+            raise HTTPException(400, "firstFrame does not accept last_frame_url")
+    elif not (body.first_frame_url or body.last_frame_url):
+        raise HTTPException(400, "firstLastFrame requires at least one keyframe")
     try:
         backend = await _resolve_catalog_video_backend(body.model)
     except ValueError as exc:
         raise HTTPException(400, str(exc)) from exc
 
-    if body.first_frame_url and body.last_frame_url:
-        execution_mode = "first_last_frame"
-    elif body.first_frame_url:
-        execution_mode = "first_frame"
-    else:
-        # 目录暂不新增独立 last_frame 能力。仅尾帧仍属于关键帧能力，最终协议只下发
-        # last_frame_image，不把它伪装成首帧。
-        execution_mode = "first_last_frame"
+    requested_mode = body.gen_mode
+    execution_mode = (
+        "first_frame" if requested_mode == "firstFrame" else "first_last_frame"
+    )
 
     request_schema, model_params, capabilities = await _resolve_catalog_request(
         "video",
         body.model,
         body.model_params,
-        mode=execution_mode,
+        mode=requested_mode,
     )
-    _require_catalog_video_mode(capabilities, execution_mode)
+    _require_catalog_video_mode(capabilities, requested_mode)
     reference_limits = _catalog_reference_limits(
         capabilities,
         image_default=2,
@@ -8046,6 +8051,7 @@ async def freezone_video_keyframes(
             model_id=body.model,
             catalog_id=_catalog_entry_id(capabilities) or None,
             gen_mode=execution_mode,
+            requested_gen_mode=requested_mode,
             model_params=model_params,
             request_schema=request_schema,
             capabilities=capabilities,
@@ -8085,7 +8091,7 @@ async def freezone_video_omni_gen(
         "video",
         body.model,
         body.model_params,
-        mode=body.gen_mode or "all_reference",
+        mode=body.gen_mode,
     )
     mode_enabled = _catalog_mode_enabled(capabilities, "all_reference")
     if mode_enabled is False:
@@ -8212,7 +8218,8 @@ async def freezone_video_omni_gen(
             node_id=body.node_id or None,
             model_id=body.model,
             catalog_id=_catalog_entry_id(capabilities) or None,
-            gen_mode=body.gen_mode or "all_reference",
+            gen_mode="all_reference",
+            requested_gen_mode=body.gen_mode,
             model_params=model_params,
             request_schema=request_schema,
             capabilities=capabilities,
@@ -8256,7 +8263,7 @@ async def freezone_video_edit(
         "video",
         body.model,
         body.model_params,
-        mode=body.gen_mode or "video_edit",
+        mode=body.gen_mode,
     )
     mode_enabled = _catalog_mode_enabled(capabilities, "video_edit")
     if mode_enabled is False or (
@@ -8331,7 +8338,8 @@ async def freezone_video_edit(
             node_id=body.node_id or None,
             model_id=body.model,
             catalog_id=_catalog_entry_id(capabilities) or None,
-            gen_mode=body.gen_mode or "video_edit",
+            gen_mode="video_edit",
+            requested_gen_mode=body.gen_mode,
             model_params=model_params,
             request_schema=request_schema,
             capabilities=capabilities,

--- a/src/novelvideo/api/routes/freezone.py
+++ b/src/novelvideo/api/routes/freezone.py
@@ -92,6 +92,7 @@ from novelvideo.freezone import canvas_store
 from novelvideo.media_model_request_schema import (
     MediaModelSchemaError,
     media_request_schema_for_mode,
+    normalize_media_model_mode,
     validate_media_model_params,
     validate_media_request_schema,
 )
@@ -7174,15 +7175,7 @@ def _require_catalog_video_mode(
     capabilities: dict[str, Any] | None,
     mode: str,
 ) -> None:
-    normalized = {
-        "textToVideo": "text_to_video",
-        "firstFrame": "first_frame",
-        "imageToVideo": "image_to_video",
-        "firstLastFrame": "first_last_frame",
-        "imageReference": "image_reference",
-        "allReference": "all_reference",
-        "videoEdit": "video_edit",
-    }.get(mode, mode)
+    normalized = normalize_media_model_mode(mode)
     if _catalog_mode_enabled(capabilities, normalized) is False:
         raise HTTPException(400, f"this model does not support {normalized} mode")
 

--- a/src/novelvideo/api/schemas.py
+++ b/src/novelvideo/api/schemas.py
@@ -1052,7 +1052,10 @@ class FreezoneVideoGenRequest(BaseModel):
     )
     canvas_id: str = Field(default="", description="可选：来源画布 id，用于记录节点生成历史")
     node_id: str = Field(default="", description="可选：来源节点 id，用于记录节点生成历史")
-    gen_mode: Optional[str] = Field(default=None, description="可选：生成模式，用于还原节点时回填 genMode")
+    gen_mode: Literal["textToVideo"] = Field(
+        default="textToVideo",
+        description="文生视频入口的固定业务模式",
+    )
     model_params: dict[str, Any] = Field(default_factory=dict)
 
 
@@ -1165,6 +1168,9 @@ class FreezoneKeyframeVideoRequest(BaseModel):
     )
     canvas_id: str = Field(default="", description="可选：来源画布 id，用于记录节点生成历史")
     node_id: str = Field(default="", description="可选：来源节点 id，用于记录节点生成历史")
+    gen_mode: Literal["firstFrame", "firstLastFrame"] = Field(
+        description="必填：首帧或首尾帧业务模式；不能根据实际上传的帧数推断",
+    )
     model_params: dict[str, Any] = Field(default_factory=dict)
 
 
@@ -1216,7 +1222,10 @@ class FreezoneVideoEditRequest(BaseModel):
     )
     canvas_id: str = Field(default="", description="可选：来源画布 id，用于记录节点生成历史")
     node_id: str = Field(default="", description="可选：来源节点 id，用于记录节点生成历史")
-    gen_mode: Optional[str] = Field(default=None, description="可选：生成模式，用于还原节点时回填 genMode")
+    gen_mode: Literal["videoEdit"] = Field(
+        default="videoEdit",
+        description="视频编辑入口的固定业务模式",
+    )
     model_params: dict[str, Any] = Field(default_factory=dict)
 
 
@@ -1378,7 +1387,10 @@ class FreezoneVideoOmniGenRequest(BaseModel):
     )
     canvas_id: str = Field(default="", description="可选：来源画布 id，用于记录节点生成历史")
     node_id: str = Field(default="", description="可选：来源节点 id，用于记录节点生成历史")
-    gen_mode: Optional[str] = Field(default=None, description="可选：生成模式，用于还原节点时回填 genMode")
+    gen_mode: Literal["allReference"] = Field(
+        default="allReference",
+        description="全能参考入口的固定业务模式",
+    )
     model_params: dict[str, Any] = Field(default_factory=dict)
 
 

--- a/src/novelvideo/media_model_request_schema.py
+++ b/src/novelvideo/media_model_request_schema.py
@@ -23,6 +23,7 @@ BLOCKED_ROOTS = {
 }
 MODE_ALIASES = {
     "textToVideo": "text_to_video",
+    "firstFrame": "first_frame",
     # 画布「图生视频」是单张图片参考：图片影响整体画面，但不锁定第一帧。
     # 真正的首帧模式由首尾帧入口按槽位派生为 first_frame。
     "imageToVideo": "image_to_video",
@@ -66,6 +67,12 @@ RESERVED_CATALOG_CONFIG_FIELDS = {
 
 class MediaModelSchemaError(ValueError):
     pass
+
+
+def normalize_media_model_mode(mode: str | None) -> str:
+    """Normalize canvas business mode names to media catalog mode names."""
+    raw_mode = str(mode or "")
+    return MODE_ALIASES.get(raw_mode, raw_mode)
 
 
 def _validate_js_number(value: int | float, field: str) -> None:
@@ -401,7 +408,7 @@ def media_request_schema_for_mode(schema: object, mode: str | None) -> dict[str,
     normalized_schema = validate_media_request_schema(schema)
     if not normalized_schema:
         return {}
-    normalized_mode = MODE_ALIASES.get(str(mode or ""), str(mode or ""))
+    normalized_mode = normalize_media_model_mode(mode)
     filtered = copy.deepcopy(normalized_schema)
     filtered["parameters"] = [
         item

--- a/src/novelvideo/task_backend/runners/video.py
+++ b/src/novelvideo/task_backend/runners/video.py
@@ -65,8 +65,9 @@ def _append_freezone_video_node_history(
     extra: dict[str, Any] = {}
     if payload.get("model_id"):
         extra["model"] = str(payload["model_id"])
-    if payload.get("gen_mode"):
-        extra["gen_mode"] = str(payload["gen_mode"])
+    history_mode = payload.get("requested_gen_mode") or payload.get("gen_mode")
+    if history_mode:
+        extra["gen_mode"] = str(history_mode)
 
     record = build_node_history_record(
         task_type="freezone_video_gen",

--- a/tests/contract/test_m06_route_contracts.py
+++ b/tests/contract/test_m06_route_contracts.py
@@ -680,7 +680,11 @@ def _freezone_task_cases(client: TestClient, assets: SimpleNamespace):
             "freezone_video_gen",
             client.post(
                 f"/api/v1/projects/{p}/freezone/video/keyframes",
-                json={"first_frame_url": image, "prompt": "move"},
+                json={
+                    "first_frame_url": image,
+                    "prompt": "move",
+                    "gen_mode": "firstFrame",
+                },
             ),
         ),
         (

--- a/tests/test_freezone_image_backend.py
+++ b/tests/test_freezone_image_backend.py
@@ -764,7 +764,8 @@ async def test_freezone_video_generation_enqueues_feature_billing(
         human_review=False,
         scene_optimize=None,
         backend="newapi_seedance-1.0-pro-fast",
-        gen_mode="imageToVideo",
+        gen_mode="image_reference",
+        requested_gen_mode="imageToVideo",
     )
 
     assert result["data"]["task_type"] == "freezone_video_gen"
@@ -792,6 +793,8 @@ async def test_freezone_video_generation_enqueues_feature_billing(
         "video_input_present": False,
         "input_video_duration_seconds": 0.0,
     }
+    assert captured["payload"]["gen_mode"] == "image_reference"
+    assert captured["payload"]["requested_gen_mode"] == "imageToVideo"
 
 
 @pytest.mark.asyncio

--- a/tests/test_freezone_video_route_modes.py
+++ b/tests/test_freezone_video_route_modes.py
@@ -7,7 +7,13 @@ from fastapi import HTTPException
 from pydantic import ValidationError
 
 from novelvideo.api.routes import freezone as freezone_routes
-from novelvideo.api.schemas import FreezoneImageToVideoRequest, FreezoneKeyframeVideoRequest
+from novelvideo.api.schemas import (
+    FreezoneImageToVideoRequest,
+    FreezoneKeyframeVideoRequest,
+    FreezoneVideoEditRequest,
+    FreezoneVideoGenRequest,
+    FreezoneVideoOmniGenRequest,
+)
 
 
 def _catalog(*modes: str) -> dict:
@@ -72,6 +78,7 @@ async def test_image_to_video_uses_one_reference_image_not_first_frame(
 
     assert captured["request_mode"] == "imageToVideo"
     assert captured["start"]["gen_mode"] == "image_reference"
+    assert captured["start"]["requested_gen_mode"] == "imageToVideo"
     assert captured["start"]["reference_items"] == [
         {"type": "image", "path": "https://example.com/ref.png", "role": "图片参考"}
     ]
@@ -151,6 +158,7 @@ async def test_image_reference_keeps_multi_image_reference_protocol(
 
     assert captured["request_mode"] == "imageReference"
     assert captured["start"]["gen_mode"] == "image_reference"
+    assert captured["start"]["requested_gen_mode"] == "imageReference"
     assert [item["path"] for item in captured["start"]["reference_items"]] == [
         "https://example.com/a.png",
         "https://example.com/b.png",
@@ -165,23 +173,61 @@ def test_image_to_video_requires_an_explicit_new_mode() -> None:
         )
 
 
+def test_fixed_video_routes_reject_cross_route_modes() -> None:
+    with pytest.raises(ValidationError, match="gen_mode"):
+        FreezoneVideoGenRequest(prompt="rain", gen_mode="allReference")
+    with pytest.raises(ValidationError, match="gen_mode"):
+        FreezoneVideoOmniGenRequest(prompt="rain", gen_mode="textToVideo")
+    with pytest.raises(ValidationError, match="gen_mode"):
+        FreezoneVideoEditRequest(video_url="video.mp4", gen_mode="firstFrame")
+
+
+def test_keyframe_route_requires_explicit_mode() -> None:
+    with pytest.raises(ValidationError, match="gen_mode"):
+        FreezoneKeyframeVideoRequest(
+            first_frame_url="https://example.com/ref.png",
+            model="catalog-video",
+        )
+
+
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    ("first_url", "last_url", "expected_mode", "expected_image_path"),
+    ("requested_mode", "first_url", "last_url", "expected_mode", "expected_image_path"),
     [
-        ("https://example.com/first.png", None, "first_frame", "https://example.com/first.png"),
         (
+            "firstFrame",
+            "https://example.com/first.png",
+            None,
+            "first_frame",
+            "https://example.com/first.png",
+        ),
+        (
+            "firstLastFrame",
+            "https://example.com/first.png",
+            None,
+            "first_last_frame",
+            "https://example.com/first.png",
+        ),
+        (
+            "firstLastFrame",
             "https://example.com/first.png",
             "https://example.com/last.png",
             "first_last_frame",
             "https://example.com/first.png",
         ),
-        (None, "https://example.com/last.png", "first_last_frame", None),
+        (
+            "firstLastFrame",
+            None,
+            "https://example.com/last.png",
+            "first_last_frame",
+            None,
+        ),
     ],
 )
-async def test_keyframe_route_derives_first_both_and_last_only_protocols(
+async def test_keyframe_route_preserves_selected_mode_for_all_frame_combinations(
     monkeypatch,
     tmp_path: Path,
+    requested_mode: str,
     first_url: str | None,
     last_url: str | None,
     expected_mode: str,
@@ -199,14 +245,50 @@ async def test_keyframe_route_derives_first_both_and_last_only_protocols(
             first_frame_url=first_url,
             last_frame_url=last_url,
             model="catalog-video",
+            gen_mode=requested_mode,
         ),
         {"username": "admin"},
     )
 
-    assert captured["request_mode"] == expected_mode
+    assert captured["request_mode"] == requested_mode
     assert captured["start"]["gen_mode"] == expected_mode
+    assert captured["start"]["requested_gen_mode"] == requested_mode
     assert captured["start"]["last_frame_path"] == last_url
     first_items = [
         item for item in captured["start"]["reference_items"] if item["role"] == "首帧"
     ]
     assert (first_items[0]["path"] if first_items else None) == expected_image_path
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("first_url", "last_url", "message"),
+    [
+        (None, None, "requires first_frame_url"),
+        (
+            "https://example.com/first.png",
+            "https://example.com/last.png",
+            "does not accept last_frame_url",
+        ),
+    ],
+)
+async def test_first_frame_mode_rejects_invalid_frame_combinations(
+    monkeypatch,
+    tmp_path: Path,
+    first_url: str | None,
+    last_url: str | None,
+    message: str,
+) -> None:
+    await _install_route_fakes(monkeypatch, tmp_path, _catalog("first_frame"))
+
+    with pytest.raises(HTTPException, match=message):
+        await freezone_routes.freezone_video_keyframes(
+            "project",
+            FreezoneKeyframeVideoRequest(
+                first_frame_url=first_url,
+                last_frame_url=last_url,
+                model="catalog-video",
+                gen_mode="firstFrame",
+            ),
+            {"username": "admin"},
+        )

--- a/tests/test_history_asset_model_mode.py
+++ b/tests/test_history_asset_model_mode.py
@@ -44,7 +44,8 @@ def test_video_history_persists_model_and_gen_mode(tmp_path: Path) -> None:
         "canvas_id": "default",
         "prompt": "深夜古街",
         "model_id": "happyhouse_1_0",
-        "gen_mode": "firstLastFrame",
+        "gen_mode": "first_last_frame",
+        "requested_gen_mode": "firstLastFrame",
     }
     rec = _append_freezone_video_node_history(
         ctx=ctx,

--- a/tests/test_media_model_request_schema.py
+++ b/tests/test_media_model_request_schema.py
@@ -4,6 +4,7 @@ from novelvideo.media_model_request_schema import (
     MediaModelSchemaError,
     apply_media_request_schema,
     media_request_schema_for_mode,
+    normalize_media_model_mode,
     validate_media_model_catalog_config,
     validate_media_model_params,
     validate_media_request_schema,
@@ -112,6 +113,52 @@ def test_filters_mode_specific_parameters_and_defaults():
     assert validate_media_model_params(filtered, {}) == {"seed": 1}
     with pytest.raises(MediaModelSchemaError, match="unknown model parameters"):
         validate_media_model_params(filtered, {"camera_fixed": True})
+
+
+@pytest.mark.parametrize(
+    ("business_mode", "catalog_mode"),
+    [
+        ("textToVideo", "text_to_video"),
+        ("firstFrame", "first_frame"),
+        ("firstLastFrame", "first_last_frame"),
+        ("imageToVideo", "image_to_video"),
+        ("imageReference", "image_reference"),
+        ("allReference", "all_reference"),
+        ("videoEdit", "video_edit"),
+    ],
+)
+def test_normalizes_all_canvas_video_modes(business_mode, catalog_mode):
+    assert normalize_media_model_mode(business_mode) == catalog_mode
+
+
+def test_first_frame_alias_keeps_and_validates_mode_specific_parameters():
+    schema = {
+        "endpoint": "video/generations",
+        "parameters": [
+            {
+                "key": "camera_fixed",
+                "control": "switch",
+                "requestPath": "camera_fixed",
+                "required": True,
+                "modes": ["first_frame"],
+            },
+            {
+                "key": "reference_strength",
+                "control": "number",
+                "requestPath": "reference_strength",
+                "modes": ["image_reference"],
+            },
+        ],
+    }
+
+    filtered = media_request_schema_for_mode(schema, "firstFrame")
+
+    assert [item["key"] for item in filtered["parameters"]] == ["camera_fixed"]
+    assert validate_media_model_params(filtered, {"camera_fixed": True}) == {
+        "camera_fixed": True
+    }
+    with pytest.raises(MediaModelSchemaError, match="parameter is required: camera_fixed"):
+        validate_media_model_params(filtered, {})
 
 
 def test_image_to_video_and_image_reference_parameters_are_independent():


### PR DESCRIPTION
## Summary

- require the frontend to send an explicit video generation mode for every Freezone video route
- preserve the selected business mode separately from the provider execution protocol
- stop inferring first-frame versus first/last-frame behavior from the number of submitted images
- persist the selected mode in node history and add regression coverage for all keyframe combinations

## Root cause

The keyframe route inferred the execution mode from whether one or two images were present. As a result, selecting first/last-frame mode with only one connected image was silently reclassified as first-frame mode, which could conflict with the model capabilities configured in the media catalog.

## Impact

Admin-configured video capabilities, frontend mode selection, backend validation, billing metadata, task payloads, and history restoration now use one consistent business-mode contract. Provider-specific execution values remain internal to the task payload.

## Validation

- `uv run pytest -q tests/test_freezone_video_route_modes.py tests/test_freezone_image_backend.py tests/test_history_asset_model_mode.py tests/contract/test_m06_route_contracts.py` — 225 passed
- focused Ruff checks — passed
- frontend TypeScript check — passed
- `git diff --check origin/main...HEAD` — passed
