### PR TITLE
fix NewAPI media request protocol

### DIFF
--- a/frontend/src/__tests__/api/freezone-video-edit.test.ts
+++ b/frontend/src/__tests__/api/freezone-video-edit.test.ts
@@ -1,0 +1,44 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { apiCall } from "@/api/client";
+import { submitFreezoneVideoEdit } from "@/api/ops";
+
+vi.mock("@/api/client", () => ({
+  apiCall: vi.fn(),
+  apiClient: {},
+}));
+
+describe("submitFreezoneVideoEdit", () => {
+  beforeEach(() => {
+    vi.mocked(apiCall).mockReset();
+    vi.mocked(apiCall).mockResolvedValue({ job_id: "job-1" });
+  });
+
+  it("forwards references while leaving geometry and duration to the source video", async () => {
+    await submitFreezoneVideoEdit("project-1", {
+      videoUrl: "/static/source.mp4",
+      imageUrls: ["/static/style.png"],
+      audioUrls: ["/static/music.mp3"],
+      model: "catalog-video",
+      genMode: "videoEdit",
+    });
+
+    expect(apiCall).toHaveBeenCalledWith(
+      "projects/project-1/freezone/video/video-edit",
+      expect.objectContaining({
+        method: "POST",
+        json: expect.objectContaining({
+          video_url: "/static/source.mp4",
+          image_urls: ["/static/style.png"],
+          audio_urls: ["/static/music.mp3"],
+          gen_mode: "videoEdit",
+        }),
+      }),
+    );
+    const request = vi.mocked(apiCall).mock.calls[0]?.[1] as {
+      json?: Record<string, unknown>;
+    };
+    expect(request.json).not.toHaveProperty("aspect_ratio");
+    expect(request.json).not.toHaveProperty("duration_seconds");
+  });
+});

--- a/frontend/src/__tests__/features/canvas/catalog-image-model-request.test.ts
+++ b/frontend/src/__tests__/features/canvas/catalog-image-model-request.test.ts
@@ -81,6 +81,14 @@ beforeEach(() => {
 });
 
 describe("目录模型的 provider/model 往返", () => {
+  it("小写分辨率目录仍默认选择 2k 档位", () => {
+    const definition = toImageModelDefinition(
+      entry({ resolutionOptions: ["1k", "2k", "4k"] }),
+    );
+
+    expect(definition.defaultResolution).toBe("2k");
+  });
+
   it("OpenRouter 命名空间模型：provider 归 openrouter，model 保留完整多段名", async () => {
     const body = await submittedBody(entry({}));
     expect(body.provider).toBe("openrouter");

--- a/frontend/src/__tests__/features/canvas/media-model-options.test.ts
+++ b/frontend/src/__tests__/features/canvas/media-model-options.test.ts
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: Elastic-2.0
+// Copyright (c) 2026 ClaymoreLab
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  formatResolutionLabel,
+  resolveModelAspectOptions,
+  resolveModelSizeOptions,
+} from '@/features/canvas/domain/mediaModelOptions';
+
+describe('媒体模型公共选项归一化', () => {
+  it('把历史 adaptive 比例收敛为唯一的 auto 选项', () => {
+    expect(
+      resolveModelAspectOptions({ ratioOptions: ['adaptive', 'Auto', '16:9'] }),
+    ).toEqual(['auto', '16:9']);
+  });
+
+  it('保留后台配置的分辨率档位顺序', () => {
+    expect(resolveModelSizeOptions({ resolutionOptions: ['720p', '1080p'] })).toEqual([
+      '720p',
+      '1080p',
+    ]);
+  });
+
+  it('分辨率只在显示层统一成小写', () => {
+    expect(formatResolutionLabel('4K')).toBe('4k');
+    expect(formatResolutionLabel('1080P')).toBe('1080p');
+  });
+});

--- a/frontend/src/__tests__/features/canvas/video-model-capabilities.test.ts
+++ b/frontend/src/__tests__/features/canvas/video-model-capabilities.test.ts
@@ -19,7 +19,10 @@ import {
   referenceDurationLimitsMs,
   resolveVideoKeyframeUrls,
   videoEmptyStateCtaModes,
+  videoModeForcesAutomaticAspectRatio,
   videoModeRequiresPrompt,
+  videoModelDefaultGenerateAudio,
+  videoModelSupportsGenerateAudio,
   videoModelReferenceDisabledReason,
   videoMultiImageAutoSwitchMode,
   videoReferenceAutoSwitchAction,
@@ -27,6 +30,20 @@ import {
   videoSubmitMediaRejectionReason,
   videoUpstreamImageDefaultMode,
 } from "@/features/canvas/nodes/shared/videoModelCapabilities";
+
+describe("视频模式有效比例", () => {
+  it.each([
+    ["firstFrame", true],
+    ["firstLastFrame", true],
+    ["videoEdit", true],
+    ["textToVideo", false],
+    ["imageToVideo", false],
+    ["imageReference", false],
+    ["allReference", false],
+  ] as const)("%s 是否强制跟随输入素材", (mode, expected) => {
+    expect(videoModeForcesAutomaticAspectRatio(mode)).toBe(expected);
+  });
+});
 
 // 对齐后端 freezone/video_node.py 的真实模型 id（apiModel == id == 后端 model）。
 const SEEDANCE2_FAST = "newapi_seedance-2.0-fast";
@@ -65,6 +82,27 @@ describe("video model family detection", () => {
     }
     // 分隔符不敏感：normalize 后 `seedance20` 仍是 2.0，不会漏成 1.x。
     expect(isSeedance2VideoModel("SEEDANCE 2.0 FAST")).toBe(true);
+  });
+});
+
+describe("video native audio capability", () => {
+  it("preserves legacy support and default when catalog fields are absent", () => {
+    expect(videoModelSupportsGenerateAudio(SEEDANCE2_FAST)).toBe(true);
+    expect(videoModelDefaultGenerateAudio({ apiModel: SEEDANCE2_FAST })).toBe(true);
+  });
+
+  it("defaults native audio on whenever the model supports it", () => {
+    expect(videoModelSupportsGenerateAudio({ supportsGenerateAudio: true })).toBe(true);
+    expect(
+      videoModelDefaultGenerateAudio({
+        supportsGenerateAudio: true,
+      }),
+    ).toBe(true);
+    expect(
+      videoModelDefaultGenerateAudio({
+        supportsGenerateAudio: false,
+      }),
+    ).toBe(false);
   });
 });
 
@@ -289,6 +327,28 @@ describe("videoSubmitMediaRejectionReason — 提交前素材守卫 (P1/P2)", ()
       videoSubmitMediaRejectionReason("imageReference", HAPPYHORSE, { images: 5, videos: 0, audios: 0 }),
     ).toBeNull();
   });
