### PR TITLE
chore: release v1.3.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "supertale-ce"
-version = "1.3.1"
+version = "1.3.2"
 description = "SuperTale Community Edition API and video pipeline"
 readme = "README.md"
 requires-python = ">=3.11,<3.13"

--- a/src/novelvideo/release-notes.md
+++ b/src/novelvideo/release-notes.md
@@ -1,27 +1,30 @@
 ---
-version: 1.3.1
+version: 1.3.2
 attention: low
 ---
-# v1.3.1
+# v1.3.2
 
 ## User-facing Highlights (zh)
 
-- **官方媒体模型目录可更新**: CE 设置页现在可手动检查官方媒体模型目录更新，也可开启进入设置页时自动检查；新目录生效后，虾画图片和视频模型选项会立即刷新。
-- **视频能力与素材限制更准确**: 图生视频能力可独立配置，参考音频和视频支持单条及合计时长限制；前后端会在计费和任务投递前拦截不符合要求的素材。
-- **画布创建与模型选择更顺畅**: 低缩放下通过快捷栏、技能入口或拖线菜单创建节点时会自动聚焦，同时模型选择器会依据媒体目录准确判断视频素材是否可用。
+- **本地 ComfyUI 配置更简单**: MiniMax H3 现在以单一模型接入多个 Workflow，由虾驿根据文生视频、首帧或全能参考模式自动选择流程，并支持一键清理本地配置。
+- **视频生成模式更准确**: 画布选择的首帧、首尾帧等业务模式会在校验、计费、任务执行和历史恢复中保持一致，不再根据素材数量被静默改写。
+- **主线生成默认值优化**: 场景参考图提升为中等质量，主线视频模型列表加入 Seedance 2.0 Mini 并精简不推荐选项，同时将新小说上传上限调整为 512KB。
 
 ## User-facing Highlights (en)
 
-- **Updatable official media catalog**: CE settings can now check for official media model catalog updates manually or automatically when the settings panel opens; image and video model options refresh immediately after an update.
-- **More accurate video capabilities and reference limits**: Image-to-video can be configured independently, with per-item and total duration limits for reference audio and video; invalid media is rejected before billing or task dispatch.
-- **Smoother canvas creation and model selection**: Nodes created from quick-add, skill, or connection menus are focused automatically at low zoom, while the model picker now uses the media catalog to determine video-reference compatibility.
+- **Simpler local ComfyUI setup**: MiniMax H3 now uses one model entry for multiple workflows, with RelayClaw selecting the appropriate text-to-video, first-frame, or all-reference workflow and an option to clear local configuration in one action.
+- **More accurate video generation modes**: Canvas selections such as first-frame and first/last-frame now remain consistent through validation, billing, task execution, and history restoration instead of being silently changed based on reference count.
+- **Improved mainline defaults**: Scene reference images now use medium quality, Seedance 2.0 Mini is available while less suitable mainline choices are hidden, and the new novel upload limit is set to 512KB.
 
 ## New Features
 
-- CE 支持查看并更新官方媒体模型目录，并可选择在打开设置页时自动检查更新 (#271).
-- 视频模型支持独立声明图生视频能力，并配置参考音频、参考视频的单条及合计时长限制 (#268).
+- 简化本地 ComfyUI 配置，使用单一 MiniMax-H3-local 模型承载多个 Workflow，并支持一键清理配置 (#277).
+- 主线视频模型新增 Seedance 2.0 Mini，并保留已有项目和任务对旧模型的执行兼容性 (#267).
 
 ## Bug Fixes
 
-- 修复模型选择器未按媒体目录判断视频素材能力，导致可选模型进入无可用模式状态的问题 (#269).
-- 修复低缩放下通过快捷栏、技能入口或拖线菜单创建节点后，新节点不在可见区域的问题 (#270).
+- 修复首帧、首尾帧等视频生成模式会因参考图片数量而被错误改写的问题 (#273).
+
+## Improvements
+
+- 将场景参考图质量提升为 medium，并同步实际请求的计费参数；新小说上传限制调整为 512KB (#267).

--- a/tests/test_release_feed.py
+++ b/tests/test_release_feed.py
@@ -114,7 +114,7 @@ def test_built_wheel_contains_parseable_release_notes_artifact(tmp_path: Path) -
 def test_project_version_is_single_source_of_truth() -> None:
     pyproject = tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))
 
-    assert pyproject["project"]["version"] == "1.3.1"
+    assert pyproject["project"]["version"] == "1.3.2"
     assert importlib.metadata.version("supertale-ce") == pyproject["project"]["version"]
     assert "__version__" not in Path("src/novelvideo/__init__.py").read_text(encoding="utf-8")
 

--- a/uv.lock
+++ b/uv.lock
@@ -3419,7 +3419,7 @@ wheels = [
 
 [[package]]
 name = "supertale-ce"
-version = "1.3.1"
+version = "1.3.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## PR 类型 / Type of PR
- [ ] 🐞 Bug 修复 / Bug fix
- [ ] ✨ 新功能 / Feature
- [x] 📝 文档 / Documentation
- [ ] 🧹 重构 / 清理 / Refactor or cleanup
- [x] ⚙️ 构建 / CI / Build or CI
- [ ] ⚠️ 破坏性变更 / Breaking change

## 改动说明 / What this PR does and why

- 将项目版本从 `1.3.1` 更新为 `1.3.2`，同步版本单源测试与 `uv.lock`。
- 基于 `main` 在 v1.3.1 后合入的 #267、#273、#277 重写包内双语 release notes。
- Highlights 覆盖本地 ComfyUI 配置简化、视频生成模式一致性，以及主线场景、视频模型和小说上传默认值优化。

## 关联 issue / Linked issues

N/A

## 给 reviewer 的说明 / Notes for the reviewer

- 此 PR 仅准备 v1.3.2 发布元数据；审核合入前不会创建 tag 或 GitHub Release。
- 发布基准节点为 `035255d2de84d6ad9779c54ea558f2bba886a0d1`。
- 包内 release notes 使用 `attention: low`，不会主动点亮旧版本用户的通知红点。

## 面向用户的变更 / User-facing change
```release-note
简化本地 ComfyUI 的 MiniMax H3 配置，修复视频生成模式被错误改写的问题，并优化主线场景和视频生成默认值。
```

## 自检 / Checklist
- [x] 已自测，`uv run pytest` 通过 / Self-tested, `uv run pytest` passes
- [x] 必要的文档已更新 / Docs updated where needed
- [x] 提交信息清晰（建议 Conventional Commits）/ Clear commits (Conventional Commits suggested)
- [x] 每个 commit 都已 `git commit -s` 附 DCO 签署 / Every commit signed off with DCO
- [ ] 我已阅读并同意[贡献者协议](../CONTRIBUTING.md#贡献者协议) / I've read and agree to the [contributor terms](../CONTRIBUTING.md#贡献者协议)

## 验证 / Verification

- `UV_CACHE_DIR=/Users/newyue/claymorelab/.uv-cache uv lock --check`
- `UV_CACHE_DIR=/Users/newyue/claymorelab/.uv-cache uv sync`
- `UV_CACHE_DIR=/Users/newyue/claymorelab/.uv-cache uv run pytest tests/test_release_feed.py` (`12 passed`)
- `git diff --check`
