### PR TITLE
feat(video): support MiniMax H3 v2 lifecycle

### DIFF
--- a/src/novelvideo/generators/video_generator.py
+++ b/src/novelvideo/generators/video_generator.py
@@ -1917,6 +1917,24 @@ class NewApiVideoGenerator(VideoGeneratorBase):
                 except json.JSONDecodeError as exc:
                     raise RuntimeError(f"DramaClawAPI task query returned invalid JSON: {text}") from exc
 
+    async def _delete_json(self, url: str) -> dict:
+        async with aiohttp.ClientSession(timeout=self._client_timeout()) as session:
+            async with session.delete(url, headers=self.headers) as resp:
+                text = await resp.text()
+                if resp.status < 200 or resp.status >= 300:
+                    request_id = self._extract_request_id(text, resp.headers)
+                    raise NewApiVideoError(
+                        f"DramaClawAPI task delete failed: HTTP {resp.status} - {text}",
+                        request_id=request_id,
+                        status_code=resp.status,
+                    )
+                try:
+                    return json.loads(text)
+                except json.JSONDecodeError as exc:
+                    raise RuntimeError(
+                        f"DramaClawAPI task delete returned invalid JSON: {text}"
+                    ) from exc
+
     async def _download_video(self, url: str, output_path: str) -> bytes:
         if url.startswith("data:"):
             header, _, encoded = url.partition(",")
@@ -2312,12 +2330,93 @@ class NewApiVideoGenerator(VideoGeneratorBase):
             if "_newapi_request_id" not in merged and task.get("_newapi_request_id"):
                 merged["_newapi_request_id"] = task["_newapi_request_id"]
             return merged
+        native_task = task.get("task")
+        if isinstance(native_task, dict):
+            return native_task
         return task
 
     @classmethod
     def _task_id_from_submit_response(cls, submitted: dict) -> str:
         task = cls._task_response_data(submitted)
         return str(task.get("task_id") or task.get("id") or "").strip()
+
+    def _uses_minimax_v2(self) -> bool:
+        return (
+            self.model.strip().casefold() == "minimax-h3"
+            and self.request_schema.get("protocol") == "minimax_v2"
+        )
+
+    def _minimax_v2_url(self, operation: str, *, task_id: str = "") -> str:
+        from novelvideo.media_model_request_schema import MINIMAX_V2_OPERATIONS
+
+        if not self._uses_minimax_v2() or operation not in MINIMAX_V2_OPERATIONS:
+            raise ValueError("MiniMax v2 lifecycle is not configured for this model")
+        path = MINIMAX_V2_OPERATIONS[operation]
+        if "{task_id}" in path:
+            clean_task_id = str(task_id or "").strip()
+            if not clean_task_id:
+                raise ValueError("task_id is required")
+            path = path.replace("{task_id}", urllib.parse.quote(clean_task_id, safe=""))
+        return f"{self.base_url.removesuffix('/v1')}{path}"
+
+    @staticmethod
+    def _minimax_v2_content_item(media_type: str, url: str, role: str) -> dict:
+        return {
+            "type": f"{media_type}_url",
+            f"{media_type}_url": {"url": url},
+            "role": role,
+        }
+
+    @classmethod
+    def _minimax_v2_payload(
+        cls, payload: dict[str, object], metadata: dict[str, object]
+    ) -> dict[str, object]:
+        prompt = str(payload.get("prompt") or "").strip()
+        if not prompt:
+            raise ValueError("prompt is required for MiniMax v2 video generation")
+        content: list[dict[str, object]] = [{"type": "text", "text": prompt}]
+
+        def append_one(media_type: str, key: str, role: str) -> None:
+            value = metadata.get(key)
+            if isinstance(value, str) and value.strip():
+                content.append(cls._minimax_v2_content_item(media_type, value.strip(), role))
+
+        def append_many(media_type: str, key: str, role: str) -> None:
+            values = metadata.get(key)
+            if isinstance(values, list):
+                for value in values:
+                    if isinstance(value, str) and value.strip():
+                        content.append(cls._minimax_v2_content_item(media_type, value.strip(), role))
+
+        append_one("image", "image_url", "first_frame")
+        append_one("image", "first_frame_image", "first_frame")
+        append_one("image", "last_frame_image", "last_frame")
+        append_many("image", "reference_images", "reference_image")
+        append_many("video", "reference_videos", "reference_video")
+        append_many("audio", "reference_audios", "reference_audio")
+
+        duration = float(str(payload.get("seconds") or payload.get("duration") or 0))
+        if not duration.is_integer():
+            raise ValueError("MiniMax v2 duration must be an integer")
+        native_payload: dict[str, object] = {
+            "model": payload.get("model"),
+            "content": content,
+            "resolution": metadata.get("resolution"),
+            "duration": int(duration),
+        }
+        ratio = str(metadata.get("ratio") or "").strip()
+        if ratio:
+            native_payload["ratio"] = ratio
+        return native_payload
+
+    async def list_tasks(self, params: dict[str, object] | None = None) -> dict:
+        url = self._minimax_v2_url("list")
+        if params:
+            url = f"{url}?{urllib.parse.urlencode(params, doseq=True)}"
+        return await self._get_json(url)
+
+    async def delete_task(self, task_id: str) -> dict:
+        return await self._delete_json(self._minimax_v2_url("delete", task_id=task_id))
 
     async def _relay_seedance2_references(
         self,
@@ -2377,6 +2476,11 @@ class NewApiVideoGenerator(VideoGeneratorBase):
                 value = metadata.get(key)
                 if isinstance(value, str) and value.strip():
                     return value.strip()
+        content = task.get("content")
+        if isinstance(content, dict):
+            value = content.get("url")
+            if isinstance(value, str) and value.strip():
+                return value.strip()
         for key in ("url", "video_url"):
             value = task.get(key)
             if isinstance(value, str) and value.strip():
@@ -2865,12 +2969,18 @@ class NewApiVideoGenerator(VideoGeneratorBase):
             )
             from novelvideo.media_model_request_schema import apply_media_request_schema
 
