### PR TITLE
Fix project summaries for registered storage paths

### DIFF
--- a/license-inventory.csv
+++ b/license-inventory.csv
@@ -1785,6 +1785,7 @@ tests/test_api_narrator_voice.py,Elastic-2.0,2026 SuperTale contributors,REUSE.t
 tests/test_api_novel_prerequisites.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_api_pipeline_manual_shots.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_api_project_resolution.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
+tests/test_api_project_summary_paths.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_api_render_regenerate.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_api_render_settings.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_api_scripts.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation

--- a/src/novelvideo/api/routes/projects.py
+++ b/src/novelvideo/api/routes/projects.py
@@ -13,7 +13,6 @@ from fastapi.responses import JSONResponse
 
 from novelvideo.api.auth import get_api_user, require_scope
 from novelvideo.api.deps import (
-    get_project_paths,
     make_sqlite_store_for_context,
     make_static_url_for_context,
     validate_project_name,
@@ -97,10 +96,10 @@ def _project_updated_at(paths) -> str | None:
     return datetime.fromtimestamp(latest, tz=timezone.utc).isoformat()
 
 
-def _project_counts(username: str, project: str, status: str) -> tuple[int | None, int | None]:
+def _project_counts(paths, status: str) -> tuple[int | None, int | None]:
     if status == "deleted":
         return None, None
-    db_path = get_project_paths(username, project).data_db
+    db_path = paths.data_db
     if not db_path.exists():
         return None, None
     try:
@@ -112,7 +111,7 @@ def _project_counts(username: str, project: str, status: str) -> tuple[int | Non
         finally:
             conn.close()
     except sqlite3.Error:
-        logger.debug("project count failed: %s/%s", username, project, exc_info=True)
+        logger.debug("project count failed: %s", db_path, exc_info=True)
         return None, None
 
 
@@ -145,7 +144,7 @@ async def _summary_for_record(
     paths._runtime_dir_override = Path(record.runtime_dir)
     config = load_project_config_file_from_state_dir(record.state_dir)
     status = record.status or "active"
-    episode_count, beat_count = _project_counts(record.owner_username, record.name, status)
+    episode_count, beat_count = _project_counts(paths, status)
     return ProjectSummary(
         id=record.id,
         name=record.name,

--- a/tests/test_api_project_summary_paths.py
+++ b/tests/test_api_project_summary_paths.py
@@ -1,0 +1,44 @@
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from novelvideo.api.routes.projects import _summary_for_record
+from novelvideo.ports.project import ProjectRecord
+
+
+@pytest.mark.asyncio
+async def test_project_summary_counts_from_registered_state_dir(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    state_dir = tmp_path / "state" / "_orgs" / "org-1" / "alice" / "demo"
+    output_dir = tmp_path / "output" / "_orgs" / "org-1" / "alice" / "demo"
+    runtime_dir = tmp_path / "runtime" / "_orgs" / "org-1" / "alice" / "demo"
+    state_dir.mkdir(parents=True)
+    output_dir.mkdir(parents=True)
+    runtime_dir.mkdir(parents=True)
+    with sqlite3.connect(state_dir / "data.db") as conn:
+        conn.execute("CREATE TABLE episodes (episode_number INTEGER PRIMARY KEY)")
+        conn.execute("CREATE TABLE beats (id INTEGER PRIMARY KEY)")
+        conn.executemany("INSERT INTO episodes VALUES (?)", [(1,), (2,)])
+        conn.executemany("INSERT INTO beats VALUES (?)", [(1,), (2,), (3,)])
+
+    monkeypatch.setattr("novelvideo.api.routes.projects.is_record_home_node", lambda _record: True)
+    record = ProjectRecord(
+        id="project-1",
+        owner_type="user",
+        owner_id="user-1",
+        owner_username="alice",
+        name="demo",
+        home_node_id="local-dev",
+        output_dir=str(output_dir),
+        state_dir=str(state_dir),
+        runtime_dir=str(runtime_dir),
+        status="active",
+    )
+
+    summary = await _summary_for_record(record)
+
+    assert summary.episode_count == 2
+    assert summary.beat_count == 3


### PR DESCRIPTION
## Summary

- calculate project episode and beat counts from the registry-provided `state_dir/data.db`
- stop reconstructing the database path from owner username and project name
- add a regression test using an organization-scoped registered project path

## Why

EE channel projects can live under `_orgs/{org_id}/{username}/{project}`. Reconstructing the legacy default path made their project summaries miss the real database even though the project registry already supplied the authoritative paths.

## Validation

- targeted pytest: 1 passed
- Ruff: passed
- git diff --check: passed