+
+  it("目录显式开放音频后，视频编辑消费独立音频", () => {
+    const audioVideoEditModel = {
+      apiModel: "custom-video-editor",
+      supportedModes: ["video_edit"],
+      referenceAudioMax: 2,
+    };
+    expect(
+      videoSubmitMediaRejectionReason("videoEdit", audioVideoEditModel, {
+        images: 0,
+        videos: 1,
+        audios: 1,
+      }),
+    ).toBeNull();
+    expect(
+      videoSubmitMediaRejectionReason(
+        "videoEdit",
+        { ...audioVideoEditModel, referenceAudioMax: 0 },
+        { images: 0, videos: 1, audios: 1 },
+      ),
+    ).toBeTruthy();
+  });
 });
 
 describe("videoMultiImageAutoSwitchMode — 首帧接多图时的自动改模式", () => {
@@ -476,6 +536,19 @@ describe("videoModelReferenceDisabledReason — 模型选择器置灰守卫", ()
     expect(
       videoModelReferenceDisabledReason(HAPPYHORSE, { ...none, audios: 1 }),
     ).toBeTruthy();
+  });
+
+  it("目录声明 video_edit 且音频上限大于 0 时，带音频仍可选择模型", () => {
+    expect(
+      videoModelReferenceDisabledReason(
+        {
+          apiModel: "custom-video-editor",
+          supportedModes: ["video_edit"],
+          referenceAudioMax: 1,
+        },
+        { ...none, videos: 1, audios: 1 },
+      ),
+    ).toBeNull();
   });
 
   // 后台把某个模型的「视频编辑」下掉后，启发式那套「HappyHorse 天生能吃视频」的假设

--- a/frontend/src/__tests__/features/canvas/video-node-credit-contract.test.ts
+++ b/frontend/src/__tests__/features/canvas/video-node-credit-contract.test.ts
@@ -23,6 +23,9 @@ describe("canvas video generation credit contract", () => {
     );
     expect(panelSource).toContain("video_backend: debouncedBackend");
     expect(panelSource).toContain("pricing_quantity: videoPricingQuantity");
+    expect(panelSource).toContain(
+      "Math.max(Math.floor(debouncedInputVideoDuration), 1)",
+    );
     expect(panelSource).toContain("quantity: videoCount");
     expect(panelSource).toContain("operation: genMode");
     expect(panelSource).toContain(
@@ -66,6 +69,9 @@ describe("canvas video generation credit contract", () => {
     );
     expect(nodeSource).toContain(
       "input_video_duration_seconds: videoInputBilling.durationSeconds",
+    );
+    expect(nodeSource).toContain(
+      "Math.max(Math.floor(videoInputBilling.durationSeconds), 1)",
     );
     expect(nodeSource).toContain(
       "retryBillingProbe.error instanceof BillingRuleNotConfiguredError",

--- a/frontend/src/api/ops.ts
+++ b/frontend/src/api/ops.ts
@@ -400,19 +400,19 @@ export async function submitFreezoneVideoI2v(
 
 // /freezone/video/video-edit ---------------------------------------------- //
 //
-// HappyHorse 视频编辑：1 个源视频 + 0-5 张参考图 → 上游 video_url + reference_images。
+// 视频编辑：1 个源视频，并按媒体目录能力附带参考图片 / 独立参考音频。
 
 export interface FreezoneVideoEditPayload extends FreezoneNodeContext {
   /** 源视频静态地址，必填。 */
   videoUrl: string;
   /** 0-5 张参考图静态地址。 */
   imageUrls?: string[];
+  /** 独立参考音频静态地址；数量和时长上限由媒体模型目录决定。 */
+  audioUrls?: string[];
   prompt?: string;
   cameraTemplateId?: string | null;
   marks?: FreezoneVideoMark[];
-  aspectRatio?: FreezoneVideoAspectRatio;
   resolution?: FreezoneVideoResolution;
-  durationSeconds?: number;
   /** 视频编辑音频策略：auto 自动 / origin 保留原声。 */
   audioSetting?: "auto" | "origin";
   generateAudio?: boolean;
@@ -434,6 +434,7 @@ export async function submitFreezoneVideoEdit(
       json: {
         video_url: payload.videoUrl,
         image_urls: payload.imageUrls ?? [],
+        audio_urls: payload.audioUrls ?? [],
         prompt: payload.prompt ?? "",
         camera_template_id: payload.cameraTemplateId ?? null,
         marks: (payload.marks ?? []).map((m) => ({
@@ -447,9 +448,7 @@ export async function submitFreezoneVideoEdit(
           box_height: m.boxHeight ?? null,
           note: m.note ?? "",
         })),
-        aspect_ratio: payload.aspectRatio ?? "16:9",
         resolution: payload.resolution ?? "720p",
-        duration_seconds: Math.max(payload.durationSeconds ?? 5, 1),
         audio_setting: payload.audioSetting ?? "auto",
         generate_audio: payload.generateAudio ?? false,
         ...(payload.model ? { model: payload.model, model_id: payload.model } : {}),
@@ -1045,6 +1044,8 @@ export interface FreezoneVideoModelInfo {
   /** Supported output resolution values for this model, when advertised by backend. */
   resolutionOptions?: FreezoneVideoResolution[];
   humanReview?: boolean;
+  /** Whether this model can produce native synchronized audio. Missing means legacy-supported. */
+  supportsGenerateAudio?: boolean;
   /** Smallest supported duration in seconds, when advertised by backend. */
   minDuration?: number | null;
   /** Largest supported duration in seconds, when advertised by backend. */
@@ -1130,6 +1131,11 @@ function videoModelEntryFromObject(
     label,
     ...(resolutionOptions.length > 0 ? { resolutionOptions } : {}),
     humanReview: pickBoolean(entry, "humanReview", "human_review"),
+    supportsGenerateAudio: pickBoolean(
+      entry,
+      "supportsGenerateAudio",
+      "supports_generate_audio",
+    ),
     minDuration: pickNumber(entry, "minDuration", "min_duration"),
     maxDuration: pickNumber(entry, "maxDuration", "max_duration"),
     ...(sceneOptimizeOptions.length > 0 ? { sceneOptimizeOptions } : {}),

--- a/frontend/src/features/canvas/domain/catalogImageModels.ts
+++ b/frontend/src/features/canvas/domain/catalogImageModels.ts
@@ -23,6 +23,7 @@ import {
 } from '@/features/canvas/hooks/useFreezoneImageModels';
 import { SHARED_MODELS } from '@/features/canvas/ui/ProviderModelPicker';
 import {
+  formatResolutionLabel,
   resolveModelAspectOptions,
   resolveModelSizeOptions,
 } from '@/features/canvas/domain/mediaModelOptions';
@@ -45,7 +46,7 @@ export interface CatalogImageModelEntry {
 }
 
 /** 目录没给分辨率时，节点默认想要的档位（仍需落在实际可选档位里）。 */
-const PREFERRED_DEFAULT_RESOLUTION = '2K';
+const PREFERRED_DEFAULT_RESOLUTION = '2k';
 
 /** 把一条目录条目适配成节点用的 `ImageModelDefinition`。 */
 export function toImageModelDefinition(
@@ -53,7 +54,7 @@ export function toImageModelDefinition(
 ): ImageModelDefinition {
   const resolutions = resolveModelSizeOptions(info).map((value) => ({
     value,
-    label: value,
+    label: formatResolutionLabel(value),
   }));
   const aspectRatios = resolveModelAspectOptions(info).map((value) => ({
     value,
@@ -73,7 +74,9 @@ export function toImageModelDefinition(
     eta: '',
     defaultAspectRatio: aspectRatios[0]?.value ?? '1:1',
     defaultResolution:
-      resolutions.find((item) => item.value === PREFERRED_DEFAULT_RESOLUTION)?.value
+      resolutions.find(
+        (item) => item.value.toLowerCase() === PREFERRED_DEFAULT_RESOLUTION,
+      )?.value
       ?? resolutions[0]?.value
       ?? PREFERRED_DEFAULT_RESOLUTION,
     aspectRatios,

--- a/frontend/src/features/canvas/domain/mediaModelOptions.ts
+++ b/frontend/src/features/canvas/domain/mediaModelOptions.ts
@@ -61,6 +61,26 @@ function normalizeOptions(values: string[] | null | undefined): string[] {
   return (values ?? []).map((item) => item.trim()).filter(Boolean);
 }
 
+/**
+ * 分辨率在界面上一律使用小写展示。
+ *
+ * 只用于显示，不改变节点保存值、计费档位或提交给后端的原始值；这样也能兼容
+ * 旧目录里仍然存在的 `2K` / `1080P`。
+ */
+export function formatResolutionLabel(value: string): string {
+  return value.trim().toLowerCase();
+}
+
+function normalizeRatioOptions(values: string[] | null | undefined): string[] {
+  return [
+    ...new Set(
+      normalizeOptions(values).map((item) =>
+        ['auto', 'adaptive'].includes(item.toLowerCase()) ? 'auto' : item,
+      ),
+    ),
+  ];
+}
+
 /** 选中模型支持的分辨率档位；目录没配就用兜底。 */
 export function resolveModelSizeOptions(
   model: MediaModelCapabilities | null | undefined,
@@ -75,7 +95,7 @@ export function resolveModelAspectOptions(
   model: MediaModelCapabilities | null | undefined,
   fallback: readonly string[] = FALLBACK_IMAGE_ASPECT_OPTIONS,
 ): string[] {
-  const configured = normalizeOptions(model?.ratioOptions);
+  const configured = normalizeRatioOptions(model?.ratioOptions);
   return configured.length > 0 ? configured : [...fallback];
 }
 

--- a/frontend/src/features/canvas/domain/nodeRegistry.ts
+++ b/frontend/src/features/canvas/domain/nodeRegistry.ts
@@ -398,7 +398,6 @@ const videoNodeDefinition: CanvasNodeDefinition<VideoNodeData> = {
     model: readLastVideoModel() ?? DEFAULT_VIDEO_MODEL_ID,
     quality: '720P',
     durationSec: 5,
-    generateAudio: true,
     count: 1,
     isGenerating: false,
     generationStartedAt: null,

--- a/frontend/src/features/canvas/models/registry.ts
+++ b/frontend/src/features/canvas/models/registry.ts
@@ -70,9 +70,13 @@ export function resolveImageModelResolution(
 
   return (
     (requestedResolution
-      ? resolutionOptions.find((item) => item.value === requestedResolution)
+      ? resolutionOptions.find(
+          (item) => item.value.toLowerCase() === requestedResolution.toLowerCase(),
+        )
       : undefined) ??
-    resolutionOptions.find((item) => item.value === model.defaultResolution) ??
+    resolutionOptions.find(
+      (item) => item.value.toLowerCase() === model.defaultResolution.toLowerCase(),
+    ) ??
     resolutionOptions[0] ??
     model.resolutions[0]
   );

--- a/frontend/src/features/canvas/nodes/ImageGenNode.tsx
+++ b/frontend/src/features/canvas/nodes/ImageGenNode.tsx
@@ -35,6 +35,7 @@ import {
 } from '@/features/canvas/domain/canvasNodes';
 import { buildImageFeatureBillingParams } from '@/features/canvas/domain/imageBilling';
 import {
+  formatResolutionLabel,
   resolveModelAspectOptions,
   resolveModelQualityOptions,
   resolveModelSizeOptions,
@@ -430,7 +431,9 @@ export const ImageGenNode = memo(({ id, data, selected, width, height }: ImageGe
       })),
     [selectedModel],
   );
-  const effectiveImageSize = modelSizeOptions.includes(size) ? size : modelSizeOptions[0];
+  const effectiveImageSize =
+    modelSizeOptions.find((option) => option.toLowerCase() === size.toLowerCase())
+    ?? modelSizeOptions[0];
   const effectiveAspectRatio = snapToAllowedAspectRatio(
     aspectRatio,
     modelAspectOptions.map((item) => item.value),
@@ -2169,7 +2172,7 @@ function AspectSizeChip({ aspectRatio, size, sizeOptions, aspectOptions, quality
           </>
         )}
         <span className="text-text-muted/80">·</span>
-        <span>{size}</span>
+        <span>{formatResolutionLabel(size)}</span>
         <ChevronDown className="h-3 w-3 text-text-muted/90" />
       </button>
       {isOpen && (
@@ -2219,7 +2222,7 @@ function AspectSizeChip({ aspectRatio, size, sizeOptions, aspectOptions, quality
                       : IMAGE_PARAM_IDLE_BUTTON_CLASS
                   }`}
                 >
-                  {option}
+                  {formatResolutionLabel(option)}
                 </button>
               );
             })}

--- a/frontend/src/features/canvas/nodes/VideoNode.tsx
+++ b/frontend/src/features/canvas/nodes/VideoNode.tsx
@@ -76,8 +76,11 @@ import {
   isVideoModeSupportedByModel,
   resolveVideoKeyframeUrls,
   videoEmptyStateCtaModes,
+  videoModeForcesAutomaticAspectRatio,
   videoModeRequiresPrompt,
+  videoModelDefaultGenerateAudio,
   videoModelReferenceDisabledReason,
+  videoModelSupportsGenerateAudio,
   videoMultiImageAutoSwitchMode,
   videoReferenceAutoSwitchAction,
   videoSubmitMediaRejectionReason,
@@ -259,6 +262,8 @@ const VIDEO_EMPTY_STATE_CTA_META: Record<
 //                            referenceAudioTotalMaxSeconds）——都在提交前单独校验，
 //                            见 audioReferenceDurationRejection。时长口径不进这张表：
 //                            这里只表达条数。
+//   - videoEdit            ：默认 1 个源视频 + 5 张参考图；独立音频默认关闭，媒体目录
+//                            配置 referenceAudioMax > 0 后按该上限开放。
 //   - firstLastFrame       ：仅图片 2 张（首帧 + 尾帧），不允许任何视频 / 音频。
 //                            图片 >2 时另有自动切到 allReference 的兜底（见
 //                            VideoNode 内部 effect）。
@@ -655,9 +660,13 @@ export const VideoNode = memo(
             VIDEO_GENERATION_ASPECT_RATIOS,
             "16:9",
           );
-    // Admin 配置存在时原样提交模型声明的比例；未配置时保留旧版 auto 推导逻辑。
+    const followsInputAspectRatio = videoModeForcesAutomaticAspectRatio(genMode);
+    // 关键帧/视频编辑的画幅跟随输入素材；只改变本次请求值，不覆盖节点保存的比例。
+    // 其它模式在 Admin 配置存在时原样提交，未配置时保留旧版 auto 推导逻辑。
     const submitAspectRatio: FreezoneVideoAspectRatio =
-      !hasConfiguredAspectRatios && aspectRatio === "auto"
+      followsInputAspectRatio
+        ? "auto"
+        : !hasConfiguredAspectRatios && aspectRatio === "auto"
         ? snapToAllowedAspectRatio(
             typeof data.widthPx === "number" &&
               typeof data.heightPx === "number" &&
@@ -691,7 +700,18 @@ export const VideoNode = memo(
       sceneOptimizeOptions,
       defaultSceneOptimizeForModel(selectedVideoModel),
     );
-    const generateAudio = Boolean(data.generateAudio);
+    // Missing catalog fields preserve the legacy behavior: native audio is
+    // supported and enabled by default. Admin can explicitly disable support,
+    // in which case the control disappears and every submit path sends false.
+    const supportsGenerateAudio =
+      videoModelSupportsGenerateAudio(selectedVideoModel);
+    const defaultGenerateAudio =
+      videoModelDefaultGenerateAudio(selectedVideoModel);
+    const generateAudio =
+      supportsGenerateAudio &&
+      (typeof data.generateAudio === "boolean"
+        ? data.generateAudio
+        : defaultGenerateAudio);
     // 家族判定必须喂 `selectedVideoModelId`(apiModel ?? id)，**不能用 `modelId`**：
     // `modelId` 是 `selectedVideoModel.id`，在 EE 里是 media_model_catalog 的 ULID
     // 主键（如 `01KZ58VSE52RFFDASY2T9SY4NC`），根本不含模型名，判定恒为 false ——
@@ -702,6 +722,13 @@ export const VideoNode = memo(
       "allReference",
       selectedVideoModel,
     );
+    const supportsVideoEdit = isVideoModeSupportedByModel(
+      "videoEdit",
+      selectedVideoModel,
+    );
+    const videoEditAcceptsAudio =
+      supportsVideoEdit &&
+      (referenceCapsForMode(selectedVideoModel, "videoEdit")?.audio ?? 0) > 0;
     const supportsHumanReview = selectedVideoModel?.humanReview === true;
     const humanReview = Boolean(data.humanReview);
     const count: VideoGenCount = (data.count ?? 1) as VideoGenCount;
@@ -1462,9 +1489,8 @@ export const VideoNode = memo(
       updateNodeData,
     ]);
 
-    // Audio refs only carry meaning under the omni-gen (allReference) path —
-    // textToVideo / firstFrame / firstLastFrame / imageToVideo discard them. So when an
-    // audio upstream first appears, force the mode to `allReference`. Tracked
+    // 音频引用由全能参考消费；媒体目录明确为 video_edit 配置音频上限后，视频编辑也
+    // 可以消费。其它模式仍会丢弃音频，因此音频首次接入时切到 allReference。Tracked
     // through a ref so we only fire on the 0 → ≥1 transition; once the user
     // disconnects all audio and reconnects, it fires again.
     // 是否可消费音频由媒体目录的 all_reference 能力决定；未声明该能力的模型由
@@ -1481,6 +1507,7 @@ export const VideoNode = memo(
         !prev &&
         hasAudioUpstream &&
         data.genMode !== "allReference" &&
+        !(data.genMode === "videoEdit" && videoEditAcceptsAudio) &&
         !isHappyHorseModel &&
         supportsAllReference
       ) {
@@ -1493,6 +1520,7 @@ export const VideoNode = memo(
       isHappyHorseModel,
       supportsAllReference,
       updateNodeData,
+      videoEditAcceptsAudio,
     ]);
 
     // Seedance 1.x 吃不下视频 / 音频，留在上面只能收获一次必然失败的提交。用户把
@@ -1526,7 +1554,14 @@ export const VideoNode = memo(
       }
       if (action.kind === "none") return;
       autoSwitchedForMediaRef.current = true;
-      updateNodeData(id, { model: action.modelId, genMode: action.genMode });
+      const nextModel = availableVideoModels.find(
+        (model) => model.id === action.modelId,
+      );
+      updateNodeData(id, {
+        model: action.modelId,
+        genMode: action.genMode,
+        generateAudio: videoModelDefaultGenerateAudio(nextModel),
+      });
       // 刻意不调 writeLastVideoModel：这是替用户救场，不是他表达的偏好，不该顺手
       // 把后续新建视频节点继承的默认模型也改掉。
     }, [
@@ -1538,15 +1573,15 @@ export const VideoNode = memo(
       videoModelsLoading,
     ]);
 
-    // 上游接入视频素材时，只有「全能参考」能消费视频；其它模式（文生 / 图生 /
-    // 首尾帧 / 图片参考）都会把视频丢弃。所以只要上游存在视频就强制切到
-    // allReference 并锁死——下面的 tab 禁用规则会把其它 tab 一并禁用。
+    // 上游接入视频素材时，「全能参考」和目录声明的「视频编辑」都能消费；其它模式
+    // 会把视频丢弃。已经处于合法 videoEdit 时不要再强制改成 allReference。
     // 与音频的「0→≥1 transition」不同，这里每次都纠正，确保视频在场期间无法切走。
     // 是否可消费视频由媒体目录的 all_reference 能力决定；未声明该能力的模型不强推，
     // 以免顶进提交必 400 的模式。
     useEffect(() => {
       if (upstreamCounts.videos === 0) return;
       if (isHappyHorseModel) return;
+      if (genMode === "videoEdit" && supportsVideoEdit) return;
       if (!supportsAllReference) return;
       if (genMode === "allReference") return;
       updateNodeData(id, { genMode: "allReference" });
@@ -1556,6 +1591,7 @@ export const VideoNode = memo(
       id,
       isHappyHorseModel,
       supportsAllReference,
+      supportsVideoEdit,
       updateNodeData,
     ]);
 
@@ -1892,7 +1928,11 @@ export const VideoNode = memo(
             : {}),
           video_backend: videoBackendForCost,
           resolution: qualityToResolution(quality),
-          pricing_quantity: Math.min(Math.max(count, 1), 4) * durationSec,
+          pricing_quantity:
+            Math.min(Math.max(count, 1), 4) *
+            (genMode === "videoEdit"
+              ? Math.max(Math.floor(videoInputBilling.durationSeconds), 1)
+              : durationSec),
           operation: genMode,
           generate_audio: generateAudio,
           video_input_present: videoInputBilling.present,
@@ -1995,6 +2035,97 @@ export const VideoNode = memo(
           return resolveVideoKeyframeUrls(candidates);
         };
 
+        const validateReferenceDurations = async (
+          media: "audio" | "video",
+          refs: Array<{ url: string; label: string; durationMs: number | null }>,
+        ): Promise<boolean> => {
+          const configured = referenceDurationLimitsMs(selectedVideoModel, media);
+          const limits = {
+            minMs:
+              configured.minMs ??
+              (media === "audio" && isSeedance20Model
+                ? MIN_AUDIO_REFERENCE_DURATION_MS
+                : undefined),
+            maxMs:
+              configured.maxMs ??
+              (media === "audio" && isSeedance20Model
+                ? MAX_AUDIO_REFERENCE_DURATION_MS
+                : undefined),
+            totalMinMs: configured.totalMinMs,
+            totalMaxMs:
+              configured.totalMaxMs ??
+              (media === "audio" && isSeedance20Model
+                ? MAX_AUDIO_REFERENCE_TOTAL_DURATION_MS
+                : undefined),
+          };
+          if (refs.length === 0 || Object.values(limits).every((value) => value == null)) {
+            return true;
+          }
+          const resolvedDurations = await Promise.all(
+            refs.map((ref) =>
+              typeof ref.durationMs === "number" && ref.durationMs > 0
+                ? Promise.resolve(ref.durationMs)
+                : media === "audio"
+                  ? probeAudioDurationMs(ref.url)
+                  : probeVideoDurationMs(ref.url),
+            ),
+          );
+          const rejection = audioReferenceDurationRejection(
+            refs.map((ref, index) => ({
+              label: ref.label,
+              durationMs: resolvedDurations[index] ?? null,
+            })),
+            {
+              minMs: limits.minMs ?? null,
+              maxMs: limits.maxMs ?? null,
+              totalMinMs: limits.totalMinMs,
+              totalLimitMs: limits.totalMaxMs ?? null,
+              perClipLimits: limits.minMs != null || limits.maxMs != null,
+            },
+          );
+          if (!rejection) return true;
+
+          const clips = formatAudioDurationClips(rejection.clips, (key, vars) =>
+            t(key, vars),
+          );
+          const prefix =
+            media === "audio" ? "node.videoNode.audio" : "node.videoNode.referenceDuration";
+          const message =
+            rejection.kind === "tooShort"
+              ? t(`${prefix}.${media === "audio" ? "durationTooShort" : "videoTooShort"}`, {
+                  min: formatAudioDurationSeconds(limits.minMs ?? 0),
+                  clips,
+                })
+              : rejection.kind === "tooLong"
+                ? t(`${prefix}.${media === "audio" ? "durationTooLong" : "videoTooLong"}`, {
+                    max: formatAudioDurationSeconds(limits.maxMs ?? 0),
+                    clips,
+                  })
+                : rejection.kind === "totalTooShort"
+                  ? t(
+                      `${prefix}.${media === "audio" ? "durationTotalTooShort" : "videoTotalTooShort"}`,
+                      {
+                        min: formatAudioDurationSeconds(rejection.limitMs),
+                        total: formatAudioDurationSeconds(rejection.totalMs),
+                        clips,
+                      },
+                    )
+                  : t(
+                      `${prefix}.${media === "audio" ? "durationTotalTooLong" : "videoTotalTooLong"}`,
+                      {
+                        max: formatAudioDurationSeconds(rejection.limitMs),
+                        total: formatAudioDurationSeconds(rejection.totalMs),
+                        clips,
+                      },
+                    );
+          toast.error(message, { duration: 5_000 });
+          updateNodeData(id, {
+            isGenerating: false,
+            generationStartedAt: null,
+          });
+          return false;
+        };
+
         const durationClamped = clampVideoDuration(durationSec, durationBounds);
         const cameraTemplateId = cameraMovementId;
         // 后端按 canvas_id + node_id 记录每个节点的生成历史。多条生成时每个
@@ -2068,9 +2199,8 @@ export const VideoNode = memo(
               nodeId: targetId,
             });
         } else if (genMode === "videoEdit") {
-          // 视频编辑：1 个源视频 + 0-5 张参考图 → video_url + reference_images。
-          // 不再是 HappyHorse 专属 —— 目录里声明了 video_edit 的模型都走这条路，
-          // 提交时带的是各自的 catalogId，能力由后端按目录校验。
+          // 视频编辑：1 个源视频，并按媒体目录上限附带参考图片和独立参考音频。
+          // 不再是 HappyHorse 专属 —— 目录里声明了 video_edit 的模型都走这条路。
           const upstream = collectUpstream();
           const videoUrl =
             upstream
@@ -2092,15 +2222,41 @@ export const VideoNode = memo(
             );
           }
           const imageUrls = allImageUrls.slice(0, imageLimit);
+          const audioLimit = referenceCaps?.audio ?? 0;
+          const audioRefs = upstream
+            .filter(isAudioNode)
+            .map((node, index) => {
+              const url =
+                typeof node.data.audioUrl === "string" ? node.data.audioUrl : "";
+              const rawLabel =
+                (typeof node.data.sourceFileName === "string"
+                  ? node.data.sourceFileName
+                  : "") ||
+                (typeof node.data.displayName === "string"
+                  ? node.data.displayName
+                  : "");
+              return {
+                url,
+                label:
+                  rawLabel ||
+                  t("node.videoNode.audio.clipFallbackLabel", { index: index + 1 }),
+                durationMs:
+                  typeof node.data.durationMs === "number"
+                    ? node.data.durationMs
+                    : null,
+              };
+            })
+            .filter((item) => item.url.length > 0)
+            .slice(0, audioLimit);
+          if (!(await validateReferenceDurations("audio", audioRefs))) return;
           doSubmit = (targetId) =>
             submitFreezoneVideoEdit(projectId, {
               videoUrl,
               imageUrls,
+              audioUrls: audioRefs.map((item) => item.url),
               prompt: composedPrompt,
               cameraTemplateId,
-              aspectRatio: submitAspectRatio,
               resolution: qualityToResolution(quality),
-              durationSeconds: durationClamped,
               audioSetting: "auto",
               generateAudio,
               model: selectedVideoModel?.catalogId ?? modelId,
@@ -2220,97 +2376,6 @@ export const VideoNode = memo(
             });
             return;
           }
-          const validateReferenceDurations = async (
-            media: "audio" | "video",
-            refs: typeof audioRefs,
-          ): Promise<boolean> => {
-            const configured = referenceDurationLimitsMs(selectedVideoModel, media);
-            const limits = {
-              minMs:
-                configured.minMs ??
-                (media === "audio" && isSeedance20Model
-                  ? MIN_AUDIO_REFERENCE_DURATION_MS
-                  : undefined),
-              maxMs:
-                configured.maxMs ??
-                (media === "audio" && isSeedance20Model
-                  ? MAX_AUDIO_REFERENCE_DURATION_MS
-                  : undefined),
-              totalMinMs: configured.totalMinMs,
-              totalMaxMs:
-                configured.totalMaxMs ??
-                (media === "audio" && isSeedance20Model
-                  ? MAX_AUDIO_REFERENCE_TOTAL_DURATION_MS
-                  : undefined),
-            };
-            if (refs.length === 0 || Object.values(limits).every((value) => value == null)) {
-              return true;
-            }
-            const resolvedDurations = await Promise.all(
-              refs.map((ref) =>
-                typeof ref.durationMs === "number" && ref.durationMs > 0
-                  ? Promise.resolve(ref.durationMs)
-                  : media === "audio"
-                    ? probeAudioDurationMs(ref.url)
-                    : probeVideoDurationMs(ref.url),
-              ),
-            );
-            const rejection = audioReferenceDurationRejection(
-              refs.map((ref, index) => ({
-                label: ref.label,
-                durationMs: resolvedDurations[index] ?? null,
-              })),
-              {
-                minMs: limits.minMs ?? null,
-                maxMs: limits.maxMs ?? null,
-                totalMinMs: limits.totalMinMs,
-                totalLimitMs: limits.totalMaxMs ?? null,
-                perClipLimits: limits.minMs != null || limits.maxMs != null,
-              },
-            );
-            if (rejection) {
-              const clips = formatAudioDurationClips(rejection.clips, (key, vars) =>
-                t(key, vars),
-              );
-              const prefix =
-                media === "audio" ? "node.videoNode.audio" : "node.videoNode.referenceDuration";
-              const message =
-                rejection.kind === "tooShort"
-                  ? t(`${prefix}.${media === "audio" ? "durationTooShort" : "videoTooShort"}`, {
-                      min: formatAudioDurationSeconds(limits.minMs ?? 0),
-                      clips,
-                    })
-                  : rejection.kind === "tooLong"
-                    ? t(`${prefix}.${media === "audio" ? "durationTooLong" : "videoTooLong"}`, {
-                        max: formatAudioDurationSeconds(limits.maxMs ?? 0),
-                        clips,
-                      })
-                    : rejection.kind === "totalTooShort"
-                      ? t(
-                          `${prefix}.${media === "audio" ? "durationTotalTooShort" : "videoTotalTooShort"}`,
-                          {
-                            min: formatAudioDurationSeconds(rejection.limitMs),
-                            total: formatAudioDurationSeconds(rejection.totalMs),
-                            clips,
-                          },
-                        )
-                      : t(
-                          `${prefix}.${media === "audio" ? "durationTotalTooLong" : "videoTotalTooLong"}`,
-                          {
-                            max: formatAudioDurationSeconds(rejection.limitMs),
-                            total: formatAudioDurationSeconds(rejection.totalMs),
-                            clips,
-                          },
-                        );
-              toast.error(message, { duration: 5_000 });
-              updateNodeData(id, {
-                isGenerating: false,
-                generationStartedAt: null,
-              });
-              return false;
-            }
-            return true;
-          };
           if (!(await validateReferenceDurations("audio", audioRefs))) return;
           if (!(await validateReferenceDurations("video", videoRefs))) return;
           doSubmit = (targetId) =>
@@ -3210,6 +3275,7 @@ export const VideoNode = memo(
             durationBounds={durationBounds}
             sceneOptimize={sceneOptimize}
             sceneOptimizeOptions={sceneOptimizeOptions}
+            supportsGenerateAudio={supportsGenerateAudio}
             generateAudio={generateAudio}
             supportsHumanReview={supportsHumanReview}
             humanReview={humanReview}

--- a/frontend/src/features/canvas/nodes/VideoOperationsPanel.tsx
+++ b/frontend/src/features/canvas/nodes/VideoOperationsPanel.tsx
@@ -34,9 +34,12 @@ import {
   type VideoGenQuality,
   type VideoNodeData,
 } from "@/features/canvas/domain/canvasNodes";
+import { formatResolutionLabel } from "@/features/canvas/domain/mediaModelOptions";
 import {
   isHappyHorseVideoModel,
   isVideoModeSupportedByModel,
+  videoModeForcesAutomaticAspectRatio,
+  videoModelDefaultGenerateAudio,
   videoModelReferenceDisabledReason,
 } from "@/features/canvas/nodes/shared/videoModelCapabilities";
 import { resolveImageDisplayUrl } from "@/features/canvas/application/imageData";
@@ -208,6 +211,7 @@ interface VideoOperationsPanelProps {
   durationBounds: { min: number; max: number };
   sceneOptimize: Seedance2SceneOptimize | undefined;
   sceneOptimizeOptions: readonly Seedance2SceneOptimize[];
+  supportsGenerateAudio: boolean;
   generateAudio: boolean;
   supportsHumanReview: boolean;
   humanReview: boolean;
@@ -251,6 +255,7 @@ export function VideoOperationsPanel({
   durationBounds,
   sceneOptimize,
   sceneOptimizeOptions,
+  supportsGenerateAudio,
   generateAudio,
   supportsHumanReview,
   humanReview,
@@ -342,7 +347,10 @@ export function VideoOperationsPanel({
     );
     const videoCount = Math.min(Math.max(debouncedCount, 1), 4);
     const videoPricingQuantity =
-      videoCount * debouncedDurationSec;
+      videoCount *
+      (genMode === "videoEdit"
+        ? Math.max(Math.floor(debouncedInputVideoDuration), 1)
+        : debouncedDurationSec);
     const videoCreditCost = useGenerationCreditCost(
       "feature",
       debouncedBackend && videoInputBillingReady
@@ -709,6 +717,9 @@ export function VideoOperationsPanel({
                   <ProviderModelPicker
                     selectedModelId={modelId}
                     onChange={(nextModelId) => {
+                      const nextModel = availableVideoModels.find(
+                        (item) => item.id === nextModelId,
+                      );
                       // 切换模型后，若当前 genMode 不被新模型支持（如 HappyHorse
                       // 专属的 videoEdit 切到普通模型），重置为通用安全值 textToVideo，
                       // 让状态机按新模型 + 上游重新推导；否则残留模式会在提交时打到
@@ -717,11 +728,12 @@ export function VideoOperationsPanel({
                         data.genMode != null &&
                         !isVideoModeSupportedByModel(
                           data.genMode,
-                          availableVideoModels.find((item) => item.id === nextModelId),
+                          nextModel,
                         );
                       updateNodeData(id, {
                         model: nextModelId,
                         modelParams: {},
+                        generateAudio: videoModelDefaultGenerateAudio(nextModel),
                         ...(resetGenMode
                           ? { genMode: "textToVideo" as VideoGenMode }
                           : {}),
@@ -748,6 +760,8 @@ export function VideoOperationsPanel({
                     }
                   />
                   <VideoConfigChip
+                    followInputAspectRatio={videoModeForcesAutomaticAspectRatio(genMode)}
+                    followInputDuration={genMode === "videoEdit"}
                     aspectRatio={aspectRatio}
                     aspectRatioOptions={aspectRatioOptions}
                     quality={quality}
@@ -756,6 +770,7 @@ export function VideoOperationsPanel({
                     durationBounds={durationBounds}
                     sceneOptimize={sceneOptimize}
                     sceneOptimizeOptions={sceneOptimizeOptions}
+                    supportsGenerateAudio={supportsGenerateAudio}
                     generateAudio={generateAudio}
                     onChange={(patch) => updateNodeData(id, patch)}
                   />
@@ -1121,6 +1136,8 @@ function GenModeSelect({ value, modelId, supportedModes, upstreamCounts, onChang
 }
 
 interface VideoConfigChipProps {
+  followInputAspectRatio: boolean;
+  followInputDuration: boolean;
   aspectRatio: FreezoneVideoAspectRatio;
   aspectRatioOptions: readonly FreezoneVideoAspectRatio[];
   quality: VideoGenQuality;
@@ -1129,11 +1146,14 @@ interface VideoConfigChipProps {
   durationBounds: { min: number; max: number };
   sceneOptimize?: Seedance2SceneOptimize;
   sceneOptimizeOptions: readonly Seedance2SceneOptimize[];
+  supportsGenerateAudio: boolean;
   generateAudio: boolean;
   onChange: (patch: Partial<VideoNodeData>) => void;
 }
 
 function VideoConfigChip({
+  followInputAspectRatio,
+  followInputDuration,
   aspectRatio,
   aspectRatioOptions,
   quality,
@@ -1142,6 +1162,7 @@ function VideoConfigChip({
   durationBounds,
   sceneOptimize,
   sceneOptimizeOptions,
+  supportsGenerateAudio,
   generateAudio,
   onChange,
 }: VideoConfigChipProps) {
@@ -1211,18 +1232,24 @@ function VideoConfigChip({
         className={NODE_TEXT_CONTROL_TRIGGER_CLASS}
       >
         <span>
-          {aspectRatio === "auto"
+          {followInputAspectRatio || aspectRatio === "auto"
             ? t("node.videoNode.aspect.auto")
             : aspectRatio}
         </span>
         <span className="text-text-muted/80">·</span>
-        <span>{quality}</span>
-        <span className="text-text-muted/80">·</span>
-        <span>{durationSec}s</span>
-        {generateAudio ? (
-          <Volume2 className="ml-0.5 h-3.5 w-3.5 text-text-muted/90" />
-        ) : (
-          <VolumeX className="ml-0.5 h-3.5 w-3.5 text-text-muted/90" />
+        <span>{formatResolutionLabel(quality)}</span>
+        {!followInputDuration && (
+          <>
+            <span className="text-text-muted/80">·</span>
+            <span>{durationSec}s</span>
+          </>
+        )}
+        {supportsGenerateAudio && (
+          generateAudio ? (
+            <Volume2 className="ml-0.5 h-3.5 w-3.5 text-text-muted/90" />
+          ) : (
+            <VolumeX className="ml-0.5 h-3.5 w-3.5 text-text-muted/90" />
+          )
         )}
         <ChevronDown className="h-3 w-3 text-text-muted/90" />
       </button>
@@ -1233,28 +1260,48 @@ function VideoConfigChip({
           onPointerDown={(event) => event.stopPropagation()}
           onClick={(event) => event.stopPropagation()}
         >
-          <div className={VIDEO_PARAM_LABEL_CLASS}>
-            {t("node.videoNode.aspect.title")}
-          </div>
-          <div className={`grid grid-cols-5 ${VIDEO_PARAM_ROW_CLASS}`}>
-            {aspectRatioOptions.map((ratio) => {
-              const isActive = aspectRatio === ratio;
-              return (
+          {!followInputAspectRatio && (
+            <>
+              <div className={VIDEO_PARAM_LABEL_CLASS}>
+                {t("node.videoNode.aspect.title")}
+              </div>
+              <div className={`grid grid-cols-5 ${VIDEO_PARAM_ROW_CLASS}`}>
+                {aspectRatioOptions.map((ratio) => {
+                  const isActive = aspectRatio === ratio;
+                  return (
+                    <button
+                      key={ratio}
+                      type="button"
+                      onClick={() => onChange({ aspectRatio: ratio })}
+                      className={`${VIDEO_PARAM_BUTTON_BASE_CLASS} ${
+                        isActive
+                          ? VIDEO_PARAM_ACTIVE_BUTTON_CLASS
+                          : VIDEO_PARAM_IDLE_BUTTON_CLASS
+                      }`}
+                    >
+                      {ratio === "auto" ? t("node.videoNode.aspect.auto") : ratio}
+                    </button>
+                  );
+                })}
+              </div>
+            </>
+          )}
+          {followInputAspectRatio && (
+            <>
+              <div className={VIDEO_PARAM_LABEL_CLASS}>
+                {t("node.videoNode.aspect.title")}
+              </div>
+              <div className={`grid grid-cols-5 ${VIDEO_PARAM_ROW_CLASS}`}>
                 <button
-                  key={ratio}
                   type="button"
-                  onClick={() => onChange({ aspectRatio: ratio })}
-                  className={`${VIDEO_PARAM_BUTTON_BASE_CLASS} ${
-                    isActive
-                      ? VIDEO_PARAM_ACTIVE_BUTTON_CLASS
-                      : VIDEO_PARAM_IDLE_BUTTON_CLASS
-                  }`}
+                  disabled
+                  className={`${VIDEO_PARAM_BUTTON_BASE_CLASS} ${VIDEO_PARAM_ACTIVE_BUTTON_CLASS} cursor-not-allowed`}
                 >
-                  {ratio === "auto" ? t("node.videoNode.aspect.auto") : ratio}
+                  {t("node.videoNode.aspect.auto")}
                 </button>
-              );
-            })}
-          </div>
+              </div>
+            </>
+          )}
 
           <div className={VIDEO_PARAM_LABEL_CLASS}>
             {t("node.videoNode.quality.title")}
@@ -1273,16 +1320,18 @@ function VideoConfigChip({
                       : VIDEO_PARAM_IDLE_BUTTON_CLASS
                   }`}
                 >
-                  {q}
+                  {formatResolutionLabel(q)}
                 </button>
               );
             })}
           </div>
 
-          <div className={VIDEO_PARAM_LABEL_CLASS}>
-            {t("node.videoNode.duration.title")}
-          </div>
-          <div className="mb-4 flex items-center gap-3">
+          {!followInputDuration && (
+            <>
+              <div className={VIDEO_PARAM_LABEL_CLASS}>
+                {t("node.videoNode.duration.title")}
+              </div>
+              <div className="mb-4 flex items-center gap-3">
             <input
               type="range"
               min={durationBounds.min}
@@ -1318,7 +1367,9 @@ function VideoConfigChip({
               />
               <span className="text-[11px] text-text-muted/80">s</span>
             </div>
-          </div>
+              </div>
+            </>
+          )}
 
           {sceneOptimizeOptions.length > 0 && (
             <>
@@ -1347,34 +1398,38 @@ function VideoConfigChip({
             </>
           )}
 
-          <div className={VIDEO_PARAM_LABEL_CLASS}>
-            {t("node.videoNode.audio.title")}
-          </div>
-          <div className="flex items-center justify-between rounded-md bg-white/[0.045] px-2.5 py-1.5">
-            <span className="text-xs font-medium text-text-dark/88">
-              {generateAudio
-                ? t("node.videoNode.audio.on")
-                : t("node.videoNode.audio.off")}
-            </span>
-            <button
-              type="button"
-              role="switch"
-              aria-checked={generateAudio}
-              aria-label={t("node.videoNode.audio.title")}
-              onClick={() => onChange({ generateAudio: !generateAudio })}
-              className={`relative inline-flex h-5 w-9 shrink-0 items-center rounded-full border transition-colors ${
-                generateAudio
-                  ? "border-white/24 bg-white/[0.18]"
-                  : "border-white/10 bg-white/[0.08]"
-              }`}
-            >
-              <span
-                className={`h-4 w-4 rounded-full bg-text-dark shadow-[0_2px_8px_rgba(0,0,0,0.35)] transition-transform ${
-                  generateAudio ? "translate-x-[18px]" : "translate-x-0.5"
-                }`}
-              />
-            </button>
-          </div>
+          {supportsGenerateAudio && (
+            <>
+              <div className={VIDEO_PARAM_LABEL_CLASS}>
+                {t("node.videoNode.audio.title")}
+              </div>
+              <div className="flex items-center justify-between rounded-md bg-white/[0.045] px-2.5 py-1.5">
+                <span className="text-xs font-medium text-text-dark/88">
+                  {generateAudio
+                    ? t("node.videoNode.audio.on")
+                    : t("node.videoNode.audio.off")}
+                </span>
+                <button
+                  type="button"
+                  role="switch"
+                  aria-checked={generateAudio}
+                  aria-label={t("node.videoNode.audio.title")}
+                  onClick={() => onChange({ generateAudio: !generateAudio })}
+                  className={`relative inline-flex h-5 w-9 shrink-0 items-center rounded-full border transition-colors ${
+                    generateAudio
+                      ? "border-white/24 bg-white/[0.18]"
+                      : "border-white/10 bg-white/[0.08]"
+                  }`}
+                >
+                  <span
+                    className={`h-4 w-4 rounded-full bg-text-dark shadow-[0_2px_8px_rgba(0,0,0,0.35)] transition-transform ${
+                      generateAudio ? "translate-x-[18px]" : "translate-x-0.5"
+                    }`}
+                  />
+                </button>
+              </div>
+            </>
+          )}
         </div>
       )}
     </div>

--- a/frontend/src/features/canvas/nodes/shared/videoModelCapabilities.ts
+++ b/frontend/src/features/canvas/nodes/shared/videoModelCapabilities.ts
@@ -64,6 +64,14 @@ export const GEN_MODE_TO_CATALOG_MODE: Record<VideoGenMode, string> = {
   videoEdit: "video_edit",
 };
 
+/**
+ * 这些模式的输出画幅由输入关键帧/源视频决定，不能提交用户保存的固定比例。
+ * 只计算本次请求的有效值，不覆盖节点中的比例，切回其它模式时可恢复用户选择。
+ */
+export function videoModeForcesAutomaticAspectRatio(mode: VideoGenMode): boolean {
+  return mode === "firstFrame" || mode === "firstLastFrame" || mode === "videoEdit";
+}
+
 export interface VideoKeyframeCandidate {
   url: string;
   slot?: VideoKeyframeSlot | null;
@@ -118,9 +126,20 @@ export type VideoModelRef =
       id?: string;
       apiModel?: string;
       supportedModes?: string[];
+      referenceAudioMax?: number | null;
+      supportsGenerateAudio?: boolean;
     }
   | null
   | undefined;
+
+/** 未配置的新字段沿用旧行为：支持原生音频，且默认开启。 */
+export function videoModelSupportsGenerateAudio(model: VideoModelRef): boolean {
+  return typeof model === "string" || model?.supportsGenerateAudio !== false;
+}
+
+export function videoModelDefaultGenerateAudio(model: VideoModelRef): boolean {
+  return videoModelSupportsGenerateAudio(model);
+}
 
 /** 从模型入参里取出用于能力启发式判定的 id（优先 apiModel，它才是打给上游的名字）。 */
 function videoModelIdOf(model: VideoModelRef): string | null | undefined {
@@ -500,7 +519,8 @@ export function formatAudioDurationClips(
  * 规则对齐后端 freezone i2v / omni-gen 端点（src/novelvideo/api/routes/freezone.py）：
  * - 视频素材：仅「全能参考」(omni，Seedance 2.0) 与「视频编辑」(HappyHorse) 消费，
  *   其余模式静默丢弃 → 拦；
- * - 音频素材：仅「全能参考」(omni，Seedance 2.0) 消费，其余模式静默丢弃 → 拦；
+ * - 音频素材：「全能参考」消费；「视频编辑」仅在媒体目录显式配置音频上限时消费；
+ *   其余模式静默丢弃 → 拦；
  * - 多图(>1)：i2v 端点仅 Seedance 2.0 / HappyHorse 放行，非 2.0 非 HappyHorse
  *   （Seedance 1.x）传 >1 图后端直接 400 → 拦。
  *
@@ -516,7 +536,14 @@ export function videoSubmitMediaRejectionReason(
   if (counts.videos > 0 && mode !== "allReference" && mode !== "videoEdit") {
     return "该模型不支持视频素材";
   }
-  if (counts.audios > 0 && mode !== "allReference") {
+  const videoEditAcceptsAudio =
+    mode === "videoEdit" &&
+    typeof model === "object" &&
+    model !== null &&
+    isVideoModeSupportedByModel("videoEdit", model) &&
+    typeof model.referenceAudioMax === "number" &&
+    model.referenceAudioMax > 0;
+  if (counts.audios > 0 && mode !== "allReference" && !videoEditAcceptsAudio) {
     return "该模型不支持音频素材";
   }
   if (counts.images > 1 && !videoModelAcceptsMultipleImages(model)) {
@@ -557,7 +584,11 @@ export function videoModelReferenceDisabledReason(
     if (counts.videos > 0 && !supportsAllReference && !supportsVideoEdit) {
       return "该模型不支持视频素材";
     }
-    if (counts.audios > 0 && !supportsAllReference) {
+    const supportsVideoEditAudio =
+      supportsVideoEdit &&
+      typeof model.referenceAudioMax === "number" &&
+      model.referenceAudioMax > 0;
+    if (counts.audios > 0 && !supportsAllReference && !supportsVideoEditAudio) {
       return "该模型不支持音频素材";
     }
     if (counts.images > 1 && !videoModelAcceptsMultipleImages(model)) {

--- a/frontend/src/features/canvas/ui/ProviderModelPicker.tsx
+++ b/frontend/src/features/canvas/ui/ProviderModelPicker.tsx
@@ -53,6 +53,7 @@ export interface ModelOption {
   resolutionOptions?: string[];
   qualityOptions?: string[];
   humanReview?: boolean;
+  supportsGenerateAudio?: boolean;
   minDuration?: number | null;
   maxDuration?: number | null;
   sceneOptimizeOptions?: Array<'anime' | 'realistic'>;

--- a/license-inventory.csv
+++ b/license-inventory.csv
@@ -264,6 +264,7 @@ frontend/src/__mocks__/msw/server.ts,Elastic-2.0,2026 SuperTale contributors,REU
 frontend/src/__tests__/api/canvas.test.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/__tests__/api/client.test.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/__tests__/api/freezone-scene360.test.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
+frontend/src/__tests__/api/freezone-video-edit.test.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/__tests__/api/task-poll-timeout.test.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/__tests__/components/account/avatar-upload-dialog.test.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/__tests__/components/assets/asset-panels-rename.test.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
@@ -379,6 +380,7 @@ frontend/src/__tests__/features/canvas/image-tool-feature-billing-contract.test.
 frontend/src/__tests__/features/canvas/infer-skill-connection-role.test.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/__tests__/features/canvas/inherit-mainline-fields.test.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/__tests__/features/canvas/lod-audio-playback.test.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
+frontend/src/__tests__/features/canvas/media-model-options.test.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/__tests__/features/canvas/mention-display-label.test.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/__tests__/features/canvas/node-generation-history.test.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/__tests__/features/canvas/node-generation-progress.test.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation

--- a/src/novelvideo/api/routes/freezone.py
+++ b/src/novelvideo/api/routes/freezone.py
@@ -368,7 +368,7 @@ async def _start_or_enqueue_freezone_video_gen(
     reference_items: list[dict],
     aspect_ratio: str,
     resolution: str,
-    duration_seconds: int,
+    duration_seconds: int | None,
     generate_audio: bool,
     human_review: bool,
     scene_optimize: str | None,
@@ -388,6 +388,13 @@ async def _start_or_enqueue_freezone_video_gen(
     from novelvideo.api.routes.model_credits import (
         freezone_video_generate_task_billing,
     )
+
+    # Catalog fields are optional for backward compatibility. Missing means
+    # the legacy behavior (native audio supported); an explicit false is an
+    # authoritative capability boundary and cannot be bypassed by old clients.
+    effective_generate_audio = bool(generate_audio)
+    if (capabilities or {}).get("supportsGenerateAudio") is False:
+        effective_generate_audio = False
 
     video_input_paths = [
         str(item.get("path") or "").strip()
@@ -429,13 +436,29 @@ async def _start_or_enqueue_freezone_video_gen(
             )
         except ValueError as exc:
             raise HTTPException(400, str(exc)) from exc
+    normalized_mode = str(gen_mode or "").strip()
+    if normalized_mode == "video_edit":
+        if not video_input_paths or input_video_duration_seconds <= 0:
+            raise HTTPException(400, "video editing requires a readable source video")
+        # 视频编辑的输出时长跟随主输入视频。输入和输出沿用同一套整秒
+        # 计费口径，不为视频编辑额外引入向上取整规则；发给 NewAPI 的
+        # 最终协议仍会强制使用 duration=auto。
+        effective_duration_seconds = max(
+            int(math.floor(input_video_duration_seconds)),
+            1,
+        )
+    elif duration_seconds is not None:
+        effective_duration_seconds = max(int(duration_seconds), 1)
+    else:
+        raise HTTPException(400, "duration_seconds is required for this video mode")
+
     billing = freezone_video_generate_task_billing(
         {
             "video_backend": backend,
             "resolution": resolution,
-            "pricing_quantity": duration_seconds,
+            "pricing_quantity": effective_duration_seconds,
             "operation": requested_gen_mode or gen_mode or "textToVideo",
-            "generate_audio": generate_audio,
+            "generate_audio": effective_generate_audio,
             "video_input_present": bool(video_input_paths),
             "input_video_duration_seconds": input_video_duration_seconds,
             **({"catalog_id": catalog_id} if catalog_id else {}),
@@ -453,8 +476,8 @@ async def _start_or_enqueue_freezone_video_gen(
         "reference_items": reference_items,
         "aspect_ratio": aspect_ratio,
         "resolution": resolution,
-        "duration_seconds": duration_seconds,
-        "generate_audio": generate_audio,
+        "duration_seconds": effective_duration_seconds,
+        "generate_audio": effective_generate_audio,
         "human_review": human_review,
         "scene_optimize": normalize_freezone_seedance2_scene_optimize(
             backend, scene_optimize
@@ -7436,6 +7459,46 @@ async def _probe_reference_audio_seconds(path: str) -> float | None:
         return None
 
 
+async def _validate_catalog_reference_audio_items(
+    reference_items: list[dict[str, str]],
+    *,
+    capabilities: dict[str, Any] | None,
+    backend: str,
+) -> None:
+    """按媒体目录校验参考音频时长；旧 Seedance 2.0 目录保留历史兜底。"""
+    audio_items = [item for item in reference_items if item["type"] == "audio"]
+    if not audio_items:
+        return
+
+    audio_bounds = list(_catalog_reference_duration_bounds(capabilities, "audio"))
+    if is_freezone_seedance2_backend(backend):
+        if audio_bounds[0] is None:
+            audio_bounds[0] = MIN_OMNI_REFERENCE_AUDIO_SECONDS
+        if audio_bounds[1] is None:
+            audio_bounds[1] = MAX_OMNI_REFERENCE_AUDIO_SECONDS
+        if audio_bounds[3] is None:
+            audio_bounds[3] = MAX_OMNI_REFERENCE_AUDIO_TOTAL_SECONDS
+    if not any(value is not None for value in audio_bounds):
+        return
+
+    probed_seconds = await asyncio.gather(
+        *(_probe_reference_audio_seconds(item["path"]) for item in audio_items)
+    )
+    probed = [
+        (Path(item["path"]).name or f"audio{index}", seconds)
+        for index, (item, seconds) in enumerate(
+            zip(audio_items, probed_seconds), start=1
+        )
+    ]
+    validate_omni_reference_audio_durations(
+        probed,
+        min_seconds=audio_bounds[0],
+        max_seconds=audio_bounds[1],
+        total_min_seconds=audio_bounds[2],
+        total_max_seconds=audio_bounds[3],
+    )
+
+
 def _catalog_duration_bounds(
     capabilities: dict[str, Any] | None,
 ) -> tuple[int | None, int | None]:
@@ -8300,7 +8363,8 @@ async def freezone_video_keyframes(
             job_id=job_id,
             prompt=final_prompt,
             reference_items=reference_items,
-            aspect_ratio=normalize_video_aspect_ratio(body.aspect_ratio),
+            # 关键帧画幅跟随首帧；仅尾帧时跟随尾帧，不接受固定比例。
+            aspect_ratio="auto",
             resolution=normalize_video_resolution_for_backend(
                 backend,
                 body.resolution,
@@ -8417,45 +8481,22 @@ async def freezone_video_omni_gen(
             }
         )
 
-    # 音频时长必须在预扣积分和投递任务之前校验。目录配置是服务端权威值；Seedance 2.0
-    # 的历史边界仅在旧目录尚未补齐新字段时兜底，显式配置不再被隐藏常量覆盖。
-    audio_items = [item for item in reference_items if item["type"] == "audio"]
-    audio_bounds = list(_catalog_reference_duration_bounds(capabilities, "audio"))
-    if is_freezone_seedance2_backend(backend):
-        if audio_bounds[0] is None:
-            audio_bounds[0] = MIN_OMNI_REFERENCE_AUDIO_SECONDS
-        if audio_bounds[1] is None:
-            audio_bounds[1] = MAX_OMNI_REFERENCE_AUDIO_SECONDS
-        if audio_bounds[3] is None:
-            audio_bounds[3] = MAX_OMNI_REFERENCE_AUDIO_TOTAL_SECONDS
-    if audio_items and any(value is not None for value in audio_bounds):
-        # 并发探测：ffprobe 单条有 20s 超时，串行 await 会把 3 条参考音频叠成最长 60s 的
-        # 请求耗时。gather 之后最坏就是一个超时的墙钟，也就顺带成了整体上限。
-        probed_seconds = await asyncio.gather(
-            *(_probe_reference_audio_seconds(item["path"]) for item in audio_items)
+    # 音频时长必须在预扣积分和投递任务之前校验。
+    try:
+        await _validate_catalog_reference_audio_items(
+            reference_items,
+            capabilities=capabilities,
+            backend=backend,
         )
-        probed = [
-            (Path(item["path"]).name or f"audio{index}", seconds)
-            for index, (item, seconds) in enumerate(
-                zip(audio_items, probed_seconds), start=1
-            )
-        ]
-        try:
-            validate_omni_reference_audio_durations(
-                probed,
-                min_seconds=audio_bounds[0],
-                max_seconds=audio_bounds[1],
-                total_min_seconds=audio_bounds[2],
-                total_max_seconds=audio_bounds[3],
-            )
-        except ValueError as exc:
-            raise HTTPException(400, str(exc)) from exc
+    except ValueError as exc:
+        raise HTTPException(400, str(exc)) from exc
 
     final_prompt = build_freezone_omni_video_prompt(
         user_prompt=body.prompt,
         theme=body.theme,
         camera_template_id=body.camera_template_id,
         marks=[item.model_dump() for item in body.marks],
+        reference_items=reference_items,
     )
     job_id = _new_job_id()
 
@@ -8515,9 +8556,9 @@ async def freezone_video_edit(
     body: FreezoneVideoEditRequest,
     user: dict = Depends(get_api_user),
 ):
-    """视频处理：视频编辑（HappyHorse 视频编辑功能）。
+    """视频处理：视频编辑。
 
-    输入 1 个源视频 + 0-5 张参考图，走上游 video_url + reference_images。
+    输入 1 个源视频，并按目录能力发送参考图片和独立参考音频。
     """
     ctx, username, project_name, project_dir, output_dir = await _resolve_freezone_project(
         project, user
@@ -8539,7 +8580,7 @@ async def freezone_video_edit(
     if mode_enabled is False or (
         mode_enabled is None and not is_freezone_happyhorse_backend(backend)
     ):
-        raise HTTPException(400, "video edit currently only supports HappyHorse models")
+        raise HTTPException(400, "this model does not support video_edit mode")
 
     if not body.video_url.strip():
         raise HTTPException(400, "video_url is required")
@@ -8550,6 +8591,9 @@ async def freezone_video_edit(
     image_paths = _resolve_url_list(project_dir, list(body.image_urls))
     if len(image_paths) != len(body.image_urls):
         raise HTTPException(400, "some image_urls could not be resolved")
+    audio_paths = _resolve_url_list(project_dir, list(body.audio_urls))
+    if len(audio_paths) != len(body.audio_urls):
+        raise HTTPException(400, "some audio_urls could not be resolved")
     reference_limits = _catalog_reference_limits(
         capabilities,
         image_default=5,
@@ -8563,12 +8607,28 @@ async def freezone_video_edit(
             400,
             f"this model supports at most {reference_limits['image']} image references",
         )
+    if len(audio_paths) > reference_limits["audio"]:
+        raise HTTPException(
+            400,
+            f"this model supports at most {reference_limits['audio']} audio references",
+        )
 
     reference_items: list[dict[str, str]] = [
         {"type": "video", "path": video_paths[0], "role": "视频编辑源"}
     ]
     for path in image_paths:
         reference_items.append({"type": "image", "path": path, "role": "图片参考"})
+    for path in audio_paths:
+        reference_items.append({"type": "audio", "path": path, "role": "配乐参考"})
+
+    try:
+        await _validate_catalog_reference_audio_items(
+            reference_items,
+            capabilities=capabilities,
+            backend=backend,
+        )
+    except ValueError as exc:
+        raise HTTPException(400, str(exc)) from exc
 
     final_prompt = build_freezone_image_to_video_prompt(
         user_prompt=body.prompt,
@@ -8588,17 +8648,14 @@ async def freezone_video_edit(
             job_id=job_id,
             prompt=final_prompt,
             reference_items=reference_items,
-            aspect_ratio=normalize_video_aspect_ratio(body.aspect_ratio),
+            # 视频编辑的画幅与输出时长均跟随源视频；用户只选择分辨率。
+            aspect_ratio="auto",
             resolution=normalize_video_resolution_for_backend(
                 backend,
                 body.resolution,
                 _catalog_resolution_options(capabilities),
             ),
-            duration_seconds=normalize_video_duration_for_backend(
-                backend,
-                body.duration_seconds,
-                *_catalog_duration_bounds(capabilities),
-            ),
+            duration_seconds=None,
             generate_audio=body.generate_audio,
             human_review=body.human_review,
             scene_optimize=None,

--- a/src/novelvideo/api/schemas.py
+++ b/src/novelvideo/api/schemas.py
@@ -1169,8 +1169,8 @@ class FreezoneKeyframeVideoRequest(BaseModel):
         description="局部元素标记列表。来自前端点击图片选中的主体/物体局部区域，不是普通 tags",
     )
     aspect_ratio: str = Field(
-        default="16:9",
-        description="视频比例；auto 当前回退为 16:9",
+        default="auto",
+        description="关键帧模式固定为 auto，输出比例跟随首帧或尾帧",
     )
     resolution: str = Field(
         default="720p",
@@ -1203,15 +1203,19 @@ class FreezoneKeyframeVideoRequest(BaseModel):
 
 
 class FreezoneVideoEditRequest(BaseModel):
-    """视频编辑请求（HappyHorse 视频编辑功能）。
+    """视频编辑请求。
 
-    输入 1 个源视频 + 0-5 张参考图，对视频进行编辑改写。
+    输入 1 个源视频，并按媒体模型目录配置接收参考图片和独立参考音频。
     """
 
     video_url: str = Field(description="源视频静态地址，必填")
     image_urls: list[str] = Field(
         default_factory=list,
-        description="参考图静态地址列表，0-5 张，单张 <= 10MB",
+        description="参考图静态地址列表；数量上限由媒体模型目录决定",
+    )
+    audio_urls: list[str] = Field(
+        default_factory=list,
+        description="独立参考音频静态地址列表；数量和时长上限由媒体模型目录决定",
     )
     prompt: str = Field(default="", description="用户编辑指令/视频描述，可为空")
     camera_template_id: Optional[str] = Field(
@@ -1222,18 +1226,9 @@ class FreezoneVideoEditRequest(BaseModel):
         default_factory=list,
         description="局部元素标记列表",
     )
-    aspect_ratio: str = Field(
-        default="16:9",
-        description="视频比例；视频编辑画幅由源视频决定，此字段仅占位",
-    )
     resolution: str = Field(
         default="720p",
         description="输出清晰度档位",
-    )
-    duration_seconds: int = Field(
-        default=5,
-        ge=1,
-        description="视频时长，至少 1 秒；不同模型支持的时长范围可能不同",
     )
     audio_setting: Literal["auto", "origin"] = Field(
         default="auto",

--- a/src/novelvideo/freezone/video_node.py
+++ b/src/novelvideo/freezone/video_node.py
@@ -135,7 +135,9 @@ def get_video_camera_template(template_id: str | None) -> dict[str, str] | None:
 
 def normalize_video_aspect_ratio(value: str | None) -> str:
     text = str(value or "").strip().lower()
-    if not text or text == "auto":
+    if text in {"auto", "adaptive"}:
+        return "auto"
+    if not text:
         return "16:9"
     return text
 
@@ -219,12 +221,12 @@ def normalize_video_resolution_for_backend(
             None,
         )
         if matched is not None:
-            return matched
+            return normalize_video_resolution(matched)
         preferred = next(
             (option for option in configured if option.lower() == "720p"),
             None,
         )
-        return preferred or configured[0]
+        return normalize_video_resolution(preferred or configured[0])
     options = freezone_video_resolution_options(backend)
     if resolution in options:
         return resolution
@@ -485,6 +487,7 @@ def build_freezone_omni_video_prompt(
     theme: str = "",
     camera_template_id: str | None = None,
     marks: list[dict[str, Any]] | None = None,
+    reference_items: list[dict[str, Any]] | None = None,
 ) -> str:
     parts = [str(user_prompt or "").strip()]
 
@@ -502,6 +505,15 @@ def build_freezone_omni_video_prompt(
     parts.append(
         "全能参考模式要求：综合文本、图像、视频和音频参考进行统一建模，优先保持主体身份、场景连续性、风格一致性和动作自然性。"
     )
+    counts = summarize_omni_reference_counts(reference_items or [])
+    single_video_reference_instruction = "这是视频参考生成新的视频，不是视频编辑。"
+    if (
+        counts["video_count"] == 1
+        and counts["image_count"] == 0
+        and counts["audio_count"] == 0
+        and single_video_reference_instruction not in "\n".join(parts)
+    ):
+        parts.append(single_video_reference_instruction)
     parts.append(
         "输出要求：生成单条连贯视频镜头，动作自然，运动平滑，避免闪烁、变形、跳帧和主体身份漂移。"
     )

--- a/src/novelvideo/generators/nanobanana_grid.py
+++ b/src/novelvideo/generators/nanobanana_grid.py
@@ -167,11 +167,20 @@ def _newapi_safe_request_context(
 ) -> dict[str, object]:
     reference_images = payload.get("image")
     reference_image_count = len(reference_images) if isinstance(reference_images, list) else 0
+    raw_metadata = payload.get("metadata")
+    metadata = raw_metadata if isinstance(raw_metadata, dict) else {}
+    geometry_metadata = {
+        key: metadata[key]
+        for key in ("ratio", "aspect_ratio", "resolution")
+        if key in metadata
+    }
     return {
         "endpoint": f"{endpoint}{request_path}",
         "model": model,
         "payload_keys": sorted(payload.keys()),
-        "size": payload.get("size") or "",
+        "width": payload.get("width") or "",
+        "height": payload.get("height") or "",
+        "geometry_metadata": geometry_metadata,
         "reference_image_count": reference_image_count,
         "prompt_chars": len(prompt or ""),
         "prompt_sha256": hashlib.sha256((prompt or "").encode("utf-8")).hexdigest()[:16],
@@ -183,7 +192,9 @@ def _newapi_context_for_error(context: dict[str, object]) -> str:
         f"model={context.get('model')}; "
         f"endpoint={context.get('endpoint')}; "
         f"payload_keys={context.get('payload_keys')}; "
-        f"size={context.get('size')}; "
+        f"width={context.get('width')}; "
+        f"height={context.get('height')}; "
+        f"geometry_metadata={context.get('geometry_metadata')}; "
         f"reference_image_count={context.get('reference_image_count')}; "
         f"prompt_sha256={context.get('prompt_sha256')}"
     )
@@ -443,10 +454,15 @@ def resolve_openai_image_size(
     long_edges = {
         "512": 1024,
         "0.5K": 1024,
+        "0.5k": 1024,
         "1K": 1024,
+        "1k": 1024,
         "2K": 2048,
+        "2k": 2048,
         "3K": 3072,
+        "3k": 3072,
         "4K": 3840,
+        "4k": 3840,
     }
     long_edge = long_edges.get(normalized_size)
     dynamic_max_edge = _OPENAI_MAX_EDGE
@@ -3398,28 +3414,44 @@ async def _call_newapi_image_api(
         return None, "", "DramaClawAPI API key is missing"
 
     image_config = image_config or {}
-    aspect_ratio = str(image_config.get("aspect_ratio") or "1:1").strip() or "1:1"
+    aspect_ratio = str(image_config.get("aspect_ratio") or "1:1").strip().lower() or "1:1"
     image_size = normalize_image_size(str(image_config.get("image_size") or "1K"), "newapi")
     request_schema = image_config.get("request_schema") or {}
-    try:
-        size = resolve_openai_image_size(
-            aspect_ratio,
-            image_size,
-            model,
-            allow_dynamic_resolution=True,
-            min_pixels=request_schema.get("minPixels"),
-        )
-    except ValueError as exc:
-        return None, "", str(exc)
+    from novelvideo.media_model_request_schema import normalize_media_resolution_value
 
+    resolution = normalize_media_resolution_value(image_size)
+
+    metadata: dict[str, object] = {"resolution": resolution}
     payload: dict[str, object] = {
         "model": model,
         "prompt": prompt,
-        "size": size,
         "n": 1,
         "response_format": "b64_json",
         "watermark": False,
+        "metadata": metadata,
     }
+    if aspect_ratio in {"auto", "adaptive"}:
+        # Images use ``auto`` as the public follow-input ratio value. Keep
+        # resolution independent and let NewAPI infer the geometry.
+        metadata["ratio"] = "auto"
+    else:
+        # Fixed geometry keeps the selected ratio as semantic metadata while
+        # width/height carry the pixel expectation. All three values come from
+        # this same aspect-ratio/resolution pair.
+        metadata["ratio"] = aspect_ratio
+        try:
+            size = resolve_openai_image_size(
+                aspect_ratio,
+                image_size,
+                model,
+                allow_dynamic_resolution=True,
+                min_pixels=request_schema.get("minPixels"),
+            )
+        except ValueError as exc:
+            return None, "", str(exc)
+        width, height = (int(value) for value in size.split("x", 1))
+        payload["width"] = width
+        payload["height"] = height
     include_quality = bool(
         request_schema.get("includeQuality")
     ) or _newapi_image_model_supports_quality(model)
@@ -3445,13 +3477,17 @@ async def _call_newapi_image_api(
     else:
         request_path = "/images/generations"
 
-    from novelvideo.media_model_request_schema import apply_media_request_schema
+    from novelvideo.media_model_request_schema import (
+        apply_media_request_schema,
+        enforce_newapi_media_geometry_contract,
+    )
 
     payload = apply_media_request_schema(
         payload,
         request_schema,
         image_config.get("model_params") or {},
     )
+    payload = enforce_newapi_media_geometry_contract(payload, media_type="image")
 
     if base_url:
         endpoint = base_url.rstrip("/")

--- a/src/novelvideo/generators/video_generator.py
+++ b/src/novelvideo/generators/video_generator.py
@@ -358,6 +358,13 @@ class SeedanceVideoGenerator(VideoGeneratorBase):
 
         return f"data:{mime_type};base64,{image_data}"
 
+    @staticmethod
+    def _normalize_aspect_ratio(value: str | None) -> str:
+        """Accept both legacy and canonical follow-input ratio values."""
+
+        ratio = str(value or "").strip().lower()
+        return ratio if ":" in ratio or ratio in {"auto", "adaptive"} else "9:16"
+
     async def _download_video(self, url: str, output_path: str, max_retries: int = 3) -> bool:
         """下载视频文件，失败自动重试。"""
         import httpx
@@ -471,10 +478,10 @@ class SeedanceVideoGenerator(VideoGeneratorBase):
         duration = normalize_video_duration_for_backend("seedance_fast", duration)
 
         # 映射 aspect_ratio 格式
-        ratio_text = str(aspect_ratio or "").strip().lower()
-        # Seedance I2V uses ``adaptive`` to preserve the first-frame framing.
-        # The old colon-only guard accidentally converted it back to 9:16.
-        ratio = ratio_text if ":" in ratio_text or ratio_text == "adaptive" else "9:16"
+        # Existing direct-Seedance deployments used ``adaptive`` while the
+        # canonical media contract uses ``auto``. Accept both at this legacy
+        # boundary instead of silently falling back to 9:16.
+        ratio = self._normalize_aspect_ratio(aspect_ratio)
 
         # 处理首帧
         if image_path.startswith(("http://", "https://", "data:")):

--- a/src/novelvideo/generators/video_generator.py
+++ b/src/novelvideo/generators/video_generator.py
@@ -2218,19 +2218,28 @@ class NewApiVideoGenerator(VideoGeneratorBase):
         # reliably reconstruct them from an input image's exact pixel ratio.
         resolution = metadata.get("resolution", "")
         ratio = metadata.get("ratio", "")
+        if resolution:
+            metadata["resolution"] = str(resolution).strip().lower()
+            resolution = metadata["resolution"]
+        if ratio:
+            metadata["ratio"] = str(ratio).strip().lower()
+            ratio = metadata["ratio"]
 
         duration_value = payload.pop("duration", None)
         legacy_seconds = payload.pop("seconds", None)
         if duration_value is None:
             duration_value = legacy_seconds
-        try:
-            duration_number = float(str(duration_value))
-        except (TypeError, ValueError):
-            duration_number = 0
-        if duration_number > 0:
-            payload["duration"] = (
-                int(duration_number) if duration_number.is_integer() else duration_number
-            )
+        if str(duration_value or "").strip().lower() == "auto":
+            payload["duration"] = "auto"
+        else:
+            try:
+                duration_number = float(str(duration_value))
+            except (TypeError, ValueError):
+                duration_number = 0
+            if duration_number > 0:
+                payload["duration"] = (
+                    int(duration_number) if duration_number.is_integer() else duration_number
+                )
 
         first_frame = ""
         for key in ("first_frame_image", "image_url"):
@@ -2282,14 +2291,25 @@ class NewApiVideoGenerator(VideoGeneratorBase):
         if last_frame.strip():
             metadata["last_frame_image"] = last_frame.strip()
 
-        dimensions = cls._video_dimensions(resolution, ratio)
-        if dimensions:
+        ratio_text = str(ratio or "").strip().lower()
+        if ratio_text in {"auto", "adaptive"}:
+            # Video follow-input geometry is expressed by ratio only. Sending
+            # width/height as well would turn an automatic request back into a
+            # fixed-size request at the NewAPI adapter boundary.
+            metadata["ratio"] = "auto"
+            metadata.pop("aspect_ratio", None)
+            payload.pop("width", None)
+            payload.pop("height", None)
+        elif dimensions := cls._video_dimensions(resolution, ratio_text):
             payload["width"], payload["height"] = dimensions
+            # Keep the selected ratio semantics beside the derived dimensions;
+            # resolution remains the independent model/charging tier.
+            metadata["ratio"] = ratio_text
+            metadata.pop("aspect_ratio", None)
         else:
-            ratio_text = str(ratio or "").strip()
             resolution_text = str(resolution or "").strip()
             if ratio_text:
-                metadata["aspect_ratio"] = ratio_text
+                metadata["ratio"] = ratio_text
             if resolution_text:
                 metadata["resolution"] = resolution_text
 
@@ -2556,7 +2576,11 @@ class NewApiVideoGenerator(VideoGeneratorBase):
         ratio_text = str(aspect_ratio or "").strip().lower()
         # Seedance I2V uses ``adaptive`` to preserve the first-frame framing.
         # The old colon-only guard accidentally converted it back to 9:16.
-        ratio = ratio_text if ":" in ratio_text or ratio_text == "adaptive" else "9:16"
+        ratio = (
+            ratio_text
+            if ":" in ratio_text or ratio_text in {"auto", "adaptive"}
+            else "9:16"
+        )
         image_path = str(image_path or "").strip()
         requested_mode = str(kwargs.get("gen_mode") or "").strip()
 
@@ -2863,12 +2887,24 @@ class NewApiVideoGenerator(VideoGeneratorBase):
                 resolution=request_resolution,
                 duration_seconds=duration,
             )
-            from novelvideo.media_model_request_schema import apply_media_request_schema
+            from novelvideo.media_model_request_schema import (
+                apply_media_request_schema,
+                enforce_newapi_media_geometry_contract,
+                enforce_newapi_video_duration_contract,
+                enforce_newapi_video_mode_contract,
+            )
 
             self._canonicalize_video_payload(payload, metadata)
             payload = apply_media_request_schema(
                 payload, self.request_schema, self.model_params
             )
+            payload = enforce_newapi_video_mode_contract(
+                payload,
+                mode=requested_mode,
+                fixed_duration=duration,
+            )
+            payload = enforce_newapi_media_geometry_contract(payload, media_type="video")
+            payload = enforce_newapi_video_duration_contract(payload)
             submitted = await self._post_json(
                 f"{self.base_url}/video/generations", payload
             )

--- a/src/novelvideo/media_model_request_schema.py
+++ b/src/novelvideo/media_model_request_schema.py
@@ -161,7 +161,7 @@ def enforce_newapi_media_geometry_contract(
         metadata.pop("aspect_ratio", None)
         result.pop("width", None)
         result.pop("height", None)
-    elif "width" in result and "height" in result:
+    else:
         if ratio:
             metadata["ratio"] = ratio
         metadata.pop("aspect_ratio", None)

--- a/src/novelvideo/media_model_request_schema.py
+++ b/src/novelvideo/media_model_request_schema.py
@@ -69,10 +69,161 @@ class MediaModelSchemaError(ValueError):
     pass
 
 
+def normalize_media_resolution_value(value: object) -> str:
+    """Normalize named resolution tiers without rewriting explicit pixel sizes."""
+
+    clean = str(value or "").strip()
+    lowered = clean.lower()
+    if re.fullmatch(r"(?:\d+(?:\.\d+)?k|\d{3,4}p)", lowered):
+        return lowered
+    return clean
+
+
+def normalize_media_model_catalog_config(config: object) -> dict[str, Any]:
+    """Return a storage-safe catalog config with canonical public option values."""
+
+    if not isinstance(config, dict):
+        raise MediaModelSchemaError("media model config must be an object")
+    normalized = copy.deepcopy(config)
+    # Briefly introduced during development, then removed when native-audio
+    # defaults were fixed by product policy (supported => on by default).
+    # Drop it on save/import so previewed local configs do not retain dead data.
+    normalized.pop("defaultGenerateAudio", None)
+    resolutions = normalized.get("resolutionOptions")
+    if isinstance(resolutions, list):
+        seen: set[str] = set()
+        canonical: list[object] = []
+        for item in resolutions:
+            value = normalize_media_resolution_value(item) if isinstance(item, str) else item
+            identity = f"{type(value).__name__}:{value!s}"
+            if identity in seen:
+                continue
+            seen.add(identity)
+            canonical.append(value)
+        normalized["resolutionOptions"] = canonical
+    ratios = normalized.get("ratioOptions")
+    if isinstance(ratios, list):
+        seen_ratios: set[str] = set()
+        canonical_ratios: list[object] = []
+        for item in ratios:
+            value: object = item
+            if isinstance(item, str):
+                clean = item.strip()
+                value = "auto" if clean.lower() in {"auto", "adaptive"} else clean
+            identity = f"{type(value).__name__}:{value!s}"
+            if identity in seen_ratios:
+                continue
+            seen_ratios.add(identity)
+            canonical_ratios.append(value)
+        normalized["ratioOptions"] = canonical_ratios
+    return normalized
+
+
 def normalize_media_model_mode(mode: str | None) -> str:
     """Normalize canvas business mode names to media catalog mode names."""
     raw_mode = str(mode or "")
     return MODE_ALIASES.get(raw_mode, raw_mode)
+
+
+def enforce_newapi_media_geometry_contract(
+    payload: dict[str, Any], *, media_type: str
+) -> dict[str, Any]:
+    """Enforce the final mutually exclusive NewAPI geometry representation.
+
+    Fixed geometry keeps its semantic ratio and derived width/height together.
+    Follow-input geometry is expressed by a canonical ratio value without
+    dimensions. Resolution remains independent in metadata for both forms.
+    """
+
+    result = copy.deepcopy(payload)
+    raw_metadata = result.get("metadata")
+    metadata = dict(raw_metadata) if isinstance(raw_metadata, dict) else {}
+    resolution = normalize_media_resolution_value(
+        metadata.get("resolution") or result.pop("resolution", None)
+    )
+    if resolution:
+        metadata["resolution"] = resolution
+
+    ratio = str(
+        metadata.get("ratio")
+        or metadata.get("aspect_ratio")
+        or result.get("ratio")
+        or result.get("aspect_ratio")
+        or ""
+    ).strip().lower()
+    result.pop("ratio", None)
+    result.pop("aspect_ratio", None)
+    # ``size`` is a retired merged geometry alias. Public NewAPI requests use
+    # numeric width/height for fixed geometry and omit all dimensions for auto.
+    result.pop("size", None)
+    if ratio in {"auto", "adaptive"}:
+        metadata["ratio"] = "auto"
+        metadata.pop("aspect_ratio", None)
+        result.pop("width", None)
+        result.pop("height", None)
+    elif "width" in result and "height" in result:
+        if ratio:
+            metadata["ratio"] = ratio
+        metadata.pop("aspect_ratio", None)
+
+    if metadata:
+        result["metadata"] = metadata
+    else:
+        result.pop("metadata", None)
+    return result
+
+
+def enforce_newapi_video_duration_contract(payload: dict[str, Any]) -> dict[str, Any]:
+    """Normalize the final generic NewAPI duration without provider aliases."""
+
+    result = copy.deepcopy(payload)
+    raw_duration = result.get("duration", result.get("seconds"))
+    result.pop("seconds", None)
+    if str(raw_duration or "").strip().lower() == "auto":
+        result["duration"] = "auto"
+        return result
+    try:
+        duration = float(str(raw_duration))
+    except (TypeError, ValueError):
+        result.pop("duration", None)
+        return result
+    if duration <= 0:
+        result.pop("duration", None)
+        return result
+    result["duration"] = int(duration) if duration.is_integer() else duration
+    return result
+
+
+def enforce_newapi_video_mode_contract(
+    payload: dict[str, Any],
+    *,
+    mode: str | None,
+    fixed_duration: int | float | None = None,
+) -> dict[str, Any]:
+    """Apply product-level invariants that model parameters may not override."""
+
+    result = copy.deepcopy(payload)
+    if normalize_media_model_mode(mode) != "video_edit":
+        if (
+            str(result.get("duration") or result.get("seconds") or "")
+            .strip()
+            .lower()
+            == "auto"
+            and fixed_duration is not None
+        ):
+            result["duration"] = fixed_duration
+            result.pop("seconds", None)
+        return result
+
+    raw_metadata = result.get("metadata")
+    metadata = dict(raw_metadata) if isinstance(raw_metadata, dict) else {}
+    metadata["ratio"] = "auto"
+    metadata.pop("aspect_ratio", None)
+    result["metadata"] = metadata
+    result["duration"] = "auto"
+    for key in ("seconds", "ratio", "aspect_ratio", "size", "width", "height"):
+        result.pop(key, None)
+    return result
 
 
 def _validate_js_number(value: int | float, field: str) -> None:
@@ -254,6 +405,7 @@ def validate_media_model_catalog_config(
             "referenceVideoTotalMinSeconds",
             "referenceVideoTotalMaxSeconds",
             "humanReview",
+            "supportsGenerateAudio",
             "sceneOptimizeOptions",
             "defaultSceneOptimize",
         }
@@ -364,6 +516,11 @@ def validate_media_model_catalog_config(
     if human_review is not None and not isinstance(human_review, bool):
         raise MediaModelSchemaError("humanReview must be boolean")
 
+    supports_generate_audio = config.get("supportsGenerateAudio")
+    if supports_generate_audio is not None and not isinstance(
+        supports_generate_audio, bool
+    ):
+        raise MediaModelSchemaError("supportsGenerateAudio must be boolean")
     default_scene = config.get("defaultSceneOptimize")
     scene_options = config.get("sceneOptimizeOptions") or []
     if default_scene is not None and (

--- a/src/novelvideo/model_gateway_settings.py
+++ b/src/novelvideo/model_gateway_settings.py
@@ -514,6 +514,7 @@ def save_newapi_media_model_mappings(
     mappings: dict[str, dict[str, Any]],
 ) -> dict[str, dict[str, Any]]:
     from novelvideo.media_model_request_schema import (
+        normalize_media_model_catalog_config,
         validate_media_model_catalog_config,
     )
 
@@ -528,6 +529,7 @@ def save_newapi_media_model_mappings(
         media_type = str(item.get("mediaType") or "").strip().lower()
         config = item.get("config") if isinstance(item.get("config"), dict) else {}
         if media_type in {"image", "video"}:
+            config = normalize_media_model_catalog_config(config)
             validate_media_model_catalog_config(config, media_type)
         normalized_item: dict[str, Any] = {
             "provider": provider,
@@ -743,6 +745,8 @@ def _media_model_catalog(
     provider: str | None = None,
     include_disabled: bool = False,
 ) -> list[dict[str, Any]]:
+    from novelvideo.media_model_request_schema import normalize_media_model_catalog_config
+
     wanted = str(media_type or "").strip().lower()
     if wanted not in {"image", "video"}:
         return []
@@ -754,7 +758,7 @@ def _media_model_catalog(
         if item.get("mediaType") != wanted or (disabled and not include_disabled):
             continue
         config = item.get("config") if isinstance(item.get("config"), dict) else {}
-        config = dict(config)
+        config = normalize_media_model_catalog_config(config)
         config.setdefault(
             "request",
             {

--- a/tests/test_freezone_image_backend.py
+++ b/tests/test_freezone_image_backend.py
@@ -795,6 +795,53 @@ async def test_freezone_video_generation_enqueues_feature_billing(
     }
     assert captured["payload"]["gen_mode"] == "image_reference"
     assert captured["payload"]["requested_gen_mode"] == "imageToVideo"
+    assert captured["payload"]["generate_audio"] is True
+
+
+@pytest.mark.asyncio
+async def test_freezone_video_generation_forces_audio_off_when_model_disallows_it(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    captured: dict[str, object] = {}
+
+    async def fake_enqueue_project_task(_ctx: ProjectContext, **kwargs):
+        captured.update(kwargs)
+        return SimpleNamespace(
+            task_state=SimpleNamespace(task_id="task_video_no_audio"),
+            backend="celery",
+            queue="node.node_a.video",
+        )
+
+    monkeypatch.setattr(
+        freezone_routes,
+        "get_task_backend",
+        lambda: SimpleNamespace(enqueue_project_task=fake_enqueue_project_task),
+    )
+
+    await freezone_routes._start_or_enqueue_freezone_video_gen(
+        ctx=_project_ctx(tmp_path),
+        username="admin",
+        project="demo",
+        project_dir=tmp_path / "project",
+        output_dir=str(tmp_path / "output"),
+        job_id="job_video_no_audio",
+        prompt="静音视频",
+        reference_items=[],
+        aspect_ratio="16:9",
+        resolution="720p",
+        duration_seconds=5,
+        generate_audio=True,
+        human_review=False,
+        scene_optimize=None,
+        backend="newapi_seedance-2.0",
+        gen_mode="text_to_video",
+        capabilities={"supportsGenerateAudio": False},
+    )
+
+    payload = captured["payload"]
+    assert payload["generate_audio"] is False
+    assert payload["billing"]["generate_audio"] is False
 
 
 @pytest.mark.asyncio
@@ -856,6 +903,69 @@ async def test_freezone_video_generation_probes_reference_duration_before_billin
     }
     assert billing["pricing_quantity"] == 23
     assert billing["pricing_metrics"]["input_video_billed_seconds"] == 11
+
+
+@pytest.mark.asyncio
+async def test_video_edit_uses_source_duration_for_output_reservation(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    captured: dict[str, object] = {}
+
+    async def fake_enqueue_project_task(_ctx: ProjectContext, **kwargs):
+        captured.update(kwargs)
+        return SimpleNamespace(
+            task_state=SimpleNamespace(task_id="task_video_edit"),
+            backend="celery",
+            queue="node.node_a.video",
+        )
+
+    async def fake_probe(paths):
+        assert list(paths) == ["/project/source.mp4"]
+        return 7.1
+
+    monkeypatch.setattr(
+        freezone_routes,
+        "get_task_backend",
+        lambda: SimpleNamespace(enqueue_project_task=fake_enqueue_project_task),
+    )
+    monkeypatch.setattr(
+        freezone_routes,
+        "probe_total_video_duration_seconds",
+        fake_probe,
+    )
+
+    await freezone_routes._start_or_enqueue_freezone_video_gen(
+        ctx=_project_ctx(tmp_path),
+        username="admin",
+        project="demo",
+        project_dir=tmp_path / "project",
+        output_dir=str(tmp_path / "output"),
+        job_id="job_video_edit",
+        prompt="编辑源视频",
+        reference_items=[{"type": "video", "path": "/project/source.mp4"}],
+        aspect_ratio="auto",
+        resolution="720p",
+        duration_seconds=None,
+        generate_audio=False,
+        human_review=False,
+        scene_optimize=None,
+        backend="newapi_happyhorse-1.0",
+        gen_mode="video_edit",
+        requested_gen_mode="videoEdit",
+    )
+
+    payload = captured["payload"]
+    assert payload["aspect_ratio"] == "auto"
+    assert payload["duration_seconds"] == 7
+    assert payload["billing"]["pricing_metrics"] == {
+        "call_count": 1,
+        "item_count": 1,
+        "duration_seconds": 14,
+        "output_duration_seconds": 7,
+        "input_video_duration_ms": 7100,
+        "input_video_billed_seconds": 7,
+    }
 
 
 @pytest.mark.asyncio

--- a/tests/test_freezone_video_backend.py
+++ b/tests/test_freezone_video_backend.py
@@ -469,6 +469,15 @@ def test_happyhorse_backend_detection_accepts_newapi_value() -> None:
     assert not is_freezone_happyhorse_backend("newapi_seedance-2.0-fast")
 
 
+def test_direct_seedance_ratio_accepts_canonical_and_legacy_auto_values() -> None:
+    from novelvideo.generators.video_generator import SeedanceVideoGenerator
+
+    assert SeedanceVideoGenerator._normalize_aspect_ratio("auto") == "auto"
+    assert SeedanceVideoGenerator._normalize_aspect_ratio("adaptive") == "adaptive"
+    assert SeedanceVideoGenerator._normalize_aspect_ratio("16:9") == "16:9"
+    assert SeedanceVideoGenerator._normalize_aspect_ratio("unsupported") == "9:16"
+
+
 def test_freezone_rejects_removed_wan26_backend() -> None:
     with pytest.raises(ValueError, match="unknown video model"):
         resolve_freezone_video_backend("wan26")

--- a/tests/test_freezone_video_backend.py
+++ b/tests/test_freezone_video_backend.py
@@ -228,7 +228,8 @@ def test_video_character_folder_update_and_delete(tmp_path: Path) -> None:
 
 
 def test_video_ratio_and_resolution_normalization() -> None:
-    assert normalize_video_aspect_ratio("auto") == "16:9"
+    assert normalize_video_aspect_ratio("auto") == "auto"
+    assert normalize_video_aspect_ratio("adaptive") == "auto"
     assert normalize_video_aspect_ratio("9:16") == "9:16"
     assert normalize_video_resolution("720P") == "720p"
 
@@ -244,6 +245,35 @@ def test_build_freezone_omni_video_prompt_includes_theme() -> None:
     assert "压抑、克制、纪实感" in prompt
     assert "盘旋抬升" in prompt
     assert "氧气管" in prompt
+
+
+def test_build_freezone_omni_video_prompt_marks_single_video_as_reference() -> None:
+    prompt = build_freezone_omni_video_prompt(
+        user_prompt="参考人物动作，生成新的镜头。",
+        reference_items=[{"type": "video", "path": "/tmp/reference.mp4"}],
+    )
+
+    assert prompt.count("这是视频参考生成新的视频，不是视频编辑。") == 1
+
+
+@pytest.mark.parametrize(
+    "reference_items",
+    [
+        [{"type": "video"}, {"type": "video"}],
+        [{"type": "video"}, {"type": "image"}],
+        [{"type": "video"}, {"type": "audio"}],
+        [{"type": "image"}],
+    ],
+)
+def test_build_freezone_omni_video_prompt_does_not_mark_other_inputs(
+    reference_items: list[dict[str, str]],
+) -> None:
+    prompt = build_freezone_omni_video_prompt(
+        user_prompt="参考素材生成新的镜头。",
+        reference_items=reference_items,
+    )
+
+    assert "这是视频参考生成新的视频，不是视频编辑。" not in prompt
 
 
 def test_build_freezone_image_to_video_prompt_uses_image_reference_semantics() -> None:
@@ -338,7 +368,7 @@ def test_catalog_resolution_options_override_legacy_video_whitelist() -> None:
             "4K",
             ["1080p", "4K"],
         )
-        == "4K"
+        == "4k"
     )
 
 

--- a/tests/test_freezone_video_route_modes.py
+++ b/tests/test_freezone_video_route_modes.py
@@ -44,16 +44,96 @@ async def _install_route_fakes(monkeypatch, tmp_path: Path, capabilities: dict) 
         captured["start"] = kwargs
         return {"job_id": "job-test"}
 
+    async def validate_audio(reference_items, *, capabilities, backend):
+        captured["validated_audio_items"] = reference_items
+
     monkeypatch.setattr(freezone_routes, "_resolve_freezone_project", resolve_project)
     monkeypatch.setattr(freezone_routes, "_resolve_catalog_video_backend", resolve_backend)
     monkeypatch.setattr(freezone_routes, "_resolve_catalog_request", resolve_request)
     monkeypatch.setattr(freezone_routes, "_start_or_enqueue_freezone_video_gen", start)
     monkeypatch.setattr(
         freezone_routes,
+        "_validate_catalog_reference_audio_items",
+        validate_audio,
+    )
+    monkeypatch.setattr(
+        freezone_routes,
         "_resolve_url_list",
         lambda _project_dir, urls: [str(url) for url in urls if url],
     )
     return captured
+
+
+@pytest.mark.asyncio
+async def test_video_edit_forwards_configured_independent_audio(
+    monkeypatch, tmp_path: Path
+) -> None:
+    capabilities = _catalog("video_edit")
+    capabilities.update(
+        {
+            "referenceVideoMax": 1,
+            "referenceAudioMax": 2,
+            "referenceAudioMinSeconds": 1,
+            "referenceAudioMaxSeconds": 15,
+        }
+    )
+    captured = await _install_route_fakes(monkeypatch, tmp_path, capabilities)
+
+    await freezone_routes.freezone_video_edit(
+        "project",
+        FreezoneVideoEditRequest(
+            video_url="https://example.com/source.mp4",
+            image_urls=["https://example.com/style.png"],
+            audio_urls=["https://example.com/music.mp3"],
+            model="catalog-video",
+            gen_mode="videoEdit",
+        ),
+        {"username": "admin"},
+    )
+
+    assert captured["request_mode"] == "videoEdit"
+    assert captured["start"]["gen_mode"] == "video_edit"
+    assert captured["start"]["aspect_ratio"] == "auto"
+    assert captured["start"]["duration_seconds"] is None
+    assert captured["start"]["reference_items"] == [
+        {
+            "type": "video",
+            "path": "https://example.com/source.mp4",
+            "role": "视频编辑源",
+        },
+        {
+            "type": "image",
+            "path": "https://example.com/style.png",
+            "role": "图片参考",
+        },
+        {
+            "type": "audio",
+            "path": "https://example.com/music.mp3",
+            "role": "配乐参考",
+        },
+    ]
+    assert captured["validated_audio_items"] == captured["start"]["reference_items"]
+
+
+@pytest.mark.asyncio
+async def test_video_edit_rejects_audio_when_catalog_cap_is_zero(
+    monkeypatch, tmp_path: Path
+) -> None:
+    capabilities = _catalog("video_edit")
+    capabilities.update({"referenceVideoMax": 1, "referenceAudioMax": 0})
+    await _install_route_fakes(monkeypatch, tmp_path, capabilities)
+
+    with pytest.raises(HTTPException, match="at most 0 audio references"):
+        await freezone_routes.freezone_video_edit(
+            "project",
+            FreezoneVideoEditRequest(
+                video_url="https://example.com/source.mp4",
+                audio_urls=["https://example.com/music.mp3"],
+                model="catalog-video",
+                gen_mode="videoEdit",
+            ),
+            {"username": "admin"},
+        )
 
 
 @pytest.mark.asyncio
@@ -253,11 +333,38 @@ async def test_keyframe_route_preserves_selected_mode_for_all_frame_combinations
     assert captured["request_mode"] == requested_mode
     assert captured["start"]["gen_mode"] == expected_mode
     assert captured["start"]["requested_gen_mode"] == requested_mode
+    assert captured["start"]["aspect_ratio"] == "auto"
+    assert captured["start"]["duration_seconds"] == 5
     assert captured["start"]["last_frame_path"] == last_url
     first_items = [
         item for item in captured["start"]["reference_items"] if item["role"] == "首帧"
     ]
     assert (first_items[0]["path"] if first_items else None) == expected_image_path
+
+
+@pytest.mark.asyncio
+async def test_text_to_video_preserves_selected_ratio_and_duration(
+    monkeypatch, tmp_path: Path
+) -> None:
+    captured = await _install_route_fakes(
+        monkeypatch,
+        tmp_path,
+        _catalog("text_to_video"),
+    )
+
+    await freezone_routes.freezone_video_gen(
+        "project",
+        FreezoneVideoGenRequest(
+            prompt="rainy street",
+            aspect_ratio="9:16",
+            duration_seconds=9,
+            model="catalog-video",
+        ),
+        {"username": "admin"},
+    )
+
+    assert captured["start"]["aspect_ratio"] == "9:16"
+    assert captured["start"]["duration_seconds"] == 9
 
 
 @pytest.mark.asyncio

--- a/tests/test_media_model_request_schema.py
+++ b/tests/test_media_model_request_schema.py
@@ -3,8 +3,12 @@ import pytest
 from novelvideo.media_model_request_schema import (
     MediaModelSchemaError,
     apply_media_request_schema,
+    enforce_newapi_media_geometry_contract,
+    enforce_newapi_video_duration_contract,
     media_request_schema_for_mode,
+    normalize_media_model_catalog_config,
     normalize_media_model_mode,
+    normalize_media_resolution_value,
     validate_media_model_catalog_config,
     validate_media_model_params,
     validate_media_request_schema,
@@ -32,6 +36,155 @@ SCHEMA = {
     ],
     "omitPaths": ["metadata.legacy"],
 }
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("4K", "4k"),
+        ("0.5K", "0.5k"),
+        ("1080P", "1080p"),
+        ("2048x1376", "2048x1376"),
+    ],
+)
+def test_normalizes_named_media_resolution_tiers(raw, expected):
+    assert normalize_media_resolution_value(raw) == expected
+
+
+def test_normalizes_catalog_resolutions_without_case_duplicates():
+    config = {
+        "resolutionOptions": ["1K", "2k", "4K", "4k", "2048x1376"],
+        "ratioOptions": ["Auto", "adaptive", "16:9"],
+        "defaultGenerateAudio": False,
+    }
+
+    normalized = normalize_media_model_catalog_config(config)
+
+    assert normalized["resolutionOptions"] == ["1k", "2k", "4k", "2048x1376"]
+    assert normalized["ratioOptions"] == ["auto", "16:9"]
+    assert "defaultGenerateAudio" not in normalized
+    assert config["resolutionOptions"] == ["1K", "2k", "4K", "4k", "2048x1376"]
+
+
+@pytest.mark.parametrize(
+    ("media_type", "raw_ratio", "expected_ratio"),
+    [("image", "adaptive", "auto"), ("video", "adaptive", "auto")],
+)
+def test_auto_geometry_removes_conflicting_dimensions(
+    media_type, raw_ratio, expected_ratio
+):
+    result = enforce_newapi_media_geometry_contract(
+        {
+            "width": 1920,
+            "height": 1080,
+            "size": "1920x1080",
+            "aspect_ratio": raw_ratio,
+            "resolution": "1080P",
+            "metadata": {
+                "reference_images": ["https://example.com/reference.png"],
+            },
+        },
+        media_type=media_type,
+    )
+
+    assert "width" not in result
+    assert "height" not in result
+    assert "size" not in result
+    assert result["metadata"] == {
+        "ratio": expected_ratio,
+        "reference_images": ["https://example.com/reference.png"],
+        "resolution": "1080p",
+    }
+
+
+def test_fixed_geometry_keeps_ratio_and_removes_legacy_size():
+    result = enforce_newapi_media_geometry_contract(
+        {
+            "width": 1920,
+            "height": 1080,
+            "size": "1920x1080",
+            "metadata": {"ratio": "16:9", "resolution": "4K"},
+        },
+        media_type="video",
+    )
+
+    assert result == {
+        "width": 1920,
+        "height": 1080,
+        "metadata": {"ratio": "16:9", "resolution": "4k"},
+    }
+
+
+@pytest.mark.parametrize(
+    ("raw_duration", "expected"),
+    [("auto", "auto"), ("AUTO", "auto"), ("5", 5), (5.5, 5.5)],
+)
+def test_normalizes_generic_newapi_video_duration(raw_duration, expected):
+    result = enforce_newapi_video_duration_contract(
+        {"seconds": raw_duration, "model": "video-model"}
+    )
+
+    assert result == {"duration": expected, "model": "video-model"}
+
+
+def test_model_schema_can_override_numeric_video_duration_with_auto():
+    schema = {
+        "endpoint": "video/generations",
+        "parameters": [
+            {
+                "key": "duration_mode",
+                "label": "输出时长",
+                "control": "select",
+                "requestPath": "duration",
+                "options": ["auto"],
+                "default": "auto",
+            }
+        ],
+    }
+
+    configured = apply_media_request_schema(
+        {"model": "video-model", "duration": 5}, schema, {}
+    )
+    result = enforce_newapi_video_duration_contract(configured)
+
+    assert result == {"model": "video-model", "duration": "auto"}
+
+
+def test_video_edit_forces_auto_geometry_and_duration_after_model_parameters():
+    from novelvideo.media_model_request_schema import (
+        enforce_newapi_video_mode_contract,
+    )
+
+    result = enforce_newapi_video_mode_contract(
+        {
+            "model": "video-model",
+            "duration": 5,
+            "width": 1280,
+            "height": 720,
+            "metadata": {"ratio": "16:9", "resolution": "720p"},
+        },
+        mode="videoEdit",
+    )
+
+    assert result == {
+        "model": "video-model",
+        "duration": "auto",
+        "metadata": {"ratio": "auto", "resolution": "720p"},
+    }
+
+
+def test_non_edit_mode_rejects_model_parameter_auto_duration():
+    from novelvideo.media_model_request_schema import (
+        enforce_newapi_video_mode_contract,
+    )
+
+    result = enforce_newapi_video_mode_contract(
+        {"model": "video-model", "duration": "auto"},
+        mode="allReference",
+        fixed_duration=8,
+    )
+
+    assert result == {"model": "video-model", "duration": 8}
 
 
 def test_applies_validated_parameters_without_mutating_original_payload():
@@ -274,6 +427,7 @@ def test_validates_media_catalog_capabilities():
         "referenceVideoMax": 1,
         "referenceAudioMax": 0,
         "humanReview": True,
+        "supportsGenerateAudio": True,
         "request": {"endpoint": "video/generations", "parameters": []},
     }
 
@@ -297,6 +451,39 @@ def test_validates_media_catalog_capabilities():
         validate_media_model_catalog_config(
             {**valid, "supportedModes": ["text_to_video"]},
             "video",
+        )
+
+
+def test_validates_video_native_audio_capabilities():
+    base = {
+        "request": {"endpoint": "video/generations", "parameters": []},
+    }
+    assert validate_media_model_catalog_config(
+        {
+            **base,
+            "supportsGenerateAudio": True,
+        },
+        "video",
+    )
+    assert validate_media_model_catalog_config(
+        {
+            **base,
+            "supportsGenerateAudio": False,
+        },
+        "video",
+    )
+    with pytest.raises(MediaModelSchemaError, match="supportsGenerateAudio"):
+        validate_media_model_catalog_config(
+            {**base, "supportsGenerateAudio": "yes"},
+            "video",
+        )
+    with pytest.raises(MediaModelSchemaError, match="incompatible fields"):
+        validate_media_model_catalog_config(
+            {
+                "supportsGenerateAudio": True,
+                "request": {"endpoint": "images/generations", "parameters": []},
+            },
+            "image",
         )
 
 

--- a/tests/test_media_model_request_schema.py
+++ b/tests/test_media_model_request_schema.py
@@ -115,6 +115,20 @@ def test_fixed_geometry_keeps_ratio_and_removes_legacy_size():
     }
 
 
+def test_fixed_ratio_is_preserved_without_dimensions():
+    result = enforce_newapi_media_geometry_contract(
+        {
+            "aspect_ratio": "16:9",
+            "resolution": "2K",
+        },
+        media_type="video",
+    )
+
+    assert result == {
+        "metadata": {"ratio": "16:9", "resolution": "2k"},
+    }
+
+
 @pytest.mark.parametrize(
     ("raw_duration", "expected"),
     [("auto", "auto"), ("AUTO", "auto"), ("5", 5), (5.5, 5.5)],

--- a/tests/test_model_gateway_settings.py
+++ b/tests/test_model_gateway_settings.py
@@ -3007,7 +3007,7 @@ def test_official_media_model_catalog_uses_ce_export_shape():
     ]
     seedream = next(entry for entry in images if entry["id"] == "seedream-5.0-pro")
     assert seedream["gatewayModel"] == "seedream-5.0-pro"
-    assert seedream["resolutionOptions"] == ["1K", "2K"]
+    assert seedream["resolutionOptions"] == ["1k", "2k"]
     assert seedream["minPixels"] == 3686400
     seedance = next(entry for entry in videos if entry["id"] == "seedance-2.0-mini")
     assert seedance["apiModel"] == "newapi_seedance-2.0-mini"
@@ -3015,7 +3015,7 @@ def test_official_media_model_catalog_uses_ce_export_shape():
     minimax = videos[-1]
     assert minimax["id"] == "MiniMax-H3"
     assert minimax["gatewayModel"] == "MiniMax-H3"
-    assert minimax["resolutionOptions"] == ["768P", "2K"]
+    assert minimax["resolutionOptions"] == ["768p", "2k"]
     assert minimax["ratioOptions"] == [
         "21:9",
         "16:9",

--- a/tests/test_newapi_image_gateway.py
+++ b/tests/test_newapi_image_gateway.py
@@ -181,7 +181,8 @@ def test_newapi_sketch_config_defaults_to_dc_image2_low_quality(monkeypatch):
     assert posted["timeout"] == nanobanana_grid.NEWAPI_IMAGE_HTTP_TIMEOUT_SECONDS == 1800.0
     assert posted["json"]["model"] == "LingShan-G2"
     assert posted["json"]["quality"] == "low"
-    assert posted["json"]["size"] == "688x1024"
+    assert (posted["json"]["width"], posted["json"]["height"]) == (688, 1024)
+    assert posted["json"]["metadata"] == {"ratio": "2:3", "resolution": "1k"}
     assert "extra_fields" not in posted["json"]
     assert trace == {"request_id": "req-sketch", "response_id": "resp-sketch"}
 
@@ -245,7 +246,8 @@ def test_newapi_sketch_config_can_use_dc_banana2_without_quality(monkeypatch):
     assert error == ""
     assert posted["json"]["model"] == "LingShan-NB-2"
     assert "quality" not in posted["json"]
-    assert posted["json"]["size"] == "688x1024"
+    assert (posted["json"]["width"], posted["json"]["height"]) == (688, 1024)
+    assert posted["json"]["metadata"] == {"ratio": "2:3", "resolution": "1k"}
     assert "extra_fields" not in posted["json"]
 
 
@@ -309,7 +311,9 @@ def test_catalog_can_enable_arbitrary_newapi_image_quality(monkeypatch):
     assert error == ""
     assert posted["json"]["model"] == "Seedream-Custom"
     assert posted["json"]["quality"] == "ultra"
-    assert posted["json"]["size"] == "2880x2880"
+    assert "width" not in posted["json"]
+    assert "height" not in posted["json"]
+    assert posted["json"]["metadata"] == {"ratio": "auto", "resolution": "3k"}
     assert posted["json"]["watermark"] is True
     assert "extra_fields" not in posted["json"]
 
@@ -437,8 +441,12 @@ def test_newapi_image_call_applies_admin_min_pixels(monkeypatch):
 
     assert image_bytes == b"image"
     assert error == ""
-    width, height = (int(value) for value in posted["json"]["size"].split("x"))
+    width, height = posted["json"]["width"], posted["json"]["height"]
     assert width * height >= 3_686_400
+    assert posted["json"]["metadata"] == {
+        "ratio": "3:2",
+        "resolution": "2048x1376",
+    }
     assert posted["json"]["watermark"] is False
     assert "extra_fields" not in posted["json"]
 
@@ -495,8 +503,56 @@ def test_newapi_image_call_sends_gpt_image2_params(monkeypatch):
     assert posted["json"]["model"] == "LingShan-G2"
     assert posted["json"]["prompt"] == "portrait prompt"
     assert posted["json"]["quality"] == "medium"
-    assert posted["json"]["size"] == "768x1024"
+    assert (posted["json"]["width"], posted["json"]["height"]) == (768, 1024)
+    assert posted["json"]["metadata"] == {"ratio": "3:4", "resolution": "1k"}
     assert "extra_fields" not in posted["json"]
+
+
+def test_newapi_image_auto_ratio_keeps_resolution_without_dimensions(monkeypatch):
+    import httpx
+    from novelvideo.generators import nanobanana_grid
+
+    posted = {}
+
+    class FakeResponse:
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return {"data": [{"b64_json": base64.b64encode(b"image-bytes").decode()}]}
+
+    class FakeAsyncClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return None
+
+        async def post(self, url, *, headers, json):
+            posted["json"] = json
+            return FakeResponse()
+
+    monkeypatch.setattr(httpx, "AsyncClient", FakeAsyncClient)
+
+    image_bytes, _text, error = run_async(
+        nanobanana_grid._call_newapi_image_api(
+            api_key="newapi-token",
+            model="LingShan-G2",
+            prompt="follow the reference geometry",
+            image_config={"aspect_ratio": "auto", "image_size": "2K"},
+            base_url="http://newapi.test/v1",
+        )
+    )
+
+    assert image_bytes == b"image-bytes"
+    assert error == ""
+    assert "width" not in posted["json"]
+    assert "height" not in posted["json"]
+    assert "size" not in posted["json"]
+    assert posted["json"]["metadata"] == {"ratio": "auto", "resolution": "2k"}
 
 
 def test_newapi_image_call_reports_transport_exception_type(monkeypatch):
@@ -652,7 +708,8 @@ def test_newapi_image_call_omits_quality_for_nanobanana2(monkeypatch):
     assert error == ""
     assert posted["json"]["model"] == "LingShan-NB-2"
     assert "quality" not in posted["json"]
-    assert posted["json"]["size"] == "768x1024"
+    assert (posted["json"]["width"], posted["json"]["height"]) == (768, 1024)
+    assert posted["json"]["metadata"] == {"ratio": "3:4", "resolution": "1k"}
     assert "extra_fields" not in posted["json"]
 
 
@@ -873,7 +930,9 @@ def test_newapi_image_http_error_logs_redacted_request_context(monkeypatch, capl
     assert "request_id=req-123" in error
     assert "cf-ray-456" in error
     assert "model=LingShan-G2" in error
-    assert "size=2048x1024" in error
+    assert "width=2048" in error
+    assert "height=1024" in error
+    assert "geometry_metadata={'ratio': '2:1', 'resolution': '2k'}" in error
     assert "reference_image_count=1" in error
     assert "request_id=req-123" in log_text
     assert "http://newapi.test/v1/images/edits" in log_text
@@ -1401,7 +1460,8 @@ def test_newapi_prop_reference_gpt_image2_sends_quality_medium(monkeypatch, tmp_
     assert posted["headers"]["Authorization"] == "Bearer newapi-token"
     assert posted["json"]["model"] == "LingShan-G2"
     assert posted["json"]["quality"] == "medium"
-    assert posted["json"]["size"] == "1088x608"
+    assert (posted["json"]["width"], posted["json"]["height"]) == (1088, 608)
+    assert posted["json"]["metadata"] == {"ratio": "16:9", "resolution": "1k"}
     assert "extra_fields" not in posted["json"]
 
 
@@ -1459,7 +1519,8 @@ def test_newapi_prop_reference_nanobanana2_omits_quality(monkeypatch, tmp_path):
     assert output_path.read_bytes() == b"prop-ref"
     assert posted["json"]["model"] == "LingShan-NB-2"
     assert "quality" not in posted["json"]
-    assert posted["json"]["size"] == "1088x608"
+    assert (posted["json"]["width"], posted["json"]["height"]) == (1088, 608)
+    assert posted["json"]["metadata"] == {"ratio": "16:9", "resolution": "1k"}
     assert "extra_fields" not in posted["json"]
 
 

--- a/tests/test_seedance2_request.py
+++ b/tests/test_seedance2_request.py
@@ -675,7 +675,9 @@ async def test_newapi_video_generator_handles_wrapped_failure_status(
     assert refunded["error"] == "InputImageSensitiveContentDetected.PolicyViolation"
 
 
-async def test_newapi_seedance1_generator_preserves_adaptive_ratio(tmp_path, monkeypatch):
+async def test_newapi_seedance1_generator_normalizes_adaptive_ratio_to_auto(
+    tmp_path, monkeypatch
+):
     from novelvideo.generators import video_generator as video_module
     from novelvideo.generators.video_generator import NewApiVideoGenerator
 
@@ -713,9 +715,11 @@ async def test_newapi_seedance1_generator_preserves_adaptive_ratio(tmp_path, mon
     metadata = payload["metadata"]
     assert isinstance(metadata, dict)
     assert payload["image"] == "https://example.com/first.png"
-    assert metadata["aspect_ratio"] == "adaptive"
     assert metadata["resolution"] == "720p"
-    assert metadata["ratio"] == "adaptive"
+    assert metadata["ratio"] == "auto"
+    assert "aspect_ratio" not in metadata
+    assert "width" not in payload
+    assert "height" not in payload
 
 
 def test_newapi_video_payload_keeps_public_fields_and_model_semantics():
@@ -828,10 +832,10 @@ def test_newapi_video_dimensions_distinguish_p_and_k_tiers(
     assert NewApiVideoGenerator._video_dimensions(resolution, ratio) == expected
 
 
-def test_newapi_video_4k_payload_uses_real_dimensions_and_preserves_request_value():
+def test_newapi_video_payload_uses_real_dimensions_and_lowercase_resolution():
     from novelvideo.generators.video_generator import NewApiVideoGenerator
 
-    metadata = {"resolution": "4k", "ratio": "16:9"}
+    metadata = {"resolution": "4K", "ratio": "16:9"}
     payload = {
         "model": "seedance-2.0",
         "prompt": "海边日落。",
@@ -845,6 +849,26 @@ def test_newapi_video_4k_payload_uses_real_dimensions_and_preserves_request_valu
     assert payload["height"] == 2160
     assert payload["metadata"]["resolution"] == "4k"
     assert payload["metadata"]["ratio"] == "16:9"
+
+
+def test_newapi_video_payload_preserves_auto_duration_and_ratio():
+    from novelvideo.generators.video_generator import NewApiVideoGenerator
+
+    metadata = {"resolution": "720P", "ratio": "adaptive"}
+    payload = {
+        "model": "seedance-2.5",
+        "prompt": "自动决定画幅和时长。",
+        "seconds": "auto",
+        "metadata": metadata,
+    }
+
+    NewApiVideoGenerator._canonicalize_video_payload(payload, metadata)
+
+    assert payload["duration"] == "auto"
+    assert "width" not in payload
+    assert "height" not in payload
+    assert payload["metadata"]["ratio"] == "auto"
+    assert payload["metadata"]["resolution"] == "720p"
 
 
 def test_newapi_seedance15_payload_preserves_480p_21_9_semantics():
@@ -1032,7 +1056,7 @@ async def test_newapi_happyhorse_video_generator_uses_happyhorse_payload(tmp_pat
     assert "image" not in payload
     assert "image_url" not in metadata
     assert "aspect_ratio" not in metadata
-    assert metadata["resolution"] == "1080P"
+    assert metadata["resolution"] == "1080p"
     assert metadata["reference_videos"] == ["https://example.com/input.mp4"]
     assert metadata["audio_setting"] == "origin"
     assert metadata["reference_images"] == [
@@ -1157,6 +1181,34 @@ async def test_newapi_catalog_model_builds_huimeng_protocol_multimedia_reference
         "reference_images",
         "reference_videos",
         "reference_audios",
+    }
+
+
+async def test_newapi_video_edit_keeps_independent_audio_reference():
+    from novelvideo.generators.video_generator import NewApiVideoGenerator, ShotReference
+
+    generator = NewApiVideoGenerator(
+        api_key="test-key",
+        endpoint="https://newapi.example",
+        model="happyhorse-1.0",
+    )
+    metadata: dict[str, object] = {}
+
+    await generator._apply_huimeng_protocol_media_inputs(
+        metadata,
+        mode="video_edit",
+        image_path="",
+        last_frame_path=None,
+        references=[
+            ShotReference("video", "https://example.com/source.mp4", "视频编辑源"),
+            ShotReference("audio", "https://example.com/music.mp3", "配乐参考"),
+        ],
+        log=lambda _message: None,
+    )
+
+    assert metadata == {
+        "reference_videos": ["https://example.com/source.mp4"],
+        "reference_audios": ["https://example.com/music.mp3"],
     }
 
 


### PR DESCRIPTION
## 背景

图片和视频请求在多个入口中存在字段位置、枚举大小写和自动参数语义不一致的问题；视频编辑使用自动时长后，前端报价与后端预扣也需要保持同一计费口径。

## 主要改动

- 统一图片、视频发往 NewAPI 的媒体协议：
  - 固定比例保留 `metadata.ratio` / `metadata.resolution`，并发送同源的 `width` / `height`
  - 自动比例统一为 `auto`，不再发送固定尺寸
  - 分辨率枚举统一为小写
  - 统一首帧、尾帧和参考媒体字段
- 视频编辑统一发送自动比例与自动时长：
  - `ratio: auto`
  - `duration: auto`
  - 前端报价与后端预扣均按输入视频实际整秒时长计算
- 首尾帧模式强制使用自动比例。
- 视频编辑支持独立参考音频，并按媒体目录能力校验素材数量和时长。
- 模型的原生音频能力由后台目录声明，用户仍可在支持时选择是否生成音频。
- 全能参考仅输入一个视频时，在最终请求提示词中明确这是视频参考生成新视频，不是视频编辑。
- 分辨率在 DramaClaw 界面中统一以小写显示。
- 保留模型专用可选参数机制，未选择的参数不会发送。

## 影响

- 不包含数据库迁移。
- 不修改促销、预扣、确认或退款流程。
- 计费规则的唯一语义变化是视频编辑 `duration=auto` 时，报价与预扣使用输入视频时长；其他计费单位与公式保持不变。

## 验证

- 后端定向测试：403 passed
- 前端定向测试：5 files / 110 tests passed
- `bun run build:ce`：passed
- `git diff --check origin/main...HEAD`：passed