-            self._canonicalize_video_payload(payload, metadata)
-            payload = apply_media_request_schema(
-                payload, self.request_schema, self.model_params
-            )
+            if self._uses_minimax_v2():
+                payload = self._minimax_v2_payload(payload, metadata)
+            else:
+                self._canonicalize_video_payload(payload, metadata)
+                payload = apply_media_request_schema(
+                    payload, self.request_schema, self.model_params
+                )
             submitted = await self._post_json(
-                f"{self.base_url}/video/generations", payload
+                self._minimax_v2_url("create")
+                if self._uses_minimax_v2()
+                else f"{self.base_url}/video/generations",
+                payload,
             )
             task_id = self._task_id_from_submit_response(submitted)
             provider_request_id = str(submitted.get("_newapi_request_id") or "").strip()
@@ -2900,7 +3010,11 @@ class NewApiVideoGenerator(VideoGeneratorBase):
 
             for poll_count in range(max_polls):
                 task = self._task_response_data(
-                    await self._get_json(f"{self.base_url}/video/generations/{task_id}")
+                    await self._get_json(
+                        self._minimax_v2_url("query", task_id=task_id)
+                        if self._uses_minimax_v2()
+                        else f"{self.base_url}/video/generations/{task_id}"
+                    )
                 )
                 status = str(task.get("status") or "").lower()
                 progress(0.2 + (poll_count / max(max_polls, 1)) * 0.7)

--- a/src/novelvideo/media_model_request_schema.py
+++ b/src/novelvideo/media_model_request_schema.py
@@ -10,6 +10,12 @@ from typing import Any
 KEY_RE = re.compile(r"^[A-Za-z][A-Za-z0-9_]{0,63}$")
 PATH_RE = re.compile(r"^[A-Za-z][A-Za-z0-9_]*(?:\.[A-Za-z][A-Za-z0-9_]*){0,3}$")
 CONTROL_TYPES = {"select", "number", "switch", "text", "multiselect"}
