### PR TITLE
feat(freezone): 资产库按用途分类目、按文件夹归位

### DIFF
--- a/frontend/src/__tests__/components/episode/beat-workbench/batch-bar.test.tsx
+++ b/frontend/src/__tests__/components/episode/beat-workbench/batch-bar.test.tsx
@@ -467,8 +467,8 @@ describe("BatchBar", () => {
     expect(screen.queryByText("0.5K")).not.toBeInTheDocument();
   });
 
-  it("shows the backend batch quote for narrated projects", async () => {
-    const user = userEvent.setup();
+  it("hides whole-beat video prompt generation from the batch toolbar", () => {
+    // 解说片 (narrated) 是这个入口原先唯一露头的地方，现在也不给了。
     const { rerender } = render(
       <I18nextProvider i18n={i18n}>
         <BatchBar
@@ -483,13 +483,9 @@ describe("BatchBar", () => {
       </I18nextProvider>,
     );
 
-    const batchButton = screen.getByRole("button", {
-      name: /生成全 Beat 视频提示词/,
-    });
-    expect(batchButton).toHaveTextContent("12");
-    await user.click(batchButton);
-    expect(screen.getAllByText("12").length).toBeGreaterThanOrEqual(2);
-    await user.click(screen.getByRole("button", { name: "取消" }));
+    expect(
+      screen.queryByRole("button", { name: /生成全 Beat 视频提示词/ }),
+    ).not.toBeInTheDocument();
 
     rerender(
       <I18nextProvider i18n={i18n}>
@@ -528,96 +524,30 @@ describe("BatchBar", () => {
     expect(screen.queryByRole("button", { name: "补生成草图" })).not.toBeInTheDocument();
   });
 
-  it("shows whole-episode audio cost on the button and confirm action", async () => {
-    const user = userEvent.setup();
-    render(
-      <I18nextProvider i18n={i18n}>
-        <BatchBar
-          project="demo"
-          episode={1}
-          beats={DEFAULT_BEATS}
-          videoBackend="seedance"
-          spineTemplate="narrated"
-          sketchAspectRatio="2:3"
-          onSketchAspectRatioChange={vi.fn()}
-        />
-      </I18nextProvider>,
-    );
+  it.each([
+    ["narrated" as const, "seedance"],
+    ["narrated" as const, "huimeng_seedance-2.0-fast"],
+    ["drama" as const, "seedance"],
+  ])(
+    "hides whole-episode audio from the batch toolbar (%s / %s)",
+    (spineTemplate, videoBackend) => {
+      render(
+        <I18nextProvider i18n={i18n}>
+          <BatchBar
+            project="demo"
+            episode={1}
+            beats={DEFAULT_BEATS}
+            videoBackend={videoBackend}
+            spineTemplate={spineTemplate}
+            sketchAspectRatio="2:3"
+            onSketchAspectRatioChange={vi.fn()}
+          />
+        </I18nextProvider>,
+      );
 
-    expect(screen.getByRole("button", { name: "生成音频" })).toBeInTheDocument();
-    await user.click(screen.getByRole("button", { name: "生成音频" }));
-
-    expect(screen.getByRole("button", { name: "确认执行" })).toBeInTheDocument();
-    expect(screen.getAllByText("18").length).toBeGreaterThanOrEqual(2);
-  });
-
-  it("stops whole-episode audio before confirmation when the quote reports a voice prerequisite", async () => {
-    audioQuoteState.prereqErrors = [
-      "Beat 01 解说声线缺失：项目解说人声线未配置，请上传或录制解说人音频",
-    ];
-    const user = userEvent.setup();
-    render(
-      <I18nextProvider i18n={i18n}>
-        <BatchBar
-          project="demo"
-          episode={1}
-          beats={DEFAULT_BEATS}
-          videoBackend="seedance"
-          spineTemplate="narrated"
-          sketchAspectRatio="2:3"
-          onSketchAspectRatioChange={vi.fn()}
-        />
-      </I18nextProvider>,
-    );
-
-    await user.click(screen.getByRole("button", { name: "生成音频" }));
-
-    expect(screen.queryByRole("button", { name: "确认执行" })).not.toBeInTheDocument();
-    expect(
-      screen.getByText(
-        "Beat 01 解说声线缺失：项目解说人声线未配置，请上传或录制解说人音频",
-      ),
-    ).toBeInTheDocument();
-  });
-
-  it("keeps whole-episode TTS generation visible but unavailable when Seedance2 is selected", async () => {
-    render(
-      <I18nextProvider i18n={i18n}>
-        <BatchBar
-          project="demo"
-          episode={1}
-          beats={DEFAULT_BEATS}
-          videoBackend="huimeng_seedance-2.0-fast"
-          spineTemplate="narrated"
-          sketchAspectRatio="2:3"
-          onSketchAspectRatioChange={vi.fn()}
-        />
-      </I18nextProvider>,
-    );
-
-    expect(screen.getByRole("button", { name: "生成音频" })).toHaveAttribute(
-      "aria-disabled",
-      "true",
-    );
-  });
-
-  it("hides whole-episode audio for 精品剧 (drama) projects", () => {
-    render(
-      <I18nextProvider i18n={i18n}>
-        <BatchBar
-          project="demo"
-          episode={1}
-          beats={DEFAULT_BEATS}
-          videoBackend="seedance"
-          spineTemplate="drama"
-          sketchAspectRatio="2:3"
-          onSketchAspectRatioChange={vi.fn()}
-        />
-      </I18nextProvider>,
-    );
-
-    expect(screen.queryByRole("button", { name: "生成音频" })).not.toBeInTheDocument();
-  });
+      expect(screen.queryByRole("button", { name: "生成音频" })).not.toBeInTheDocument();
+    },
+  );
 
   it("shows AI detect and reassign color actions in the top batch toolbar", async () => {
     const user = userEvent.setup();

--- a/frontend/src/__tests__/features/canvas/asset-library-modal-categories.test.tsx
+++ b/frontend/src/__tests__/features/canvas/asset-library-modal-categories.test.tsx
@@ -1,0 +1,507 @@
+// SPDX-License-Identifier: Elastic-2.0
+// Copyright (c) 2026 ClaymoreLab
+//
+// 资产库弹窗：「全部」只列文件夹、类目 tab 按标签平铺，右上角统一放批量操作与
+// 新建（新建文件夹 / 上传资产）。
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+
+const fetchFreezoneVideoCharacterLibrary = vi.fn();
+const syncFreezoneAssetLibraryFromMainline = vi.fn();
+const fetchFreezoneAssetLibraryFolders = vi.fn();
+const createFreezoneAssetLibraryFolder = vi.fn();
+const deleteFreezoneVideoCharacterLibraryItem = vi.fn();
+const updateFreezoneAssetLibraryFolder = vi.fn();
+const deleteFreezoneAssetLibraryFolder = vi.fn();
+
+vi.mock("@/api/ops", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/api/ops")>()),
+  fetchFreezoneVideoCharacterLibrary: (...args: unknown[]) =>
+    fetchFreezoneVideoCharacterLibrary(...args),
+  syncFreezoneAssetLibraryFromMainline: (...args: unknown[]) =>
+    syncFreezoneAssetLibraryFromMainline(...args),
+  fetchFreezoneAssetLibraryFolders: (...args: unknown[]) =>
+    fetchFreezoneAssetLibraryFolders(...args),
+  createFreezoneAssetLibraryFolder: (...args: unknown[]) =>
+    createFreezoneAssetLibraryFolder(...args),
+  deleteFreezoneVideoCharacterLibraryItem: (...args: unknown[]) =>
+    deleteFreezoneVideoCharacterLibraryItem(...args),
+  updateFreezoneAssetLibraryFolder: (...args: unknown[]) =>
+    updateFreezoneAssetLibraryFolder(...args),
+  deleteFreezoneAssetLibraryFolder: (...args: unknown[]) =>
+    deleteFreezoneAssetLibraryFolder(...args),
+}));
+
+import { AssetLibraryModal } from "@/features/canvas/ui/AssetLibraryModal";
+
+const LIBRARY = [
+  {
+    id: "mainline:scene:厨房",
+    name: "厨房",
+    media: "image",
+    source: "scene",
+    image_urls: ["/static/kitchen.png"],
+  },
+  {
+    id: "up-1",
+    name: "参考图A",
+    media: "image",
+    source: "upload",
+    image_urls: ["/static/a.png"],
+  },
+  {
+    id: "up-2",
+    name: "赛博霓虹",
+    media: "image",
+    source: "upload",
+    category: "style",
+    image_urls: ["/static/b.png"],
+  },
+  {
+    id: "up-3",
+    name: "脚步声",
+    media: "audio",
+    source: "upload",
+    category: "audio",
+    audio_url: "/static/step.mp3",
+  },
+];
+
+function renderModal(props: Partial<React.ComponentProps<typeof AssetLibraryModal>> = {}) {
+  return render(
+    <AssetLibraryModal open project="demo" onClose={() => {}} {...props} />,
+  );
+}
+
+describe("AssetLibraryModal 类目与文件夹", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    fetchFreezoneVideoCharacterLibrary.mockResolvedValue({ items: LIBRARY });
+    syncFreezoneAssetLibraryFromMainline.mockResolvedValue({ items: LIBRARY });
+    fetchFreezoneAssetLibraryFolders.mockResolvedValue([]);
+    deleteFreezoneVideoCharacterLibraryItem.mockResolvedValue({ ok: true });
+  });
+
+  it("「全部」只列文件夹，主线资产收在一个文件夹里", async () => {
+    renderModal();
+
+    expect(await screen.findByRole("button", { name: "文件夹 主线" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "文件夹 待分类资产" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "文件夹 风格" })).toBeInTheDocument();
+    // 顶层看不到条目本身，得点进文件夹。
+    expect(screen.queryByText("厨房")).toBeNull();
+    expect(screen.queryByText("参考图A")).toBeNull();
+    // 写操作统一收在右上角，网格里不再有上传卡片。
+    expect(screen.getByRole("button", { name: "批量操作" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "新建" })).toBeInTheDocument();
+  });
+
+  it("点进主线文件夹只看到同步来的条目，面包屑能退回全部", async () => {
+    renderModal();
+
+    fireEvent.click(await screen.findByRole("button", { name: "文件夹 主线" }));
+    expect(await screen.findByText("厨房")).toBeInTheDocument();
+    expect(screen.queryByText("参考图A")).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "返回全部" }));
+    expect(await screen.findByRole("button", { name: "文件夹 待分类资产" })).toBeInTheDocument();
+    expect(screen.queryByText("厨房")).toBeNull();
+  });
+
+  it("待分类资产文件夹只装没归类的上传", async () => {
+    renderModal();
+
+    fireEvent.click(await screen.findByRole("button", { name: "文件夹 待分类资产" }));
+    expect(await screen.findByText("参考图A")).toBeInTheDocument();
+    expect(screen.queryByText("赛博霓虹")).toBeNull();
+  });
+
+  it("类目 tab 按标签平铺条目，不再分文件夹", async () => {
+    renderModal();
+
+    await screen.findByRole("button", { name: "文件夹 主线" });
+    fireEvent.click(screen.getByRole("button", { name: "风格" }));
+    expect(await screen.findByText("赛博霓虹")).toBeInTheDocument();
+    expect(screen.queryByText("参考图A")).toBeNull();
+    expect(screen.queryByRole("button", { name: "文件夹 待分类资产" })).toBeNull();
+  });
+
+  it("allowedMedia 只要图片时，音效类目和音频条目都不出现", async () => {
+    renderModal({ allowedMedia: ["image"] });
+
+    await screen.findByRole("button", { name: "文件夹 主线" });
+    expect(screen.queryByRole("button", { name: "音效" })).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "文件夹 待分类资产" }));
+    expect(await screen.findByText("参考图A")).toBeInTheDocument();
+    expect(screen.queryByText("脚步声")).toBeNull();
+  });
+});
+
+describe("AssetLibraryModal 新建", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    fetchFreezoneVideoCharacterLibrary.mockResolvedValue({ items: LIBRARY });
+    syncFreezoneAssetLibraryFromMainline.mockResolvedValue({ items: LIBRARY });
+    fetchFreezoneAssetLibraryFolders.mockResolvedValue([]);
+  });
+
+  it("新建文件夹保存后立刻出现并进到该文件夹", async () => {
+    const created = { id: "fld-1", name: "第一集素材" };
+    createFreezoneAssetLibraryFolder.mockResolvedValue(created);
+    // 建完会重新拉一次文件夹列表。
+    fetchFreezoneAssetLibraryFolders
+      .mockResolvedValueOnce([])
+      .mockResolvedValue([created]);
+
+    renderModal();
+    await screen.findByRole("button", { name: "文件夹 主线" });
+
+    fireEvent.click(screen.getByRole("button", { name: "新建" }));
+    fireEvent.click(screen.getByRole("button", { name: "新建文件夹" }));
+
+    const input = screen.getByPlaceholderText("请输入文件夹名称");
+    fireEvent.change(input, { target: { value: "第一集素材" } });
+    fireEvent.click(screen.getByRole("button", { name: "保存" }));
+
+    await waitFor(() =>
+      expect(createFreezoneAssetLibraryFolder).toHaveBeenCalledWith(
+        "demo",
+        "第一集素材",
+      ),
+    );
+    // 建完直接进新文件夹：面包屑上是它，且里面还没有素材。
+    expect(await screen.findByText("第一集素材")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "返回全部" })).toBeInTheDocument();
+  });
+
+  it("上传资产弹窗要先选保存位置才能保存，主线不在可选之列", async () => {
+    fetchFreezoneAssetLibraryFolders.mockResolvedValue([
+      { id: "fld-1", name: "第一集素材" },
+    ]);
+    renderModal();
+    await screen.findByRole("button", { name: "文件夹 主线" });
+
+    fireEvent.click(screen.getByRole("button", { name: "新建" }));
+    fireEvent.click(screen.getByRole("button", { name: "上传资产" }));
+
+    // 没选文件、没选保存位置，保存不可用。
+    expect(screen.getByRole("button", { name: "保存" })).toBeDisabled();
+
+    fireEvent.click(screen.getByRole("button", { name: "选择保存位置" }));
+    expect(screen.getByRole("button", { name: "待分类资产" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "第一集素材" })).toBeInTheDocument();
+    // 主线是同步产物，不能当上传目标。
+    expect(screen.queryByRole("button", { name: "主线" })).toBeNull();
+  });
+});
+
+describe("AssetLibraryModal 底部分页", () => {
+  // 26 条无标签上传 → 全都落在「待分类资产」里，够翻两页。
+  const MANY = Array.from({ length: 26 }, (_, i) => ({
+    id: `up-${i + 1}`,
+    name: `素材${i + 1}`,
+    media: "image",
+    source: "upload",
+    image_urls: [`/static/${i + 1}.png`],
+  }));
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    fetchFreezoneVideoCharacterLibrary.mockResolvedValue({ items: MANY });
+    syncFreezoneAssetLibraryFromMainline.mockResolvedValue({ items: MANY });
+    fetchFreezoneAssetLibraryFolders.mockResolvedValue([]);
+  });
+
+  it("管理态底部只剩分页，没有「确定」", async () => {
+    renderModal();
+
+    expect(await screen.findByRole("button", { name: "第 1 页" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "每页条数" })).toHaveTextContent(
+      "20条/页",
+    );
+    expect(screen.queryByRole("button", { name: "确定" })).toBeNull();
+  });
+
+  it("挑素材给节点用时「确定」还在", async () => {
+    renderModal({ onConfirm: vi.fn() });
+
+    expect(await screen.findByRole("button", { name: "确定" })).toBeInTheDocument();
+  });
+
+  it("默认每页 20 条，翻页看后面的", async () => {
+    renderModal();
+
+    fireEvent.click(await screen.findByRole("button", { name: "文件夹 待分类资产" }));
+    expect(await screen.findByText("素材1")).toBeInTheDocument();
+    expect(screen.getByText("素材20")).toBeInTheDocument();
+    expect(screen.queryByText("素材21")).toBeNull();
+    // 26 条 → 2 页。
+    expect(screen.queryByRole("button", { name: "第 3 页" })).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "下一页" }));
+    expect(await screen.findByText("素材21")).toBeInTheDocument();
+    expect(screen.queryByText("素材1")).toBeNull();
+  });
+
+  it("改每页条数后回到第一页并一次列全", async () => {
+    renderModal();
+
+    fireEvent.click(await screen.findByRole("button", { name: "文件夹 待分类资产" }));
+    fireEvent.click(screen.getByRole("button", { name: "下一页" }));
+    expect(await screen.findByText("素材21")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "每页条数" }));
+    fireEvent.click(screen.getByRole("button", { name: "40条/页" }));
+
+    expect(await screen.findByText("素材1")).toBeInTheDocument();
+    expect(screen.getByText("素材26")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "第 2 页" })).toBeNull();
+  });
+});
+
+describe("AssetLibraryModal 文件夹操作", () => {
+  const CUSTOM = {
+    id: "fld-1",
+    name: "第一集素材",
+    created_at: "2026-08-12T10:20:30",
+  };
+  const FILED = [
+    ...LIBRARY,
+    {
+      id: "up-4",
+      name: "女主定妆",
+      media: "image",
+      source: "upload",
+      category: "character",
+      folder: "fld-1",
+      image_urls: ["/static/c.png"],
+    },
+  ];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    fetchFreezoneVideoCharacterLibrary.mockResolvedValue({ items: FILED });
+    syncFreezoneAssetLibraryFromMainline.mockResolvedValue({ items: FILED });
+    fetchFreezoneAssetLibraryFolders.mockResolvedValue([CUSTOM]);
+    updateFreezoneAssetLibraryFolder.mockResolvedValue(CUSTOM);
+    deleteFreezoneAssetLibraryFolder.mockResolvedValue({ deleted_items: 1 });
+  });
+
+  it("只有自建文件夹带「…」菜单，系统文件夹没有", async () => {
+    renderModal();
+
+    expect(
+      await screen.findByRole("button", { name: "第一集素材 更多操作" }),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "主线 更多操作" })).toBeNull();
+    // 名字挪到卡片下边，条数不再显示，建夹日期显示在名字下面一行。
+    expect(screen.queryByText("1 个")).toBeNull();
+    expect(screen.getByText("2026-08-12")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "待分类资产 更多操作" }),
+    ).toBeNull();
+  });
+
+  it("「发送到画布」把整个文件夹交给调用方并关掉弹窗", async () => {
+    const onSendFolderToCanvas = vi.fn();
+    const onClose = vi.fn();
+    renderModal({ onSendFolderToCanvas, onClose });
+
+    // 每个非空文件夹上都有一个，按卡片圈定再点。
+    const card = await screen.findByRole("button", { name: "文件夹 第一集素材" });
+    fireEvent.click(within(card).getByRole("button", { name: "发送到画布" }));
+
+    expect(onSendFolderToCanvas).toHaveBeenCalledTimes(1);
+    expect(onSendFolderToCanvas.mock.calls[0][0]).toMatchObject({
+      key: "fld-1",
+      label: "第一集素材",
+    });
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("重命名走 PATCH，只改名字", async () => {
+    renderModal();
+
+    fireEvent.click(
+      await screen.findByRole("button", { name: "第一集素材 更多操作" }),
+    );
+    fireEvent.click(screen.getByRole("button", { name: "重命名" }));
+
+    const input = screen.getByPlaceholderText("请输入文件夹名称");
+    expect(input).toHaveValue("第一集素材");
+    fireEvent.change(input, { target: { value: "第一集" } });
+    fireEvent.click(screen.getByRole("button", { name: "保存" }));
+
+    await waitFor(() =>
+      expect(updateFreezoneAssetLibraryFolder).toHaveBeenCalledWith(
+        "demo",
+        "fld-1",
+        { name: "第一集" },
+      ),
+    );
+  });
+
+  it("改封面从文件夹内的图片里挑", async () => {
+    renderModal();
+
+    fireEvent.click(
+      await screen.findByRole("button", { name: "第一集素材 更多操作" }),
+    );
+    fireEvent.click(screen.getByRole("button", { name: "修改封面" }));
+
+    // 只列这个文件夹自己的图片，别的文件夹的不出现。
+    expect(screen.queryByRole("button", { name: "选择封面 参考图A" })).toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: "选择封面 女主定妆" }));
+    fireEvent.click(screen.getByRole("button", { name: "保存" }));
+
+    await waitFor(() =>
+      expect(updateFreezoneAssetLibraryFolder).toHaveBeenCalledWith(
+        "demo",
+        "fld-1",
+        { cover: "/static/c.png" },
+      ),
+    );
+  });
+
+  it("删除文件夹要二次确认，确认后整柜删掉", async () => {
+    const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(true);
+    renderModal();
+
+    fireEvent.click(
+      await screen.findByRole("button", { name: "第一集素材 更多操作" }),
+    );
+    fireEvent.click(screen.getByRole("button", { name: "删除" }));
+
+    // 确认文案要写明里面的素材也会没。
+    expect(confirmSpy.mock.calls[0][0]).toContain("1 项素材会一起删掉");
+    await waitFor(() =>
+      expect(deleteFreezoneAssetLibraryFolder).toHaveBeenCalledWith(
+        "demo",
+        "fld-1",
+      ),
+    );
+  });
+
+  it("确认文案按整柜的真实条数算，不受 allowedMedia 过滤影响", async () => {
+    // 生图节点只让看图片，但后端删的是整柜——文案要照实说 2 项，不然那条视频
+    // 会在用户毫不知情的情况下没掉。
+    const withVideo = [
+      ...FILED,
+      {
+        id: "up-5",
+        name: "定妆花絮",
+        media: "video",
+        source: "upload",
+        category: "character",
+        folder: "fld-1",
+        video_url: "/static/d.mp4",
+      },
+    ];
+    fetchFreezoneVideoCharacterLibrary.mockResolvedValue({ items: withVideo });
+    syncFreezoneAssetLibraryFromMainline.mockResolvedValue({ items: withVideo });
+    const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(true);
+    renderModal({ allowedMedia: ["image"] });
+
+    fireEvent.click(
+      await screen.findByRole("button", { name: "第一集素材 更多操作" }),
+    );
+    fireEvent.click(screen.getByRole("button", { name: "删除" }));
+
+    expect(confirmSpy.mock.calls[0][0]).toContain("2 项素材会一起删掉");
+  });
+});
+
+describe("AssetLibraryModal 批量操作", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    fetchFreezoneVideoCharacterLibrary.mockResolvedValue({ items: LIBRARY });
+    syncFreezoneAssetLibraryFromMainline.mockResolvedValue({ items: LIBRARY });
+    fetchFreezoneAssetLibraryFolders.mockResolvedValue([]);
+    deleteFreezoneVideoCharacterLibraryItem.mockResolvedValue({ ok: true });
+  });
+
+  it("批量态下能删掉本地上传的素材，主线素材不可选", async () => {
+    vi.spyOn(window, "confirm").mockReturnValue(true);
+    renderModal();
+    await screen.findByRole("button", { name: "文件夹 主线" });
+
+    fireEvent.click(screen.getByRole("button", { name: "批量操作" }));
+    fireEvent.click(screen.getByRole("button", { name: "文件夹 待分类资产" }));
+
+    fireEvent.click(await screen.findByRole("button", { name: "选中待删除" }));
+    expect(screen.getByText("1")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "删除所选" }));
+    await waitFor(() =>
+      expect(deleteFreezoneVideoCharacterLibraryItem).toHaveBeenCalledWith(
+        "demo",
+        "up-1",
+      ),
+    );
+  });
+
+  it("批量删除里有一条失败，剩下的照删", async () => {
+    // 最常见的失败是这个 id 已经被别处删掉了。为它把整批放弃说不过去。
+    const items = [
+      {
+        id: "up-1",
+        name: "参考图A",
+        media: "image",
+        source: "upload",
+        image_urls: ["/static/a.png"],
+      },
+      {
+        id: "up-9",
+        name: "参考图B",
+        media: "image",
+        source: "upload",
+        image_urls: ["/static/e.png"],
+      },
+    ];
+    fetchFreezoneVideoCharacterLibrary.mockResolvedValue({ items });
+    syncFreezoneAssetLibraryFromMainline.mockResolvedValue({ items });
+    deleteFreezoneVideoCharacterLibraryItem.mockImplementation(
+      (_project: unknown, id: unknown) =>
+        id === "up-1"
+          ? Promise.reject(new Error("item not found"))
+          : Promise.resolve({ ok: true }),
+    );
+    vi.spyOn(window, "confirm").mockReturnValue(true);
+    renderModal();
+    await screen.findByRole("button", { name: "文件夹 主线" });
+
+    fireEvent.click(screen.getByRole("button", { name: "批量操作" }));
+    fireEvent.click(screen.getByRole("button", { name: "文件夹 待分类资产" }));
+
+    fireEvent.click(
+      (await screen.findAllByRole("button", { name: "选中待删除" }))[0],
+    );
+    fireEvent.click(screen.getByRole("button", { name: "选中待删除" }));
+    fireEvent.click(screen.getByRole("button", { name: "删除所选" }));
+
+    await waitFor(() =>
+      expect(deleteFreezoneVideoCharacterLibraryItem).toHaveBeenCalledWith(
+        "demo",
+        "up-9",
+      ),
+    );
+    expect(deleteFreezoneVideoCharacterLibraryItem).toHaveBeenCalledWith(
+      "demo",
+      "up-1",
+    );
+  });
+
+  it("批量态下主线素材的勾选框禁用", async () => {
+    renderModal();
+    await screen.findByRole("button", { name: "文件夹 主线" });
+
+    fireEvent.click(screen.getByRole("button", { name: "批量操作" }));
+    fireEvent.click(screen.getByRole("button", { name: "文件夹 主线" }));
+
+    const checkbox = await screen.findByRole("button", {
+      name: "主线同步来的素材不能删除",
+    });
+    expect(checkbox).toBeDisabled();
+  });
+});

--- a/frontend/src/__tests__/features/freezone/asset-library-panel-beat-context.test.tsx
+++ b/frontend/src/__tests__/features/freezone/asset-library-panel-beat-context.test.tsx
@@ -7,6 +7,9 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const listFreezoneBeatContext = vi.fn();
 const listFreezoneProjectAssets = vi.fn();
