### PR TITLE
fix(model-gateway): 自定义渠道初始化连不上 NewAPI 时快速报错

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,6 +24,10 @@ NEWAPI_PROVISIONER_ENABLED=true
 NEWAPI_ADMIN_BASE_URL=http://127.0.0.1:3000
 
 NEWAPI_PROVISIONER_INIT_TIMEOUT_MS=120000
+# 端口完全没人监听时的放弃时限。启动中的容器会先绑端口再就绪（HTTP 5xx），
+# 所以持续连不上基本只有一种解释：这套部署里没有 NewAPI 服务。此时提前失败并
+# 给出排查指引，不必等满上面那个 120s。
+NEWAPI_PROVISIONER_CONNECT_TIMEOUT_MS=20000
 NEWAPI_RELAY_TOKEN_NAME=dramaclaw-ce-runtime
 
 # 是否让 newAPI 文本模型客户端读取系统代理。默认 true。

--- a/frontend/src/lib/queries/model-gateway.ts
+++ b/frontend/src/lib/queries/model-gateway.ts
@@ -457,11 +457,14 @@ export function useInitCustomNewApi() {
   const qc = useQueryClient();
   return useMutation({
     // 初始化要连 NewAPI、建 token、写库，耗时较长，放宽超时。
+    // 必须大于后端 NEWAPI_PROVISIONER_INIT_TIMEOUT_MS（默认 120s）：否则前端先超时，
+    // 用户只看到一句 Request timed out，后端那条带排查指引的错误永远到不了界面。
+    // 连不上 NewAPI 的常见情况后端会在 20s 内快速失败，不会真的等满这里。
     mutationFn: (input: InitCustomNewApiInput) =>
       api
         .post("api/v1/model-gateway/custom/newapi/init", {
           json: input,
-          timeout: 60_000,
+          timeout: 180_000,
           throwHttpErrors: false,
         })
         .json<OkResponse<InitCustomNewApiResult> | ErrorResponse | FastApiErrorResponse>(),

--- a/src/novelvideo/newapi_provisioner.py
+++ b/src/novelvideo/newapi_provisioner.py
@@ -172,6 +172,10 @@ class NewApiProvisionerConfig:
     admin_username: str
     init_timeout_ms: int
     relay_token_name: str
+    # 端口完全没人监听时的放弃时限，独立于 init_timeout_ms。容器启动中至少会
+    # 绑上端口（此时是 HTTP 5xx 而非连接失败），所以持续连不上基本只有一种解释：
+    # 这套部署里没有 NewAPI 服务。见 wait_for_newapi。
+    connect_timeout_ms: int = 20000
 
 
 @dataclass(frozen=True)
@@ -360,6 +364,9 @@ def get_provisioner_config(
         init_timeout_ms=int(
             os.environ.get("NEWAPI_PROVISIONER_INIT_TIMEOUT_MS", "120000")
         ),
+        connect_timeout_ms=int(
+            os.environ.get("NEWAPI_PROVISIONER_CONNECT_TIMEOUT_MS", "20000")
+        ),
         relay_token_name=(
             os.environ.get("NEWAPI_RELAY_TOKEN_NAME", "dramaclaw-ce-runtime").strip()
             or "dramaclaw-ce-runtime"
@@ -429,21 +436,49 @@ def wait_for_db(cfg: NewApiProvisionerConfig) -> NewApiDB:
     raise RuntimeError(f"database not ready: {last_error}")
 
 
+def _newapi_unreachable_error(
+    cfg: NewApiProvisionerConfig,
+    last_error: Exception | None,
+) -> RuntimeError:
+    """连不上 NewAPI 时给出可执行的提示，而不是只抛底层连接错误。
+
+    最常见的原因是启动了不含 NewAPI 的官方渠道 Compose，然后在设置里切到
+    「自定义」。这种情况下原始报错（Connection refused）对用户毫无指向性。
+    """
+    return RuntimeError(
+        f"无法连接 NewAPI（{cfg.admin_base_url}）：{last_error}。"
+        "自定义模型渠道需要本地 NewAPI 服务；官方渠道的 docker-compose.yml 不包含它。"
+        "请改用 docker-compose.selfhosted.yml 启动，"
+        "或把 NEWAPI_ADMIN_BASE_URL 指向已有的 NewAPI 实例。"
+    )
+
+
 def wait_for_newapi(cfg: NewApiProvisionerConfig) -> None:
     if not cfg.admin_base_url:
         raise RuntimeError("NEWAPI_ADMIN_BASE_URL is required")
-    deadline = time.monotonic() + cfg.init_timeout_ms / 1000
+    started_at = time.monotonic()
+    deadline = started_at + cfg.init_timeout_ms / 1000
+    # 端口没人监听 ≠ 服务正在启动：启动中的容器会先绑端口再就绪，表现为 HTTP 5xx。
+    # 所以「一次 HTTP 响应都没拿到」持续过久时提前放弃，否则要等满 init_timeout_ms，
+    # 前端早已超时，用户只会看到一句无指向性的 Request timed out。
+    connect_deadline = started_at + cfg.connect_timeout_ms / 1000
     last_error: Exception | None = None
+    responded = False
     while time.monotonic() < deadline:
         try:
             with httpx.Client(timeout=5) as client:
                 res = client.get(f"{cfg.admin_base_url}/api/setup")
+            responded = True
             if res.status_code < 500:
                 return
             last_error = RuntimeError(f"HTTP {res.status_code}")
         except Exception as exc:
             last_error = exc
+            if not responded and time.monotonic() >= connect_deadline:
+                raise _newapi_unreachable_error(cfg, last_error) from last_error
         time.sleep(1.5)
+    if not responded:
+        raise _newapi_unreachable_error(cfg, last_error)
     raise RuntimeError(f"NewAPI not ready: {last_error}")
 
 

--- a/tests/test_model_gateway_settings.py
+++ b/tests/test_model_gateway_settings.py
@@ -5,6 +5,7 @@ import json
 import os
 from pathlib import Path
 
+import httpx
 import pytest
 import respx
 from fastapi import FastAPI
@@ -58,6 +59,7 @@ from novelvideo.newapi_provisioner import (
     require_provisioner_enabled,
     update_provider_channel_credentials,
     upsert_channel,
+    wait_for_newapi,
 )
 
 
@@ -88,6 +90,54 @@ def test_comfyui_channel_update_replaces_removed_workflow_models():
 
     assert merged["models"] == "kept"
     assert json.loads(merged["model_mapping"]) == {"kept": "kept"}
+
+
+def _provisioner_cfg(**overrides) -> NewApiProvisionerConfig:
+    base = {
+        "admin_base_url": "http://new-api:3000",
+        "sql_dsn": "local",
+        "sqlite_path": "/tmp/one-api.db",
+        "admin_username": "root",
+        "init_timeout_ms": 60000,
+        "relay_token_name": "dramaclaw-ce-runtime",
+    }
+    base.update(overrides)
+    return NewApiProvisionerConfig(**base)
+
+
+@respx.mock
+def test_wait_for_newapi_fails_fast_when_nothing_is_listening():
+    """官方渠道 Compose 不含 NewAPI：必须在 connect_timeout_ms 内放弃并给出排查指引。
+
+    回归 #281：过去要等满 init_timeout_ms(默认 120s)，而前端 60s 就超时了，
+    用户只能看到一句无指向性的 Request timed out。
+    """
+    respx.get("http://new-api:3000/api/setup").mock(
+        side_effect=httpx.ConnectError("Connection refused")
+    )
+    cfg = _provisioner_cfg(init_timeout_ms=60000, connect_timeout_ms=0)
+
+    with pytest.raises(RuntimeError) as excinfo:
+        wait_for_newapi(cfg)
+
+    message = str(excinfo.value)
+    # 指向真实原因和可执行的下一步，而不是只抛底层连接错误。
+    assert "http://new-api:3000" in message
+    assert "docker-compose.selfhosted.yml" in message
+    assert "Connection refused" in message
+
+
+@respx.mock
+def test_wait_for_newapi_keeps_waiting_while_service_is_booting():
+    """启动中的容器会先绑端口再就绪(HTTP 5xx)，这种情况不能按「没部署」提前放弃。"""
+    route = respx.get("http://new-api:3000/api/setup").mock(
+        side_effect=[Response(503), Response(200, json={"success": True})]
+    )
+    cfg = _provisioner_cfg(init_timeout_ms=60000, connect_timeout_ms=0)
+
+    wait_for_newapi(cfg)
+
+    assert route.call_count == 2
 
 
 @respx.mock


### PR DESCRIPTION
## 背景

修 #281。用户在 WSL 部署后，在设置里选「自定义」模型渠道并初始化，只看到：

```
Request timed out: POST http://localhost:8080/api/v1/model-gateway/custom/newapi/init
```

看不到任何真实原因。

## 根因

两处超时错配，导致后端的错误永远到不了界面：

| 环节 | 值 |
| --- | --- |
| 后端 `wait_for_newapi()` 重试窗口 | `NEWAPI_PROVISIONER_INIT_TIMEOUT_MS` 默认 **120s** |
| 前端 `useInitCustomNewApi` 超时 | **60s** ← 先触发 |

前端在 60s 抛 `Request timed out`，而后端还要再撞 60s 才会给出真实错误。

而连不上的原因是：官方渠道的 `docker-compose.yml` 只有 `api` / `web` / `ce-data`，**不含 `newapi` 服务**（`docker-compose.selfhosted.yml` 才有）。自定义渠道需要本地 NewAPI。

## 改动

- `wait_for_newapi` 区分**端口没人监听**和**服务正在启动**：启动中的容器会先绑端口再就绪（表现为 HTTP 5xx），因此「一次 HTTP 响应都没拿到」且超过 `connect_timeout_ms`（默认 20s）时提前放弃，不再等满 120s。这样既能快速失败，也不会误伤冷启动较慢的正常部署。
- 连不上时的报错改为带排查指引：指出需要本地 NewAPI、官方渠道 compose 不含它，并给出 `docker-compose.selfhosted.yml` 与 `NEWAPI_ADMIN_BASE_URL` 两条出路。前端 `getResponseErrorMessage()` 会优先取 `detail`，所以这条消息能直接展示给用户。
- 前端 init 超时 60s → 180s，保证大于后端上限。否则前端先超时会继续吞掉后端的错误信息。
- 新增 `connect_timeout_ms` 配置项（`NEWAPI_PROVISIONER_CONNECT_TIMEOUT_MS`），带默认值，不影响现有调用。

## 影响

- 用户体验：从「等 60 秒后看到一句无指向性的超时」变成「约 20 秒内看到该怎么办」。
- 不改变成功路径，也不改变正常部署下的等待逻辑。
- 无数据库迁移，无配置强制项。

## 验证

- `uv run pytest tests/test_model_gateway_settings.py tests/test_newapi_text_gateway.py tests/test_newapi_image_gateway.py -q` — 144 passed
- `uv run ruff check src/novelvideo/newapi_provisioner.py tests/test_model_gateway_settings.py` — 通过
- `pnpm exec tsc -b` — 通过

新增两条回归测试：

- `test_wait_for_newapi_fails_fast_when_nothing_is_listening` — 锁住快速失败与报错内容
- `test_wait_for_newapi_keeps_waiting_while_service_is_booting` — 锁住「HTTP 5xx 时继续等」，防止把冷启动误判成未部署

## 未覆盖

UI 层还可以在检测不到本地 NewAPI 时提前提示或禁用「自定义」选项，避免用户点下去才知道。属于体验改进，不在本 PR 范围。

Closes #281

🤖 Generated with [Claude Code](https://claude.com/claude-code)
