### PR TITLE
Fix EE task integration contracts

### DIFF
--- a/frontend/src/__tests__/components/projects/share-project-dialog.test.tsx
+++ b/frontend/src/__tests__/components/projects/share-project-dialog.test.tsx
@@ -43,6 +43,7 @@ vi.mock("react-i18next", () => ({
 }));
 
 const runtimeState = vi.hoisted(() => ({ isCeRuntime: false }));
+const queryMocks = vi.hoisted(() => ({ useUserSearch: vi.fn() }));
 
 vi.mock("@/lib/runtime-config", () => ({
   isCeRuntime: () => runtimeState.isCeRuntime,
@@ -50,7 +51,10 @@ vi.mock("@/lib/runtime-config", () => ({
 
 vi.mock("@/lib/queries/projects", () => ({
   useProjectGrants: () => ({ data: { data: [] } }),
-  useUserSearch: () => ({ data: { data: [] } }),
+  useUserSearch: (...args: unknown[]) => {
+    queryMocks.useUserSearch(...args);
+    return { data: { data: [] } };
+  },
   useAddProjectGrant: () => ({ mutateAsync: vi.fn(), isPending: false }),
   useUpdateProjectGrant: () => ({ mutateAsync: vi.fn(), isPending: false }),
   useDeleteProjectGrant: () => ({ mutateAsync: vi.fn(), isPending: false }),
@@ -72,11 +76,13 @@ function renderDialog() {
 describe("ShareProjectDialog (edition gating)", () => {
   beforeEach(() => {
     runtimeState.isCeRuntime = false;
+    queryMocks.useUserSearch.mockClear();
   });
 
   it("renders the share dialog in EE runtime", () => {
     renderDialog();
     expect(screen.getByText("共享项目")).toBeInTheDocument();
+    expect(queryMocks.useUserSearch).toHaveBeenCalledWith("p1", "");
   });
 
   it("renders nothing in CE runtime", () => {

--- a/frontend/src/components/projects/share-project-dialog.tsx
+++ b/frontend/src/components/projects/share-project-dialog.tsx
@@ -74,7 +74,7 @@ export function ShareProjectDialog({
   const [role, setRole] = useState<GrantRole>("editor");
   const projectId = project?.id ?? "";
   const grants = useProjectGrants(projectId, open && Boolean(projectId));
-  const users = useUserSearch(query);
+  const users = useUserSearch(projectId, query);
   const addGrant = useAddProjectGrant(projectId);
   const updateGrant = useUpdateProjectGrant(projectId);
   const deleteGrant = useDeleteProjectGrant(projectId);

--- a/frontend/src/lib/queries/projects.ts
+++ b/frontend/src/lib/queries/projects.ts
@@ -203,18 +203,18 @@ export function useProjectGrants(project: string, enabled = true) {
   });
 }
 
-export function useUserSearch(query: string) {
+export function useUserSearch(project: string, query: string) {
   const trimmed = query.trim();
   return useQuery({
-    queryKey: queryKeys.userSearch(trimmed),
+    queryKey: queryKeys.userSearch(project, trimmed),
     queryFn: ({ signal }) =>
       api
         .get("api/v1/users/search", {
-          searchParams: { q: trimmed },
+          searchParams: { project, q: trimmed },
           signal,
         })
         .json<OkResponse<UserSearchResult[]>>(),
-    enabled: trimmed.length >= 3,
+    enabled: Boolean(project) && trimmed.length >= 3,
   });
 }
 

--- a/frontend/src/lib/query-keys.ts
+++ b/frontend/src/lib/query-keys.ts
@@ -22,7 +22,8 @@ export const queryKeys = {
   projectSummaries: () => ["projects", "summaries"] as const,
   project: (p: string) => ["projects", p] as const,
   projectGrants: (p: string) => ["projects", p, "grants"] as const,
-  userSearch: (q: string) => ["users", "search", q] as const,
+  userSearch: (project: string, q: string) =>
+    ["users", "search", project, q] as const,
   pipelineStatus: (p: string) => ["projects", p, "pipeline-status"] as const,
   characters: (p: string) => ["projects", p, "characters"] as const,
   character: (p: string, name: string) =>

--- a/src/novelvideo/api/routes/tasks.py
+++ b/src/novelvideo/api/routes/tasks.py
@@ -336,14 +336,16 @@ async def clear_project_completed_tasks(
         deleted = 0
         for task in mgr.list_tasks_for_project(ctx):
             if _effective_task_status(task) == "completed":
-                mgr.delete_task_for_project(
+                was_deleted = mgr.delete_task_for_project(
                     ctx,
                     task.task_type,
                     task.episode,
                     beat_num=task.beat_num,
                     scope=task.scope,
+                    expected_task_id=task.task_id,
                 )
-                deleted += 1
+                if was_deleted:
+                    deleted += 1
         return deleted
 
     deleted = await run_in_threadpool(clear_completed)

--- a/src/novelvideo/task_state.py
+++ b/src/novelvideo/task_state.py
@@ -1443,14 +1443,21 @@ class TaskStateManager:
         episode: int,
         beat_num: int = None,
         scope: str | None = None,
-    ):
+        expected_task_id: str | None = None,
+    ) -> bool:
+        if not expected_task_id:
+            raise ValueError("expected_task_id is required to delete project task state")
         key = self._project_key(task_type, ctx.project_id, episode, beat_num, scope)
         with self._connect_context(ctx) as conn:
-            conn.execute(
-                "DELETE FROM task_states WHERE task_key = ? AND project_id = ?",
-                (key, ctx.project_id),
+            cursor = conn.execute(
+                """DELETE FROM task_states
+                   WHERE task_key = ? AND project_id = ? AND task_id = ?""",
+                (key, ctx.project_id, expected_task_id),
             )
-        logger.debug("Project task deleted: %s", key)
+        deleted = cursor.rowcount > 0
+        if deleted:
+            logger.debug("Project task deleted: %s", key)
+        return deleted
 
     def list_tasks_for_project(self, ctx: ProjectContext) -> List[TaskState]:
         tasks: list[TaskState] = []

--- a/tests/test_project_task_routes.py
+++ b/tests/test_project_task_routes.py
@@ -269,6 +269,83 @@ async def test_project_task_clear_completed_uses_editor_role(tmp_path, monkeypat
 
 
 @pytest.mark.asyncio
+async def test_project_task_clear_completed_passes_expected_task_id(tmp_path, monkeypatch):
+    ctx = _ctx(tmp_path, role="editor")
+    manager = TaskStateManager()
+    completed = manager.create_task_for_project(ctx, "single_video", 1, beat_num=15)
+    manager.complete_task_for_project(
+        ctx,
+        "single_video",
+        1,
+        beat_num=15,
+        expected_task_id=completed.task_id,
+    )
+    original_delete = manager.delete_task_for_project
+    delete_calls: list[str | None] = []
+
+    def tracked_delete(*args, expected_task_id=None, **kwargs):
+        delete_calls.append(expected_task_id)
+        return original_delete(
+            *args,
+            expected_task_id=expected_task_id,
+            **kwargs,
+        )
+
+    async def fake_resolve_project_context(**kwargs):
+        return ctx
+
+    monkeypatch.setattr(tasks_route, "resolve_project_context", fake_resolve_project_context)
+    monkeypatch.setattr(tasks_route, "get_task_manager", lambda: manager)
+    monkeypatch.setattr(manager, "delete_task_for_project", tracked_delete)
+
+    response = await tasks_route.clear_project_completed_tasks(
+        "proj_123", user={"username": "bob"}
+    )
+
+    assert response == {"ok": True, "data": {"deleted": 1}}
+    assert delete_calls == [completed.task_id]
+
+
+@pytest.mark.asyncio
+async def test_project_task_clear_completed_does_not_count_stale_delete(
+    tmp_path,
+    monkeypatch,
+):
+    ctx = _ctx(tmp_path, role="editor")
+    manager = TaskStateManager()
+    completed = manager.create_task_for_project(ctx, "single_video", 1, beat_num=15)
+    manager.complete_task_for_project(
+        ctx,
+        "single_video",
+        1,
+        beat_num=15,
+        expected_task_id=completed.task_id,
+    )
+
+    async def fake_resolve_project_context(**kwargs):
+        return ctx
+
+    monkeypatch.setattr(tasks_route, "resolve_project_context", fake_resolve_project_context)
+    monkeypatch.setattr(tasks_route, "get_task_manager", lambda: manager)
+    monkeypatch.setattr(manager, "delete_task_for_project", lambda *args, **kwargs: False)
+
+    response = await tasks_route.clear_project_completed_tasks(
+        "proj_123", user={"username": "bob"}
+    )
+
+    assert response == {"ok": True, "data": {"deleted": 0}}
+
+
+def test_project_task_delete_requires_expected_task_id(tmp_path):
+    ctx = _ctx(tmp_path, role="editor")
+    manager = TaskStateManager()
+    manager.create_task_for_project(ctx, "single_video", 1, beat_num=15)
+
+    with pytest.raises(ValueError, match="expected_task_id is required"):
+        manager.delete_task_for_project(ctx, "single_video", 1, beat_num=15)
+
+
+@pytest.mark.asyncio
 async def test_project_task_clear_completed_removes_stale_full_progress(
     tmp_path,
     monkeypatch,


### PR DESCRIPTION
## Summary

- Make completed-task cleanup pass the observed task ID and count only successful conditional deletes.
- Enforce task-ID compare-and-delete in the CE task-state implementation to match the EE store contract.
- Scope user search requests and React Query cache keys by project.

## Verification

- `uv run ruff check src/novelvideo/api/routes/tasks.py src/novelvideo/task_state.py tests/test_project_task_routes.py`
- `uv run pytest tests/test_project_task_routes.py tests/contract/test_m07_tasks.py -q` (27 passed)
- `pnpm --dir frontend test -- share-project-dialog.test.tsx` (2 passed)
- `pnpm --dir frontend build`
- `git diff --check`

Companion integration fixes for claymorelab/SuperTale#58.