+const fetchFreezoneVideoCharacterLibrary = vi.fn();
+const fetchFreezoneAssetLibraryFolders = vi.fn();
+const syncFreezoneAssetLibraryFromMainline = vi.fn();
 
 vi.mock("@/api/projects", async (importOriginal) => ({
   ...(await importOriginal<typeof import("@/api/projects")>()),
@@ -14,8 +17,33 @@ vi.mock("@/api/projects", async (importOriginal) => ({
   listFreezoneProjectAssets: (...args: unknown[]) => listFreezoneProjectAssets(...args),
 }));
 
+vi.mock("@/api/ops", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/api/ops")>()),
+  fetchFreezoneVideoCharacterLibrary: (...args: unknown[]) =>
+    fetchFreezoneVideoCharacterLibrary(...args),
+  fetchFreezoneAssetLibraryFolders: (...args: unknown[]) =>
+    fetchFreezoneAssetLibraryFolders(...args),
+  syncFreezoneAssetLibraryFromMainline: (...args: unknown[]) =>
+    syncFreezoneAssetLibraryFromMainline(...args),
+}));
+
 vi.mock("@/features/freezone/CanvasesTab", () => ({
   CanvasesTab: () => null,
+}));
+
+// 「主线资产」tab 受后台的 mainline product surface 开关控制,默认按开着测。
+let mainlineAvailable = true;
+vi.mock("@/lib/queries/product-surfaces", () => ({
+  useProductSurfaces: () => ({ data: undefined, isPending: false }),
+  surfaceAccess: (_data: unknown, code: string) =>
+    code === "mainline"
+      ? {
+          surface_code: "mainline",
+          label: "虾集",
+          available: mainlineAvailable,
+          unavailable_message: "",
+        }
+      : undefined,
 }));
 
 import { AssetLibraryPanel } from "@/features/freezone/AssetLibraryPanel";
@@ -30,6 +58,7 @@ function makeWrapper() {
 describe("AssetLibraryPanel beat context", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mainlineAvailable = true;
   });
 
   it("shares one project asset request across matching panels", async () => {
@@ -117,7 +146,7 @@ describe("AssetLibraryPanel beat context", () => {
       { wrapper: makeWrapper() },
     );
 
-    fireEvent.click(screen.getByRole("button", { name: "主线资产" }));
+    fireEvent.click(screen.getByRole("tab", { name: "主线资产" }));
     await screen.findByText(/项目素材加载失败：network down/);
 
     act(() => {
@@ -196,7 +225,7 @@ describe("AssetLibraryPanel beat context", () => {
       { wrapper: makeWrapper() },
     );
 
-    fireEvent.click(screen.getByRole("button", { name: "主线资产" }));
+    fireEvent.click(screen.getByRole("tab", { name: "主线资产" }));
     fireEvent.click(screen.getByRole("button", { name: /场景/ }));
     expect(await screen.findByText("厨房")).toBeInTheDocument();
     expect(screen.queryByText("导演合成图")).toBeNull();
@@ -352,7 +381,7 @@ describe("AssetLibraryPanel beat context", () => {
       { wrapper: makeWrapper() },
     );
 
-    fireEvent.click(screen.getByRole("button", { name: "主线资产" }));
+    fireEvent.click(screen.getByRole("tab", { name: "主线资产" }));
     fireEvent.click(screen.getByRole("button", { name: /场景/ }));
 
     expect(await screen.findByText("厨房 / master")).toBeInTheDocument();
@@ -374,5 +403,196 @@ describe("AssetLibraryPanel beat context", () => {
     expect(screen.queryByText("背面世界")).toBeNull();
     expect(screen.queryByText("360世界")).toBeNull();
     expect(screen.getByRole("button", { name: /场景.*4/ })).toBeInTheDocument();
+  });
+
+  it("hides the mainline asset tab when the mainline surface is disabled", async () => {
+    mainlineAvailable = false;
+    listFreezoneProjectAssets.mockResolvedValue([]);
+    listFreezoneBeatContext.mockResolvedValue({
+      scope: { episode: null, beat: null },
+      episodes: [],
+      assets: [],
+    });
+
+    render(
+      <AssetLibraryPanel
+        project="demo"
+        metadata={{ kind: "default" }}
+        currentCanvasId="user_admin_demo"
+        collapsed={false}
+      />,
+      { wrapper: makeWrapper() },
+    );
+
+    expect(screen.queryByRole("tab", { name: "主线资产" })).toBeNull();
+    expect(screen.queryByPlaceholderText("搜索素材...")).toBeNull();
+    // 「项目画布」不受这个开关影响,必须还在。
+    expect(screen.getByRole("tab", { name: "项目画布" })).toBeInTheDocument();
+  });
+
+  it("falls back to the canvases tab when mainline is switched off while open", async () => {
+    listFreezoneProjectAssets.mockResolvedValue([]);
+    listFreezoneBeatContext.mockResolvedValue({
+      scope: { episode: null, beat: null },
+      episodes: [],
+      assets: [],
+    });
+
+    const { rerender } = render(
+      <AssetLibraryPanel
+        project="demo"
+        metadata={{ kind: "default" }}
+        currentCanvasId="user_admin_demo"
+        collapsed={false}
+      />,
+      { wrapper: makeWrapper() },
+    );
+
+    fireEvent.click(screen.getByRole("tab", { name: "主线资产" }));
+    expect(screen.getByPlaceholderText("搜索素材...")).toBeInTheDocument();
+
+    mainlineAvailable = false;
+    act(() => {
+      rerender(
+        <AssetLibraryPanel
+          project="demo"
+          metadata={{ kind: "default" }}
+          currentCanvasId="user_admin_demo"
+          collapsed={false}
+        />,
+      );
+    });
+
+    await vi.waitFor(() => {
+      expect(screen.queryByPlaceholderText("搜索素材...")).toBeNull();
+    });
+    expect(screen.queryByRole("tab", { name: "主线资产" })).toBeNull();
+  });
+
+  it("browses the project asset library under its own tab", async () => {
+    listFreezoneProjectAssets.mockResolvedValue([]);
+    listFreezoneBeatContext.mockResolvedValue({
+      scope: { episode: null, beat: null },
+      episodes: [],
+      assets: [],
+    });
+    fetchFreezoneVideoCharacterLibrary.mockResolvedValue({
+      items: [
+        {
+          id: "lib-1",
+          name: "参考图A",
+          media: "image",
+          source: "upload",
+          image_urls: ["/static/library/a.png"],
+        },
+        {
+          id: "lib-2",
+          name: "厨房静帧",
+          media: "image",
+          source: "scene",
+          image_urls: ["/static/library/kitchen.png"],
+        },
+        {
+          id: "lib-3",
+          name: "片段B",
+          media: "video",
+          source: "upload",
+          video_url: "/static/library/b.mp4",
+        },
+      ],
+    });
+
+    render(
+      <AssetLibraryPanel
+        project="demo"
+        metadata={{ kind: "default" }}
+        currentCanvasId="user_admin_demo"
+        collapsed={false}
+      />,
+      { wrapper: makeWrapper() },
+    );
+
+    fireEvent.click(screen.getByRole("tab", { name: "资产库" }));
+
+    // 根目录只有文件夹,条目要点进去才看得到。
+    expect(
+      await screen.findByRole("button", { name: "文件夹 主线" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "文件夹 待分类资产" }),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("参考图A")).toBeNull();
+
+    // 主线同步来的条目(不论人物/场景/道具)统统收在一个【主线】文件夹里。
+    fireEvent.click(screen.getByRole("button", { name: "文件夹 主线" }));
+    expect(await screen.findByText("厨房静帧")).toBeInTheDocument();
+    expect(screen.queryByText("参考图A")).toBeNull();
+
+    // 面包屑退回根目录,再进【待分类资产】看本地上传的图片和视频。
+    fireEvent.click(screen.getByRole("button", { name: "返回资产库根目录" }));
+    fireEvent.click(
+      await screen.findByRole("button", { name: "文件夹 待分类资产" }),
+    );
+    expect(await screen.findByText("参考图A")).toBeInTheDocument();
+    expect(screen.getByText("片段B")).toBeInTheDocument();
+    expect(screen.queryByText("厨房静帧")).toBeNull();
+  });
+
+  it("keeps the asset library tab available when mainline is disabled", async () => {
+    mainlineAvailable = false;
+    listFreezoneProjectAssets.mockResolvedValue([]);
+    listFreezoneBeatContext.mockResolvedValue({
+      scope: { episode: null, beat: null },
+      episodes: [],
+      assets: [],
+    });
+    fetchFreezoneVideoCharacterLibrary.mockResolvedValue({ items: [] });
+
+    render(
+      <AssetLibraryPanel
+        project="demo"
+        metadata={{ kind: "default" }}
+        currentCanvasId="user_admin_demo"
+        collapsed={false}
+      />,
+      { wrapper: makeWrapper() },
+    );
+
+    // 资产库装的是本地上传的素材,不属于主线,开关关掉也得留着。
+    expect(screen.queryByRole("tab", { name: "主线资产" })).toBeNull();
+    fireEvent.click(screen.getByRole("tab", { name: "资产库" }));
+    expect(await screen.findByText(/资产库还是空的/)).toBeInTheDocument();
+  });
+
+  it("opens the asset library modal from the tab bar icon", async () => {
+    listFreezoneProjectAssets.mockResolvedValue([]);
+    listFreezoneBeatContext.mockResolvedValue({
+      scope: { episode: null, beat: null },
+      episodes: [],
+      assets: [],
+    });
+    fetchFreezoneVideoCharacterLibrary.mockResolvedValue({ items: [] });
+    fetchFreezoneAssetLibraryFolders.mockResolvedValue([]);
+    syncFreezoneAssetLibraryFromMainline.mockResolvedValue({ items: [] });
+
+    render(
+      <AssetLibraryPanel
+        project="demo"
+        metadata={{ kind: "default" }}
+        currentCanvasId="user_admin_demo"
+        collapsed={false}
+      />,
+      { wrapper: makeWrapper() },
+    );
+
+    // 入口常驻,停在「项目画布」tab 上也能点开。
+    expect(screen.getByRole("tab", { name: "项目画布" })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+    fireEvent.click(screen.getByRole("button", { name: "资产管理" }));
+
+    expect(await screen.findByRole("button", { name: "新建" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "批量操作" })).toBeInTheDocument();
   });
 });

--- a/frontend/src/api/ops.ts
+++ b/frontend/src/api/ops.ts
@@ -2577,11 +2577,35 @@ export type FreezoneAssetLibrarySource =
   | "scene"
   | "prop";
 
+/** 用途类目。老条目没有该字段，读取侧按 source/media 兜底推导。 */
+export type FreezoneAssetLibraryCategory =
+  | "other"
+  | "character"
+  | "scene"
+  | "prop"
+  | "style"
+  | "audio";
+
+/**
+ * 用户自建的资产库文件夹。系统文件夹（主线 / 待分类资产 / 各类目同名目录）不落盘，
+ * 由前端按保留 key 生成，只有这里的自建文件夹会从后端读回来。
+ */
+export interface FreezoneAssetLibraryFolder {
+  id: string;
+  name: string;
+  /** 封面图 URL，取自文件夹内某个素材；没设过时为空,前端画默认文件夹图标。 */
+  cover?: string | null;
+  created_at?: string;
+}
+
 export interface FreezoneVideoCharacterLibraryItem {
   id?: string;
   name: string;
   media?: FreezoneAssetLibraryMedia;
   source?: FreezoneAssetLibrarySource;
+  category?: FreezoneAssetLibraryCategory;
+  /** 保存位置：系统文件夹 key 或自建文件夹 id。老条目没有，读取侧按类目兜底。 */
+  folder?: string;
   image_urls?: string[];
   video_url?: string | null;
   audio_url?: string | null;
@@ -2597,6 +2621,8 @@ export interface FreezoneAddVideoCharacterLibraryItemPayload {
   imageUrls?: string[];
   videoUrl?: string;
   audioUrl?: string;
+  category?: FreezoneAssetLibraryCategory;
+  folder?: string;
 }
 
 export async function fetchFreezoneVideoCharacterLibrary(
@@ -2620,9 +2646,52 @@ export async function submitFreezoneAddVideoCharacterLibraryItem(
   }
   if (payload.videoUrl) body.video_url = payload.videoUrl;
   if (payload.audioUrl) body.audio_url = payload.audioUrl;
+  if (payload.category) body.category = payload.category;
+  if (payload.folder) body.folder = payload.folder;
   return await apiCall<unknown>(
     `projects/${encodeURIComponent(project)}/freezone/video/character-library`,
     { method: "POST", json: body },
+  );
+}
+
+export async function fetchFreezoneAssetLibraryFolders(
+  project: string,
+): Promise<FreezoneAssetLibraryFolder[]> {
+  return await apiCall<FreezoneAssetLibraryFolder[]>(
+    `projects/${encodeURIComponent(project)}/freezone/video/asset-library/folders`,
+  );
+}
+
+export async function createFreezoneAssetLibraryFolder(
+  project: string,
+  name: string,
+): Promise<FreezoneAssetLibraryFolder> {
+  return await apiCall<FreezoneAssetLibraryFolder>(
+    `projects/${encodeURIComponent(project)}/freezone/video/asset-library/folders`,
+    { method: "POST", json: { name } },
+  );
+}
+
+/** 改名 / 换封面。只传要改的字段,另一个原样保留。 */
+export async function updateFreezoneAssetLibraryFolder(
+  project: string,
+  folderId: string,
+  patch: { name?: string; cover?: string },
+): Promise<FreezoneAssetLibraryFolder> {
+  return await apiCall<FreezoneAssetLibraryFolder>(
+    `projects/${encodeURIComponent(project)}/freezone/video/asset-library/folders/${encodeURIComponent(folderId)}`,
+    { method: "PATCH", json: patch },
+  );
+}
+
+/** 整柜清空:删掉文件夹连同里面的素材。返回被删掉的素材条数。 */
+export async function deleteFreezoneAssetLibraryFolder(
+  project: string,
+  folderId: string,
+): Promise<{ deleted_items: number }> {
+  return await apiCall<{ deleted_items: number }>(
+    `projects/${encodeURIComponent(project)}/freezone/video/asset-library/folders/${encodeURIComponent(folderId)}`,
+    { method: "DELETE" },
   );
 }
 

--- a/frontend/src/components/episode/beat-workbench/batch-bar.tsx
+++ b/frontend/src/components/episode/beat-workbench/batch-bar.tsx
@@ -54,6 +54,12 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 
+// 产品决定：这两个批量入口从工具栏下线，任何 spineTemplate 下都不给。后端路由、
+// 账单口径和任务控制都原样留着（其它入口和历史任务仍要用），这里只掐掉入口。
+// 恢复时把常量翻回 true，下面原有的 spineTemplate 条件继续生效。
+const SHOW_GLOBAL_OPTIMIZE_ENTRY = false;
+const SHOW_EPISODE_AUDIO_ENTRY = false;
+
 const TOOLBAR_CONTROL_CLASS =
   "h-[26px] gap-1.5 rounded-[6px] border border-white/10 bg-transparent px-2 py-0 text-[11px] font-medium text-foreground/85 transition-colors hover:border-primary/40 hover:bg-white/[0.04] hover:text-foreground focus-visible:ring-2 focus-visible:ring-sidebar-ring disabled:text-muted-foreground/50";
 
@@ -151,7 +157,7 @@ export function BatchBar({
     (option) => option.value === videoBackend,
   );
   const audioUnavailableForVideoBackend = selectedVideoBackend?.is_seedance2 === true;
-  const showGlobalOptimize = spineTemplate === "narrated";
+  const showGlobalOptimize = SHOW_GLOBAL_OPTIMIZE_ENTRY && spineTemplate === "narrated";
   const episodeAudioCostDisplay =
     episodeAudioBillingQuote.data?.data.display ??
     (episodeAudioBillingQuote.error instanceof BillingRuleNotConfiguredError
@@ -347,7 +353,7 @@ export function BatchBar({
             {t("episode.workbench.batch.reassignColors")}
           </Button>
           {/* 精品剧 (spine_template === "drama") 把解说烘进渲染视频，没有独立音频阶段 —— 隐藏「生成全集音频」 */}
-          {spineTemplate !== "drama" && (
+          {SHOW_EPISODE_AUDIO_ENTRY && spineTemplate !== "drama" && (
           <Tooltip>
             <TooltipTrigger
               delay={150}

--- a/frontend/src/features/canvas/ui/AssetLibraryFolderCoverDialog.tsx
+++ b/frontend/src/features/canvas/ui/AssetLibraryFolderCoverDialog.tsx
@@ -1,0 +1,144 @@
+// SPDX-License-Identifier: Elastic-2.0
+// Copyright (c) 2026 ClaymoreLab
+//
+// 「修改封面」弹窗：从该文件夹自己的图片素材里挑一张当封面。
+//
+// 只列图片——视频抽帧要解码、音频压根没有画面，都不适合当封面；文件夹里一张图
+// 都没有时给一句空态提示，而不是弹一个空网格。封面存的是素材 URL 本身，所以这里
+// 不涉及上传，素材被删掉后封面自然回落到默认图标。
+import { useEffect, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { Loader2, X } from 'lucide-react';
+
+import { Button } from '@/components/ui/button';
+import { resolveImageDisplayUrl } from '@/features/canvas/application/imageData';
+import { folderCoverUrl, type AssetFolder } from './assetLibraryItems';
+
+export interface AssetLibraryFolderCoverDialogProps {
+  open: boolean;
+  folder: AssetFolder | null;
+  onClose: () => void;
+  /** 抛错即视为失败，错误信息显示在底部，弹窗保持打开。 */
+  onSubmit: (cover: string) => Promise<void>;
+}
+
+export function AssetLibraryFolderCoverDialog({
+  open,
+  folder,
+  onClose,
+  onSubmit,
+}: AssetLibraryFolderCoverDialogProps) {
+  const [picked, setPicked] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  // 每次打开预选当前封面，用户只想换别的时一眼能看出现在是哪张。
+  useEffect(() => {
+    if (!open) return;
+    setPicked(folder ? folderCoverUrl(folder) : null);
+    setError(null);
+    setSubmitting(false);
+  }, [open, folder]);
+
+  if (typeof document === 'undefined' || !open || !folder) return null;
+
+  const images = folder.items.filter(
+    (entry) => entry.media === 'image' && entry.url,
+  );
+  const canSubmit = Boolean(picked) && !submitting;
+
+  const handleSubmit = async () => {
+    if (!picked || submitting) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      await onSubmit(picked);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+      setSubmitting(false);
+    }
+  };
+
+  return createPortal(
+    <div
+      className="fixed inset-0 z-[320] flex items-center justify-center"
+      role="dialog"
+      aria-label="修改封面"
+    >
+      <div className="absolute inset-0 bg-black/55" onClick={onClose} />
+      <div className="relative flex max-h-[80vh] w-[min(720px,92vw)] flex-col overflow-hidden rounded-[10px] border border-white/[0.12] bg-[#1b1c22] shadow-[0_18px_48px_rgba(0,0,0,0.5)]">
+        <div className="flex items-center justify-between border-b border-white/[0.08] px-5 py-3.5">
+          <h3 className="text-sm font-semibold text-text-dark">
+            修改封面 · {folder.label}
+          </h3>
+          <button
+            type="button"
+            onClick={onClose}
+            title="关闭"
+            className="inline-flex h-7 w-7 items-center justify-center rounded-md text-text-muted/90 transition-colors hover:bg-white/[0.08] hover:text-text-dark"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+
+        <div className="ui-scrollbar min-h-0 flex-1 overflow-y-auto px-5 py-4">
+          {images.length === 0 ? (
+            <div className="py-10 text-center text-xs text-text-muted/70">
+              这个文件夹里还没有图片素材，先上传一张再来设封面。
+            </div>
+          ) : (
+            <div
+              className="grid gap-3"
+              style={{
+                gridTemplateColumns: 'repeat(auto-fill, minmax(120px, 1fr))',
+              }}
+            >
+              {images.map((entry, idx) => (
+                <button
+                  key={entry.id ?? `img-${idx}`}
+                  type="button"
+                  onClick={() => setPicked(entry.url)}
+                  aria-label={`选择封面 ${entry.name}`}
+                  className={`relative aspect-square overflow-hidden rounded-[8px] border transition-colors ${
+                    picked === entry.url
+                      ? 'border-accent/70 ring-1 ring-accent/45'
+                      : 'border-white/[0.10] hover:border-white/[0.24]'
+                  }`}
+                >
+                  <img
+                    src={resolveImageDisplayUrl(entry.url)}
+                    alt={entry.name}
+                    className="h-full w-full object-cover"
+                    draggable={false}
+                  />
+                </button>
+              ))}
+            </div>
+          )}
+          {error && <div className="mt-3 text-[11px] text-red-400">{error}</div>}
+        </div>
+
+        <div className="flex shrink-0 items-center justify-end gap-2 px-5 pb-4 pt-1">
+          <Button
+            size="sm"
+            variant="ghost"
+            className="px-4 text-text-muted hover:text-text-dark"
+            onClick={onClose}
+          >
+            取消
+          </Button>
+          <Button
+            size="sm"
+            className="bg-white px-4 text-[#15161b] hover:bg-white/90"
+            disabled={!canSubmit}
+            onClick={() => void handleSubmit()}
+          >
+            {submitting && <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />}
+            保存
+          </Button>
+        </div>
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/frontend/src/features/canvas/ui/AssetLibraryItemMedia.tsx
+++ b/frontend/src/features/canvas/ui/AssetLibraryItemMedia.tsx
@@ -1,0 +1,248 @@
+// SPDX-License-Identifier: Elastic-2.0
+// Copyright (c) 2026 ClaymoreLab
+//
+// 资产库卡片的画面层：图片直接铺，视频给首帧封面 + 悬停就地预览，音频给一个
+// 自绘的小播放器。
+//
+// 音频过去直接摆原生 <audio controls>——浏览器给的那条灰色胶囊和整个面板的深色
+// 皮肤格格不入，还会把卡片下沿的名字挤掉。这里换成「圆形播放键 + 波形进度条 +
+// 时间」，和视频卡的播放角标视觉对齐，两种非图片素材看起来才像一套东西。
+import { useEffect, useRef, useState, type MouseEvent as ReactMouseEvent } from 'react';
+import { Play, Pause } from 'lucide-react';
+
+import { resolveImageDisplayUrl } from '@/features/canvas/application/imageData';
+import type { LibraryItem } from './assetLibraryItems';
+
+/** mm:ss；时长还没读出来时按 0:00 显示，别让卡片上闪一串 NaN。 */
+function formatClock(seconds: number): string {
+  const safe = Number.isFinite(seconds) && seconds > 0 ? seconds : 0;
+  const total = Math.floor(safe);
+  return `${Math.floor(total / 60)}:${(total % 60).toString().padStart(2, '0')}`;
+}
+
+/**
+ * 同一时间只留一条音轨在响。卡片是网格铺开的，挨个点过去很容易叠成一片噪音，
+ * 这里在模块级记着当前那条，新的一播就把旧的按停。
+ */
+let playingAudio: HTMLAudioElement | null = null;
+
+const WAVEFORM_BARS = 28;
+
+/**
+ * 按 URL 生成一串固定的波形高度。
+ *
+ * 真波形要解码整段音频才画得出来，代价太大；这里只要「每条音轨看起来不一样、
+ * 但每次打开都一样」，用 URL 做种子的线性同余就够了。
+ */
+function waveformHeights(seed: string): number[] {
+  let state = 0;
+  for (let i = 0; i < seed.length; i += 1) {
+    state = (state * 31 + seed.charCodeAt(i)) >>> 0;
+  }
+  return Array.from({ length: WAVEFORM_BARS }, () => {
+    state = (state * 1664525 + 1013904223) >>> 0;
+    return 26 + ((state >>> 16) % 74);
+  });
+}
+
+export interface AssetLibraryItemMediaProps {
+  entry: LibraryItem;
+}
+
+/** 卡片画面层。外层负责方形容器与选中/删除等浮层，这里只管把内容画满。 */
+export function AssetLibraryItemMedia({ entry }: AssetLibraryItemMediaProps) {
+  const src = resolveImageDisplayUrl(entry.url);
+  if (entry.media === 'video') return <VideoThumb src={src} />;
+  if (entry.media === 'audio') return <AudioThumb src={src} />;
+  return (
+    <img
+      src={src}
+      alt={entry.name}
+      className="h-full w-full object-cover"
+      draggable={false}
+    />
+  );
+}
+
+function VideoThumb({ src }: { src: string }) {
+  const videoRef = useRef<HTMLVideoElement>(null);
+  const [duration, setDuration] = useState(0);
+  const [previewing, setPreviewing] = useState(false);
+
+  // `#t=0.1` 让浏览器 seek 到 0.1 秒并把那一帧画出来当封面；t=0 在部分浏览器
+  // 是黑帧。preload=metadata 只拉首帧，不下整段。
+  const posterSrc = src.includes('#') ? src : `${src}#t=0.1`;
+
+  const startPreview = () => {
+    const el = videoRef.current;
+    if (!el) return;
+    void el.play().catch(() => undefined);
+  };
+  const stopPreview = () => {
+    const el = videoRef.current;
+    if (!el) return;
+    el.pause();
+    // 回到封面帧，鼠标划过一排卡片后不会留下一堆停在半截的画面。
+    el.currentTime = 0.1;
+  };
+
+  return (
+    <div
+      className="relative h-full w-full"
+      onMouseEnter={startPreview}
+      onMouseLeave={stopPreview}
+    >
+      <video
+        ref={videoRef}
+        src={posterSrc}
+        className="h-full w-full object-cover"
+        muted
+        loop
+        playsInline
+        preload="metadata"
+        tabIndex={-1}
+        onLoadedMetadata={(event) => {
+          const value = event.currentTarget.duration;
+          if (Number.isFinite(value) && value > 0) setDuration(value);
+        }}
+        onPlay={() => setPreviewing(true)}
+        onPause={() => setPreviewing(false)}
+      />
+      {/* 播放角标：预览一起来就淡出，别糊在画面中间。 */}
+      <span
+        className={`pointer-events-none absolute left-1/2 top-1/2 flex h-10 w-10 -translate-x-1/2 -translate-y-1/2 items-center justify-center rounded-full bg-black/45 ring-1 ring-white/25 backdrop-blur-[2px] transition-opacity duration-200 ${
+          previewing ? 'opacity-0' : 'opacity-100'
+        }`}
+      >
+        <Play className="ml-0.5 h-4 w-4 text-white" fill="currentColor" />
+      </span>
+      {duration > 0 && (
+        // 摆左下：右下是删除按钮的位置，底边留给名字。
+        <span className="pointer-events-none absolute bottom-8 left-2 rounded bg-black/55 px-1.5 py-0.5 text-[10px] tabular-nums text-white/90">
+          {formatClock(duration)}
+        </span>
+      )}
+    </div>
+  );
+}
+
+function AudioThumb({ src }: { src: string }) {
+  const audioRef = useRef<HTMLAudioElement>(null);
+  const [playing, setPlaying] = useState(false);
+  const [time, setTime] = useState(0);
+  const [duration, setDuration] = useState(0);
+  const [bars] = useState(() => waveformHeights(src));
+
+  // 播放中用 rAF 推进度：timeupdate 事件一秒才来四次，波形会一格一格地跳。
+  useEffect(() => {
+    if (!playing) return;
+    let raf = 0;
+    const tick = () => {
+      const el = audioRef.current;
+      if (el) setTime(el.currentTime);
+      raf = requestAnimationFrame(tick);
+    };
+    raf = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(raf);
+  }, [playing]);
+
+  // 卡片被翻页/切目录换掉时，声音得跟着停——组件没了但 <audio> 还在响是最糟的。
+  // 元素移出文档时规范本来也会暂停，但那是副作用不是保证，这里显式停一次。
+  useEffect(
+    () => () => {
+      const el = audioRef.current;
+      if (!el) return;
+      el.pause();
+      if (playingAudio === el) playingAudio = null;
+    },
+    [],
+  );
+
+  // 试听不该顺手把卡片选中；卡片其余部分照旧点了就选。
+  const toggle = (event: ReactMouseEvent) => {
+    event.stopPropagation();
+    const el = audioRef.current;
+    if (!el) return;
+    if (el.paused) {
+      if (playingAudio && playingAudio !== el) playingAudio.pause();
+      playingAudio = el;
+      void el.play().catch(() => undefined);
+    } else {
+      el.pause();
+    }
+  };
+
+  const seekTo = (event: ReactMouseEvent<HTMLElement>) => {
+    event.stopPropagation();
+    const el = audioRef.current;
+    if (!el || duration <= 0) return;
+    const rect = event.currentTarget.getBoundingClientRect();
+    const clientX = event.clientX;
+    const ratio = Math.min(1, Math.max(0, (clientX - rect.left) / rect.width));
+    el.currentTime = ratio * duration;
+    setTime(el.currentTime);
+  };
+
+  const progress = duration > 0 ? Math.min(1, time / duration) : 0;
+
+  return (
+    <div className="relative flex h-full w-full flex-col items-center justify-center gap-2.5 bg-[radial-gradient(120%_100%_at_50%_0%,rgba(120,140,255,0.16),rgba(255,255,255,0.02))] pb-7">
+      <audio
+        ref={audioRef}
+        src={src}
+        preload="metadata"
+        onLoadedMetadata={(event) => {
+          const value = event.currentTarget.duration;
+          if (Number.isFinite(value) && value > 0) setDuration(value);
+        }}
+        onPlay={() => setPlaying(true)}
+        onPause={() => setPlaying(false)}
+        onEnded={() => {
+          setPlaying(false);
+          setTime(0);
+        }}
+      />
+
+      <button
+        type="button"
+        onClick={toggle}
+        aria-label={playing ? '暂停' : '播放'}
+        className="flex h-10 w-10 items-center justify-center rounded-full bg-white/92 text-[#15161b] shadow-[0_2px_10px_rgba(0,0,0,0.35)] transition hover:scale-105 hover:bg-white"
+      >
+        {playing ? (
+          <Pause className="h-4 w-4" fill="currentColor" />
+        ) : (
+          <Play className="ml-0.5 h-4 w-4" fill="currentColor" />
+        )}
+      </button>
+
+      {/* 波形即进度条：播过的柱子亮起来，点哪跳哪。 */}
+      <div
+        role="slider"
+        aria-label="播放进度"
+        aria-valuemin={0}
+        aria-valuemax={Math.round(duration)}
+        aria-valuenow={Math.round(time)}
+        tabIndex={0}
+        onClick={seekTo}
+        className="flex h-5 w-[76%] cursor-pointer items-center justify-between gap-px"
+      >
+        {bars.map((height, index) => (
+          <span
+            key={index}
+            style={{ height: `${height}%` }}
+            className={`w-[2px] shrink-0 rounded-full transition-colors ${
+              index / bars.length < progress ? 'bg-white/85' : 'bg-white/22'
+            }`}
+          />
+        ))}
+      </div>
+
+      <div className="text-[10px] tabular-nums text-white/55">
+        {playing || time > 0
+          ? `${formatClock(time)} / ${formatClock(duration)}`
+          : formatClock(duration)}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/features/canvas/ui/AssetLibraryModal.tsx
+++ b/frontend/src/features/canvas/ui/AssetLibraryModal.tsx
@@ -4,56 +4,81 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import {
   Check,
+  ChevronLeft,
+  ChevronRight,
+  ChevronsUpDown,
+  Folder,
   Loader2,
+  MoreHorizontal,
   Music,
+  Plus,
   RefreshCw,
+  Send,
   Trash2,
-  Upload,
   Video as VideoIcon,
   X,
 } from 'lucide-react';
 
 import {
+  createFreezoneAssetLibraryFolder,
+  deleteFreezoneAssetLibraryFolder,
   deleteFreezoneVideoCharacterLibraryItem,
+  fetchFreezoneAssetLibraryFolders,
   fetchFreezoneVideoCharacterLibrary,
   submitFreezoneAddVideoCharacterLibraryItem,
   syncFreezoneAssetLibraryFromMainline,
+  updateFreezoneAssetLibraryFolder,
   uploadFreezoneImage,
   uploadFreezoneVideo,
-  type FreezoneAssetLibraryMedia,
-  type FreezoneAssetLibrarySource,
+  type FreezoneAssetLibraryFolder,
 } from '@/api/ops';
 import { resolveImageDisplayUrl } from '@/features/canvas/application/imageData';
+import { AssetLibraryItemMedia } from './AssetLibraryItemMedia';
 import { Button } from '@/components/ui/button';
+import { AssetLibraryFolderCoverDialog } from './AssetLibraryFolderCoverDialog';
+import { AssetLibraryNewFolderDialog } from './AssetLibraryNewFolderDialog';
+import {
+  AssetLibraryUploadDialog,
+  type AssetLibraryUploadPick,
+} from './AssetLibraryUploadDialog';
+// 条目模型与类目定义和左侧面板的「资产库」tab 共用，见 ./assetLibraryItems
+import {
+  ALL_CATEGORY_KEY,
+  ASSET_CATEGORIES,
+  ASSET_LIBRARY_CARD_CLASS,
+  ASSET_LIBRARY_CARD_HOVER_CLASS,
+  SOURCE_LABEL,
+  buildAssetFolders,
+  folderCoverUrl,
+  formatFolderDate,
+  normalizeLibraryList,
+  systemFolderLabel,
+  type AssetCategory,
+  type AssetFolder,
+  type AssetFolderKey,
+  type AssetLibraryMedia,
+  type AssetLibraryTabKey,
+  type LibraryItem,
+} from './assetLibraryItems';
+
+/** 每页条数可选档位，第一个是默认值。 */
+const ASSET_LIBRARY_PAGE_SIZES = [20, 40, 80, 100] as const;
 
 const ASSET_LIBRARY_MODAL_CLASS =
-  'relative flex h-[min(720px,82vh)] w-[min(1120px,92vw)] flex-col overflow-hidden rounded-[10px] border border-white/[0.12] bg-[#15161b]/96 shadow-[0_18px_48px_rgba(0,0,0,0.45)] backdrop-blur-md';
-const ASSET_LIBRARY_CARD_CLASS =
-  'overflow-hidden rounded-[12px] border border-white/[0.10] bg-white/[0.04] transition-colors';
-const ASSET_LIBRARY_CARD_HOVER_CLASS =
-  'hover:border-white/[0.18] hover:bg-white/[0.06]';
-const ASSET_LIBRARY_UPLOAD_CARD_CLASS =
-  'flex aspect-square flex-col items-center justify-center gap-3 rounded-[12px] border border-dashed border-white/[0.12] bg-white/[0.04] px-4 text-text-dark transition-colors hover:border-white/[0.18] hover:bg-white/[0.06]';
+  'relative flex h-[min(880px,90vh)] w-[min(1440px,94vw)] flex-col overflow-hidden rounded-[10px] border border-white/[0.12] bg-[#15161b]/96 shadow-[0_18px_48px_rgba(0,0,0,0.45)] backdrop-blur-md';
 
-export type AssetLibraryMedia = FreezoneAssetLibraryMedia;
+export type { AssetLibraryMedia };
 
 interface PendingUpload {
   id: string;
   fileName: string;
   previewUrl: string;
   media: AssetLibraryMedia;
+  /** 标签可以不选，后端会按媒介兜底推一个。 */
+  category: AssetCategory | null;
+  folder: AssetFolderKey;
   status: 'uploading' | 'failed';
   error?: string;
-}
-
-interface LibraryItem {
-  id: string | null;
-  name: string;
-  media: AssetLibraryMedia;
-  source: FreezoneAssetLibrarySource;
-  /** 该条目在其 media 类型下的主展示 / 引用地址。 */
-  url: string;
-  raw: Record<string, unknown>;
 }
 
 export interface AssetLibrarySelection {
@@ -71,65 +96,12 @@ export interface AssetLibraryModalProps {
   maxSelectable?: number;
   /** 允许的媒体类型 Tab;缺省三类都开。生图/图片编辑节点只传 ['image']。 */
   allowedMedia?: AssetLibraryMedia[];
+  /**
+   * 把整个文件夹的素材发到画布并编成一组（组名 = 文件夹名）。不传时文件夹卡片上
+   * 不出现「发送到画布」——节点里打开的选素材弹窗没有「发到画布」这个语义。
+   */
+  onSendFolderToCanvas?: (folder: AssetFolder) => void;
 }
-
-type AssetTabKey = 'image' | 'scene' | 'video' | 'audio';
-
-interface AssetTab {
-  key: AssetTabKey;
-  label: string;
-  /** 该 Tab 对应的媒体类型——决定上传接口、卡片渲染与 accept。 */
-  media: AssetLibraryMedia;
-  accept: string;
-  /** 是否允许在该 Tab 本地上传。场景为主线同步的只读类目。 */
-  allowUpload: boolean;
-  /** 该 Tab 展示哪些库条目。 */
-  matches: (entry: LibraryItem) => boolean;
-}
-
-// 场景在数据上仍是 image（master 静帧），但按产品要求单独成一个浏览 Tab；
-// 「图片」Tab 因此要排除掉场景条目，避免场景静帧混在人物/道具参考图里。
-const ASSET_TABS: AssetTab[] = [
-  {
-    key: 'image',
-    label: '图片',
-    media: 'image',
-    accept: 'image/*',
-    allowUpload: true,
-    matches: (e) => e.media === 'image' && e.source !== 'scene',
-  },
-  {
-    key: 'scene',
-    label: '场景',
-    media: 'image',
-    accept: 'image/*',
-    allowUpload: false,
-    matches: (e) => e.media === 'image' && e.source === 'scene',
-  },
-  {
-    key: 'video',
-    label: '视频',
-    media: 'video',
-    accept: 'video/*',
-    allowUpload: true,
-    matches: (e) => e.media === 'video',
-  },
-  {
-    key: 'audio',
-    label: '音频',
-    media: 'audio',
-    accept: 'audio/*',
-    allowUpload: true,
-    matches: (e) => e.media === 'audio',
-  },
-];
-
-const SOURCE_LABEL: Record<FreezoneAssetLibrarySource, string> = {
-  upload: '上传',
-  character: '人物',
-  scene: '场景',
-  prop: '道具',
-};
 
 function makeId(): string {
   return `al_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
@@ -140,56 +112,6 @@ function stripExtension(name: string): string {
   return dot > 0 ? name.slice(0, dot) : name;
 }
 
-function itemUrl(media: AssetLibraryMedia, it: Record<string, unknown>): string {
-  if (media === 'video') return typeof it.video_url === 'string' ? it.video_url : '';
-  if (media === 'audio') return typeof it.audio_url === 'string' ? it.audio_url : '';
-  const urls = it.image_urls ?? it.imageUrls ?? it.images;
-  if (Array.isArray(urls)) {
-    const first = urls.find((u): u is string => typeof u === 'string');
-    if (first) return first;
-  }
-  return typeof it.cover_url === 'string' ? it.cover_url : '';
-}
-
-function normalizeLibraryList(payload: unknown): LibraryItem[] {
-  let arr: unknown[] = [];
-  if (Array.isArray(payload)) {
-    arr = payload;
-  } else if (payload && typeof payload === 'object') {
-    const rec = payload as Record<string, unknown>;
-    for (const key of ['items', 'data', 'characters', 'list', 'records']) {
-      if (Array.isArray(rec[key])) {
-        arr = rec[key] as unknown[];
-        break;
-      }
-    }
-  }
-  return arr
-    .filter(
-      (it): it is Record<string, unknown> =>
-        Boolean(it && typeof it === 'object' && !Array.isArray(it)),
-    )
-    .map((it) => {
-      const idRaw = it.id ?? it.item_id ?? it.itemId ?? null;
-      const id =
-        typeof idRaw === 'string' ? idRaw : idRaw != null ? String(idRaw) : null;
-      const name = typeof it.name === 'string' ? it.name : '';
-      // 缺省 image 兼容老数据（历史条目没有 media 字段）。
-      const mediaRaw = typeof it.media === 'string' ? it.media : 'image';
-      const media: AssetLibraryMedia =
-        mediaRaw === 'video' || mediaRaw === 'audio' ? mediaRaw : 'image';
-      const sourceRaw = typeof it.source === 'string' ? it.source : 'upload';
-      const source: FreezoneAssetLibrarySource =
-        sourceRaw === 'character' ||
-        sourceRaw === 'scene' ||
-        sourceRaw === 'prop'
-          ? sourceRaw
-          : 'upload';
-      return { id, name, media, source, url: itemUrl(media, it), raw: it };
-    })
-    .filter((it) => Boolean(it.url));
-}
-
 export function AssetLibraryModal({
   open,
   project,
@@ -198,20 +120,25 @@ export function AssetLibraryModal({
   onConfirm,
   maxSelectable = 9,
   allowedMedia,
+  onSendFolderToCanvas,
 }: AssetLibraryModalProps) {
-  const tabs = useMemo(
+  // 类目（标签）按用途分，不按媒介分；allowedMedia 只在两个地方起作用：整类都装
+  // 不下的类目（如只收音频的「音效」在只要图片的节点里）不出现在 tab 条上，条目
+  // 本身再过滤一遍。
+  const categories = useMemo(
     () =>
-      ASSET_TABS.filter(
-        (tab) => !allowedMedia || allowedMedia.includes(tab.media),
+      ASSET_CATEGORIES.filter(
+        (category) =>
+          !allowedMedia || category.media.some((m) => allowedMedia.includes(m)),
       ),
     [allowedMedia],
   );
-  const fileInputRef = useRef<HTMLInputElement | null>(null);
   // 把 onSuccess 收进 ref，避免它进 initializeLibrary 依赖后，父组件每次渲染换新
   // 函数身份就触发「打开自动同步」effect 反复重跑。
   const onSuccessRef = useRef(onSuccess);
   onSuccessRef.current = onSuccess;
   const [library, setLibrary] = useState<LibraryItem[]>([]);
+  const [customFolders, setCustomFolders] = useState<FreezoneAssetLibraryFolder[]>([]);
   const [isLoadingLibrary, setIsLoadingLibrary] = useState(false);
   const [libraryError, setLibraryError] = useState<string | null>(null);
   const [isSyncing, setIsSyncing] = useState(false);
@@ -221,21 +148,46 @@ export function AssetLibraryModal({
   pendingRef.current = pendingUploads;
   const [isDragging, setIsDragging] = useState(false);
   const [selectedKeys, setSelectedKeys] = useState<string[]>([]);
-  const [activeTabKey, setActiveTabKey] = useState<AssetTabKey>(
-    tabs[0]?.key ?? 'image',
+  const [activeTabKey, setActiveTabKey] =
+    useState<AssetLibraryTabKey>(ALL_CATEGORY_KEY);
+  // 「全部」下先看文件夹，点进去才看条目；非空即当前打开的文件夹。选中状态跨层级
+  // 保留（selectedKeys 与视图无关），所以进出文件夹不会掉勾。
+  const [openFolderKey, setOpenFolderKey] = useState<AssetFolderKey | null>(null);
+  const [createMenuOpen, setCreateMenuOpen] = useState(false);
+  const [newFolderOpen, setNewFolderOpen] = useState(false);
+  const [uploadOpen, setUploadOpen] = useState(false);
+  // 批量操作 = 管理态：卡片上的勾选改为「选中待删除」，底部换成删除条。平时的勾选
+  // 是「挑素材给节点用」，两者各存各的，互不影响。
+  const [bulkMode, setBulkMode] = useState(false);
+  const [bulkIds, setBulkIds] = useState<string[]>([]);
+  const [isBulkDeleting, setIsBulkDeleting] = useState(false);
+  // 文件夹卡片上的「…」菜单与它派生的两个弹窗。都按 key 存而不是存整个 folder
+  // 对象——folders 每次刷新都是新对象，存 key 才能跟着最新数据走。
+  const [folderMenuKey, setFolderMenuKey] = useState<AssetFolderKey | null>(null);
+  const [renameFolderKey, setRenameFolderKey] = useState<AssetFolderKey | null>(
+    null,
   );
-  const activeTab = useMemo(
-    () => tabs.find((tab) => tab.key === activeTabKey) ?? tabs[0],
-    [tabs, activeTabKey],
+  const [coverFolderKey, setCoverFolderKey] = useState<AssetFolderKey | null>(
+    null,
   );
-  const activeMedia = activeTab?.media ?? 'image';
+  // 分页只管当前网格：「全部」顶层分文件夹，其余分条目。切 Tab / 进出文件夹 /
+  // 改每页条数都回到第一页——留在第 3 页看一个只有 2 页的目录没有意义。
+  const [page, setPage] = useState(1);
+  const [pageSize, setPageSize] = useState<number>(ASSET_LIBRARY_PAGE_SIZES[0]);
+
+  useEffect(() => {
+    setPage(1);
+  }, [activeTabKey, openFolderKey, pageSize]);
 
   // allowedMedia 变了(不同节点复用同一弹窗)时，把当前 Tab 收敛回允许集合。
   useEffect(() => {
-    if (!tabs.some((tab) => tab.key === activeTabKey)) {
-      setActiveTabKey(tabs[0]?.key ?? 'image');
+    if (
+      activeTabKey !== ALL_CATEGORY_KEY &&
+      !categories.some((category) => category.key === activeTabKey)
+    ) {
+      setActiveTabKey(ALL_CATEGORY_KEY);
     }
-  }, [tabs, activeTabKey]);
+  }, [categories, activeTabKey]);
 
   // 纯加载已有库：失败不弹红条(缺库文件/后端未就绪都当空处理)，返回加载到的条目。
   const refreshLibrary = useCallback(async (): Promise<LibraryItem[]> => {
@@ -252,6 +204,19 @@ export function AssetLibraryModal({
     }
   }, [project]);
 
+  // 自建文件夹是后加的路由，老后端会 404；当成「还没有自建文件夹」处理，系统
+  // 文件夹照常可用，不要因此整个弹窗报错。
+  const refreshFolders = useCallback(async () => {
+    if (!project) return;
+    try {
+      const folders = await fetchFreezoneAssetLibraryFolders(project);
+      setCustomFolders(Array.isArray(folders) ? folders : []);
+    } catch (err) {
+      console.warn('[asset-library] load folders failed, treat as empty', err);
+      setCustomFolders([]);
+    }
+  }, [project]);
+
   // 打开即自动同步：先加载已有库(静默兜底)，再从主线自动同步合并。只有当
   // 既无已有库、同步又失败时，才提示错误(通常代表后端还没重启/路由缺失)。
   const initializeLibrary = useCallback(
@@ -259,7 +224,7 @@ export function AssetLibraryModal({
       if (!project) return;
       setIsLoadingLibrary(true);
       setLibraryError(null);
-      const base = await refreshLibrary();
+      const [base] = await Promise.all([refreshLibrary(), refreshFolders()]);
       if (isCancelled?.()) return;
       setIsSyncing(true);
       try {
@@ -280,7 +245,7 @@ export function AssetLibraryModal({
         }
       }
     },
-    [project, refreshLibrary],
+    [project, refreshLibrary, refreshFolders],
   );
 
   useEffect(() => {
@@ -300,11 +265,19 @@ export function AssetLibraryModal({
       pendingRef.current.forEach((p) => URL.revokeObjectURL(p.previewUrl));
       setPendingUploads([]);
       setLibrary([]);
+      setCustomFolders([]);
       setLibraryError(null);
       setDeletingId(null);
       setIsDragging(false);
       setIsSyncing(false);
       setSelectedKeys([]);
+      setActiveTabKey(ALL_CATEGORY_KEY);
+      setOpenFolderKey(null);
+      setCreateMenuOpen(false);
+      setNewFolderOpen(false);
+      setUploadOpen(false);
+      setBulkMode(false);
+      setBulkIds([]);
     }, 240);
     return () => window.clearTimeout(timer);
   }, [open]);
@@ -331,6 +304,16 @@ export function AssetLibraryModal({
     }
   }, [project, isSyncing, onSuccess]);
 
+  const handleCreateFolder = useCallback(
+    async (name: string): Promise<AssetFolderKey> => {
+      if (!project) throw new Error('项目未就绪');
+      const folder = await createFreezoneAssetLibraryFolder(project, name);
+      await refreshFolders();
+      return folder.id;
+    },
+    [project, refreshFolders],
+  );
+
   const removePending = useCallback((id: string) => {
     setPendingUploads((prev) => {
       const target = prev.find((p) => p.id === id);
@@ -351,6 +334,8 @@ export function AssetLibraryModal({
         await submitFreezoneAddVideoCharacterLibraryItem(project, {
           name: stripExtension(file.name),
           media: entry.media,
+          category: entry.category ?? undefined,
+          folder: entry.folder,
           imageUrls: entry.media === 'image' ? [cleanUrl] : undefined,
           videoUrl: entry.media === 'video' ? cleanUrl : undefined,
           audioUrl: entry.media === 'audio' ? cleanUrl : undefined,
@@ -372,38 +357,34 @@ export function AssetLibraryModal({
     [project, refreshLibrary, onSuccess],
   );
 
-  const acceptsFile = useCallback(
-    (file: File, media: AssetLibraryMedia) => {
-      if (media === 'image') return file.type.startsWith('image/');
-      if (media === 'video') return file.type.startsWith('video/');
-      return file.type.startsWith('audio/');
-    },
-    [],
-  );
-
-  const handleFiles = useCallback(
-    (files: FileList | File[]) => {
-      if (!project || !activeTab?.allowUpload) return;
-      const media = activeMedia;
-      const accepted: { entry: PendingUpload; file: File }[] = [];
-      Array.from(files).forEach((file) => {
-        if (!acceptsFile(file, media)) return;
-        const entry: PendingUpload = {
+  const startUploads = useCallback(
+    (
+      picks: AssetLibraryUploadPick[],
+      folder: AssetFolderKey,
+      category: AssetCategory | null,
+    ) => {
+      if (!project || picks.length === 0) return;
+      const accepted = picks.map(({ file, media }) => ({
+        file,
+        entry: {
           id: makeId(),
           fileName: file.name,
           previewUrl: URL.createObjectURL(file),
           media,
-          status: 'uploading',
-        };
-        accepted.push({ entry, file });
-      });
-      if (accepted.length === 0) return;
+          category,
+          folder,
+          status: 'uploading' as const,
+        },
+      }));
       setPendingUploads((prev) => [...prev, ...accepted.map((a) => a.entry)]);
+      // 把视图切到目标文件夹，否则上传进度落在用户看不见的地方。
+      setActiveTabKey(ALL_CATEGORY_KEY);
+      setOpenFolderKey(folder);
       accepted.forEach(({ entry, file }) => {
         void uploadOne(entry, file);
       });
     },
-    [project, activeMedia, activeTab, acceptsFile, uploadOne],
+    [project, uploadOne],
   );
 
   const handleDeleteEntry = useCallback(
@@ -427,28 +408,177 @@ export function AssetLibraryModal({
     [project, refreshLibrary],
   );
 
+  const handleBulkDelete = useCallback(async () => {
+    if (!project || bulkIds.length === 0 || isBulkDeleting) return;
+    const confirmed = window.confirm(
+      `确定要删除选中的 ${bulkIds.length} 项素材？`,
+    );
+    if (!confirmed) return;
+    setIsBulkDeleting(true);
+    // 一条失败不能把剩下的也拦住——最常见的是这个 id 已经被别处删掉了，为它把
+    // 另外几十项的删除全放弃说不过去。逐条来，记下失败的，成功的照删。
+    const failed: string[] = [];
+    let lastError: unknown = null;
+    try {
+      for (const id of bulkIds) {
+        try {
+          await deleteFreezoneVideoCharacterLibraryItem(project, id);
+        } catch (err) {
+          console.error('[asset-library] bulk delete failed', id, err);
+          failed.push(id);
+          lastError = err;
+        }
+      }
+      // 已删掉的那些要从视图里消失，所以失败了照样刷一次。
+      const remaining = await refreshLibrary();
+      // 失败的留在选中态里方便重试，但只留后端确认还在的——已经不存在的 id 留着
+      // 只会让下一次「删除所选」重复撞同一个 404，永远删不完。
+      const alive = new Set(remaining.map((entry) => entry.id));
+      setBulkIds(failed.filter((id) => alive.has(id)));
+      if (lastError) {
+        const message =
+          lastError instanceof Error ? lastError.message : String(lastError);
+        setLibraryError(`${failed.length} 项删除失败：${message}`);
+      }
+    } finally {
+      setIsBulkDeleting(false);
+    }
+  }, [project, bulkIds, isBulkDeleting, refreshLibrary]);
+
+  // 调用方（生图/图片编辑节点只要图片）不要的媒介，在任何视图里都不出现。
+  const allowedItems = useMemo(
+    () =>
+      allowedMedia
+        ? library.filter((entry) => allowedMedia.includes(entry.media))
+        : library,
+    [library, allowedMedia],
+  );
+
+  // 「全部」下的文件夹，与左侧面板「资产库」tab 同一套分法（见 buildAssetFolders）。
+  const folders = useMemo(
+    () => buildAssetFolders(allowedItems, customFolders),
+    [allowedItems, customFolders],
+  );
+  const uploadableFolders = useMemo(
+    () => folders.filter((folder) => folder.uploadable),
+    [folders],
+  );
+
+  const openFolder = useMemo(() => {
+    if (!openFolderKey) return null;
+    const found = folders.find((folder) => folder.key === openFolderKey);
+    if (found) return found;
+    // 空的系统类目文件夹是「有内容才出现」的（见 buildAssetFolders），所以往一个
+    // 还没有素材的类目里传第一个文件时，它并不在 folders 里。这时若照常回落到
+    // 文件夹网格，上传中的卡片就没地方落——进度看不见，失败了连「移除」也点不到。
+    // 给个同 key 的空壳兜住。只在确实有上传要落进来时才造，免得把刚删掉的文件夹
+    // 又变出来。
+    if (!pendingUploads.some((p) => p.folder === openFolderKey)) return null;
+    const placeholder: AssetFolder = {
+      key: openFolderKey,
+      label: systemFolderLabel(openFolderKey) ?? openFolderKey,
+      items: [],
+      system: true,
+      uploadable: true,
+    };
+    return placeholder;
+  }, [folders, openFolderKey, pendingUploads]);
+  const renameFolder = useMemo(
+    () => folders.find((folder) => folder.key === renameFolderKey) ?? null,
+    [folders, renameFolderKey],
+  );
+  const coverFolder = useMemo(
+    () => folders.find((folder) => folder.key === coverFolderKey) ?? null,
+    [folders, coverFolderKey],
+  );
+
+  const handleDeleteFolder = useCallback(
+    async (folder: AssetFolder) => {
+      if (!project || folder.system) return;
+      // 后端删的是这个 folder 下的所有素材，不看当前弹窗只准显示哪种媒介，所以
+      // 数数要用没过滤的 library。用 folder.items 会少报——只收图片的节点里，一个
+      // 装满视频的文件夹会显示成 0 项，等于一句数据丢失的警告都不给。
+      const doomed = library.filter(
+        (entry) => entry.folder === folder.key,
+      ).length;
+      const confirmed = window.confirm(
+        doomed > 0
+          ? `确定要删除文件夹「${folder.label}」？里面的 ${doomed} 项素材会一起删掉，删了找不回来。`
+          : `确定要删除文件夹「${folder.label}」？`,
+      );
+      if (!confirmed) return;
+      try {
+        await deleteFreezoneAssetLibraryFolder(project, folder.key);
+      } catch (err) {
+        console.error('[asset-library] delete folder failed', err);
+        setLibraryError(err instanceof Error ? err.message : String(err));
+      }
+      // 删的是「文件夹 + 里面的素材」，两份数据都得重拉；失败也刷，避免视图停在
+      // 一个可能已经被删掉的文件夹上。
+      if (openFolderKey === folder.key) setOpenFolderKey(null);
+      await Promise.all([refreshLibrary(), refreshFolders()]);
+    },
+    [project, library, openFolderKey, refreshLibrary, refreshFolders],
+  );
+  // 「全部」且没点进文件夹时是文件夹视图，此时不列条目。
+  const showFolders = activeTabKey === ALL_CATEGORY_KEY && !openFolder;
+
+  // 直接往弹窗里拖文件的落点：进了可写文件夹就放那儿(不打标签)，在某个类目 tab 下
+  // 就放进该类目的同名系统文件夹并打上该标签。文件夹视图和主线文件夹不接受拖入。
+  const dropTarget = useMemo<
+    { folder: AssetFolderKey; category: AssetCategory | null; label: string } | null
+  >(() => {
+    if (activeTabKey !== ALL_CATEGORY_KEY) {
+      const category = categories.find((c) => c.key === activeTabKey);
+      return category
+        ? { folder: category.key, category: category.key, label: category.label }
+        : null;
+    }
+    if (openFolder?.uploadable) {
+      return { folder: openFolder.key, category: null, label: openFolder.label };
+    }
+    return null;
+  }, [activeTabKey, categories, openFolder]);
+
   const handleDrop = useCallback(
     (event: React.DragEvent<HTMLDivElement>) => {
       event.preventDefault();
       setIsDragging(false);
-      if (event.dataTransfer?.files?.length) {
-        handleFiles(event.dataTransfer.files);
-      }
+      const files = event.dataTransfer?.files;
+      if (!files?.length || !dropTarget) return;
+      const picks: AssetLibraryUploadPick[] = [];
+      Array.from(files).forEach((file) => {
+        const media = file.type.startsWith('image/')
+          ? ('image' as const)
+          : file.type.startsWith('video/')
+            ? ('video' as const)
+            : file.type.startsWith('audio/')
+              ? ('audio' as const)
+              : null;
+        if (!media) return;
+        if (allowedMedia && !allowedMedia.includes(media)) return;
+        picks.push({ file, media });
+      });
+      startUploads(picks, dropTarget.folder, dropTarget.category);
     },
-    [handleFiles],
+    [dropTarget, allowedMedia, startUploads],
   );
 
-  const visibleItems = useMemo(
-    () => (activeTab ? library.filter((entry) => activeTab.matches(entry)) : []),
-    [library, activeTab],
-  );
-  const visiblePending = useMemo(
-    () =>
-      activeTab && activeTab.allowUpload
-        ? pendingUploads.filter((p) => p.media === activeTab.media)
-        : [],
-    [pendingUploads, activeTab],
-  );
+  const visibleItems = useMemo(() => {
+    if (showFolders) return [];
+    if (activeTabKey === ALL_CATEGORY_KEY) return openFolder?.items ?? [];
+    return allowedItems.filter((entry) => entry.category === activeTabKey);
+  }, [showFolders, activeTabKey, openFolder, allowedItems]);
+
+  const visiblePending = useMemo(() => {
+    if (showFolders) return [];
+    if (activeTabKey === ALL_CATEGORY_KEY) {
+      return openFolder
+        ? pendingUploads.filter((p) => p.folder === openFolder.key)
+        : [];
+    }
+    return pendingUploads.filter((p) => p.category === activeTabKey);
+  }, [showFolders, activeTabKey, openFolder, pendingUploads]);
 
   const isSelected = useCallback(
     (key: string) => selectedKeys.includes(key),
@@ -478,6 +608,12 @@ export function AssetLibraryModal({
     [maxSelectable],
   );
 
+  const toggleBulk = useCallback((id: string) => {
+    setBulkIds((prev) =>
+      prev.includes(id) ? prev.filter((k) => k !== id) : [...prev, id],
+    );
+  }, []);
+
   const handleConfirm = useCallback(() => {
     if (selectedKeys.length === 0) {
       onClose();
@@ -499,13 +635,35 @@ export function AssetLibraryModal({
 
   if (typeof document === 'undefined' || !open) return null;
 
-  const totalCount = library.length + pendingUploads.length;
+  // 分页作用在当前网格上。上传中的占位卡不参与分页——它们几秒后就变成正式条目，
+  // 被翻到后面反而看不到进度。
+  const pagedTotal = showFolders ? folders.length : visibleItems.length;
+  const pageCount = Math.max(1, Math.ceil(pagedTotal / pageSize));
+  // 删素材会让总页数缩水，停在已经不存在的页上就成空白了，这里兜一下。
+  const safePage = Math.min(page, pageCount);
+  const pageStart = (safePage - 1) * pageSize;
+  const pagedFolders = showFolders
+    ? folders.slice(pageStart, pageStart + pageSize)
+    : [];
+  const pagedItems = showFolders
+    ? []
+    : visibleItems.slice(pageStart, pageStart + pageSize);
   const selectedCount = selectedKeys.length;
-  // 当前 Tab（媒介）内已选数量，用于配额显示与「选满禁选」判断；确定按钮仍看全局。
-  const activeSelectedCount = selectedKeys.filter((k) =>
-    k.startsWith(`${activeMedia}:`),
-  ).length;
+  // 配额按媒介算（selectionKey 前缀即 media），所以「选满禁选」也得按条目自己的
+  // 媒介判断——文件夹里图片和视频是混着的。
+  const selectedCountOf = (media: AssetLibraryMedia) =>
+    selectedKeys.filter((k) => k.startsWith(`${media}:`)).length;
   const hasSelection = selectedCount > 0;
+  const tabs: Array<{ key: AssetLibraryTabKey; label: string }> = [
+    { key: ALL_CATEGORY_KEY, label: '全部' },
+    ...categories.map((category) => ({
+      key: category.key,
+      label: category.label,
+    })),
+  ];
+
+  const headerButtonClass =
+    'inline-flex h-8 items-center gap-1.5 rounded-md bg-white/[0.08] px-3 text-xs font-medium text-text-dark transition-colors hover:bg-white/[0.14] disabled:cursor-not-allowed disabled:opacity-50';
 
   return createPortal(
     <div className="fixed inset-0 z-[300] flex items-center justify-center">
@@ -522,7 +680,7 @@ export function AssetLibraryModal({
         }}
         onDrop={handleDrop}
       >
-        {/* Title bar */}
+        {/* Title bar：批量操作 / 新建 统一收在右上角 */}
         <div className="flex shrink-0 items-center justify-between px-5 py-4">
           <div className="flex items-center gap-2">
             <h2 className="text-base font-semibold text-text-dark">资产库</h2>
@@ -532,7 +690,7 @@ export function AssetLibraryModal({
               type="button"
               onClick={() => void handleSyncFromMainline()}
               disabled={!project || isSyncing}
-              className="inline-flex h-8 items-center gap-1.5 rounded-md bg-white/[0.08] px-3 text-xs font-medium text-text-dark transition-colors hover:bg-white/[0.14] disabled:cursor-not-allowed disabled:opacity-50"
+              className={headerButtonClass}
               title="打开时已自动同步；如主线新增了人物 / 场景 / 道具，可点此重新同步"
             >
               {isSyncing ? (
@@ -542,6 +700,62 @@ export function AssetLibraryModal({
               )}
               重新同步
             </button>
+            <button
+              type="button"
+              onClick={() => {
+                setBulkMode((prev) => !prev);
+                setBulkIds([]);
+                setCreateMenuOpen(false);
+              }}
+              className={`${headerButtonClass} ${
+                bulkMode ? 'bg-white/[0.18] text-text-dark' : ''
+              }`}
+              title="进入批量删除模式"
+            >
+              {bulkMode ? '退出批量' : '批量操作'}
+            </button>
+            <div className="relative">
+              <button
+                type="button"
+                onClick={() => setCreateMenuOpen((prev) => !prev)}
+                disabled={!project}
+                className={headerButtonClass}
+              >
+                <Plus className="h-3.5 w-3.5" />
+                新建
+              </button>
+              {createMenuOpen && (
+                <>
+                  {/* 点空白处收起菜单 */}
+                  <div
+                    className="fixed inset-0 z-10"
+                    onClick={() => setCreateMenuOpen(false)}
+                  />
+                  <div className="absolute right-0 top-9 z-20 w-28 overflow-hidden rounded-md border border-white/[0.12] bg-[#232429] py-1 shadow-[0_12px_28px_rgba(0,0,0,0.45)]">
+                    <button
+                      type="button"
+                      onClick={() => {
+                        setCreateMenuOpen(false);
+                        setNewFolderOpen(true);
+                      }}
+                      className="block w-full px-3 py-1.5 text-left text-xs text-text-muted/85 transition-colors hover:bg-white/[0.08] hover:text-text-dark"
+                    >
+                      新建文件夹
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => {
+                        setCreateMenuOpen(false);
+                        setUploadOpen(true);
+                      }}
+                      className="block w-full px-3 py-1.5 text-left text-xs text-text-muted/85 transition-colors hover:bg-white/[0.08] hover:text-text-dark"
+                    >
+                      上传资产
+                    </button>
+                  </div>
+                </>
+              )}
+            </div>
             <button
               type="button"
               onClick={onClose}
@@ -560,7 +774,11 @@ export function AssetLibraryModal({
               <button
                 key={tab.key}
                 type="button"
-                onClick={() => setActiveTabKey(tab.key)}
+                onClick={() => {
+                  setActiveTabKey(tab.key);
+                  // 换 tab 一律退回文件夹层，免得「全部」里还留着上次点进去的目录。
+                  setOpenFolderKey(null);
+                }}
                 className={`rounded-md px-3 py-1.5 text-xs font-medium transition-colors ${
                   tab.key === activeTabKey
                     ? 'bg-white/[0.12] text-text-dark'
@@ -571,33 +789,38 @@ export function AssetLibraryModal({
               </button>
             ))}
           </div>
-          <div className="flex items-center gap-3 text-xs text-text-muted/85">
-            <span>
-              已录入 <span className="text-text-dark">{totalCount}</span> 个
-            </span>
-            <span className="h-3 w-px bg-white/10" />
-            <span>
-              已选{' '}
-              <span
-                className={
-                  activeSelectedCount > 0 ? 'text-primary' : 'text-text-dark'
-                }
-              >
-                {activeSelectedCount}
-              </span>
-              /{maxSelectable}
-            </span>
-            {isLoadingLibrary && (
-              <Loader2 className="ml-1 inline h-3.5 w-3.5 animate-spin text-text-muted" />
-            )}
-          </div>
+          {/* 「已录入 N 个 / 已选 x/y」两个计数去掉了：条数底部分页已经在说，选了
+              几个卡片自己有勾。这里只留个加载指示。 */}
+          {isLoadingLibrary && (
+            <Loader2 className="h-3.5 w-3.5 animate-spin text-text-muted" />
+          )}
         </div>
+
+        {/* 面包屑：只在「全部」点进某个文件夹后出现 */}
+        {activeTabKey === ALL_CATEGORY_KEY && openFolder && (
+          <div className="flex shrink-0 items-center gap-1 px-5 pb-3 text-xs text-text-muted/85">
+            <button
+              type="button"
+              onClick={() => setOpenFolderKey(null)}
+              aria-label="返回全部"
+              className="inline-flex items-center gap-0.5 rounded-md px-1.5 py-1 transition-colors hover:bg-white/[0.08] hover:text-text-dark"
+            >
+              <ChevronLeft className="h-3.5 w-3.5" />
+              全部
+            </button>
+            <span className="text-text-muted/50">/</span>
+            <span className="px-1 text-text-dark">{openFolder.label}</span>
+            <span className="text-text-muted/50">
+              （{openFolder.items.length}）
+            </span>
+          </div>
+        )}
 
         {/* Grid */}
         <div className="ui-scrollbar relative flex-1 overflow-y-auto px-5 pb-2">
-          {isDragging && activeTab?.allowUpload && (
+          {isDragging && dropTarget && (
             <div className="pointer-events-none absolute inset-x-5 inset-y-0 z-10 flex items-center justify-center rounded-[8px] border border-dashed border-accent/60 bg-accent/10 text-sm text-text-dark">
-              松开以上传{activeTab?.label ?? '文件'}
+              松开以上传到「{dropTarget.label}」
             </div>
           )}
           {libraryError && (
@@ -611,40 +834,41 @@ export function AssetLibraryModal({
               gridTemplateColumns: 'repeat(auto-fill, minmax(176px, 176px))',
             }}
           >
-            {/* Upload card — 场景等只读类目不显示 */}
-            {activeTab?.allowUpload && (
-              <>
-                <div className={ASSET_LIBRARY_UPLOAD_CARD_CLASS}>
-                  <button
-                    type="button"
-                    onClick={() => fileInputRef.current?.click()}
-                    disabled={!project}
-                    className="inline-flex h-8 items-center justify-center rounded-md bg-white/[0.10] px-4 text-xs font-medium text-text-dark transition-colors hover:bg-white/[0.16] disabled:cursor-not-allowed disabled:opacity-50"
-                  >
-                    <Upload className="mr-1.5 h-3.5 w-3.5" />
-                    本地上传
-                  </button>
-                  <div className="text-[11px] text-text-muted/75">
-                    {activeMedia === 'image'
-                      ? '支持 PNG / JPG / WebP，可拖入'
-                      : activeMedia === 'video'
-                        ? '支持 MP4 / MOV 等，可拖入'
-                        : '支持 MP3 / WAV / M4A，可拖入'}
-                  </div>
-                </div>
-                <input
-                  ref={fileInputRef}
-                  type="file"
-                  accept={activeTab?.accept ?? 'image/*'}
-                  multiple
-                  className="hidden"
-                  onChange={(event) => {
-                    if (event.target.files) handleFiles(event.target.files);
-                    event.target.value = '';
+            {/* 文件夹卡片 — 只在「全部」的顶层出现 */}
+            {showFolders &&
+              pagedFolders.map((folder) => (
+                <FolderCard
+                  key={folder.key}
+                  folder={folder}
+                  menuOpen={folderMenuKey === folder.key}
+                  onToggleMenu={() =>
+                    setFolderMenuKey((prev) =>
+                      prev === folder.key ? null : folder.key,
+                    )
+                  }
+                  onOpen={() => setOpenFolderKey(folder.key)}
+                  onSend={
+                    onSendFolderToCanvas
+                      ? () => {
+                          onSendFolderToCanvas(folder);
+                          onClose();
+                        }
+                      : undefined
+                  }
+                  onEditCover={() => {
+                    setFolderMenuKey(null);
+                    setCoverFolderKey(folder.key);
+                  }}
+                  onRename={() => {
+                    setFolderMenuKey(null);
+                    setRenameFolderKey(folder.key);
+                  }}
+                  onDelete={() => {
+                    setFolderMenuKey(null);
+                    void handleDeleteFolder(folder);
                   }}
                 />
-              </>
-            )}
+              ))}
 
             {/* In-flight uploads */}
             {visiblePending.map((p) => (
@@ -699,71 +923,65 @@ export function AssetLibraryModal({
             ))}
 
             {/* Existing items */}
-            {visibleItems.map((entry, idx) => {
+            {pagedItems.map((entry, idx) => {
               const isDeleting = deletingId != null && entry.id === deletingId;
               const key = selectionKey(entry);
-              const selected = isSelected(key);
-              const disabledSelect =
-                !selected && activeSelectedCount >= maxSelectable;
+              // 批量态下只有本地上传的条目可选——主线条目删了也会被下次同步拉回来。
+              const bulkEligible = bulkMode && entry.source === 'upload' && !!entry.id;
+              const selected = bulkMode
+                ? Boolean(entry.id && bulkIds.includes(entry.id))
+                : isSelected(key);
+              const disabledSelect = bulkMode
+                ? !bulkEligible
+                : !selected && selectedCountOf(entry.media) >= maxSelectable;
+              const activate = () => {
+                if (disabledSelect) return;
+                if (bulkMode) {
+                  if (entry.id) toggleBulk(entry.id);
+                } else {
+                  toggleSelect(key);
+                }
+              };
               return (
                 <div
                   key={entry.id ?? `idx-${idx}`}
                   className={`group relative aspect-square ${ASSET_LIBRARY_CARD_CLASS} ${
                     selected
-                      ? 'border-accent/70 ring-1 ring-accent/45'
+                      ? bulkMode
+                        ? 'border-red-400/70 ring-1 ring-red-400/45'
+                        : 'border-accent/70 ring-1 ring-accent/45'
                       : ASSET_LIBRARY_CARD_HOVER_CLASS
-                  } cursor-pointer`}
-                  onClick={() => {
-                    if (disabledSelect) return;
-                    toggleSelect(key);
-                  }}
+                  } ${disabledSelect ? 'cursor-default' : 'cursor-pointer'}`}
+                  onClick={activate}
                 >
-                  {entry.media === 'image' ? (
-                    <img
-                      src={resolveImageDisplayUrl(entry.url)}
-                      alt={entry.name}
-                      className="h-full w-full object-cover"
-                      draggable={false}
-                    />
-                  ) : entry.media === 'video' ? (
-                    <video
-                      src={resolveImageDisplayUrl(entry.url)}
-                      className="h-full w-full object-cover"
-                      muted
-                      playsInline
-                      preload="metadata"
-                    />
-                  ) : (
-                    <div className="flex h-full w-full flex-col items-center justify-center gap-2 bg-white/[0.03] text-text-muted/70">
-                      <Music className="h-9 w-9" />
-                      <audio
-                        src={resolveImageDisplayUrl(entry.url)}
-                        controls
-                        className="w-[86%]"
-                        onClick={(event) => event.stopPropagation()}
-                      />
-                    </div>
-                  )}
+                  <AssetLibraryItemMedia entry={entry} />
 
                   {/* Checkbox top-left */}
                   <button
                     type="button"
                     onClick={(event) => {
                       event.stopPropagation();
-                      if (disabledSelect) return;
-                      toggleSelect(key);
+                      activate();
                     }}
                     disabled={disabledSelect}
                     title={
-                      disabledSelect
-                        ? `最多可选 ${maxSelectable} 个`
-                        : selected
-                          ? '取消选择'
-                          : '选择'
+                      bulkMode
+                        ? bulkEligible
+                          ? selected
+                            ? '取消选择'
+                            : '选中待删除'
+                          : '主线同步来的素材不能删除'
+                        : disabledSelect
+                          ? `最多可选 ${maxSelectable} 个`
+                          : selected
+                            ? '取消选择'
+                            : '选择'
                     }
                     className={`absolute left-2 top-2 inline-flex h-5 w-5 items-center justify-center rounded-full border transition-colors ${
                       selected
-                        ? 'border-accent bg-accent text-white'
+                        ? bulkMode
+                          ? 'border-red-400 bg-red-500 text-white'
+                          : 'border-accent bg-accent text-white'
                         : 'border-white/70 bg-black/35 text-transparent hover:border-white'
                     } ${disabledSelect ? 'cursor-not-allowed opacity-40' : ''}`}
                   >
@@ -781,8 +999,9 @@ export function AssetLibraryModal({
                     <div className="truncate">{entry.name || '(未命名)'}</div>
                   </div>
                   {/* 只有本地上传的条目可删；主线同步来的条目删了也会在下次打开自动同步时
-                      重新出现，所以不提供删除入口，避免「删不掉」的误导。 */}
-                  {entry.source === 'upload' && (
+                      重新出现，所以不提供删除入口，避免「删不掉」的误导。批量态下走
+                      底部的「删除所选」，卡片上不再摆单删按钮。 */}
+                  {!bulkMode && entry.source === 'upload' && (
                     <button
                       type="button"
                       onClick={(event) => {
@@ -806,30 +1025,382 @@ export function AssetLibraryModal({
           </div>
 
           {!isLoadingLibrary &&
+            !showFolders &&
             visibleItems.length === 0 &&
             visiblePending.length === 0 &&
             !libraryError && (
               <div className="mt-3 text-center text-[11px] text-text-muted/70">
-                {activeTab?.allowUpload
-                  ? '该类目暂无素材，可点击「本地上传」添加；主线资产已自动同步，也可点右上角「重新同步」。'
-                  : '主线暂无场景，或已自动同步为空；可点右上角「重新同步」重试。'}
+                这里暂无素材，可点右上角「新建 → 上传资产」添加；主线资产已自动同步，也可点「重新同步」。
               </div>
             )}
         </div>
 
         {/* Footer */}
         <div className="flex shrink-0 items-center justify-end gap-3 px-5 pb-3 pt-2">
-          <Button
-            size="sm"
-            className="bg-white px-4 text-[#15161b] hover:bg-white/90"
-            disabled={!hasSelection}
-            onClick={handleConfirm}
-          >
-            确定
-          </Button>
+          {bulkMode ? (
+            <>
+              <span className="mr-auto text-xs text-text-muted/85">
+                已选 <span className="text-text-dark">{bulkIds.length}</span> 项
+                （只能删除本地上传的素材）
+              </span>
+              <Button
+                size="sm"
+                variant="ghost"
+                className="px-4 text-text-muted hover:text-text-dark"
+                onClick={() => {
+                  setBulkMode(false);
+                  setBulkIds([]);
+                }}
+              >
+                退出批量
+              </Button>
+              <Button
+                size="sm"
+                className="bg-red-500 px-4 text-white hover:bg-red-500/90"
+                disabled={bulkIds.length === 0 || isBulkDeleting}
+                onClick={() => void handleBulkDelete()}
+              >
+                {isBulkDeleting && (
+                  <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
+                )}
+                删除所选
+              </Button>
+            </>
+          ) : (
+            <>
+              <AssetLibraryPagination
+                page={safePage}
+                pageCount={pageCount}
+                pageSize={pageSize}
+                onPageChange={setPage}
+                onPageSizeChange={setPageSize}
+              />
+              {/* 「确定」只在挑素材给节点用时才有意义；侧栏点开的资产管理态没有
+                  接收方，那儿的底部就只剩分页。 */}
+              {onConfirm && (
+                <Button
+                  size="sm"
+                  className="bg-white px-4 text-[#15161b] hover:bg-white/90"
+                  disabled={!hasSelection}
+                  onClick={handleConfirm}
+                >
+                  确定
+                </Button>
+              )}
+            </>
+          )}
         </div>
       </div>
+
+      <AssetLibraryNewFolderDialog
+        open={newFolderOpen}
+        onClose={() => setNewFolderOpen(false)}
+        onSubmit={async (name) => {
+          const key = await handleCreateFolder(name);
+          setNewFolderOpen(false);
+          // 建完直接进去，省得用户回头在一堆文件夹里找。
+          setActiveTabKey(ALL_CATEGORY_KEY);
+          setOpenFolderKey(key);
+        }}
+      />
+
+      <AssetLibraryUploadDialog
+        open={uploadOpen}
+        folders={uploadableFolders}
+        defaultFolderKey={openFolder?.uploadable ? openFolder.key : null}
+        categories={categories}
+        allowedMedia={allowedMedia}
+        onCreateFolder={handleCreateFolder}
+        onSubmit={startUploads}
+        onClose={() => setUploadOpen(false)}
+      />
+
+      <AssetLibraryNewFolderDialog
+        open={Boolean(renameFolder)}
+        title="重命名"
+        initialName={renameFolder?.label ?? ''}
+        onClose={() => setRenameFolderKey(null)}
+        onSubmit={async (name) => {
+          if (!renameFolder || !project) return;
+          await updateFreezoneAssetLibraryFolder(project, renameFolder.key, {
+            name,
+          });
+          setRenameFolderKey(null);
+          await refreshFolders();
+        }}
+      />
+
+      <AssetLibraryFolderCoverDialog
+        open={Boolean(coverFolder)}
+        folder={coverFolder}
+        onClose={() => setCoverFolderKey(null)}
+        onSubmit={async (cover) => {
+          if (!coverFolder || !project) return;
+          await updateFreezoneAssetLibraryFolder(project, coverFolder.key, {
+            cover,
+          });
+          setCoverFolderKey(null);
+          await refreshFolders();
+        }}
+      />
     </div>,
     document.body,
   );
+}
+
+/**
+ * 文件夹卡片。有封面就铺封面（用户设的优先，否则拿夹内第一张图），没有就画图标。
+ *
+ * 卡片本体是 div 而非 button —— 里面还要放「发送到画布」和「…」两个按钮，
+ * button 套 button 是非法 HTML，浏览器会把内层拆出去。role/tabIndex 补齐可达性。
+ */
+function FolderCard({
+  folder,
+  menuOpen,
+  onToggleMenu,
+  onOpen,
+  onSend,
+  onEditCover,
+  onRename,
+  onDelete,
+}: {
+  folder: AssetFolder;
+  menuOpen: boolean;
+  onToggleMenu: () => void;
+  onOpen: () => void;
+  /** 不传表示当前场景没有画布可发（如节点里打开的选素材弹窗）。 */
+  onSend?: () => void;
+  onEditCover: () => void;
+  onRename: () => void;
+  onDelete: () => void;
+}) {
+  const cover = folderCoverUrl(folder);
+  const created = formatFolderDate(folder.createdAt);
+  return (
+    // 外壳平时不画边框/底色，hover 才浮出来。border 常在只是透明，免得 hover
+    // 时多出 1px 把卡片顶动。
+    <div className="flex flex-col overflow-hidden rounded-[12px] border border-transparent p-2 transition-colors hover:border-white/[0.14] hover:bg-white/[0.05]">
+    <div
+      role="button"
+      tabIndex={0}
+      onClick={onOpen}
+      onKeyDown={(event) => {
+        if (event.key === 'Enter' || event.key === ' ') {
+          event.preventDefault();
+          onOpen();
+        }
+      }}
+      // 类目 tab 和文件夹同名（如「风格」），加个前缀让两者可区分。
+      aria-label={`文件夹 ${folder.label}`}
+      className="group relative flex aspect-square cursor-pointer flex-col items-center justify-center gap-2 overflow-hidden rounded-[8px] bg-white/[0.03]"
+    >
+      {cover ? (
+        <img
+          src={resolveImageDisplayUrl(cover)}
+          alt=""
+          className="absolute inset-0 h-full w-full object-cover"
+          draggable={false}
+        />
+      ) : (
+        <Folder className="h-11 w-11 text-text-muted/55 transition-colors group-hover:text-text-muted/80" />
+      )}
+
+      {/* 悬停才出现：整柜发到画布。缩到右下角一个小图标——原先是横在封面正中
+          的一条文字按钮，鼠标从上往下移到卡片就正好压在上面，很容易误触。 */}
+      {onSend && folder.items.length > 0 && (
+        <button
+          type="button"
+          onClick={(event) => {
+            event.stopPropagation();
+            onSend();
+          }}
+          aria-label="发送到画布"
+          title="发送到画布"
+          className="absolute bottom-2 right-2 hidden h-7 w-7 items-center justify-center rounded-[6px] bg-black/70 text-white transition-colors hover:bg-black/90 group-hover:inline-flex"
+        >
+          <Send className="h-3.5 w-3.5" />
+        </button>
+      )}
+    </div>
+
+      {/* 名字挪到方块外面，封面就不用被文字压掉一条；条数不显示，进去就知道 */}
+      <div className="mt-2 flex items-center gap-1 px-0.5">
+        <div className="min-w-0 flex-1 truncate text-xs text-text-dark" title={folder.label}>
+          {folder.label}
+        </div>
+        {/* 系统文件夹是按标签派生的，没有实体记录，改名/删除/封面都无从谈起 */}
+        {!folder.system && (
+          <div className="relative shrink-0">
+            <button
+              type="button"
+              onClick={onToggleMenu}
+              aria-label={`${folder.label} 更多操作`}
+              className="inline-flex h-5 w-5 items-center justify-center rounded-[4px] text-text-muted/70 transition-colors hover:bg-white/[0.10] hover:text-text-dark"
+            >
+              <MoreHorizontal className="h-3.5 w-3.5" />
+            </button>
+            {menuOpen && (
+              <>
+                {/* 点空白处收起菜单 */}
+                <div className="fixed inset-0 z-10" onClick={onToggleMenu} />
+                {/* 卡片在网格最下一行时菜单要往上开，否则会被列表的滚动容器裁掉 */}
+                <div className="absolute bottom-6 right-0 z-20 w-[112px] overflow-hidden rounded-[6px] border border-white/[0.12] bg-[#232429] py-1 shadow-[0_12px_28px_rgba(0,0,0,0.45)]">
+                  <button
+                    type="button"
+                    onClick={onEditCover}
+                    className="block w-full px-3 py-1.5 text-left text-xs text-text-dark transition-colors hover:bg-white/[0.08]"
+                  >
+                    修改封面
+                  </button>
+                  <button
+                    type="button"
+                    onClick={onRename}
+                    className="block w-full px-3 py-1.5 text-left text-xs text-text-dark transition-colors hover:bg-white/[0.08]"
+                  >
+                    重命名
+                  </button>
+                  <button
+                    type="button"
+                    onClick={onDelete}
+                    className="block w-full px-3 py-1.5 text-left text-xs text-red-400 transition-colors hover:bg-white/[0.08]"
+                  >
+                    删除
+                  </button>
+                </div>
+              </>
+            )}
+          </div>
+        )}
+      </div>
+
+      {/* 建夹日期。系统文件夹没有这个字段，留一行等高的空位让网格对齐。 */}
+      <div className="mt-1 h-4 px-0.5 text-right text-[11px] text-text-muted/60">
+        {created}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * 底部分页。页码窗口最多 7 格、两端省略，够用又不会把 footer 撑开。
+ *
+ * 每页条数的下拉往上开：它贴着弹窗底边，往下开会被 overflow-hidden 裁掉。
+ */
+function AssetLibraryPagination({
+  page,
+  pageCount,
+  pageSize,
+  onPageChange,
+  onPageSizeChange,
+}: {
+  page: number;
+  pageCount: number;
+  pageSize: number;
+  onPageChange: (page: number) => void;
+  onPageSizeChange: (size: number) => void;
+}) {
+  const [sizeMenuOpen, setSizeMenuOpen] = useState(false);
+  const stepClass =
+    'inline-flex h-7 w-7 items-center justify-center rounded-[6px] text-text-muted/85 transition-colors hover:bg-white/[0.08] hover:text-text-dark disabled:cursor-not-allowed disabled:opacity-35 disabled:hover:bg-transparent';
+
+  return (
+    <div className="mr-auto flex items-center gap-1.5">
+      <button
+        type="button"
+        aria-label="上一页"
+        disabled={page <= 1}
+        onClick={() => onPageChange(page - 1)}
+        className={stepClass}
+      >
+        <ChevronLeft className="h-4 w-4" />
+      </button>
+      {pageWindow(page, pageCount).map((slot, idx) =>
+        slot === '...' ? (
+          <span
+            key={`gap-${idx}`}
+            className="px-1 text-xs text-text-muted/60"
+            aria-hidden
+          >
+            …
+          </span>
+        ) : (
+          <button
+            key={slot}
+            type="button"
+            aria-label={`第 ${slot} 页`}
+            aria-current={slot === page ? 'page' : undefined}
+            onClick={() => onPageChange(slot)}
+            className={`inline-flex h-7 min-w-7 items-center justify-center rounded-[6px] px-1.5 text-xs transition-colors ${
+              slot === page
+                ? 'bg-white/[0.12] text-text-dark'
+                : 'text-text-muted/85 hover:bg-white/[0.08] hover:text-text-dark'
+            }`}
+          >
+            {slot}
+          </button>
+        ),
+      )}
+      <button
+        type="button"
+        aria-label="下一页"
+        disabled={page >= pageCount}
+        onClick={() => onPageChange(page + 1)}
+        className={stepClass}
+      >
+        <ChevronRight className="h-4 w-4" />
+      </button>
+
+      <div className="relative ml-1">
+        <button
+          type="button"
+          aria-label="每页条数"
+          onClick={() => setSizeMenuOpen((prev) => !prev)}
+          className="inline-flex h-7 items-center gap-1.5 rounded-[6px] border border-white/[0.10] bg-white/[0.04] px-2.5 text-xs text-text-muted/85 transition-colors hover:border-white/[0.20] hover:text-text-dark"
+        >
+          {pageSize}条/页
+          <ChevronsUpDown className="h-3 w-3 opacity-60" />
+        </button>
+        {sizeMenuOpen && (
+          <>
+            <div
+              className="fixed inset-0 z-10"
+              onClick={() => setSizeMenuOpen(false)}
+            />
+            <div className="absolute bottom-9 right-0 z-20 w-[92px] overflow-hidden rounded-[6px] border border-white/[0.12] bg-[#232429] py-1 shadow-[0_12px_28px_rgba(0,0,0,0.45)]">
+              {ASSET_LIBRARY_PAGE_SIZES.map((size) => (
+                <button
+                  key={size}
+                  type="button"
+                  onClick={() => {
+                    setSizeMenuOpen(false);
+                    onPageSizeChange(size);
+                  }}
+                  className={`block w-full px-3 py-1.5 text-left text-xs transition-colors hover:bg-white/[0.08] ${
+                    size === pageSize ? 'text-text-dark' : 'text-text-muted/85'
+                  }`}
+                >
+                  {size}条/页
+                </button>
+              ))}
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/** 页码窗口：总页数 ≤7 全列，否则首尾常驻、当前页两侧各留一格，中间省略。 */
+function pageWindow(page: number, pageCount: number): Array<number | '...'> {
+  if (pageCount <= 7) {
+    return Array.from({ length: pageCount }, (_, i) => i + 1);
+  }
+  const slots: Array<number | '...'> = [1];
+  const start = Math.max(2, Math.min(page - 1, pageCount - 4));
+  const end = Math.min(pageCount - 1, Math.max(page + 1, 5));
+  if (start > 2) slots.push('...');
+  for (let p = start; p <= end; p += 1) slots.push(p);
+  if (end < pageCount - 1) slots.push('...');
+  slots.push(pageCount);
+  return slots;
 }

--- a/frontend/src/features/canvas/ui/AssetLibraryNewFolderDialog.tsx
+++ b/frontend/src/features/canvas/ui/AssetLibraryNewFolderDialog.tsx
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: Elastic-2.0
+// Copyright (c) 2026 ClaymoreLab
+//
+// 「新建文件夹」弹窗。只收一个名字，重名/超长由后端判定并回显在输入框下方。
+// 它可能开在「上传资产」弹窗之上（保存位置那里也能现建文件夹），所以 z-index
+// 通过 layer 拉高，不写死。
+import { useEffect, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { Loader2, X } from 'lucide-react';
+
+import { Button } from '@/components/ui/button';
+import { FOLDER_NAME_MAX_LEN } from './assetLibraryItems';
+
+export interface AssetLibraryNewFolderDialogProps {
+  open: boolean;
+  onClose: () => void;
+  /** 抛错即视为失败，错误信息直接显示在输入框下方，弹窗保持打开。 */
+  onSubmit: (name: string) => Promise<void>;
+  /** 叠在上传弹窗之上时传更高的层级。 */
+  z?: number;
+  /** 重命名复用同一个弹窗，只换标题与初始值。 */
+  title?: string;
+  initialName?: string;
+}
+
+export function AssetLibraryNewFolderDialog({
+  open,
+  onClose,
+  onSubmit,
+  z = 320,
+  title = '新建文件夹',
+  initialName = '',
+}: AssetLibraryNewFolderDialogProps) {
+  const [name, setName] = useState(initialName);
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  useEffect(() => {
+    if (open) {
+      setName(initialName);
+      setError(null);
+      setSubmitting(false);
+    }
+  }, [open, initialName]);
+
+  if (typeof document === 'undefined' || !open) return null;
+
+  const clean = name.trim();
+  const canSubmit = clean.length > 0 && !submitting;
+
+  const handleSubmit = async () => {
+    if (!canSubmit) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      await onSubmit(clean);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      // 必须在 finally 里复位：成功时弹窗会被关掉，这次 setState 无关紧要；但
+      // handler 也可能什么都没做就 return（比如 project 还是 null），那时只在
+      // catch 里复位就等于把「保存」永久按灰，用户连错误提示都看不到。
+      setSubmitting(false);
+    }
+  };
+
+  return createPortal(
+    <div
+      className="fixed inset-0 flex items-center justify-center"
+      style={{ zIndex: z }}
+      role="dialog"
+      aria-label={title}
+    >
+      <div className="absolute inset-0 bg-black/55" onClick={onClose} />
+      <div className="relative w-[min(600px,90vw)] overflow-hidden rounded-[10px] border border-white/[0.12] bg-[#1b1c22] shadow-[0_18px_48px_rgba(0,0,0,0.5)]">
+        <div className="flex items-center justify-between border-b border-white/[0.08] px-5 py-3.5">
+          <h3 className="text-sm font-semibold text-text-dark">{title}</h3>
+          <button
+            type="button"
+            onClick={onClose}
+            title="关闭"
+            className="inline-flex h-7 w-7 items-center justify-center rounded-md text-text-muted/90 transition-colors hover:bg-white/[0.08] hover:text-text-dark"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+
+        <div className="px-5 py-4">
+          <label
+            htmlFor="asset-folder-name"
+            className="mb-2 block text-xs text-text-muted/90"
+          >
+            文件夹名称 <span className="text-red-400">*</span>
+          </label>
+          {/* 全局 --radius 是 1rem，rounded-md 落在 36px 高的输入框上会圆成胶囊，
+              所以这里按项目里输入类控件的惯例写死 6px。 */}
+          <div className="flex items-center rounded-[6px] border border-white/[0.10] bg-white/[0.04] px-3 focus-within:border-white/[0.22]">
+            <input
+              id="asset-folder-name"
+              value={name}
+              autoFocus
+              maxLength={FOLDER_NAME_MAX_LEN}
+              placeholder="请输入文件夹名称"
+              onChange={(event) => setName(event.target.value)}
+              onKeyDown={(event) => {
+                if (event.key === 'Enter') void handleSubmit();
+              }}
+              className="h-9 flex-1 bg-transparent text-sm text-text-dark outline-none placeholder:text-text-muted/50"
+            />
+            <span className="ml-2 shrink-0 text-[11px] text-text-muted/60">
+              {name.length}/{FOLDER_NAME_MAX_LEN}
+            </span>
+          </div>
+          {error && (
+            <div className="mt-2 text-[11px] text-red-400">{error}</div>
+          )}
+        </div>
+
+        <div className="flex items-center justify-end gap-2 px-5 pb-4">
+          <Button
+            size="sm"
+            variant="ghost"
+            className="px-4 text-text-muted hover:text-text-dark"
+            onClick={onClose}
+          >
+            取消
+          </Button>
+          <Button
+            size="sm"
+            className="bg-white px-4 text-[#15161b] hover:bg-white/90"
+            disabled={!canSubmit}
+            onClick={() => void handleSubmit()}
+          >
+            {submitting && <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />}
+            保存
+          </Button>
+        </div>
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/frontend/src/features/canvas/ui/AssetLibraryUploadDialog.tsx
+++ b/frontend/src/features/canvas/ui/AssetLibraryUploadDialog.tsx
@@ -1,0 +1,431 @@
+// SPDX-License-Identifier: Elastic-2.0
+// Copyright (c) 2026 ClaymoreLab
+//
+// 「上传资产」弹窗：左边挑文件，右边选保存位置（必填）和标签（可选）。
+//
+// 保存位置 = 文件夹，标签 = 类目，两者独立——同一个文件夹里可以放不同标签的素材，
+// 顶部类目 tab 按标签筛。这里只负责收集参数，真正的上传仍由 AssetLibraryModal
+// 执行（进度条和失败重试都在那边的卡片上）。
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import {
+  ChevronDown,
+  ChevronUp,
+  Image as ImageIcon,
+  Music,
+  Plus,
+  Video as VideoIcon,
+  X,
+} from 'lucide-react';
+
+import { Button } from '@/components/ui/button';
+import { AssetLibraryNewFolderDialog } from './AssetLibraryNewFolderDialog';
+import {
+  mediaOfFile,
+  type AssetCategory,
+  type AssetCategoryDef,
+  type AssetFolder,
+  type AssetFolderKey,
+  type AssetLibraryMedia,
+} from './assetLibraryItems';
+
+export interface AssetLibraryUploadPick {
+  file: File;
+  media: AssetLibraryMedia;
+}
+
+export interface AssetLibraryUploadDialogProps {
+  open: boolean;
+  /** 可作为保存位置的文件夹（主线已被调用方剔除）。 */
+  folders: AssetFolder[];
+  /** 打开时默认选中的保存位置，通常是当前正在看的文件夹。 */
+  defaultFolderKey?: AssetFolderKey | null;
+  /** 标签选项，已按 allowedMedia 过滤。 */
+  categories: AssetCategoryDef[];
+  /** 调用方允许的媒介，决定 accept 与提示文案。 */
+  allowedMedia?: AssetLibraryMedia[];
+  /** 现场新建文件夹，返回新文件夹的 key，弹窗会直接选中它。 */
+  onCreateFolder: (name: string) => Promise<AssetFolderKey>;
+  onSubmit: (
+    picks: AssetLibraryUploadPick[],
+    folder: AssetFolderKey,
+    category: AssetCategory | null,
+  ) => void;
+  onClose: () => void;
+}
+
+interface PickedFile extends AssetLibraryUploadPick {
+  id: string;
+  previewUrl: string;
+}
+
+const MEDIA_ACCEPT: Record<AssetLibraryMedia, string> = {
+  image: 'image/*',
+  video: 'video/*',
+  audio: 'audio/*',
+};
+const MEDIA_HINT: Record<AssetLibraryMedia, string> = {
+  image: 'jpg/jpeg/png/webp',
+  video: 'mp4',
+  audio: 'mp3/wav',
+};
+const MEDIA_ICON = {
+  image: ImageIcon,
+  video: VideoIcon,
+  audio: Music,
+} as const;
+
+function pickId(): string {
+  return `pick_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+}
+
+export function AssetLibraryUploadDialog({
+  open,
+  folders,
+  defaultFolderKey,
+  categories,
+  allowedMedia,
+  onCreateFolder,
+  onSubmit,
+  onClose,
+}: AssetLibraryUploadDialogProps) {
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const [picked, setPicked] = useState<PickedFile[]>([]);
+  const pickedRef = useRef<PickedFile[]>([]);
+  pickedRef.current = picked;
+  const [folderKey, setFolderKey] = useState<AssetFolderKey | null>(null);
+  const [category, setCategory] = useState<AssetCategory | null>(null);
+  const [folderOpen, setFolderOpen] = useState(false);
+  const [categoryOpen, setCategoryOpen] = useState(false);
+  const [newFolderOpen, setNewFolderOpen] = useState(false);
+
+  const media = useMemo<AssetLibraryMedia[]>(
+    () => allowedMedia ?? ['image', 'video', 'audio'],
+    [allowedMedia],
+  );
+  const accept = media.map((m) => MEDIA_ACCEPT[m]).join(',');
+
+  // 每次打开都从干净状态起：保存位置带上当前正在看的文件夹，标签留空（不猜）。
+  useEffect(() => {
+    if (!open) return;
+    setFolderKey(defaultFolderKey ?? null);
+    setCategory(null);
+    setFolderOpen(false);
+    setCategoryOpen(false);
+  }, [open, defaultFolderKey]);
+
+  useEffect(() => {
+    if (open) return;
+    pickedRef.current.forEach((p) => URL.revokeObjectURL(p.previewUrl));
+    setPicked([]);
+  }, [open]);
+
+  useEffect(
+    () => () => {
+      pickedRef.current.forEach((p) => URL.revokeObjectURL(p.previewUrl));
+    },
+    [],
+  );
+
+  const addFiles = useCallback(
+    (files: FileList | File[]) => {
+      const next: PickedFile[] = [];
+      Array.from(files).forEach((file) => {
+        const kind = mediaOfFile(file);
+        if (!kind || !media.includes(kind)) return;
+        next.push({
+          id: pickId(),
+          file,
+          media: kind,
+          previewUrl: URL.createObjectURL(file),
+        });
+      });
+      if (next.length > 0) setPicked((prev) => [...prev, ...next]);
+    },
+    [media],
+  );
+
+  const removePicked = useCallback((id: string) => {
+    setPicked((prev) => {
+      const target = prev.find((p) => p.id === id);
+      if (target) URL.revokeObjectURL(target.previewUrl);
+      return prev.filter((p) => p.id !== id);
+    });
+  }, []);
+
+  if (typeof document === 'undefined' || !open) return null;
+
+  const selectedFolder = folders.find((folder) => folder.key === folderKey);
+  const selectedCategory = categories.find((c) => c.key === category);
+  const canSubmit = picked.length > 0 && Boolean(folderKey);
+
+  const handleSubmit = () => {
+    if (!canSubmit || !folderKey) return;
+    onSubmit(
+      picked.map(({ file, media: kind }) => ({ file, media: kind })),
+      folderKey,
+      category,
+    );
+    onClose();
+  };
+
+  const fieldButtonClass =
+    'flex h-9 w-full items-center justify-between rounded-[6px] border border-white/[0.10] bg-white/[0.04] px-3 text-xs transition-colors hover:border-white/[0.20]';
+
+  return createPortal(
+    <div
+      className="fixed inset-0 z-[310] flex items-center justify-center"
+      role="dialog"
+      aria-label="上传资产"
+    >
+      <div className="absolute inset-0 bg-black/55" onClick={onClose} />
+      <div className="relative flex w-[min(940px,92vw)] flex-col overflow-hidden rounded-[10px] border border-white/[0.12] bg-[#1b1c22] shadow-[0_18px_48px_rgba(0,0,0,0.5)]">
+        <div className="flex items-center justify-between border-b border-white/[0.08] px-5 py-3.5">
+          <h3 className="text-sm font-semibold text-text-dark">上传资产</h3>
+          <button
+            type="button"
+            onClick={onClose}
+            title="关闭"
+            className="inline-flex h-7 w-7 items-center justify-center rounded-md text-text-muted/90 transition-colors hover:bg-white/[0.08] hover:text-text-dark"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+
+        <div className="flex gap-6 px-5 py-4">
+          {/* ── 左：选文件 ── */}
+          <div
+            className="ui-scrollbar h-[320px] flex-1 overflow-y-auto rounded-md border border-white/[0.08] bg-white/[0.02] p-4"
+            onDragOver={(event) => event.preventDefault()}
+            onDrop={(event) => {
+              event.preventDefault();
+              if (event.dataTransfer?.files?.length) {
+                addFiles(event.dataTransfer.files);
+              }
+            }}
+          >
+            <div className="flex flex-wrap gap-3">
+              <button
+                type="button"
+                onClick={() => fileInputRef.current?.click()}
+                aria-label="选择文件"
+                className="flex h-[120px] w-[120px] items-center justify-center rounded-md border border-dashed border-white/[0.16] text-text-muted/60 transition-colors hover:border-white/[0.30] hover:text-text-dark"
+              >
+                <Plus className="h-7 w-7" strokeWidth={1.5} />
+              </button>
+              <input
+                ref={fileInputRef}
+                type="file"
+                accept={accept}
+                multiple
+                className="hidden"
+                onChange={(event) => {
+                  if (event.target.files) addFiles(event.target.files);
+                  event.target.value = '';
+                }}
+              />
+              {picked.map((p) => (
+                <div
+                  key={p.id}
+                  className="group relative h-[120px] w-[120px] overflow-hidden rounded-md border border-white/[0.10] bg-white/[0.04]"
+                  title={p.file.name}
+                >
+                  {p.media === 'image' ? (
+                    <img
+                      src={p.previewUrl}
+                      alt=""
+                      className="h-full w-full object-cover"
+                      draggable={false}
+                    />
+                  ) : p.media === 'video' ? (
+                    <video
+                      src={p.previewUrl}
+                      className="h-full w-full object-cover"
+                      muted
+                      playsInline
+                      preload="metadata"
+                    />
+                  ) : (
+                    <div className="flex h-full w-full items-center justify-center text-text-muted/60">
+                      <Music className="h-8 w-8" />
+                    </div>
+                  )}
+                  <div className="pointer-events-none absolute inset-x-0 bottom-0 truncate bg-black/65 px-1.5 py-1 text-[10px] text-white/85">
+                    {p.file.name}
+                  </div>
+                  <button
+                    type="button"
+                    onClick={() => removePicked(p.id)}
+                    aria-label={`移除 ${p.file.name}`}
+                    className="absolute right-1 top-1 inline-flex h-5 w-5 items-center justify-center rounded bg-black/60 text-white opacity-0 transition-opacity hover:bg-black/80 group-hover:opacity-100"
+                  >
+                    <X className="h-3 w-3" />
+                  </button>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          {/* ── 右：保存位置 + 标签 ── */}
+          <div className="w-[240px] shrink-0 space-y-4">
+            <div className="relative">
+              <div className="mb-1.5 text-xs text-text-muted/90">
+                保存位置 <span className="text-red-400">*</span>
+              </div>
+              <button
+                type="button"
+                aria-label="选择保存位置"
+                onClick={() => {
+                  setFolderOpen((prev) => !prev);
+                  setCategoryOpen(false);
+                }}
+                className={fieldButtonClass}
+              >
+                <span
+                  className={
+                    selectedFolder ? 'text-text-dark' : 'text-text-muted/55'
+                  }
+                >
+                  {selectedFolder?.label ?? '请选择文件夹'}
+                </span>
+                {folderOpen ? (
+                  <ChevronUp className="h-3.5 w-3.5 text-text-muted/70" />
+                ) : (
+                  <ChevronDown className="h-3.5 w-3.5 text-text-muted/70" />
+                )}
+              </button>
+              {folderOpen && (
+                <div className="absolute z-10 mt-1 w-full overflow-hidden rounded-[6px] border border-white/[0.12] bg-[#232429] py-1 shadow-[0_12px_28px_rgba(0,0,0,0.45)]">
+                  <div className="flex items-center justify-between border-b border-white/[0.08] px-3 py-1.5 text-xs text-text-dark">
+                    项目资产库
+                    <button
+                      type="button"
+                      aria-label="新建文件夹"
+                      title="新建文件夹"
+                      onClick={() => setNewFolderOpen(true)}
+                      className="inline-flex h-5 w-5 items-center justify-center rounded text-text-muted/80 transition-colors hover:bg-white/[0.10] hover:text-text-dark"
+                    >
+                      <Plus className="h-3.5 w-3.5" />
+                    </button>
+                  </div>
+                  <div className="ui-scrollbar max-h-[180px] overflow-y-auto">
+                    {folders.map((folder) => (
+                      <button
+                        key={folder.key}
+                        type="button"
+                        onClick={() => {
+                          setFolderKey(folder.key);
+                          setFolderOpen(false);
+                        }}
+                        className={`block w-full truncate px-5 py-1.5 text-left text-xs transition-colors hover:bg-white/[0.08] ${
+                          folder.key === folderKey
+                            ? 'text-text-dark'
+                            : 'text-text-muted/85'
+                        }`}
+                      >
+                        {folder.label}
+                      </button>
+                    ))}
+                  </div>
+                </div>
+              )}
+            </div>
+
+            <div className="relative">
+              <div className="mb-1.5 text-xs text-text-muted/90">标签</div>
+              <button
+                type="button"
+                aria-label="选择标签"
+                onClick={() => {
+                  setCategoryOpen((prev) => !prev);
+                  setFolderOpen(false);
+                }}
+                className={fieldButtonClass}
+              >
+                <span
+                  className={
+                    selectedCategory ? 'text-text-dark' : 'text-text-muted/55'
+                  }
+                >
+                  {selectedCategory?.label ?? '请选择'}
+                </span>
+                {categoryOpen ? (
+                  <ChevronUp className="h-3.5 w-3.5 text-text-muted/70" />
+                ) : (
+                  <ChevronDown className="h-3.5 w-3.5 text-text-muted/70" />
+                )}
+              </button>
+              {categoryOpen && (
+                <div className="ui-scrollbar absolute z-10 mt-1 max-h-[180px] w-full overflow-y-auto rounded-[6px] border border-white/[0.12] bg-[#232429] py-1 shadow-[0_12px_28px_rgba(0,0,0,0.45)]">
+                  {categories.map((item) => (
+                    <button
+                      key={item.key}
+                      type="button"
+                      onClick={() => {
+                        setCategory(item.key);
+                        setCategoryOpen(false);
+                      }}
+                      className={`block w-full px-3 py-1.5 text-left text-xs transition-colors hover:bg-white/[0.08] ${
+                        item.key === category
+                          ? 'text-text-dark'
+                          : 'text-text-muted/85'
+                      }`}
+                    >
+                      {item.label}
+                    </button>
+                  ))}
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+
+        <div className="flex items-end justify-between gap-4 px-5 pb-4">
+          <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-[11px] text-text-muted/60">
+            <span>支持的文件格式</span>
+            {media.map((kind) => {
+              const Icon = MEDIA_ICON[kind];
+              return (
+                <span key={kind} className="inline-flex items-center gap-1">
+                  <Icon className="h-3.5 w-3.5" />
+                  {MEDIA_HINT[kind]}
+                </span>
+              );
+            })}
+          </div>
+          <div className="flex shrink-0 items-center gap-2">
+            <Button
+              size="sm"
+              variant="ghost"
+              className="px-4 text-text-muted hover:text-text-dark"
+              onClick={onClose}
+            >
+              取消
+            </Button>
+            <Button
+              size="sm"
+              className="bg-white px-4 text-[#15161b] hover:bg-white/90"
+              disabled={!canSubmit}
+              onClick={handleSubmit}
+            >
+              保存
+            </Button>
+          </div>
+        </div>
+      </div>
+
+      <AssetLibraryNewFolderDialog
+        open={newFolderOpen}
+        z={330}
+        onClose={() => setNewFolderOpen(false)}
+        onSubmit={async (name) => {
+          const key = await onCreateFolder(name);
+          setFolderKey(key);
+          setNewFolderOpen(false);
+          setFolderOpen(false);
+        }}
+      />
+    </div>,
+    document.body,
+  );
+}

--- a/frontend/src/features/canvas/ui/assetLibraryItems.ts
+++ b/frontend/src/features/canvas/ui/assetLibraryItems.ts
@@ -1,0 +1,280 @@
+// SPDX-License-Identifier: Elastic-2.0
+// Copyright (c) 2026 ClaymoreLab
+//
+// 资产库的条目模型与类目定义。弹窗(AssetLibraryModal，选参考图用)和 Freezone 左侧
+// 面板的「资产库」tab(只浏览)共用这里，类目和归一化逻辑只有一份，避免两边漂移。
+// 上传/删除/同步等写操作仍只在弹窗里，不放进来。
+import type {
+  FreezoneAssetLibraryCategory,
+  FreezoneAssetLibraryFolder,
+  FreezoneAssetLibraryMedia,
+  FreezoneAssetLibrarySource,
+} from '@/api/ops';
+
+export const ASSET_LIBRARY_CARD_CLASS =
+  'overflow-hidden rounded-[12px] border border-white/[0.10] bg-white/[0.04] transition-colors';
+export const ASSET_LIBRARY_CARD_HOVER_CLASS =
+  'hover:border-white/[0.18] hover:bg-white/[0.06]';
+
+export type AssetLibraryMedia = FreezoneAssetLibraryMedia;
+
+export interface LibraryItem {
+  id: string | null;
+  name: string;
+  media: AssetLibraryMedia;
+  source: FreezoneAssetLibrarySource;
+  /** 用途类目（标签）。老条目后端不返回时按 source/media 兜底推导，见 deriveCategory。 */
+  category: AssetCategory;
+  /** 保存位置（文件夹 key）。老条目没有该字段时按类目归位，见 deriveFolder。 */
+  folder: AssetFolderKey;
+  /** 该条目在其 media 类型下的主展示 / 引用地址。 */
+  url: string;
+  raw: Record<string, unknown>;
+}
+
+/**
+ * 资产类目。分类不再按媒介（图片/视频/音频）切，而是按用途切——同一个类目下
+ * 图片、视频、音频都可能有。`audio`（音效）是唯一天然只装音频的类目。
+ */
+export type AssetCategory = FreezoneAssetLibraryCategory;
+
+export interface AssetCategoryDef {
+  key: AssetCategory;
+  label: string;
+  /** 该类目收哪些媒介的文件——决定上传时的 accept 与提示文案。 */
+  media: AssetLibraryMedia[];
+}
+
+export const ASSET_CATEGORIES: AssetCategoryDef[] = [
+  { key: 'other', label: '其它', media: ['image', 'video'] },
+  { key: 'character', label: '人物', media: ['image', 'video'] },
+  { key: 'scene', label: '场景', media: ['image', 'video'] },
+  { key: 'prop', label: '物品', media: ['image', 'video'] },
+  { key: 'style', label: '风格', media: ['image', 'video'] },
+  { key: 'audio', label: '音效', media: ['audio'] },
+];
+
+/** 「全部」页签的 key，和类目 key 同处一个 tab 条上，所以单独留一个字面量。 */
+export const ALL_CATEGORY_KEY = 'all';
+export type AssetLibraryTabKey = typeof ALL_CATEGORY_KEY | AssetCategory;
+
+/** 从 File 的 MIME 判断它属于哪种媒介；认不出来返回 null（直接丢弃该文件）。 */
+export function mediaOfFile(file: File): AssetLibraryMedia | null {
+  if (file.type.startsWith('image/')) return 'image';
+  if (file.type.startsWith('video/')) return 'video';
+  if (file.type.startsWith('audio/')) return 'audio';
+  return null;
+}
+
+const CATEGORY_KEYS = new Set<string>(ASSET_CATEGORIES.map((c) => c.key));
+
+/**
+ * 老条目没有 category 字段，按它的来源/媒介兜底推一个：主线同步来的人物/场景/
+ * 道具直接对号入座，音频归音效，剩下的本地上传归「其它」。
+ */
+export function deriveCategory(
+  raw: unknown,
+  source: FreezoneAssetLibrarySource,
+  media: AssetLibraryMedia,
+): AssetCategory {
+  if (typeof raw === 'string' && CATEGORY_KEYS.has(raw)) {
+    return raw as AssetCategory;
+  }
+  if (source === 'character' || source === 'scene' || source === 'prop') {
+    return source;
+  }
+  return media === 'audio' ? 'audio' : 'other';
+}
+
+export const SOURCE_LABEL: Record<FreezoneAssetLibrarySource, string> = {
+  upload: '上传',
+  character: '人物',
+  scene: '场景',
+  prop: '道具',
+};
+
+/**
+ * 文件夹（保存位置）和类目（标签）是两个独立维度：类目只说「这素材是干嘛的」，
+ * 文件夹说「它放在哪」。key 的取值有三种——
+ *   - `mainline`：主线同步来的资产的固定去处，不接受上传；
+ *   - 类目 key（other/character/…）：同名系统文件夹，老条目没有 folder 字段时
+ *     按类目落进来，所以不需要数据迁移；
+ *   - 其余：用户自建文件夹的 id（后端随机生成，不会和上面撞）。
+ * 与后端 video_node.py 的 RESERVED_FOLDER_KEYS / _resolve_library_folder 对应。
+ */
+export type AssetFolderKey = string;
+
+export const MAINLINE_FOLDER_KEY = 'mainline';
+/** 没归类的本地上传落在「其它」类目，文件夹上换个更直白的名字。 */
+export const UNSORTED_FOLDER_LABEL = '待分类资产';
+/** 与后端 FOLDER_NAME_MAX_LEN 一致。 */
+export const FOLDER_NAME_MAX_LEN = 20;
+
+const SYSTEM_FOLDER_LABELS: Record<string, string> = {
+  [MAINLINE_FOLDER_KEY]: '主线',
+  ...Object.fromEntries(
+    ASSET_CATEGORIES.map((category) => [
+      category.key,
+      category.key === 'other' ? UNSORTED_FOLDER_LABEL : category.label,
+    ]),
+  ),
+};
+
+/** 系统文件夹的显示名；不是系统 key（自建文件夹的 id）时返回 null。 */
+export function systemFolderLabel(key: AssetFolderKey): string | null {
+  return SYSTEM_FOLDER_LABELS[key] ?? null;
+}
+
+/** 用户建不出来的名字（会和系统文件夹撞），与后端 RESERVED_FOLDER_NAMES 一致。 */
+export const RESERVED_FOLDER_NAMES = Object.values(SYSTEM_FOLDER_LABELS).concat(
+  ASSET_CATEGORIES.map((category) => category.label),
+);
+
+export interface AssetFolder {
+  key: AssetFolderKey;
+  label: string;
+  items: LibraryItem[];
+  /** 系统文件夹不可重命名/删除/改封面——它们是按标签派生的，没有实体记录。 */
+  system: boolean;
+  /** 能否作为上传的保存位置。主线是同步产物，只读。 */
+  uploadable: boolean;
+  /** 用户设的封面图 URL；没设过时按文件夹里第一张图兜底，都没有就画图标。 */
+  cover?: string | null;
+  /** 建夹时间（ISO）。系统文件夹是按标签派生的，没有这个字段。 */
+  createdAt?: string | null;
+}
+
+/** 建夹日期，只取到天：卡片上够用，也免得时区把时分秒显示歪。 */
+export function formatFolderDate(iso: string | null | undefined): string {
+  if (!iso) return '';
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return '';
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}`;
+}
+
+/** 文件夹封面：用户指定的优先，否则拿文件夹里第一张图顶上（音频没有可用画面）。 */
+export function folderCoverUrl(folder: AssetFolder): string | null {
+  if (folder.cover) return folder.cover;
+  const firstImage = folder.items.find(
+    (entry) => entry.media === 'image' && entry.url,
+  );
+  return firstImage?.url ?? null;
+}
+
+/** 老条目没有 folder 字段：主线的进主线，本地上传的按类目进同名系统文件夹。 */
+export function deriveFolder(
+  raw: unknown,
+  source: FreezoneAssetLibrarySource,
+  category: AssetCategory,
+): AssetFolderKey {
+  if (typeof raw === 'string' && raw) return raw;
+  return source === 'upload' ? category : MAINLINE_FOLDER_KEY;
+}
+
+/**
+ * 把条目摆进文件夹。【主线】和【待分类资产】恒在——库是空的时候也得有地方可点；
+ * 其余系统文件夹有内容才出现；自建文件夹一律出现（刚建完还是空的也要看得见）。
+ */
+export function buildAssetFolders(
+  items: LibraryItem[],
+  customFolders: FreezoneAssetLibraryFolder[] = [],
+): AssetFolder[] {
+  const own = (key: AssetFolderKey) =>
+    items.filter((entry) => entry.folder === key);
+  const folders: AssetFolder[] = [
+    {
+      key: MAINLINE_FOLDER_KEY,
+      label: SYSTEM_FOLDER_LABELS[MAINLINE_FOLDER_KEY],
+      items: items.filter(
+        (entry) =>
+          entry.folder === MAINLINE_FOLDER_KEY || entry.source !== 'upload',
+      ),
+      system: true,
+      uploadable: false,
+    },
+  ];
+  for (const category of ASSET_CATEGORIES) {
+    const owned = own(category.key);
+    if (category.key !== 'other' && owned.length === 0) continue;
+    folders.push({
+      key: category.key,
+      label: SYSTEM_FOLDER_LABELS[category.key],
+      items: owned,
+      system: true,
+      uploadable: true,
+    });
+  }
+  for (const folder of customFolders) {
+    folders.push({
+      key: folder.id,
+      label: folder.name,
+      items: own(folder.id),
+      system: false,
+      uploadable: true,
+      cover: folder.cover ?? null,
+      createdAt: folder.created_at ?? null,
+    });
+  }
+  return folders;
+}
+
+function itemUrl(media: AssetLibraryMedia, it: Record<string, unknown>): string {
+  if (media === 'video') return typeof it.video_url === 'string' ? it.video_url : '';
+  if (media === 'audio') return typeof it.audio_url === 'string' ? it.audio_url : '';
+  const urls = it.image_urls ?? it.imageUrls ?? it.images;
+  if (Array.isArray(urls)) {
+    const first = urls.find((u): u is string => typeof u === 'string');
+    if (first) return first;
+  }
+  return typeof it.cover_url === 'string' ? it.cover_url : '';
+}
+
+export function normalizeLibraryList(payload: unknown): LibraryItem[] {
+  let arr: unknown[] = [];
+  if (Array.isArray(payload)) {
+    arr = payload;
+  } else if (payload && typeof payload === 'object') {
+    const rec = payload as Record<string, unknown>;
+    for (const key of ['items', 'data', 'characters', 'list', 'records']) {
+      if (Array.isArray(rec[key])) {
+        arr = rec[key] as unknown[];
+        break;
+      }
+    }
+  }
+  return arr
+    .filter(
+      (it): it is Record<string, unknown> =>
+        Boolean(it && typeof it === 'object' && !Array.isArray(it)),
+    )
+    .map((it) => {
+      const idRaw = it.id ?? it.item_id ?? it.itemId ?? null;
+      const id =
+        typeof idRaw === 'string' ? idRaw : idRaw != null ? String(idRaw) : null;
+      const name = typeof it.name === 'string' ? it.name : '';
+      // 缺省 image 兼容老数据（历史条目没有 media 字段）。
+      const mediaRaw = typeof it.media === 'string' ? it.media : 'image';
+      const media: AssetLibraryMedia =
+        mediaRaw === 'video' || mediaRaw === 'audio' ? mediaRaw : 'image';
+      const sourceRaw = typeof it.source === 'string' ? it.source : 'upload';
+      const source: FreezoneAssetLibrarySource =
+        sourceRaw === 'character' ||
+        sourceRaw === 'scene' ||
+        sourceRaw === 'prop'
+          ? sourceRaw
+          : 'upload';
+      const category = deriveCategory(it.category, source, media);
+      return {
+        id,
+        name,
+        media,
+        source,
+        category,
+        folder: deriveFolder(it.folder, source, category),
+        url: itemUrl(media, it),
+        raw: it,
+      };
+    })
+    .filter((it) => Boolean(it.url));
+}

--- a/frontend/src/features/freezone/AssetLibraryBrowser.tsx
+++ b/frontend/src/features/freezone/AssetLibraryBrowser.tsx
@@ -1,0 +1,166 @@
+// SPDX-License-Identifier: Elastic-2.0
+// Copyright (c) 2026 ClaymoreLab
+//
+// 左侧面板「资产库」tab 的内容：项目级资产库的只读浏览，两级——先文件夹，点进去
+// 看条目，顶上有面包屑退回。
+//
+// 与 AssetLibraryModal 的关系：条目归一化和文件夹分法共用
+// `@/features/canvas/ui/assetLibraryItems`，所以两边看到的目录结构始终一致；
+// 但这里只读——上传、删除、从主线同步仍然只在弹窗里做（侧栏 300px 放不下，
+// 而且写操作有确认/进度态，不适合塞进抽屉）。条目暂时没有点击/拖拽交互。
+import { useMemo, useState } from "react";
+import { ChevronLeft, Folder, Music, Video as VideoIcon } from "lucide-react";
+
+import { resolveImageDisplayUrl } from "@/features/canvas/application/imageData";
+import {
+  useFreezoneAssetLibrary,
+  useFreezoneAssetLibraryFolders,
+} from "@/lib/queries/freezone";
+import {
+  buildAssetFolders,
+  type AssetFolderKey,
+} from "@/features/canvas/ui/assetLibraryItems";
+
+interface AssetLibraryBrowserProps {
+  project: string;
+}
+
+export function AssetLibraryBrowser({ project }: AssetLibraryBrowserProps) {
+  const [openKey, setOpenKey] = useState<AssetFolderKey | null>(null);
+  const libraryQuery = useFreezoneAssetLibrary(project);
+  const foldersQuery = useFreezoneAssetLibraryFolders(project);
+  const items = useMemo(() => libraryQuery.data ?? [], [libraryQuery.data]);
+  const folders = useMemo(
+    () => buildAssetFolders(items, foldersQuery.data ?? []),
+    [items, foldersQuery.data],
+  );
+  const openFolder = openKey
+    ? (folders.find((folder) => folder.key === openKey) ?? null)
+    : null;
+
+  if (libraryQuery.isError) {
+    return (
+      <div className="ui-scrollbar min-h-0 flex-1 overflow-y-auto px-3 py-2.5">
+        <div className="rounded-lg border border-red-500/20 bg-red-500/5 px-3 py-2 text-xs text-red-400">
+          资产库加载失败：
+          {libraryQuery.error instanceof Error
+            ? libraryQuery.error.message
+            : String(libraryQuery.error)}
+        </div>
+      </div>
+    );
+  }
+
+  if (libraryQuery.isPending) {
+    return (
+      <div className="min-h-0 flex-1 px-3 py-6 text-center text-xs text-white/25">
+        加载中…
+      </div>
+    );
+  }
+
+  // 库为空、也没建过文件夹时不摆两个空目录，直接说清入口在弹窗里，省得用户在侧栏里找上传。
+  if (items.length === 0 && (foldersQuery.data?.length ?? 0) === 0) {
+    return (
+      <div className="min-h-0 flex-1 px-4 py-6 text-center text-[11px] leading-relaxed text-white/25">
+        资产库还是空的。上传素材或从主线同步，请在节点上打开「资产库」。
+      </div>
+    );
+  }
+
+  return (
+    <>
+      {/* ── 面包屑（进了文件夹才有） ── */}
+      {openFolder ? (
+        <div className="flex shrink-0 items-center gap-1 px-3 pt-2.5 pb-1.5 text-xs text-white/40">
+          <button
+            type="button"
+            onClick={() => setOpenKey(null)}
+            aria-label="返回资产库根目录"
+            className="inline-flex items-center gap-0.5 rounded px-1 py-0.5 transition-colors hover:bg-white/[0.06] hover:text-white/70"
+          >
+            <ChevronLeft className="h-3.5 w-3.5" />
+            资产库
+          </button>
+          <span className="text-white/20">/</span>
+          <span className="truncate px-0.5 text-white/80">
+            {openFolder.label}
+          </span>
+        </div>
+      ) : null}
+
+      <div className="ui-scrollbar min-h-0 flex-1 overflow-y-auto px-2 pb-3 pt-1.5">
+        {/* ── 根目录：文件夹列表 ── */}
+        {!openFolder
+          ? folders.map((folder) => (
+              <button
+                key={folder.key}
+                type="button"
+                onClick={() => setOpenKey(folder.key)}
+                aria-label={`文件夹 ${folder.label}`}
+                className="flex w-full items-center gap-2.5 rounded-lg px-1.5 py-1.5 text-left transition-colors hover:bg-white/[0.06]"
+              >
+                <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-md bg-white/[0.06]">
+                  <Folder className="h-4.5 w-4.5 text-white/40" />
+                </span>
+                <span className="min-w-0 flex-1 truncate text-xs text-white/85">
+                  {folder.label}
+                </span>
+                <span className="shrink-0 pr-1 text-[11px] text-white/25">
+                  {folder.items.length}
+                </span>
+              </button>
+            ))
+          : null}
+
+        {/* ── 文件夹内：条目列表 ── */}
+        {openFolder && openFolder.items.length === 0 ? (
+          <div className="px-2 py-6 text-center text-[11px] text-white/25">
+            「{openFolder.label}」暂无素材。
+          </div>
+        ) : null}
+
+        {openFolder?.items.map((entry, idx) => (
+          <div
+            key={entry.id ?? `idx-${idx}`}
+            className="flex w-full items-center gap-2.5 rounded-lg px-1.5 py-1.5 transition-colors hover:bg-white/[0.06]"
+            title={entry.name || "(未命名)"}
+          >
+            <span className="relative h-10 w-10 shrink-0 overflow-hidden rounded-md bg-white/[0.06]">
+              {entry.media === "image" ? (
+                <img
+                  src={resolveImageDisplayUrl(entry.url)}
+                  alt={entry.name}
+                  className="h-full w-full object-cover"
+                  draggable={false}
+                  loading="lazy"
+                />
+              ) : entry.media === "video" ? (
+                <>
+                  <video
+                    src={resolveImageDisplayUrl(entry.url)}
+                    className="h-full w-full object-cover"
+                    muted
+                    playsInline
+                    preload="metadata"
+                  />
+                  {/* 视频没有 poster 时是一片黑，补个角标让它和图片区分开 */}
+                  <span className="pointer-events-none absolute left-0.5 top-0.5 rounded bg-black/55 p-0.5 text-white/90">
+                    <VideoIcon className="h-2.5 w-2.5" />
+                  </span>
+                </>
+              ) : (
+                <span className="flex h-full w-full items-center justify-center text-white/40">
+                  <Music className="h-4 w-4" />
+                </span>
+              )}
+            </span>
+            <span className="min-w-0 flex-1 truncate text-xs text-white/85">
+              {entry.name || "(未命名)"}
+            </span>
+          </div>
+        ))}
+      </div>
+    </>
+  );
+}

--- a/frontend/src/features/freezone/AssetLibraryPanel.tsx
+++ b/frontend/src/features/freezone/AssetLibraryPanel.tsx
@@ -13,13 +13,24 @@ import {
 } from "react";
 import {
   AudioLines,
+  BookOpen,
   ChevronDown,
   ChevronLeft,
   ChevronRight,
   ImageOff,
   Video,
 } from "lucide-react";
+import { useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { AssetLibraryModal } from "@/features/canvas/ui/AssetLibraryModal";
+import type {
+  AssetFolder,
+  LibraryItem,
+} from "@/features/canvas/ui/assetLibraryItems";
+import { queryKeys } from "@/lib/query-keys";
 import { CanvasesTab } from "./CanvasesTab";
+import { AssetLibraryBrowser } from "./AssetLibraryBrowser";
 import { hasLegacyPresetCanvasMetadata } from "@/features/freezone/projections";
 import {
   type FreezoneBeatContextBeat,
@@ -30,8 +41,20 @@ import {
   useFreezoneBeatContext,
   useFreezoneProjectAssets,
 } from "@/lib/queries/freezone";
-import { DEFAULT_NODE_WIDTH } from "@/features/canvas/domain/canvasNodes";
-import { withImageCacheBust } from "@/features/canvas/application/imageData";
+import { surfaceAccess, useProductSurfaces } from "@/lib/queries/product-surfaces";
+import {
+  DEFAULT_NODE_WIDTH,
+  EXPORT_RESULT_NODE_MIN_HEIGHT,
+  EXPORT_RESULT_NODE_MIN_WIDTH,
+} from "@/features/canvas/domain/canvasNodes";
+import {
+  resolveImageDisplayUrl,
+  withImageCacheBust,
+} from "@/features/canvas/application/imageData";
+import {
+  aspectRatioFromImageDimensions,
+  resolveMinEdgeFittedSize,
+} from "@/features/canvas/application/imageNodeSizing";
 import {
   CANVAS_ASSET_DRAG_MIME,
   spawnAssetNode,
@@ -155,7 +178,8 @@ const BEAT_SCOPED_LIBRARY_ASSET_ROLES = new Set([
 
 const BEAT_SCOPED_LIBRARY_ASSET_KINDS = new Set(["video", "audio"]);
 
-type PanelTab = "library" | "canvases";
+/** library = 主线资产，canvases = 项目画布，assets = 项目级资产库（只读浏览）。 */
+type PanelTab = "library" | "canvases" | "assets";
 
 interface AssetLibraryPanelProps {
   project: string;
@@ -511,8 +535,26 @@ export function AssetLibraryPanel({
   ];
 
   const [panelTab, setPanelTab] = useState<PanelTab>("canvases");
+  // 后台可以按用户组关掉「虾集(主线)」;关掉后左侧的「主线资产」tab 也要一起隐藏
+  //(「项目画布」保留),否则顶部导航没了虾集、这里却还能翻出主线的资产。
+  // 加载中先按可用处理,与顶部导航一致。
+  const productSurfaces = useProductSurfaces();
+  const mainlineAvailable =
+    surfaceAccess(productSurfaces.data, "mainline")?.available ?? productSurfaces.isPending;
+  useEffect(() => {
+    if (!mainlineAvailable) setPanelTab("canvases");
+  }, [mainlineAvailable]);
+  const panelTabItems: Array<{ id: PanelTab; label: string }> = [
+    { id: "canvases", label: "项目画布" },
+    ...(mainlineAvailable ? [{ id: "library" as const, label: "主线资产" }] : []),
+    { id: "assets", label: "资产库" },
+  ];
   const [tab, setTab] = useState<AssetTab>("beat");
   const [query, setQuery] = useState("");
+  // 侧栏的「资产库」只读，写操作都在弹窗里；tab 条右端常驻一个入口，不管当前停在
+  // 哪个 tab 都能打开。
+  const [assetManagerOpen, setAssetManagerOpen] = useState(false);
+  const queryClient = useQueryClient();
   const hasPresetLabel = hasLegacyPresetCanvasMetadata(metadata);
   // 替换/提交成功后自增,用于强制重新拉取素材列表。
   const [internalReloadToken, setInternalReloadToken] = useState(0);
@@ -738,33 +780,43 @@ export function AssetLibraryPanel({
           }`}
           style={{ width: 300 }}
         >
-          {/* ─ 分段 Tab 栏 ── */}
-          <div className="flex rounded-full border border-white/10 mx-3 mt-4 mb-1.5 p-0.5 gap-0.5">
-            <button
-              type="button"
-              onClick={() => setPanelTab("canvases")}
-              className={`flex-1 py-1.5 text-xs font-medium transition-colors rounded-full ${
-                panelTab === "canvases"
-                  ? "bg-white/[0.08] text-white"
-                  : "text-white/40 hover:text-white/65"
-              }`}
-            >
-              项目画布
-            </button>
-            <button
-              type="button"
-              onClick={() => setPanelTab("library")}
-              className={`flex-1 py-1.5 text-xs font-medium transition-colors rounded-full ${
-                panelTab === "library"
-                  ? "bg-white/[0.08] text-white"
-                  : "text-white/40 hover:text-white/65"
-              }`}
-            >
-              主线资产
-            </button>
-          </div>
+          {/* ─ 面板 Tab 栏 ── 与下面的画布条同一种下划线 tab，后续加新 tab 只往
+              panelTabItems 里塞一项即可 */}
+          <Tabs
+            value={panelTab}
+            onValueChange={(value) => setPanelTab(value as PanelTab)}
+            className="shrink-0 gap-0 px-3 pt-3"
+          >
+            {/* 整行共用一条基线，选中 tab 的下划线正好压在上面 */}
+            <div className="flex items-center gap-1 border-b border-white/[0.07]">
+              <TabsList variant="line" className="gap-0 p-0">
+                {panelTabItems.map((item) => (
+                  <TabsTrigger
+                    key={item.id}
+                    value={item.id}
+                    // after:bottom-0 让下划线落在整行的基线上，而不是浮在下面 5px
+                    className="h-full flex-none rounded-none px-2.5 text-xs group-data-horizontal/tabs:after:bottom-0"
+                  >
+                    {item.label}
+                  </TabsTrigger>
+                ))}
+              </TabsList>
+              <button
+                type="button"
+                onClick={() => setAssetManagerOpen(true)}
+                aria-label="资产管理"
+                title="资产管理"
+                className="group/assets relative ml-auto mb-1.5 inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-[6px] border border-white/[0.10] text-white/60 transition-colors hover:border-white/[0.22] hover:bg-white/[0.06] hover:text-white/90"
+              >
+                <BookOpen className="h-3.5 w-3.5" />
+                <span className="pointer-events-none absolute right-0 top-8 z-20 whitespace-nowrap rounded-[6px] border border-white/10 bg-[#101116]/95 px-2 py-1 text-[11px] font-medium text-white/75 opacity-0 shadow-[0_10px_24px_rgba(0,0,0,0.28)] backdrop-blur-md transition-opacity duration-150 group-hover/assets:opacity-100">
+                  资产管理
+                </span>
+              </button>
+            </div>
+          </Tabs>
 
-          {panelTab === "library" ? (
+          {panelTab === "library" && mainlineAvailable ? (
             <>
               {/* ── 分类标签 + 搜索（固定头部） ── */}
               <div className="sticky top-0 z-10">
@@ -830,6 +882,8 @@ export function AssetLibraryPanel({
                 </div>
               )}
             </>
+          ) : panelTab === "assets" ? (
+            <AssetLibraryBrowser project={project} />
           ) : (
             <CanvasesTab
               project={project}
@@ -842,6 +896,23 @@ export function AssetLibraryPanel({
           )}
         </div>
       </aside>
+
+      {/* 纯管理态：不传 onConfirm，弹窗里选中只是浏览，「确定」等同关闭。关掉后把
+          资产库的两个查询作废，新建的文件夹/上传的素材立刻反映到侧栏。 */}
+      <AssetLibraryModal
+        open={assetManagerOpen}
+        project={project}
+        onSendFolderToCanvas={(folder) => void sendAssetFolderToCanvas(folder)}
+        onClose={() => {
+          setAssetManagerOpen(false);
+          void queryClient.invalidateQueries({
+            queryKey: queryKeys.freezoneAssetLibrary(project),
+          });
+          void queryClient.invalidateQueries({
+            queryKey: queryKeys.freezoneAssetLibraryFolders(project),
+          });
+        }}
+      />
     </AssetReplaceContext.Provider>
   );
 }
@@ -1941,6 +2012,19 @@ function isThreeDAsset(asset: LibraryAsset): boolean {
   return false;
 }
 
+/** 视口中心在画布坐标系里的位置；拿不到视口尺寸时退回原点附近的固定点。 */
+function viewportCenter(
+  store: ReturnType<typeof useCanvasStore.getState>,
+): { x: number; y: number } {
+  const { width, height } = store.canvasViewportSize;
+  if (width <= 0 || height <= 0) return { x: -720, y: 120 };
+  const zoom = Math.max(0.01, store.currentViewport.zoom || 1);
+  return {
+    x: -store.currentViewport.x / zoom + width / (2 * zoom),
+    y: -store.currentViewport.y / zoom + height / (2 * zoom),
+  };
+}
+
 function viewportCenteredPosition(
   store: ReturnType<typeof useCanvasStore.getState>,
   index: number,
@@ -2041,6 +2125,140 @@ function assetToDragPayload(asset: LibraryAsset): CanvasAssetDragPayload | null 
   }
   if (asset.mediaType === "text" || asset.mediaType === "file") return null;
   return { kind: "image", label: asset.label, url: asset.url, aspectRatio: asset.aspectRatio, source: sourceMeta, mainlineContext: mainline };
+}
+
+/** 资产库条目 → 画布节点 payload。库里只有图/视频/音频三种，没有 3D。 */
+function libraryItemToDragPayload(entry: LibraryItem): CanvasAssetDragPayload | null {
+  if (!entry.url) return null;
+  return {
+    kind: entry.media,
+    label: entry.name,
+    url: entry.url,
+    // 溯源信息按需最小化：够 commit / 替换时认出「这是资产库来的」即可，不把整条
+    // 库记录塞进节点(里面还带着 image_urls 之类会过期的字段)。
+    source: {
+      origin: "asset_library",
+      asset_library_id: entry.id,
+      asset_library_folder: entry.folder,
+    },
+  };
+}
+
+/**
+ * 量素材的真实宽高比，给不出就返回 null。
+ *
+ * 资产库的条目只存了 URL，没有尺寸；不带 aspectRatio 建出来的图片/视频节点一律
+ * 按 1:1 铺开，宽图就会上下留两条黑边（节点内是 object-contain）。
+ *
+ * 加载失败或太慢都当量不出来处理——发到画布不该被一张坏图卡住。
+ */
+function measureAspectRatio(payload: CanvasAssetDragPayload): Promise<string | null> {
+  if (payload.kind !== "image" && payload.kind !== "video") return Promise.resolve(null);
+  if (typeof document === "undefined") return Promise.resolve(null);
+  const src = resolveImageDisplayUrl(payload.url);
+  return new Promise((resolve) => {
+    let settled = false;
+    const done = (value: string | null) => {
+      if (settled) return;
+      settled = true;
+      window.clearTimeout(timer);
+      resolve(value);
+    };
+    const timer = window.setTimeout(() => done(null), 4000);
+
+    if (payload.kind === "image") {
+      const image = new Image();
+      image.onload = () =>
+        done(aspectRatioFromImageDimensions(image.naturalWidth, image.naturalHeight));
+      image.onerror = () => done(null);
+      image.src = src;
+      return;
+    }
+
+    const video = document.createElement("video");
+    video.preload = "metadata";
+    video.muted = true;
+    video.onloadedmetadata = () =>
+      done(aspectRatioFromImageDimensions(video.videoWidth, video.videoHeight));
+    video.onerror = () => done(null);
+    video.src = src;
+  });
+}
+
+/**
+ * 节点建出来大概多大——只用来排网格，不写进节点。
+ *
+ * 图片节点的尺寸跟着比例走（最小短边 300），视频和音频节点是各自组件里的固定
+ * 尺寸，这里跟着写一份常量即可：排版差几像素没关系，别让节点压在一起就行。
+ */
+function spawnedNodeSize(payload: CanvasAssetDragPayload): { width: number; height: number } {
+  if (payload.kind === "audio") return { width: 480, height: 210 };
+  if (payload.kind === "video") return { width: 580, height: 380 };
+  return resolveMinEdgeFittedSize(payload.aspectRatio || "1:1", {
+    minWidth: EXPORT_RESULT_NODE_MIN_WIDTH,
+    minHeight: EXPORT_RESULT_NODE_MIN_HEIGHT,
+  });
+}
+
+/**
+ * 把整个文件夹发到画布：素材在视口中心铺成网格，再编成一个组，组名 = 文件夹名。
+ *
+ * 不复用 addAssetToCanvas 的逐个落位——那个函数每次都拿同一份 store 快照做碰撞
+ * 检测，连发多个时新节点互相看不见，会叠在一起。这里一次算好整块网格。
+ *
+ * 网格按每个节点的实际尺寸排（列宽取该列最宽、行高取该行最高），因为节点大小是
+ * 跟着图片比例走的，用一个固定格子会让竖图互相压住。
+ */
+async function sendAssetFolderToCanvas(folder: AssetFolder): Promise<void> {
+  const payloads = folder.items
+    .map(libraryItemToDragPayload)
+    .filter((payload): payload is CanvasAssetDragPayload => payload !== null);
+  if (payloads.length === 0) return;
+
+  const ratios = await Promise.all(payloads.map(measureAspectRatio));
+  const sized = payloads.map((payload, index) => {
+    const withRatio = ratios[index] ? { ...payload, aspectRatio: ratios[index] } : payload;
+    return { payload: withRatio, size: spawnedNodeSize(withRatio) };
+  });
+
+  const GAP = 32;
+  const cols = Math.min(4, Math.ceil(Math.sqrt(sized.length)));
+  const rows = Math.ceil(sized.length / cols);
+  const colWidths = Array.from({ length: cols }, (_, c) =>
+    Math.max(...sized.filter((_, i) => i % cols === c).map((it) => it.size.width)),
+  );
+  const rowHeights = Array.from({ length: rows }, (_, r) =>
+    Math.max(
+      ...sized
+        .filter((_, i) => Math.floor(i / cols) === r)
+        .map((it) => it.size.height),
+    ),
+  );
+  const blockWidth =
+    colWidths.reduce((sum, w) => sum + w, 0) + GAP * (cols - 1);
+  const blockHeight =
+    rowHeights.reduce((sum, h) => sum + h, 0) + GAP * (rows - 1);
+
+  const store = useCanvasStore.getState();
+  const { x: cx, y: cy } = viewportCenter(store);
+  const startX = cx - blockWidth / 2;
+  const startY = cy - blockHeight / 2;
+
+  const ids = sized.map(({ payload }, index) => {
+    const col = index % cols;
+    const row = Math.floor(index / cols);
+    const x =
+      startX + colWidths.slice(0, col).reduce((sum, w) => sum + w + GAP, 0);
+    const y =
+      startY + rowHeights.slice(0, row).reduce((sum, h) => sum + h + GAP, 0);
+    return spawnAssetNode(store, payload, { x, y });
+  });
+
+  // groupNodes 要求 ≥2 个成员，单个素材成不了组、保持独立节点即可。
+  const groupId =
+    ids.length >= 2 ? store.groupNodes(ids, { label: folder.label }) : null;
+  store.requestFocusNode(groupId ?? ids[0]);
+  toast.success(`已发送到画布：${folder.label}`);
 }
 
 function addAssetToCanvas(asset: LibraryAsset, index: number): void {

--- a/frontend/src/lib/queries/freezone.ts
+++ b/frontend/src/lib/queries/freezone.ts
@@ -6,6 +6,11 @@ import {
   listFreezoneBeatContext,
   listFreezoneProjectAssets,
 } from "@/api/projects";
+import {
+  fetchFreezoneAssetLibraryFolders,
+  fetchFreezoneVideoCharacterLibrary,
+} from "@/api/ops";
+import { normalizeLibraryList } from "@/features/canvas/ui/assetLibraryItems";
 import { api } from "@/lib/api";
 import { p } from "@/lib/api-path";
 import { queryKeys } from "@/lib/query-keys";
@@ -100,6 +105,61 @@ export function useFreezoneProjectAssets(
         throw new Error("project is required");
       }
       return listFreezoneProjectAssets(project, { signal });
+    },
+    enabled: enabled && Boolean(project),
+    staleTime: 15_000,
+  });
+}
+
+/**
+ * 资产库（项目级素材库）的只读列表。写操作（上传/删除/从主线同步）仍在
+ * AssetLibraryModal 里走裸调用，这里只负责浏览侧的读取与缓存。
+ */
+export function useFreezoneAssetLibrary(
+  project: string | null | undefined,
+  enabled = true,
+) {
+  return useQuery({
+    queryKey: project
+      ? queryKeys.freezoneAssetLibrary(project)
+      : ["projects", "__missing__", "freezone", "asset-library"],
+    queryFn: async () => {
+      if (!project) {
+        throw new Error("project is required");
+      }
+      return normalizeLibraryList(
+        await fetchFreezoneVideoCharacterLibrary(project),
+      );
+    },
+    enabled: enabled && Boolean(project),
+    staleTime: 15_000,
+  });
+}
+
+/**
+ * 用户自建的资产库文件夹。系统文件夹（主线 / 待分类资产 / 类目同名目录）不落盘，
+ * 由 buildAssetFolders 直接生成，所以这个查询只补自建的那部分。老后端没有该路由
+ * 时按空列表处理，浏览侧照常显示系统文件夹。
+ */
+export function useFreezoneAssetLibraryFolders(
+  project: string | null | undefined,
+  enabled = true,
+) {
+  return useQuery({
+    queryKey: project
+      ? queryKeys.freezoneAssetLibraryFolders(project)
+      : ["projects", "__missing__", "freezone", "asset-library", "folders"],
+    queryFn: async () => {
+      if (!project) {
+        throw new Error("project is required");
+      }
+      try {
+        const folders = await fetchFreezoneAssetLibraryFolders(project);
+        return Array.isArray(folders) ? folders : [];
+      } catch (err) {
+        console.warn("[asset-library] load folders failed, treat as empty", err);
+        return [];
+      }
     },
     enabled: enabled && Boolean(project),
     staleTime: 15_000,

--- a/frontend/src/lib/query-keys.ts
+++ b/frontend/src/lib/query-keys.ts
@@ -102,6 +102,10 @@ export const queryKeys = {
     ["projects", p, "freezone", "canvases"] as const,
   freezoneProjectAssets: (p: string) =>
     ["projects", p, "freezone", "assets"] as const,
+  freezoneAssetLibrary: (p: string) =>
+    ["projects", p, "freezone", "asset-library"] as const,
+  freezoneAssetLibraryFolders: (p: string) =>
+    ["projects", p, "freezone", "asset-library", "folders"] as const,
   freezoneBeatContext: (p: string, episode?: number | null, beat?: number | null) =>
     ["projects", p, "freezone", "beat-context", episode ?? null, beat ?? null] as const,
   styles: (p?: string) =>

--- a/license-inventory.csv
+++ b/license-inventory.csv
@@ -334,6 +334,7 @@ frontend/src/__tests__/components/themed-toaster.test.tsx,Elastic-2.0,2026 Super
 frontend/src/__tests__/components/ui/header-refresh-button.test.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/__tests__/features/canvas/asset-drag-director-bundle.test.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/__tests__/features/canvas/asset-drag-hydrate.test.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
+frontend/src/__tests__/features/canvas/asset-library-modal-categories.test.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/__tests__/features/canvas/audio-music-settings.test.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/__tests__/features/canvas/audio-node-credit-contract.test.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/__tests__/features/canvas/auto-layout.test.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
@@ -420,10 +421,10 @@ frontend/src/__tests__/features/companion/petdex-pets.test.ts,Elastic-2.0,2026 S
 frontend/src/__tests__/features/freezone/asset-library-panel-beat-context.test.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/__tests__/features/freezone/beat-context-projection.test.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/__tests__/features/freezone/canvas-draft-storage.test.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
+frontend/src/__tests__/features/freezone/canvas-outline-list.test.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/__tests__/features/freezone/canvasSaveCoordinator.test.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/__tests__/features/freezone/canvasSyncCore.test.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/__tests__/features/freezone/canvases-tab-query.test.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
-frontend/src/__tests__/features/freezone/canvas-outline-list.test.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/__tests__/features/freezone/canvases-tab.test.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/__tests__/features/freezone/commit-dialog-submit.test.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/__tests__/features/freezone/commit-dialog-targets.test.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
@@ -936,7 +937,11 @@ frontend/src/features/canvas/tools/registry.ts,Elastic-2.0,2026 SuperTale contri
 frontend/src/features/canvas/tools/types.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/features/canvas/trackpad-pan/trackpadPanStore.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/features/canvas/ui/AssetCommitHandle.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
+frontend/src/features/canvas/ui/AssetLibraryFolderCoverDialog.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
+frontend/src/features/canvas/ui/AssetLibraryItemMedia.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/features/canvas/ui/AssetLibraryModal.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
+frontend/src/features/canvas/ui/AssetLibraryNewFolderDialog.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
+frontend/src/features/canvas/ui/AssetLibraryUploadDialog.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/features/canvas/ui/AudioWaveformPlayer.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/features/canvas/ui/BackToNodesHint.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/features/canvas/ui/BackgroundCropperDialog.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
@@ -993,6 +998,7 @@ frontend/src/features/canvas/ui/UpscaleEditorOverlay.tsx,Elastic-2.0,2026 SuperT
 frontend/src/features/canvas/ui/VideoUpscaleEditorOverlay.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/features/canvas/ui/VideoViewerModal.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/features/canvas/ui/ZoomScaledToolbar.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
+frontend/src/features/canvas/ui/assetLibraryItems.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/features/canvas/ui/canvas-node-menu-shared.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/features/canvas/ui/canvasControlStyles.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/features/canvas/ui/canvasToolStore.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
@@ -1023,6 +1029,7 @@ frontend/src/features/companion/petdex/petdex-storage.ts,Elastic-2.0,2026 SuperT
 frontend/src/features/companion/piko-accessories.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/features/companion/piko-festivals.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/features/companion/use-mybuddy-companion-controller.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
+frontend/src/features/freezone/AssetLibraryBrowser.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/features/freezone/AssetLibraryPanel.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/features/freezone/CanvasDebugPanel.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/features/freezone/CanvasOutlineList.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
@@ -1489,8 +1496,8 @@ src/novelvideo/models.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggr
 src/novelvideo/newapi_provisioner.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 src/novelvideo/novel_source.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 src/novelvideo/official_defaults.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
-src/novelvideo/official_media_catalog_schema.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 src/novelvideo/official_media_catalog_remote.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
+src/novelvideo/official_media_catalog_schema.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 src/novelvideo/official_media_models.json,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 src/novelvideo/ports/__init__.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 src/novelvideo/ports/audit.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
@@ -1850,9 +1857,9 @@ tests/test_project_embedding_models.py,Elastic-2.0,2026 SuperTale contributors,R
 tests/test_project_id_route_paths.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_project_spine_template.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_project_static_media.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
-tests/test_publish_official_media_catalog.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_project_task_routes.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_prompt_style_ethnicity_layering.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
+tests/test_publish_official_media_catalog.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_ref_image_hash.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_release_feed.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_render_auto_repair_removed.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation

--- a/license-inventory.csv
+++ b/license-inventory.csv
@@ -1727,6 +1727,7 @@ tests/test_api_compose_export_contract.py,Elastic-2.0,2026 SuperTale contributor
 tests/test_api_config_runtime.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_api_coverage.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_api_episode_detail.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
+tests/test_api_freezone_asset_library_folders.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_api_freezone_canvas_from_preset.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_api_freezone_projection.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_api_generation_sketches.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation

--- a/src/novelvideo/api/routes/freezone.py
+++ b/src/novelvideo/api/routes/freezone.py
@@ -7835,7 +7835,8 @@ async def freezone_update_asset_library_folder(
         except ValueError as exc:
             raise HTTPException(400, str(exc)) from exc
         if not cover_path.exists():
-            raise HTTPException(404, f"cover not found: {cover_path}")
+            # 只回传进来的 URL：cover_path 是绝对路径，带用户名和落盘目录。
+            raise HTTPException(404, f"cover not found: {body.cover}")
     try:
         folder = update_video_character_folder(
             project_dir, folder_id, name=body.name, cover=body.cover
@@ -7856,7 +7857,11 @@ async def freezone_delete_asset_library_folder(
     folder_id: str,
     user: dict = Depends(get_api_user),
 ):
-    """视频处理：删掉一个自建文件夹，连同落在它里面的素材条目一起删。"""
+    """视频处理：删掉一个自建文件夹，柜内素材条目一并从资产库移除。
+
+    只删索引，磁盘上的素材文件保留——画布节点可能还引用着同一个 URL，真删文件会
+    造成裂图。孤儿文件归项目级清理负责，不在这条路由的职责里。
+    """
     _ctx, _username, _project_name, project_dir, _output_dir = await _resolve_freezone_project(
         project, user
     )

--- a/src/novelvideo/api/routes/freezone.py
+++ b/src/novelvideo/api/routes/freezone.py
@@ -38,6 +38,8 @@ from novelvideo.api.schemas import (
     CreateIdentityAssetRequest,
     FreezoneAnalyzeShotsRequest,
     FreezoneAnalyzeVideoStoryRequest,
+    FreezoneAssetLibraryFolderPatchRequest,
+    FreezoneAssetLibraryFolderRequest,
     FreezoneAudioMusicRequest,
     FreezoneAudioSeparateRequest,
     FreezoneAudioSpeechRequest,
@@ -241,17 +243,22 @@ from novelvideo.freezone.text_node import (
     translate_freezone_text,
 )
 from novelvideo.freezone.video_node import (
+    MAINLINE_FOLDER_KEY,
+    add_video_character_folder,
     add_video_character_library_item,
     build_freezone_image_to_video_prompt,
     build_freezone_keyframe_video_prompt,
     build_freezone_omni_video_prompt,
     build_freezone_video_prompt,
+    delete_video_character_folder,
     delete_video_character_library_item,
     get_freezone_video_model_options,
     get_video_camera_template,
     get_video_camera_templates,
     is_freezone_happyhorse_backend,
     is_freezone_seedance2_backend,
+    library_folder_keys,
+    load_video_character_folders,
     load_video_character_library,
     sync_mainline_assets_into_library,
     normalize_freezone_seedance2_scene_optimize,
@@ -260,6 +267,7 @@ from novelvideo.freezone.video_node import (
     normalize_video_resolution_for_backend,
     resolve_freezone_video_backend,
     summarize_omni_reference_counts,
+    update_video_character_folder,
     validate_omni_reference_audio_durations,
     validate_omni_reference_limits,
     MAX_OMNI_REFERENCE_AUDIO_SECONDS,
@@ -7749,6 +7757,13 @@ async def freezone_add_video_character_library_item(
         for url in body.image_urls:
             _require_local(url, "image")
 
+    # 保存位置必须是已存在的文件夹；主线是同步产物，不接受上传。
+    if body.folder:
+        if body.folder == MAINLINE_FOLDER_KEY:
+            raise HTTPException(400, "cannot upload into the mainline folder")
+        if body.folder not in library_folder_keys(project_dir):
+            raise HTTPException(404, f"folder not found: {body.folder}")
+
     item = add_video_character_library_item(
         project_dir,
         name=body.name,
@@ -7756,8 +7771,99 @@ async def freezone_add_video_character_library_item(
         image_urls=body.image_urls,
         video_url=body.video_url,
         audio_url=body.audio_url,
+        category=body.category,
+        folder=body.folder,
     )
     return {"ok": True, "data": item}
+
+
+@router.get(
+    "/projects/{project}/freezone/video/asset-library/folders",
+    tags=[TAG_FREEZONE_VIDEO],
+)
+async def freezone_asset_library_folders(
+    project: str,
+    user: dict = Depends(get_api_user),
+):
+    """视频处理：列出用户自建的资产库文件夹（系统文件夹由前端按保留 key 生成）。"""
+    _ctx, _username, _project_name, project_dir, _output_dir = await _resolve_freezone_project(
+        project, user, required_role="viewer"
+    )
+    return {"ok": True, "data": load_video_character_folders(project_dir)}
+
+
+@router.post(
+    "/projects/{project}/freezone/video/asset-library/folders",
+    tags=[TAG_FREEZONE_VIDEO],
+)
+async def freezone_add_asset_library_folder(
+    project: str,
+    body: FreezoneAssetLibraryFolderRequest,
+    user: dict = Depends(get_api_user),
+):
+    """视频处理：新建一个资产库文件夹。"""
+    _ctx, _username, _project_name, project_dir, _output_dir = await _resolve_freezone_project(
+        project, user
+    )
+    try:
+        folder = add_video_character_folder(project_dir, name=body.name)
+    except ValueError as exc:
+        raise HTTPException(400, str(exc)) from exc
+    return {"ok": True, "data": folder}
+
+
+@router.patch(
+    "/projects/{project}/freezone/video/asset-library/folders/{folder_id}",
+    tags=[TAG_FREEZONE_VIDEO],
+)
+async def freezone_update_asset_library_folder(
+    project: str,
+    folder_id: str,
+    body: FreezoneAssetLibraryFolderPatchRequest,
+    user: dict = Depends(get_api_user),
+):
+    """视频处理：给资产库文件夹改名或换封面。系统文件夹没有实体记录，一律 404。"""
+    _ctx, _username, _project_name, project_dir, _output_dir = await _resolve_freezone_project(
+        project, user
+    )
+    if body.cover:
+        # 封面只能是本项目 static 下的素材。这个字段会被所有打开资产库的协作者当
+        # <img src> 渲染，放行外链等于让别人的浏览器替你去访问第三方地址（referrer
+        # 和 IP 都带过去）。和录入素材那条路由的 _require_local 同一套要求。
+        try:
+            cover_path = resolve_static_url_to_path(body.cover, project_dir)
+        except ValueError as exc:
+            raise HTTPException(400, str(exc)) from exc
+        if not cover_path.exists():
+            raise HTTPException(404, f"cover not found: {cover_path}")
+    try:
+        folder = update_video_character_folder(
+            project_dir, folder_id, name=body.name, cover=body.cover
+        )
+    except ValueError as exc:
+        raise HTTPException(400, str(exc)) from exc
+    if folder is None:
+        raise HTTPException(404, f"folder not found: {folder_id}")
+    return {"ok": True, "data": folder}
+
+
+@router.delete(
+    "/projects/{project}/freezone/video/asset-library/folders/{folder_id}",
+    tags=[TAG_FREEZONE_VIDEO],
+)
+async def freezone_delete_asset_library_folder(
+    project: str,
+    folder_id: str,
+    user: dict = Depends(get_api_user),
+):
+    """视频处理：删掉一个自建文件夹，连同落在它里面的素材条目一起删。"""
+    _ctx, _username, _project_name, project_dir, _output_dir = await _resolve_freezone_project(
+        project, user
+    )
+    removed = delete_video_character_folder(project_dir, folder_id)
+    if removed is None:
+        raise HTTPException(404, f"folder not found: {folder_id}")
+    return {"ok": True, "data": {"deleted_items": removed}}
 
 
 @router.post(

--- a/src/novelvideo/api/schemas.py
+++ b/src/novelvideo/api/schemas.py
@@ -1003,6 +1003,34 @@ class FreezoneVideoCharacterLibraryItemRequest(BaseModel):
         default=None,
         description="音频静态地址（media=audio 时必填）",
     )
+    category: Literal["other", "character", "scene", "prop", "style", "audio"] | None = Field(
+        default=None,
+        description="用途类目（其它/人物/场景/物品/风格/音效）；不传时后端按 source/media 兜底推导",
+    )
+    folder: str | None = Field(
+        default=None,
+        description=(
+            "保存位置：系统文件夹 key（其它/人物/场景/物品/风格/音效同名，"
+            "对应 other/character/scene/prop/style/audio）或用户自建文件夹 id；"
+            "不传时按类目落到同名系统文件夹"
+        ),
+    )
+
+
+class FreezoneAssetLibraryFolderRequest(BaseModel):
+    """新建资产库文件夹请求。文件夹只管保存位置，和素材的类目标签互不影响。"""
+
+    name: str = Field(description="文件夹名称，最长 20 字，不能与系统文件夹重名")
+
+
+class FreezoneAssetLibraryFolderPatchRequest(BaseModel):
+    """改文件夹。两个字段都可选，只改传上来的那个。"""
+
+    name: str | None = Field(default=None, description="新名称；不传表示不改名")
+    cover: str | None = Field(
+        default=None,
+        description="封面图 URL，取自该文件夹内的素材；传空串表示清掉封面",
+    )
 
 
 class FreezoneVideoGenRequest(BaseModel):

--- a/src/novelvideo/freezone/paths.py
+++ b/src/novelvideo/freezone/paths.py
@@ -68,11 +68,22 @@ def resolve_static_url_to_path(url: str, project_dir: Path) -> Path:
     """Map a same-origin static URL to a local file path.
 
     Falls back to interpreting the input as a project-relative path. Raises
-    ValueError if the resolved path escapes `project_dir`.
+    ValueError if the input is not same-origin, or if the resolved path
+    escapes `project_dir`.
     """
+    parts = urlsplit(url)
+    # 只接受同源引用。带 scheme/netloc 的外链在下一行会被削成 path，攻击者只要把
+    # 自己上传素材的真实路径拼在自己的域名后面，削出来的 path 就落在项目里、校验
+    # 照过——而调用方放行后存/回显的是原始字符串（文件夹封面、素材 URL 都是这样），
+    # 于是外链就进了所有协作者的 <img src>。所以要校验整个字符串，不是削剩的 path。
+    if parts.scheme or parts.netloc:
+        raise ValueError(f"url must be a same-origin path: {url!r}")
+    # 浏览器把 `/\host` 和 `\\host` 等同于协议相对外链，urlsplit 却当普通 path。
+    if "\\" in url:
+        raise ValueError(f"url must be a same-origin path: {url!r}")
     # Strip query string + fragment — frontend cache-busters like `?v=<ts>`
     # must not become part of the filesystem path.
-    url = urlsplit(url).path or url
+    url = parts.path or url
     candidate: Path
     if url.startswith("/static/"):
         m = _STATIC_RE.match(url)

--- a/src/novelvideo/freezone/video_node.py
+++ b/src/novelvideo/freezone/video_node.py
@@ -669,6 +669,174 @@ def save_video_character_library(project_dir: Path, items: list[dict[str, Any]])
     path.write_text(json.dumps(items, ensure_ascii=False, indent=2), encoding="utf-8")
 
 
+LIBRARY_CATEGORIES = ("other", "character", "scene", "prop", "style", "audio")
+
+# 资产库目录树。文件夹（保存位置）和类目（标签）是两个独立维度：类目只管
+# 「这素材是干嘛的」，文件夹管「它放在哪」。系统文件夹两个——主线同步来的一律
+# 收进 mainline；本地上传缺省落在 other（前端显示为「待分类资产」）。类目 key
+# 同时充当同名系统文件夹的 key，这样老条目（没有 folder 字段）按类目归位即可，
+# 不需要数据迁移。用户新建的文件夹用随机 id，不会和这些保留 key 撞上。
+MAINLINE_FOLDER_KEY = "mainline"
+RESERVED_FOLDER_KEYS = (MAINLINE_FOLDER_KEY, *LIBRARY_CATEGORIES)
+# 与前端 assetLibraryItems.ts 的系统文件夹名保持一致，防止用户建出同名文件夹。
+RESERVED_FOLDER_NAMES = ("主线", "待分类资产", "其它", "人物", "场景", "物品", "风格", "音效")
+FOLDER_NAME_MAX_LEN = 20
+
+
+def video_character_folders_path(project_dir: Path) -> Path:
+    return freezone_root(project_dir) / "video_character_folders.json"
+
+
+def load_video_character_folders(project_dir: Path) -> list[dict[str, Any]]:
+    """读用户自建的资产库文件夹（系统文件夹不落盘，由前端按保留 key 生成）。"""
+    path = video_character_folders_path(project_dir)
+    if not path.exists():
+        return []
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return []
+    if not isinstance(data, list):
+        return []
+    return [item for item in data if isinstance(item, dict) and item.get("id")]
+
+
+def save_video_character_folders(project_dir: Path, folders: list[dict[str, Any]]) -> None:
+    path = video_character_folders_path(project_dir)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(folders, ensure_ascii=False, indent=2), encoding="utf-8")
+
+
+def add_video_character_folder(project_dir: Path, *, name: str) -> dict[str, Any]:
+    """新建一个资产库文件夹。重名（含系统文件夹名）直接拒绝，避免目录里两个同名项。"""
+    clean = name.strip()
+    folders = load_video_character_folders(project_dir)
+    _validate_folder_name(clean, folders)
+    folder = {
+        "id": uuid.uuid4().hex[:12],
+        "name": clean,
+        "created_at": datetime.now().isoformat(),
+    }
+    folders.append(folder)
+    save_video_character_folders(project_dir, folders)
+    return folder
+
+
+def _validate_folder_name(clean: str, folders: list[dict[str, Any]], *, skip_id: str = "") -> None:
+    """新建/重命名共用的一套校验：非空、不超长、不撞系统名、不与其它文件夹重名。"""
+    if not clean:
+        raise ValueError("folder name is required")
+    if len(clean) > FOLDER_NAME_MAX_LEN:
+        raise ValueError(f"folder name must be <= {FOLDER_NAME_MAX_LEN} characters")
+    if clean in RESERVED_FOLDER_NAMES:
+        raise ValueError(f"folder name is reserved: {clean}")
+    for folder in folders:
+        if skip_id and str(folder.get("id")) == skip_id:
+            continue
+        if str(folder.get("name") or "").strip() == clean:
+            raise ValueError(f"folder already exists: {clean}")
+
+
+def update_video_character_folder(
+    project_dir: Path,
+    folder_id: str,
+    *,
+    name: str | None = None,
+    cover: str | None = None,
+) -> dict[str, Any] | None:
+    """改名 / 换封面。只动传进来的字段，两者都不传视作空操作。
+
+    封面存的是素材本身的 URL（前端从文件夹里挑一张），所以不需要额外的文件管理；
+    素材被删掉后封面会指向失效 URL，前端按缺省封面渲染即可。
+    """
+    folders = load_video_character_folders(project_dir)
+    target = next((f for f in folders if str(f.get("id")) == folder_id), None)
+    if target is None:
+        return None
+    if name is not None:
+        clean = name.strip()
+        _validate_folder_name(clean, folders, skip_id=folder_id)
+        target["name"] = clean
+    if cover is not None:
+        target["cover"] = cover.strip() or None
+    save_video_character_folders(project_dir, folders)
+    return target
+
+
+def delete_video_character_folder(project_dir: Path, folder_id: str) -> int | None:
+    """整柜清空：删掉文件夹本身，连同落在里面的素材条目。
+
+    返回被删掉的素材条数；文件夹不存在时返回 ``None``。系统文件夹（主线/类目同名
+    目录）不落盘，也就永远走不到这里——路由层按 id 找不到直接 404。
+    """
+    folders = load_video_character_folders(project_dir)
+    kept_folders = [f for f in folders if str(f.get("id")) != folder_id]
+    if len(kept_folders) == len(folders):
+        return None
+    items = load_video_character_library(project_dir)
+    kept_items = [item for item in items if str(item.get("folder") or "") != folder_id]
+    removed = len(items) - len(kept_items)
+    if removed:
+        save_video_character_library(project_dir, kept_items)
+    save_video_character_folders(project_dir, kept_folders)
+    return removed
+
+
+def library_folder_keys(project_dir: Path) -> set[str]:
+    """当前可用作「保存位置」的文件夹 key：系统保留 key + 用户自建文件夹 id。"""
+    keys = set(RESERVED_FOLDER_KEYS)
+    for folder in load_video_character_folders(project_dir):
+        keys.add(str(folder.get("id")))
+    return keys
+
+
+def _resolve_library_folder(
+    folder: str | None,
+    *,
+    existing: dict[str, Any] | None,
+    source: str,
+    category: str,
+) -> str:
+    """定出条目落在哪个文件夹，与前端 assetLibraryItems.ts 的归位逻辑保持一致。
+
+    显式指定优先；其次沿用条目已有的位置（重复同步/重复登记不能把用户挪好的
+    位置冲掉）；最后兜底——主线同步来的进 mainline，本地上传按类目进同名系统
+    文件夹（没归类的就是 other，即「待分类资产」）。
+    """
+    if folder:
+        return str(folder)
+    if existing is not None:
+        kept = existing.get("folder")
+        if kept:
+            return str(kept)
+    if source != "upload":
+        return MAINLINE_FOLDER_KEY
+    return category
+
+
+def _resolve_library_category(
+    category: str | None,
+    *,
+    existing: dict[str, Any] | None,
+    source: str,
+    media: str,
+) -> str:
+    """定出条目的用途类目，与前端 assetLibraryItems.ts 的 deriveCategory 保持一致。
+
+    优先用显式传入的类目；其次沿用条目已有的类目（主线重复同步不能把用户归好的
+    类冲掉）；最后按来源/媒介兜底——人物/场景/道具对号入座，音频归音效，其余归其它。
+    """
+    if category in LIBRARY_CATEGORIES:
+        return str(category)
+    if existing is not None:
+        kept = existing.get("category")
+        if kept in LIBRARY_CATEGORIES:
+            return str(kept)
+    if source in ("character", "scene", "prop"):
+        return source
+    return "audio" if media == "audio" else "other"
+
+
 def _upsert_library_item(
     items: list[dict[str, Any]],
     *,
@@ -679,6 +847,8 @@ def _upsert_library_item(
     video_url: str | None,
     audio_url: str | None,
     item_id: str | None,
+    category: str | None = None,
+    folder: str | None = None,
 ) -> dict[str, Any]:
     """纯内存 upsert：按 id 就地更新或追加 ``items``，返回写入的条目。
 
@@ -697,11 +867,18 @@ def _upsert_library_item(
         (i for i, it in enumerate(items) if it.get("id") == resolved_id), None
     )
     existing = items[existing_idx] if existing_idx is not None else None
+    resolved_category = _resolve_library_category(
+        category, existing=existing, source=source, media=media
+    )
     item = {
         "id": resolved_id,
         "name": name.strip(),
         "media": media,
         "source": source,
+        "category": resolved_category,
+        "folder": _resolve_library_folder(
+            folder, existing=existing, source=source, category=resolved_category
+        ),
         "image_urls": urls,
         "video_url": video_url,
         "audio_url": audio_url,
@@ -726,11 +903,15 @@ def add_video_character_library_item(
     video_url: str | None = None,
     audio_url: str | None = None,
     item_id: str | None = None,
+    category: str | None = None,
+    folder: str | None = None,
 ) -> dict[str, Any]:
     """把一条素材登记到资产库。
 
     图片走 ``image_urls``，视频/音频走 ``video_url`` / ``audio_url``。``item_id``
     非空时按 id upsert（主线同步用稳定合成 id，重复同步是更新而非新增）。
+    ``category`` 是用途类目（标签），``folder`` 是保存位置，两者互不影响，缺省时
+    分别按来源/媒介、按类目兜底推导。
     """
     items = load_video_character_library(project_dir)
     item = _upsert_library_item(
@@ -742,6 +923,8 @@ def add_video_character_library_item(
         video_url=video_url,
         audio_url=audio_url,
         item_id=item_id,
+        category=category,
+        folder=folder,
     )
     save_video_character_library(project_dir, items)
     return item
@@ -782,6 +965,7 @@ def sync_mainline_assets_into_library(
             media=media,
             source=str(asset.get("source") or "upload"),
             item_id=str(asset.get("id") or "") or None,
+            category=str(asset.get("category") or "") or None,
             image_urls=[url] if media == "image" else None,
             video_url=url if media == "video" else None,
             audio_url=url if media == "audio" else None,

--- a/tests/test_api_freezone_asset_library_folders.py
+++ b/tests/test_api_freezone_asset_library_folders.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture()
+def folders_client(monkeypatch, tmp_path):
+    from novelvideo.api.auth import get_api_user
+    from novelvideo.api.routes import freezone
+
+    project_dir = tmp_path / "project"
+    project_dir.mkdir(parents=True, exist_ok=True)
+
+    ctx = SimpleNamespace(
+        project_id="proj_demo",
+        owner_username="alice",
+        project_name="demo",
+        output_dir=str(project_dir),
+        state_dir=str(project_dir),
+        runtime_dir=str(project_dir / "_runtime"),
+        is_home_node=True,
+    )
+
+    async def fake_resolve(project: str, user: dict, *, required_role: str = "editor"):
+        return ctx, "alice", "demo", project_dir, str(project_dir)
+
+    monkeypatch.setattr(freezone, "_resolve_freezone_project", fake_resolve)
+
+    app = FastAPI()
+    app.include_router(freezone.router, prefix="/api/v1")
+    app.dependency_overrides[get_api_user] = lambda: {
+        "id": "u-alice",
+        "username": "alice",
+    }
+    return TestClient(app), project_dir
+
+
+_FOLDERS = "/api/v1/projects/proj_demo/freezone/video/asset-library/folders"
+
+
+def _new_folder(client: TestClient, name: str = "第一集素材") -> str:
+    response = client.post(_FOLDERS, json={"name": name})
+    assert response.status_code == 200, response.text
+    return str(response.json()["data"]["id"])
+
+
+def _cover(client: TestClient, folder_id: str) -> str | None:
+    response = client.get(_FOLDERS)
+    assert response.status_code == 200, response.text
+    for folder in response.json()["data"]:
+        if str(folder["id"]) == folder_id:
+            return folder.get("cover")
+    raise AssertionError(f"folder {folder_id} missing from listing")
+
+
+def test_folder_cover_accepts_same_origin_asset(folders_client) -> None:
+    client, project_dir = folders_client
+    asset = project_dir / "freezone" / "_uploads" / "封面.png"
+    asset.parent.mkdir(parents=True)
+    asset.write_bytes(b"png")
+    folder_id = _new_folder(client)
+
+    response = client.patch(
+        f"{_FOLDERS}/{folder_id}",
+        json={"cover": "/freezone/_uploads/%E5%B0%81%E9%9D%A2.png"},
+    )
+
+    assert response.status_code == 200, response.text
+    assert _cover(client, folder_id) == "/freezone/_uploads/%E5%B0%81%E9%9D%A2.png"
+
+
+@pytest.mark.parametrize(
+    "cover",
+    [
+        "https://evil.example/freezone/_uploads/foo.png",
+        "//evil.example/freezone/_uploads/foo.png",
+        "/\\evil.example/freezone/_uploads/foo.png",
+    ],
+)
+def test_folder_cover_rejects_cross_origin_url(folders_client, cover: str) -> None:
+    """封面是所有协作者的 <img src>，外链等于让别人的浏览器去访问第三方地址。
+
+    攻击者用自己上传素材的真实路径拼在外链域名后面，削出来的 path 是落在项目里
+    的——所以校验必须看整个字符串，且落库的要和校验过的是同一个值。
+    """
+    client, project_dir = folders_client
+    decoy = project_dir / "freezone" / "_uploads" / "foo.png"
+    decoy.parent.mkdir(parents=True)
+    decoy.write_bytes(b"png")
+    folder_id = _new_folder(client)
+
+    response = client.patch(f"{_FOLDERS}/{folder_id}", json={"cover": cover})
+
+    assert response.status_code == 400, response.text
+    assert _cover(client, folder_id) in (None, "")
+
+
+def test_folder_cover_missing_file_does_not_leak_server_path(folders_client) -> None:
+    client, project_dir = folders_client
+    folder_id = _new_folder(client)
+
+    response = client.patch(
+        f"{_FOLDERS}/{folder_id}",
+        json={"cover": "/freezone/_uploads/nope.png"},
+    )
+
+    assert response.status_code == 404, response.text
+    detail = str(response.json().get("detail", ""))
+    assert str(project_dir) not in detail
+    assert "/freezone/_uploads/nope.png" in detail

--- a/tests/test_freezone_paths.py
+++ b/tests/test_freezone_paths.py
@@ -46,3 +46,30 @@ def test_resolve_static_url_still_rejects_escaped_encoded_paths(tmp_path: Path) 
             "/static/projects/proj_123/%2E%2E/secret.png",
             project_dir,
         )
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://evil.example/freezone/_uploads/foo.png",
+        "http://evil.example/static/projects/proj_123/a.png",
+        "//evil.example/freezone/_uploads/foo.png",
+        "javascript:alert(1)",
+        "data:image/svg+xml;base64,PHN2Zy8+",
+        # 浏览器把 `/\` 当成 `//` 处理，等价于协议相对外链。
+        "/\\evil.example/freezone/_uploads/foo.png",
+    ],
+)
+def test_resolve_static_url_rejects_cross_origin_urls(tmp_path: Path, url: str) -> None:
+    """外链不能靠「path 部分恰好落在项目内」蒙混过关。
+
+    调用方拿校验结果放行、却把原始字符串存下来（文件夹封面就是这样），
+    所以这里必须校验整个字符串，不能只看削出来的 path。
+    """
+    project_dir = tmp_path / "project"
+    decoy = project_dir / "freezone" / "_uploads" / "foo.png"
+    decoy.parent.mkdir(parents=True)
+    decoy.write_bytes(b"png")
+
+    with pytest.raises(ValueError, match="same-origin"):
+        resolve_static_url_to_path(url, project_dir)

--- a/tests/test_freezone_video_backend.py
+++ b/tests/test_freezone_video_backend.py
@@ -14,7 +14,12 @@ from novelvideo.generators.video_generator import (
 from novelvideo.generators.video_generator import VideoGenResult, VideoGenStatus
 from novelvideo.video_duration import video_duration_bounds_for_backend
 from novelvideo.freezone.video_node import (
+    RESERVED_FOLDER_KEYS,
+    add_video_character_folder,
+    delete_video_character_folder,
     add_video_character_library_item,
+    library_folder_keys,
+    update_video_character_folder,
     build_freezone_image_to_video_prompt,
     build_freezone_keyframe_video_prompt,
     build_freezone_omni_video_prompt,
@@ -32,6 +37,7 @@ from novelvideo.freezone.video_node import (
     normalize_video_resolution_for_backend,
     resolve_freezone_video_backend,
     summarize_omni_reference_counts,
+    sync_mainline_assets_into_library,
     validate_omni_reference_audio_durations,
     validate_omni_reference_limits,
 )
@@ -75,6 +81,150 @@ def test_video_character_library_roundtrip(tmp_path: Path) -> None:
     deleted = delete_video_character_library_item(project_dir, item["id"])
     assert deleted is True
     assert load_video_character_library(project_dir) == []
+
+
+def test_video_character_library_category(tmp_path: Path) -> None:
+    project_dir = tmp_path / "project"
+
+    # 不传类目时按来源/媒介兜底：本地上传的图片归「其它」，音频归「音效」。
+    plain = add_video_character_library_item(
+        project_dir, name="参考图", image_urls=["/static/a.png"]
+    )
+    assert plain["category"] == "other"
+    bgm = add_video_character_library_item(
+        project_dir, name="脚步声", media="audio", audio_url="/static/step.mp3"
+    )
+    assert bgm["category"] == "audio"
+
+    styled = add_video_character_library_item(
+        project_dir, name="赛博霓虹", image_urls=["/static/b.png"], category="style"
+    )
+    assert styled["category"] == "style"
+
+    # 主线同步按 source 归类，且不会把已经归好的类目冲掉。
+    sync_mainline_assets_into_library(
+        project_dir,
+        assets=[
+            {
+                "id": "mainline:scene:厨房",
+                "name": "厨房",
+                "media": "image",
+                "source": "scene",
+                "url": "/static/kitchen.png",
+            },
+            {
+                "id": styled["id"],
+                "name": "赛博霓虹",
+                "media": "image",
+                "source": "upload",
+                "url": "/static/b.png",
+            },
+        ],
+    )
+    items = {str(it["id"]): it for it in load_video_character_library(project_dir)}
+    assert items["mainline:scene:厨房"]["category"] == "scene"
+    assert items[styled["id"]]["category"] == "style"
+
+
+def test_video_character_library_folder(tmp_path: Path) -> None:
+    project_dir = tmp_path / "project"
+
+    # 不传保存位置时按类目落到同名系统文件夹，主线同步来的一律进 mainline。
+    plain = add_video_character_library_item(
+        project_dir, name="参考图", image_urls=["/static/a.png"]
+    )
+    assert plain["folder"] == "other"
+    styled = add_video_character_library_item(
+        project_dir, name="赛博霓虹", image_urls=["/static/b.png"], category="style"
+    )
+    assert styled["folder"] == "style"
+
+    # 文件夹和标签是两个独立维度：可以放进自建文件夹、同时打「人物」标签。
+    folder = add_video_character_folder(project_dir, name="第一集素材")
+    assert folder["name"] == "第一集素材"
+    assert folder["id"] not in RESERVED_FOLDER_KEYS
+    assert folder["id"] in library_folder_keys(project_dir)
+
+    filed = add_video_character_library_item(
+        project_dir,
+        name="女主定妆",
+        image_urls=["/static/c.png"],
+        category="character",
+        folder=folder["id"],
+    )
+    assert filed["folder"] == folder["id"]
+    assert filed["category"] == "character"
+
+    # 重名（含系统文件夹名）建不出来。
+    with pytest.raises(ValueError):
+        add_video_character_folder(project_dir, name="第一集素材")
+    with pytest.raises(ValueError):
+        add_video_character_folder(project_dir, name="待分类资产")
+    with pytest.raises(ValueError):
+        add_video_character_folder(project_dir, name="x" * 21)
+
+    # 主线同步不会把用户挪好的位置冲掉。
+    sync_mainline_assets_into_library(
+        project_dir,
+        assets=[
+            {
+                "id": "mainline:scene:厨房",
+                "name": "厨房",
+                "media": "image",
+                "source": "scene",
+                "url": "/static/kitchen.png",
+            },
+            {
+                "id": filed["id"],
+                "name": "女主定妆",
+                "media": "image",
+                "source": "upload",
+                "url": "/static/c.png",
+            },
+        ],
+    )
+    items = {str(it["id"]): it for it in load_video_character_library(project_dir)}
+    assert items["mainline:scene:厨房"]["folder"] == "mainline"
+    assert items[filed["id"]]["folder"] == folder["id"]
+
+
+def test_video_character_folder_update_and_delete(tmp_path: Path) -> None:
+    project_dir = tmp_path / "project"
+    folder = add_video_character_folder(project_dir, name="第一集素材")
+    other = add_video_character_folder(project_dir, name="第二集素材")
+
+    # 改名 / 换封面互不影响：只传一个字段时另一个原样保留。
+    renamed = update_video_character_folder(project_dir, folder["id"], name="第一集")
+    assert renamed is not None and renamed["name"] == "第一集"
+    covered = update_video_character_folder(
+        project_dir, folder["id"], cover="/static/c.png"
+    )
+    assert covered is not None
+    assert covered["cover"] == "/static/c.png"
+    assert covered["name"] == "第一集"
+
+    # 改名走的是和新建同一套校验；改成自己现在的名字不算重名。
+    assert update_video_character_folder(project_dir, folder["id"], name="第一集")
+    with pytest.raises(ValueError):
+        update_video_character_folder(project_dir, folder["id"], name="第二集素材")
+    with pytest.raises(ValueError):
+        update_video_character_folder(project_dir, folder["id"], name="主线")
+    assert update_video_character_folder(project_dir, "nope", name="随便") is None
+
+    inside = add_video_character_library_item(
+        project_dir, name="女主定妆", image_urls=["/static/c.png"], folder=folder["id"]
+    )
+    outside = add_video_character_library_item(
+        project_dir, name="路人", image_urls=["/static/d.png"], folder=other["id"]
+    )
+
+    # 整柜清空：文件夹和里面的素材一起没，别的文件夹不受牵连。
+    assert delete_video_character_folder(project_dir, folder["id"]) == 1
+    assert folder["id"] not in library_folder_keys(project_dir)
+    remaining = {str(it["id"]) for it in load_video_character_library(project_dir)}
+    assert inside["id"] not in remaining
+    assert outside["id"] in remaining
+    assert delete_video_character_folder(project_dir, folder["id"]) is None
 
 
 def test_video_ratio_and_resolution_normalization() -> None:


### PR DESCRIPTION
## 做了什么

资产库原来只有一个平铺的网格，素材一多就找不着。这一版把它拆成两个正交的维度：

- **类目（标签）**：其它 / 人物 / 场景 / 物品 / 风格 / 音效。不再按媒介切，同一个类目下图片、视频、音频都可能有。
- **文件夹（保存位置）**：主线（同步产物，只读）、与类目同名的系统文件夹（有内容才出现）、用户自建文件夹。

老条目缺 `category` / `folder` 字段时分别由 `deriveCategory` / `deriveFolder` 兜底推导，**不需要数据迁移**。

## 后端

新增自建文件夹的四条路由（`/projects/{project}/freezone/video/asset-library/folders`，GET / POST / PATCH / DELETE）。文件夹记录以自由 JSON 存在 `<project_dir>/freezone/` 下，删文件夹时柜内素材一并从资产库移除，但**磁盘上的文件保留**——画布节点可能还引用着同一个 URL，真删文件会造成裂图；孤儿文件归项目级清理负责。

- 名字长度、保留名（会和系统文件夹撞）、重名统一在 `_validate_folder_name` 里挡。
- 封面必须是本项目 static 下的素材，走 `resolve_static_url_to_path` 校验。这个字段会被所有协作者当 `<img src>` 渲染，放行外链等于让别人的浏览器替你去访问第三方地址。

## 弹窗

- 顶部 tab 条切类目；「全部」下先列文件夹，点进去才列条目，带面包屑返回。
- 自建文件夹卡片带「…」菜单：修改封面（只能从柜内图片里挑）/ 重命名 / 删除。
- 卡片样式：封面方块 + 名字与「…」一行 + 右对齐的建夹日期；默认不画边框，hover 才浮出来。
- 底部换成分页（20 / 40 / 80 / 100 条每页，菜单向上开）。「确定」只在挑素材给节点用时出现，侧栏点开的纯管理态没有接收方，那儿只剩分页。原来的「已录入 N 个 / 已选 x/y」去掉了。

### 音视频卡片

音频扔掉原生 `<audio controls>`（浏览器那条灰胶囊和深色皮肤格格不入，还把名字挤没了），改成圆形播放键 + 波形进度条 + 时间。波形高度用 URL 做种子生成——真波形要解码整段音频，代价太大，这样每条音轨长得不一样但每次打开都一致。同一时间只留一条音轨在响。

视频用 `#t=0.1` 拿真首帧当封面（`t=0` 在部分浏览器是黑帧），hover 就地静音循环预览，左下角显示时长。

## 侧栏 · 发送到画布

侧栏「资产库」tab 复用同一套条目模型与分法（`assetLibraryItems.ts` 是唯一事实来源）。文件夹卡片右下角多一个「发送到画布」：整柜素材在视口中心铺成网格并编成一个组，组名 = 文件夹名。

发之前先量每个素材的真实宽高比再建节点——不带 `aspectRatio` 的图片节点一律按 1:1 铺开，宽图会上下留两条黑边。网格也按每个节点的实际尺寸排（列宽取该列最宽、行高取该行最高），固定格子会让竖图互相压住。量不出来或超时都当没量到，一张坏图不会把整个文件夹的发送卡住。

## 评审修复

自查 + code review 后修掉的 6 处：

| 严重度 | 问题 |
|---|---|
| 高 | 往一个还没有素材的类目里传第一个文件时，目标系统文件夹尚未出现在列表里，视图回落到文件夹网格 → 上传进度和失败提示（含「移除」按钮）都渲染不出来。改为在 `openFolder` 推导处给一个同 key 的空壳兜住 |
| 中 | 删文件夹的二次确认用了被 `allowedMedia` 过滤过的条数。只收图片的节点里，装满视频的文件夹会显示成 0 项，等于不给数据丢失的警告。改用未过滤的 `library` 计数 |
| 中 | 批量删除第一条失败就整批中断，`bulkIds` 也不清，再点还是撞同一个 404。改为逐条继续，失败的只保留后端确认还在的 |
| 低 | 文件夹封面没走本地校验（见上） |
| 低 | 新建/重命名对话框的 `submitting` 只在 catch 里复位，遇到静默 return 的 handler 会把「保存」永久按灰。挪进 `finally` |
| 低 | 音频卡卸载时只清了模块级指针没调 `pause()`，靠「元素移出文档规范自动暂停」这个副作用兜着 |

## 评审修复 · 第二轮（`201c11ed`）

针对 @lywaterman 的 review：

| 严重度 | 问题 | 修法 |
|---|---|---|
| 高 | 封面校验只看 `urlsplit(url).path` 削剩的部分，外链把项目内真实路径拼在自己域名后即可通过，而落库的是原串 → 进所有协作者的 `<img src>` | 收到源头：`resolve_static_url_to_path` 校验整个字符串，带 scheme/netloc 一律拒；顺带拦掉浏览器当协议相对外链、`urlsplit` 当普通 path 的 `/\host` 写法。素材录入那条路由的 `_require_local` 是同一形状，一并收口 |
| 低 | 404 文案回传解析后的绝对路径（带用户名和落盘目录） | 改回传入的 URL |
| — | 该校验零测试覆盖（原有用例都在模型层，校验在路由层） | 新增 `tests/test_api_freezone_asset_library_folders.py` 路由级用例 |

`resolve_static_url_to_path` 的 24 处调用点逐个核对过，无一依赖外链解析——统一把 `ValueError` 当「输入不支持」转 400/422/skip。行为变化只有一处：外链从含糊的 `404 not found: /abs/path` 变成明确的 `400 url must be a same-origin path`。

## 搭车改动 · 主线镜头工具栏（`6f75d569`）

**和资产库无关，是另一件事搭在同一分支上**，评审时可以单独看这一个 commit。

「生成全集音频」和「生成全 Beat 视频提示词」两个批量入口从镜头工具栏下线，任何 `spineTemplate` 下都不给（原先分别是 `!== "drama"` 和 `=== "narrated"`）。

用模块级常量掐条件而不是删 JSX：删了要连带清掉 `useGlobalOptimize`、`useAudioBillingQuote`、两个 `useTaskController`、两个 handler 和计费展示一大串，diff 大且不可逆。后端路由、账单口径和任务控制原样留着——其它入口和历史任务还要用，这里只掐入口，恢复把常量翻回 `true` 即可。

原有 4 条断言按钮存在的用例（报价展示、计费确认、声线缺失前置校验、Seedance2 下置灰）前提没了，换成隐藏断言，跟着文件里已有的「hides whole-episode … from the batch toolbar」写法。

## 测试

- 前端：新增 `asset-library-modal-categories.test.tsx`（20 条，覆盖类目/文件夹视图、文件夹 CRUD、发送到画布、分页，以及上面两条中危修复的回归）；全量 **333 文件 / 2258 用例通过**（搭车改动净减 1 条），`tsc -b` 与 `pnpm build` 均干净。
- 后端：`tests/test_freezone_video_backend.py` **34 项通过**；新增 `tests/test_api_freezone_asset_library_folders.py`（路由级，跨源封面断言 400 且不落库）与 `tests/test_freezone_paths.py` 的 6 种跨源写法单测。
- 全量 Python 测试改动前后各跑一遍，**失败集合逐字相同**（5 项预存在失败，是模型命名与网关 env，与本 PR 无关），无新增。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