+MINIMAX_V2_OPERATIONS = {
+    "create": "/v2/video_generation",
+    "query": "/v2/query/video_generation/{task_id}",
+    "list": "/v2/query/video_generation",
+    "delete": "/v2/video_generation/{task_id}",
+}
 JS_MAX_SAFE_INTEGER = 2**53 - 1
 MAX_MEDIA_IMAGE_PIXELS = 16_777_216
 BLOCKED_ROOTS = {
@@ -139,6 +145,12 @@ def validate_media_request_schema(schema: object) -> dict[str, Any]:
     endpoint = str(schema.get("endpoint") or "").strip()
     if endpoint not in {"images/generations", "video/generations", "audio/speech"}:
         raise MediaModelSchemaError("unsupported NewAPI media endpoint")
+    protocol = str(schema.get("protocol") or "").strip()
+    if protocol:
+        if protocol != "minimax_v2" or endpoint != "video/generations":
+            raise MediaModelSchemaError("unsupported media request protocol")
+        if schema.get("operations") != MINIMAX_V2_OPERATIONS:
+            raise MediaModelSchemaError("invalid MiniMax v2 lifecycle operations")
     parameters = schema.get("parameters") or []
     if not isinstance(parameters, list) or len(parameters) > 32:
         raise MediaModelSchemaError("parameters must be a list with at most 32 items")

--- a/src/novelvideo/official_media_models.json
+++ b/src/novelvideo/official_media_models.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "catalogVersion": "2026.08.06.1",
+  "catalogVersion": "2026.08.13.1",
   "name": "DramaClaw CE official media models",
   "mediaModels": {
     "LingShan-G2": {
@@ -229,15 +229,25 @@
       "sortOrder": 110,
       "aliases": [],
       "config": {
-        "request": {"endpoint": "video/generations", "parameters": []},
+        "request": {
+          "endpoint": "video/generations",
+          "protocol": "minimax_v2",
+          "operations": {
+            "create": "/v2/video_generation",
+            "query": "/v2/query/video_generation/{task_id}",
+            "list": "/v2/query/video_generation",
+            "delete": "/v2/video_generation/{task_id}"
+          },
+          "parameters": []
+        },
         "minDuration": 4,
         "maxDuration": 15,
-        "ratioOptions": ["21:9", "16:9", "4:3", "1:1", "3:4", "9:16"],
+        "ratioOptions": ["adaptive", "21:9", "16:9", "4:3", "1:1", "3:4", "9:16"],
         "supportedModes": ["text_to_video", "first_frame", "first_last_frame", "image_to_video", "image_reference", "all_reference"],
         "referenceAudioMax": 3,
         "referenceImageMax": 9,
         "referenceVideoMax": 3,
-        "resolutionOptions": ["768P", "2K"]
+        "resolutionOptions": ["2K"]
       }
     }
   }

--- a/tests/test_model_gateway_settings.py
+++ b/tests/test_model_gateway_settings.py
@@ -3015,8 +3015,9 @@ def test_official_media_model_catalog_uses_ce_export_shape():
     minimax = videos[-1]
     assert minimax["id"] == "MiniMax-H3"
     assert minimax["gatewayModel"] == "MiniMax-H3"
-    assert minimax["resolutionOptions"] == ["768P", "2K"]
+    assert minimax["resolutionOptions"] == ["2K"]
     assert minimax["ratioOptions"] == [
+        "adaptive",
         "21:9",
         "16:9",
         "4:3",
@@ -3037,6 +3038,13 @@ def test_official_media_model_catalog_uses_ce_export_shape():
     assert minimax["referenceImageMax"] == 9
     assert minimax["referenceVideoMax"] == 3
     assert minimax["referenceAudioMax"] == 3
+    assert minimax["request"]["protocol"] == "minimax_v2"
+    assert minimax["request"]["operations"] == {
+        "create": "/v2/video_generation",
+        "query": "/v2/query/video_generation/{task_id}",
+        "list": "/v2/query/video_generation",
+        "delete": "/v2/video_generation/{task_id}",
+    }
 
 
 def test_custom_media_model_accepts_arbitrary_image_and_video_models():

--- a/tests/test_seedance2_request.py
+++ b/tests/test_seedance2_request.py
@@ -675,6 +675,129 @@ async def test_newapi_video_generator_handles_wrapped_failure_status(
     assert refunded["error"] == "InputImageSensitiveContentDetected.PolicyViolation"
 
 
+async def test_newapi_minimax_h3_uses_native_v2_lifecycle(tmp_path, monkeypatch):
+    from pathlib import Path
+
+    from novelvideo.generators import video_generator as video_module
+    from novelvideo.generators.video_generator import NewApiVideoGenerator, VideoGenStatus
+    from novelvideo.media_model_request_schema import MINIMAX_V2_OPERATIONS
+
+    captured: dict[str, object] = {}
+    generator = NewApiVideoGenerator(
+        api_key="test-key",
+        endpoint="https://relay.example/v1",
+        model="MiniMax-H3",
+        resolution="2K",
+        request_schema={
+            "endpoint": "video/generations",
+            "protocol": "minimax_v2",
+            "operations": dict(MINIMAX_V2_OPERATIONS),
+            "parameters": [],
+        },
+    )
+
+    async def fake_reserve(*_args, **_kwargs):
+        return "reservation-1"
+
+    async def fake_noop(*_args, **_kwargs):
+        return None
+
+    async def fake_post_json(url: str, payload: dict):
+        captured["create_url"] = url
+        captured["payload"] = payload
+        return {"task_id": "task-1"}
+
+    async def fake_get_json(url: str):
+        captured["query_url"] = url
+        return {
+            "task": {
+                "id": "task-1",
+                "status": "success",
+                "content": {"url": "https://example.com/out.mp4"},
+            }
+        }
+
+    async def fake_download_video(_url: str, output_path: str):
+        Path(output_path).write_bytes(b"video")
+        return b"video"
+
+    monkeypatch.setattr(video_module, "_reserve_video_model_call", fake_reserve)
+    monkeypatch.setattr(video_module, "_confirm_video_model_call", fake_noop)
+    monkeypatch.setattr(video_module, "_refund_video_model_call", fake_noop)
+    monkeypatch.setattr(generator, "_post_json", fake_post_json)
+    monkeypatch.setattr(generator, "_get_json", fake_get_json)
+    monkeypatch.setattr(generator, "_download_video", fake_download_video)
+
+    result = await generator.generate(
+        image_path="https://example.com/first.png",
+        prompt="A camera slowly approaches the subject.",
+        output_path=str(tmp_path / "out.mp4"),
+        duration=6,
+        aspect_ratio="adaptive",
+        poll_interval=0,
+        max_polls=1,
+    )
+
+    assert result.status == VideoGenStatus.DONE
+    assert captured["create_url"] == "https://relay.example/v2/video_generation"
+    assert captured["query_url"] == "https://relay.example/v2/query/video_generation/task-1"
+    assert captured["payload"] == {
+        "model": "MiniMax-H3",
+        "content": [
+            {"type": "text", "text": "A camera slowly approaches the subject."},
+            {
+                "type": "image_url",
+                "image_url": {"url": "https://example.com/first.png"},
+                "role": "first_frame",
+            },
+        ],
+        "resolution": "2K",
+        "duration": 6,
+        "ratio": "adaptive",
+    }
+    assert result.video_url == "https://example.com/out.mp4"
+
+
+async def test_newapi_minimax_h3_lists_and_deletes_native_tasks(monkeypatch):
+    from novelvideo.generators.video_generator import NewApiVideoGenerator
+    from novelvideo.media_model_request_schema import MINIMAX_V2_OPERATIONS
+
+    generator = NewApiVideoGenerator(
+        api_key="test-key",
+        endpoint="https://api.minimax.io",
+        model="MiniMax-H3",
+        request_schema={
+            "endpoint": "video/generations",
+            "protocol": "minimax_v2",
+            "operations": dict(MINIMAX_V2_OPERATIONS),
+            "parameters": [],
+        },
+    )
+    captured: dict[str, str] = {}
+
+    async def fake_get_json(url: str):
+        captured["list"] = url
+        return {"items": [], "total": 0}
+
+    async def fake_delete_json(url: str):
+        captured["delete"] = url
+        return {"task_id": "task/1", "action": "delete", "status": "success"}
+
+    monkeypatch.setattr(generator, "_get_json", fake_get_json)
+    monkeypatch.setattr(generator, "_delete_json", fake_delete_json)
+
+    assert await generator.list_tasks({"page_num": 1, "filter.status": "success"}) == {
+        "items": [],
+        "total": 0,
+    }
+    assert (await generator.delete_task("task/1"))["task_id"] == "task/1"
+    assert captured["list"] == (
+        "https://api.minimax.io/v2/query/video_generation?"
+        "page_num=1&filter.status=success"
+    )
+    assert captured["delete"] == "https://api.minimax.io/v2/video_generation/task%2F1"
+
+
 async def test_newapi_seedance1_generator_preserves_adaptive_ratio(tmp_path, monkeypatch):
     from novelvideo.generators import video_generator as video_module
     from novelvideo.generators.video_generator import NewApiVideoGenerator


### PR DESCRIPTION
Reason: MiniMax-H3 is registered but cannot use its native v2 create, query, list, and delete task lifecycle.

## Changes

- validate and publish the fixed native lifecycle operations in the official media catalog
- build native multimodal creation payloads and route create and query requests through the v2 endpoints
- expose focused list and delete task helpers and accept native task result URLs

## Verification

- `uv run pytest tests/test_seedance2_request.py::test_newapi_minimax_h3_uses_native_v2_lifecycle tests/test_seedance2_request.py::test_newapi_minimax_h3_lists_and_deletes_native_tasks tests/test_model_gateway_settings.py::test_official_media_model_catalog_uses_ce_export_shape`
- `uv run ruff check src/novelvideo/generators/video_generator.py src/novelvideo/media_model_request_schema.py tests/test_model_gateway_settings.py tests/test_seedance2_request.py`

No migration or new credential configuration is required.
