### PR TITLE
Fix typed scene task-start errors

### DIFF
--- a/license-inventory.csv
+++ b/license-inventory.csv
@@ -1385,6 +1385,7 @@ src/novelvideo/api/routes/scripts.py,Elastic-2.0,2026 SuperTale contributors,REU
 src/novelvideo/api/routes/styles.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 src/novelvideo/api/routes/tasks.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 src/novelvideo/api/schemas.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
+src/novelvideo/api/task_start_errors.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 src/novelvideo/api/viewer_manifests.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 src/novelvideo/api/wsgi.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 src/novelvideo/assets/__init__.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
@@ -1810,6 +1811,7 @@ tests/test_batch_render_removed.py,Elastic-2.0,2026 SuperTale contributors,REUSE
 tests/test_batch_render_video_actions_removed.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_billing_error_extension.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_billing_fatal_predicate_invariant.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
+tests/test_billing_identity_error.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_block_world_node_unavailable.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_canvas_scene_refs_override.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_ce_allowlist.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
@@ -1965,6 +1967,7 @@ tests/test_scene_gallery_backend_removed.py,Elastic-2.0,2026 SuperTale contribut
 tests/test_scene_name_migration.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_scene_plate_resolution.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_scene_reference_prompt.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
+tests/test_scene_task_start_errors.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_screenplay_normalizer.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_screenplay_scene_parser.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_seedance2_assets.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
@@ -1987,6 +1990,7 @@ tests/test_sqlite_store.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml ag
 tests/test_sqlite_store_indextts2_migration.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_stage_asset_scene_360_credit.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_stage_asset_scene_360_provider.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
+tests/test_stage_asset_step_contract.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_storyboard_prompt_visual_authority.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_superpower_model_config.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_task_backend_celery_metadata.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation

--- a/src/novelvideo/api/routes/freezone.py
+++ b/src/novelvideo/api/routes/freezone.py
@@ -85,6 +85,7 @@ from novelvideo.api.schemas import (
     ProjectionStatusRequest,
     PushRequest,
 )
+from novelvideo.api.task_start_errors import handle_task_start_runtime_error
 from novelvideo.config import (
     IMAGE_GENERATION_SELECTIONS,
     image_generation_selection_options,
@@ -101,11 +102,6 @@ from novelvideo.media_model_request_schema import (
     validate_media_request_schema,
 )
 from novelvideo.ports.authz import find_authz_error
-from novelvideo.shared.billing_errors import (
-    find_billing_error,
-    find_billing_rule_not_configured_error,
-    find_insufficient_credits_error,
-)
 from novelvideo.freezone.audio_node import (
     create_user_audio_voice,
     freezone_audio_eleven_music_output_path,
@@ -289,13 +285,6 @@ from novelvideo.project_context import (
 )
 from novelvideo.seedance2_i2v.voice_clone import resolve_character_voice
 from novelvideo.ports import get_task_backend
-from novelvideo.task_backend.limits import (
-    ChannelTaskLimitExceeded,
-    GlobalLaneQueueLimitExceeded,
-    ProjectTaskLimitExceeded,
-    ProjectUserTaskLimitExceeded,
-    UserTaskLimitExceeded,
-)
 from novelvideo.task_identity import (
     project_task_state_key,
     selection_scope,
@@ -356,44 +345,8 @@ def _raise_project_context_required(task_type: str) -> None:
     )
 
 
-def _raise_if_task_limit_exception(exc: RuntimeError) -> None:
-    # Every admission-limit exception here is a RuntimeError subclass, so the
-    # wide `except RuntimeError` in the callers below would turn it into a bare
-    # 503 unless it is re-raised for the app-level 429 handler (same reason as
-    # the AuthzError branch below). GlobalLaneQueueLimitExceeded was leaking
-    # exactly that way (M8 step 7 / TCP-P44); the channel and user gates are
-    # listed as defence in depth for the EE path.
-    if isinstance(
-        exc,
-        (
-            ProjectTaskLimitExceeded,
-            ProjectUserTaskLimitExceeded,
-            GlobalLaneQueueLimitExceeded,
-            ChannelTaskLimitExceeded,
-            UserTaskLimitExceeded,
-        ),
-    ):
-        raise exc
-
-
 def _handle_task_start_runtime_error(message: str, exc: RuntimeError) -> None:
-    _raise_if_task_limit_exception(exc)
-    insufficient_credits = find_insufficient_credits_error(exc)
-    if insufficient_credits is not None:
-        raise insufficient_credits
-    billing_rule_not_configured = find_billing_rule_not_configured_error(exc)
-    if billing_rule_not_configured is not None:
-        raise billing_rule_not_configured
-    billing = find_billing_error(exc)
-    if billing is not None:
-        raise billing
-    # AuthzError is a RuntimeError subclass, so without this it fell through to
-    # the warning below and callers turned an organization denial into a bare
-    # 503. Re-raise so the app-level handler renders the contracted 4xx.
-    authz_denial = find_authz_error(exc)
-    if authz_denial is not None:
-        raise authz_denial
-    logger.warning("%s: %s", message, exc, exc_info=True)
+    handle_task_start_runtime_error(logger, message, exc)
 
 
 async def _start_or_enqueue_freezone_video_gen(

--- a/src/novelvideo/api/routes/scenes.py
+++ b/src/novelvideo/api/routes/scenes.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import io
+import logging
 import shutil
 import tempfile
 import time
@@ -24,6 +25,7 @@ from novelvideo.api.schemas import (
     SceneReferenceGenerateRequest,
     SceneUpdate,
 )
+from novelvideo.api.task_start_errors import handle_task_start_runtime_error
 from novelvideo.api.viewer_manifests import (
     build_director_stage_manifest,
     build_pano_viewer_manifest,
@@ -51,6 +53,7 @@ from novelvideo.utils.path_resolver import (
 )
 
 router = APIRouter()
+logger = logging.getLogger("novelvideo.api.scenes")
 
 _SCENE_TIME_TOKENS = {
     "清晨",
@@ -1404,6 +1407,11 @@ async def _start_3gs_single_face_task(
             params=params,
         )
     except RuntimeError as exc:
+        handle_task_start_runtime_error(
+            logger,
+            "failed to start single-face stage asset task",
+            exc,
+        )
         return {"ok": False, "error": str(exc)}
 
     return {
@@ -1489,6 +1497,11 @@ async def generate_scene_3gs_pano_ply(
             params=params,
         )
     except RuntimeError as exc:
+        handle_task_start_runtime_error(
+            logger,
+            "failed to start pano stage asset task",
+            exc,
+        )
         return {"ok": False, "error": str(exc)}
 
     return {
@@ -1539,6 +1552,11 @@ async def generate_scene_pano(
             params=params,
         )
     except RuntimeError as exc:
+        handle_task_start_runtime_error(
+            logger,
+            "failed to start scene pano generation task",
+            exc,
+        )
         return {"ok": False, "error": str(exc)}
 
     return {

--- a/src/novelvideo/api/task_start_errors.py
+++ b/src/novelvideo/api/task_start_errors.py
@@ -1,0 +1,53 @@
+"""Preserve typed task-start failures for application-level HTTP handlers."""
+
+from __future__ import annotations
+
+import logging
+
+from novelvideo.ports.authz import find_authz_error
+from novelvideo.shared.billing_errors import (
+    find_billing_error,
+    find_billing_rule_not_configured_error,
+    find_insufficient_credits_error,
+    iter_exception_chain,
+)
+from novelvideo.task_backend.limits import (
+    ChannelTaskLimitExceeded,
+    GlobalLaneQueueLimitExceeded,
+    ProjectTaskLimitExceeded,
+    ProjectUserTaskLimitExceeded,
+    UserTaskLimitExceeded,
+)
+
+_TASK_LIMIT_ERRORS = (
+    ProjectTaskLimitExceeded,
+    ProjectUserTaskLimitExceeded,
+    GlobalLaneQueueLimitExceeded,
+    ChannelTaskLimitExceeded,
+    UserTaskLimitExceeded,
+)
+
+
+def handle_task_start_runtime_error(
+    logger: logging.Logger,
+    message: str,
+    exc: RuntimeError,
+) -> None:
+    """Re-raise typed failures and log ordinary task-start runtime errors."""
+    for item in iter_exception_chain(exc):
+        if isinstance(item, _TASK_LIMIT_ERRORS):
+            raise item
+
+    billing = find_insufficient_credits_error(exc)
+    if billing is None:
+        billing = find_billing_rule_not_configured_error(exc)
+    if billing is None:
+        billing = find_billing_error(exc)
+    if billing is not None:
+        raise billing
+
+    authz_denial = find_authz_error(exc)
+    if authz_denial is not None:
+        raise authz_denial
+
+    logger.warning("%s: %s", message, exc, exc_info=True)

--- a/src/novelvideo/shared/billing_errors.py
+++ b/src/novelvideo/shared/billing_errors.py
@@ -8,6 +8,9 @@ INSUFFICIENT_CREDITS_CODE = "INSUFFICIENT_CREDITS"
 INSUFFICIENT_CREDITS_MESSAGE = "积分不足，请联系管理员充值"
 BILLING_RULE_NOT_CONFIGURED_CODE = "BILLING_RULE_NOT_CONFIGURED"
 BILLING_RULE_NOT_CONFIGURED_MESSAGE = "计费规则未配置，请联系管理员设置积分规则"
+FEATURE_BILLING_IDENTITY_INVALID_CODE = "FEATURE_BILLING_IDENTITY_INVALID"
+FEATURE_BILLING_IDENTITY_INVALID_MESSAGE = "计费身份无效或无法确定，请联系管理员"
+FEATURE_BILLING_IDENTITY_REASON_MAX_LENGTH = 512
 GENERATION_BILLING_UNITS = {
     "call",
     "item",
@@ -74,6 +77,22 @@ class BillingRuleNotConfiguredError(BillingError):
 
     def details(self) -> dict[str, Any]:
         return {"billing_kind": self.kind, "billing_key": self.key}
+
+
+class FeatureBillingIdentityError(BillingError):
+    """Raised when the billing identity for a feature cannot be trusted."""
+
+    error_code = FEATURE_BILLING_IDENTITY_INVALID_CODE
+    http_status = 409
+    user_message = FEATURE_BILLING_IDENTITY_INVALID_MESSAGE
+
+    def __init__(self, *, internal_reason: str = "") -> None:
+        safe_reason = internal_reason if type(internal_reason) is str else ""
+        if len(safe_reason) > FEATURE_BILLING_IDENTITY_REASON_MAX_LENGTH:
+            safe_reason = (
+                safe_reason[: FEATURE_BILLING_IDENTITY_REASON_MAX_LENGTH - 3] + "..."
+            )
+        super().__init__(safe_reason or "feature billing identity is invalid")
 
 
 def iter_exception_chain(exc: BaseException | None):
@@ -150,9 +169,7 @@ def is_insufficient_credits_error(
     )
 
 
-def is_fatal_billing_error(
-    exc: BaseException | None = None, message: str = ""
-) -> bool:
+def is_fatal_billing_error(exc: BaseException | None = None, message: str = "") -> bool:
     return find_billing_error(exc) is not None or is_insufficient_credits_error(
         exc, message
     )
@@ -195,6 +212,10 @@ __all__ = [
     "BILLING_RULE_NOT_CONFIGURED_MESSAGE",
     "BillingError",
     "BillingRuleNotConfiguredError",
+    "FEATURE_BILLING_IDENTITY_INVALID_CODE",
+    "FEATURE_BILLING_IDENTITY_INVALID_MESSAGE",
+    "FEATURE_BILLING_IDENTITY_REASON_MAX_LENGTH",
+    "FeatureBillingIdentityError",
     "GENERATION_BILLING_UNITS",
     "INSUFFICIENT_CREDITS_CODE",
     "INSUFFICIENT_CREDITS_MESSAGE",

--- a/src/novelvideo/task_backend/runners/stage_asset.py
+++ b/src/novelvideo/task_backend/runners/stage_asset.py
@@ -20,6 +20,18 @@ from novelvideo.task_backend.registry import register_project_task_runner
 from novelvideo.task_identity import project_task_state_key
 from novelvideo.task_state import get_task_manager
 
+SUPPORTED_STAGE_ASSET_STEPS = frozenset(
+    {
+        "single_face_sharp",
+        "pano_sharp",
+        "splat_collision",
+        "voxel_world_from_360",
+        "upload_scene_package",
+        "pano_from_master",
+        "pano_from_text",
+    }
+)
+
 
 def _extract_trusted_egress_context(
     envelope: dict[str, Any],
@@ -79,6 +91,8 @@ def run_stage_asset(
     payload = envelope.get("payload") or {}
     scene_name = str(payload["scene_name"])
     step = str(payload["step"])
+    if step not in SUPPORTED_STAGE_ASSET_STEPS:
+        raise ValueError(f"unknown stage_asset step: {step}")
     params = dict(payload.get("params") or {})
     project_dir = Path(str(payload.get("project_dir") or ctx.output_dir))
     scope = envelope.get("scope")

--- a/tests/test_billing_identity_error.py
+++ b/tests/test_billing_identity_error.py
@@ -1,0 +1,88 @@
+import pytest
+from fastapi.testclient import TestClient
+
+from novelvideo.api.app import create_app
+from novelvideo.shared.billing_errors import (
+    FEATURE_BILLING_IDENTITY_INVALID_CODE,
+    FEATURE_BILLING_IDENTITY_INVALID_MESSAGE,
+    FEATURE_BILLING_IDENTITY_REASON_MAX_LENGTH,
+    BillingError,
+    FeatureBillingIdentityError,
+    billing_error_payload,
+)
+
+
+def test_feature_billing_identity_error_contract() -> None:
+    error = FeatureBillingIdentityError(internal_reason="missing billing principal")
+
+    assert isinstance(error, BillingError)
+    assert error.error_code == FEATURE_BILLING_IDENTITY_INVALID_CODE
+    assert error.error_code == "FEATURE_BILLING_IDENTITY_INVALID"
+    assert error.http_status == 409
+    assert error.user_message == FEATURE_BILLING_IDENTITY_INVALID_MESSAGE
+    assert error.user_message == "计费身份无效或无法确定，请联系管理员"
+
+
+def test_feature_billing_identity_payload_redacts_internal_reason() -> None:
+    error = FeatureBillingIdentityError(internal_reason="ambiguous principal")
+
+    assert "ambiguous principal" in str(error)
+    assert billing_error_payload(error) == {
+        "error_code": FEATURE_BILLING_IDENTITY_INVALID_CODE,
+        "message": FEATURE_BILLING_IDENTITY_INVALID_MESSAGE,
+    }
+
+
+def test_feature_billing_identity_error_survives_hostile_reason_rendering() -> None:
+    class HostileReason:
+        def __str__(self) -> str:
+            raise RuntimeError("hostile __str__")
+
+        def __repr__(self) -> str:
+            raise RuntimeError("hostile __repr__")
+
+    error = FeatureBillingIdentityError(internal_reason=HostileReason())  # type: ignore[arg-type]
+
+    assert isinstance(error, FeatureBillingIdentityError)
+    assert str(error) == "feature billing identity is invalid"
+
+
+def test_feature_billing_identity_error_truncates_long_reason() -> None:
+    error = FeatureBillingIdentityError(internal_reason="x" * 10_000)
+
+    rendered = str(error)
+    assert len(rendered) == FEATURE_BILLING_IDENTITY_REASON_MAX_LENGTH
+    assert rendered.endswith("...")
+
+
+def test_feature_billing_identity_error_rejects_identity_context_kwargs() -> None:
+    with pytest.raises(TypeError):
+        FeatureBillingIdentityError(
+            internal_reason="principal mismatch",
+            user_id="user-secret",  # type: ignore[call-arg]
+            org_id="org-secret",
+        )
+
+
+def test_feature_billing_identity_error_uses_generic_http_handler() -> None:
+    app = create_app()
+
+    @app.get("/__feature-billing-identity-error")
+    async def raise_feature_billing_identity_error() -> None:
+        raise FeatureBillingIdentityError(
+            internal_reason="principal mismatch",
+        )
+
+    response = TestClient(app, raise_server_exceptions=False).get(
+        "/__feature-billing-identity-error"
+    )
+
+    assert response.status_code == 409
+    assert response.json() == {
+        "ok": False,
+        "error": FEATURE_BILLING_IDENTITY_INVALID_MESSAGE,
+        "data": {
+            "error_code": FEATURE_BILLING_IDENTITY_INVALID_CODE,
+            "message": FEATURE_BILLING_IDENTITY_INVALID_MESSAGE,
+        },
+    }

--- a/tests/test_scene_task_start_errors.py
+++ b/tests/test_scene_task_start_errors.py
@@ -1,0 +1,276 @@
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from fastapi.testclient import TestClient
+
+from novelvideo.models import NovelScene
+from novelvideo.ports.authz import AuthzError
+from novelvideo.project_context import ProjectContext
+from novelvideo.shared.billing_errors import (
+    BillingError,
+    BillingRuleNotConfiguredError,
+    InsufficientCreditsError,
+)
+from novelvideo.task_backend.limits import ProjectUserTaskLimitExceeded
+
+
+class _SceneStore:
+    async def get_scene(self, name: str) -> NovelScene | None:
+        if name == "中庭":
+            return NovelScene(name=name)
+        return None
+
+
+class _GenericBillingError(BillingError):
+    error_code = "GENERIC_BILLING_ERROR"
+    http_status = 418
+    user_message = "generic billing failure"
+
+
+@pytest.fixture()
+def scene_task_start_client(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+):
+    from novelvideo.api.app import create_app
+    from novelvideo.api.routes import scenes
+    from novelvideo.director_world import stage_manifest
+    from novelvideo.utils.path_resolver import canonical_scene_master_path
+
+    project_dir = tmp_path / "output" / "alice" / "demo"
+    project_dir.mkdir(parents=True)
+    master_path = canonical_scene_master_path(project_dir, "中庭")
+    master_path.parent.mkdir(parents=True)
+    master_path.write_bytes(b"png")
+    pano_path = stage_manifest.stage_dir(project_dir, "中庭") / "pano_360.png"
+    pano_path.parent.mkdir(parents=True)
+    pano_path.write_bytes(b"png")
+    stage_manifest.update_manifest(project_dir, "中庭", pano_path=pano_path.name)
+    ctx = ProjectContext(
+        project_id="proj_scenes",
+        project_name="demo",
+        owner_type="user",
+        owner_id="alice-id",
+        owner_username="alice",
+        requester_user_id="alice-id",
+        requester_username="alice",
+        requester_principals=(),
+        effective_role="owner",
+        home_node_id="local",
+        output_dir=project_dir,
+        state_dir=tmp_path / "state",
+        runtime_dir=tmp_path / "runtime",
+        is_home_node=True,
+    )
+    store = _SceneStore()
+
+    async def resolve_scene_project(*_args, **_kwargs):
+        return ctx, "alice", "demo", project_dir, str(project_dir), store
+
+    monkeypatch.setattr(scenes, "_resolve_scene_project", resolve_scene_project)
+
+    def build(exc: RuntimeError) -> TestClient:
+        async def enqueue_project_task(*_args, **_kwargs):
+            raise exc
+
+        monkeypatch.setattr(
+            scenes,
+            "get_task_backend",
+            lambda: SimpleNamespace(enqueue_project_task=enqueue_project_task),
+        )
+        app = create_app()
+        app.dependency_overrides[scenes.get_api_user] = lambda: {
+            "id": "alice-id",
+            "username": "alice",
+        }
+        return TestClient(app, raise_server_exceptions=False)
+
+    return build
+
+
+def test_scene_single_face_task_start_preserves_billing_error(
+    scene_task_start_client,
+) -> None:
+    billing = InsufficientCreditsError(user_id="alice-id", cost=40, balance=8)
+    wrapper = RuntimeError("failed to enqueue stage asset")
+    wrapper.__cause__ = billing
+    client = scene_task_start_client(wrapper)
+
+    response = client.post(
+        "/api/v1/projects/demo/scenes/中庭/3gs/master-ply/generate-async"
+    )
+
+    assert response.status_code == 402
+    assert response.json()["data"] == {
+        "error_code": "INSUFFICIENT_CREDITS",
+        "message": "积分不足，请联系管理员充值",
+        "user_id": "alice-id",
+        "required": 40,
+        "balance": 8,
+    }
+
+
+def test_scene_task_start_prefers_wrapped_insufficient_credits(
+    scene_task_start_client,
+) -> None:
+    outer = _GenericBillingError("generic billing failure")
+    outer.__cause__ = InsufficientCreditsError(
+        user_id="alice-id",
+        cost=40,
+        balance=8,
+    )
+    client = scene_task_start_client(outer)
+
+    response = client.post(
+        "/api/v1/projects/demo/scenes/中庭/3gs/master-ply/generate-async"
+    )
+
+    assert response.status_code == 402
+    assert response.json()["data"]["error_code"] == "INSUFFICIENT_CREDITS"
+
+
+def test_scene_task_start_prefers_wrapped_missing_billing_rule(
+    scene_task_start_client,
+) -> None:
+    outer = _GenericBillingError("generic billing failure")
+    outer.__cause__ = BillingRuleNotConfiguredError(
+        kind="feature",
+        key="scene.pano",
+    )
+    client = scene_task_start_client(outer)
+
+    response = client.post(
+        "/api/v1/projects/demo/scenes/中庭/3gs/master-ply/generate-async"
+    )
+
+    assert response.status_code == 409
+    assert response.json()["data"]["error_code"] == "BILLING_RULE_NOT_CONFIGURED"
+
+
+def test_scene_pano_task_start_preserves_billing_error(scene_task_start_client) -> None:
+    billing = InsufficientCreditsError(user_id="alice-id", cost=60, balance=7)
+    wrapper = RuntimeError("failed to enqueue stage asset")
+    wrapper.__cause__ = billing
+    client = scene_task_start_client(wrapper)
+
+    response = client.post(
+        "/api/v1/projects/demo/scenes/中庭/3gs/pano-ply/generate-async"
+    )
+
+    assert response.status_code == 402
+    assert response.json()["data"]["required"] == 60
+    assert response.json()["data"]["balance"] == 7
+
+
+def test_scene_pano_generation_task_start_preserves_billing_error(
+    scene_task_start_client,
+) -> None:
+    billing = InsufficientCreditsError(user_id="alice-id", cost=80, balance=6)
+    wrapper = RuntimeError("failed to enqueue scene pano generation")
+    wrapper.__cause__ = billing
+    client = scene_task_start_client(wrapper)
+
+    response = client.post(
+        "/api/v1/projects/demo/scenes/中庭/pano/generate-async",
+        json={"source": "text"},
+    )
+
+    assert response.status_code == 402
+    assert response.json()["data"]["required"] == 80
+    assert response.json()["data"]["balance"] == 6
+
+
+def test_scene_pano_generation_keeps_legacy_response_for_plain_runtime_error(
+    scene_task_start_client,
+) -> None:
+    client = scene_task_start_client(RuntimeError("broker unavailable"))
+
+    response = client.post(
+        "/api/v1/projects/demo/scenes/中庭/pano/generate-async",
+        json={"source": "text"},
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {"ok": False, "error": "broker unavailable"}
+
+
+def test_scene_single_face_task_start_preserves_authz_error(
+    scene_task_start_client,
+) -> None:
+    denial = AuthzError("ORG_CREDENTIAL_MISSING")
+    wrapper = RuntimeError("failed to enqueue stage asset")
+    wrapper.__cause__ = denial
+    client = scene_task_start_client(wrapper)
+
+    response = client.post(
+        "/api/v1/projects/demo/scenes/中庭/3gs/master-ply/generate-async"
+    )
+
+    assert response.status_code == 409
+    assert response.json()["data"]["error_code"] == "ORG_CREDENTIAL_MISSING"
+
+
+def test_scene_pano_task_start_preserves_task_limit_error(
+    scene_task_start_client,
+) -> None:
+    limit = ProjectUserTaskLimitExceeded(
+        project_id="proj_scenes",
+        requester_user_id="alice-id",
+        queue_kind="world",
+        limit=1,
+        active=1,
+    )
+    client = scene_task_start_client(limit)
+
+    response = client.post(
+        "/api/v1/projects/demo/scenes/中庭/3gs/pano-ply/generate-async"
+    )
+
+    assert response.status_code == 429
+    assert response.json()["data"]["limit_scope"] == "user"
+    assert response.json()["data"]["queue_kind"] == "world"
+
+
+def test_scene_task_start_preserves_wrapped_task_limit_error(
+    scene_task_start_client,
+) -> None:
+    limit = ProjectUserTaskLimitExceeded(
+        project_id="proj_scenes",
+        requester_user_id="alice-id",
+        queue_kind="world",
+        limit=1,
+        active=1,
+    )
+    wrapper = RuntimeError("failed to enqueue stage asset")
+    wrapper.__cause__ = limit
+    client = scene_task_start_client(wrapper)
+
+    response = client.post(
+        "/api/v1/projects/demo/scenes/中庭/3gs/master-ply/generate-async"
+    )
+
+    assert response.status_code == 429
+    assert response.json()["data"]["limit_scope"] == "user"
+    assert response.json()["data"]["queue_kind"] == "world"
+
+
+@pytest.mark.parametrize(
+    "endpoint",
+    [
+        "/api/v1/projects/demo/scenes/中庭/3gs/master-ply/generate-async",
+        "/api/v1/projects/demo/scenes/中庭/3gs/pano-ply/generate-async",
+    ],
+)
+def test_scene_task_start_keeps_legacy_response_for_plain_runtime_error(
+    scene_task_start_client,
+    endpoint: str,
+) -> None:
+    client = scene_task_start_client(RuntimeError("broker unavailable"))
+
+    response = client.post(endpoint)
+
+    assert response.status_code == 200
+    assert response.json() == {"ok": False, "error": "broker unavailable"}

--- a/tests/test_stage_asset_step_contract.py
+++ b/tests/test_stage_asset_step_contract.py
@@ -1,0 +1,178 @@
+from types import SimpleNamespace
+
+import pytest
+
+STAGE_ASSET_DISPATCH_CASES = (
+    ("single_face_sharp", "run_single_face_sharp", {"image_path": "source.png"}),
+    ("pano_sharp", "run_pano_sharp", {"pano_path": "pano.png"}),
+    ("splat_collision", "run_splat_collision", {"ply_path": "scene.ply"}),
+    ("voxel_world_from_360", "run_voxel_world_from_360", {}),
+    (
+        "upload_scene_package",
+        "upload_scene_package",
+        {"src_asset": "package.zip"},
+    ),
+    ("pano_from_master", "run_scene_360", {"master_path": "master.png"}),
+    ("pano_from_text", "run_scene_360", {}),
+)
+
+STAGE_ASSET_TASK_FUNCTIONS = (
+    "run_single_face_sharp",
+    "run_pano_sharp",
+    "run_splat_collision",
+    "run_voxel_world_from_360",
+    "upload_scene_package",
+    "run_scene_360",
+)
+
+
+def test_supported_stage_asset_steps_are_exported_exactly():
+    from novelvideo.task_backend.runners.stage_asset import (
+        SUPPORTED_STAGE_ASSET_STEPS,
+    )
+
+    assert SUPPORTED_STAGE_ASSET_STEPS == frozenset(
+        {
+            "single_face_sharp",
+            "pano_sharp",
+            "splat_collision",
+            "voxel_world_from_360",
+            "upload_scene_package",
+            "pano_from_master",
+            "pano_from_text",
+        }
+    )
+
+
+def test_stage_asset_dispatch_cases_match_supported_steps_exactly():
+    from novelvideo.task_backend.runners.stage_asset import (
+        SUPPORTED_STAGE_ASSET_STEPS,
+    )
+
+    assert frozenset(
+        step for step, _handler, _params in STAGE_ASSET_DISPATCH_CASES
+    ) == (SUPPORTED_STAGE_ASSET_STEPS)
+
+
+@pytest.mark.parametrize(
+    ("step", "expected_handler", "case_params"),
+    STAGE_ASSET_DISPATCH_CASES,
+    ids=[case[0] for case in STAGE_ASSET_DISPATCH_CASES],
+)
+def test_supported_stage_asset_step_dispatches_to_expected_handler(
+    step,
+    expected_handler,
+    case_params,
+    tmp_path,
+    monkeypatch,
+):
+    from novelvideo import stage_asset_tasks
+    from novelvideo.task_backend.runners import stage_asset
+
+    calls: list[str] = []
+    sentinel = object()
+
+    def unexpected_handler(name):
+        def fail(*_args, **_kwargs):
+            raise AssertionError(f"unexpected handler: {name}")
+
+        return fail
+
+    def expected(*_args, **_kwargs):
+        calls.append(expected_handler)
+        return sentinel
+
+    for function_name in STAGE_ASSET_TASK_FUNCTIONS:
+        monkeypatch.setattr(
+            stage_asset_tasks,
+            function_name,
+            unexpected_handler(function_name),
+        )
+    monkeypatch.setattr(stage_asset_tasks, expected_handler, expected)
+    monkeypatch.setattr(
+        stage_asset,
+        "get_task_manager",
+        lambda: SimpleNamespace(
+            update_progress_for_project=lambda *_args, **_kwargs: None
+        ),
+    )
+    monkeypatch.setattr(
+        stage_asset,
+        "raise_if_envelope_cancel_requested",
+        lambda *_args, **_kwargs: None,
+    )
+    params = {
+        key: (
+            str(tmp_path / value)
+            if key.endswith("path") or key == "src_asset"
+            else value
+        )
+        for key, value in case_params.items()
+    }
+
+    result = stage_asset.run_stage_asset(
+        {
+            "scope": f"scene_asset_{step}",
+            "payload": {
+                "scene_name": "Hall",
+                "step": step,
+                "params": params,
+                "project_dir": str(tmp_path),
+            },
+        },
+        SimpleNamespace(project_id="proj", output_dir=tmp_path),
+    )
+
+    assert result is sentinel
+    assert calls == [expected_handler]
+
+
+def test_unknown_stage_asset_step_is_rejected_before_side_effects(
+    tmp_path, monkeypatch
+):
+    from novelvideo import stage_asset_tasks
+    from novelvideo.task_backend.runners import stage_asset
+
+    calls: list[str] = []
+
+    def unexpected_call(name):
+        def fail(*_args, **_kwargs):
+            calls.append(name)
+            raise AssertionError(f"unexpected call: {name}")
+
+        return fail
+
+    monkeypatch.setattr(stage_asset, "get_task_manager", unexpected_call("manager"))
+    monkeypatch.setattr(
+        stage_asset,
+        "raise_if_envelope_cancel_requested",
+        unexpected_call("cancel"),
+    )
+    for function_name in (
+        "run_single_face_sharp",
+        "run_pano_sharp",
+        "run_splat_collision",
+        "run_voxel_world_from_360",
+        "upload_scene_package",
+        "run_scene_360",
+    ):
+        monkeypatch.setattr(
+            stage_asset_tasks,
+            function_name,
+            unexpected_call(function_name),
+        )
+
+    with pytest.raises(ValueError, match="^unknown stage_asset step: not_supported$"):
+        stage_asset.run_stage_asset(
+            {
+                "scope": "scene_asset",
+                "payload": {
+                    "scene_name": "Hall",
+                    "step": "not_supported",
+                    "project_dir": str(tmp_path),
+                },
+            },
+            SimpleNamespace(project_id="proj", output_dir=tmp_path),
+        )
+
+    assert calls == []


### PR DESCRIPTION
## Summary

- preserve typed billing, authorization, and task-limit failures across all three scene task-start endpoints while keeping ordinary RuntimeError compatibility responses
- centralize the task-start RuntimeError boundary and keep Freezone billing subtype priority intact
- add a typed, redacted FeatureBillingIdentityError contract for EE Release B
- publish and enforce the seven-step stage_asset contract before task-manager side effects, with real dispatch drift coverage

## Root cause

Several scene routes caught RuntimeError broadly. Because billing and authorization failures inherit from RuntimeError, those routes converted structured 402, 409, and 429 failures into legacy HTTP 200 error bodies. The stage runner also exposed no enforceable shared step contract for EE billing policy.

## Carried-forward review feedback

- [x] preserve wrapped task-limit failures and existing 429 handlers
- [x] retain InsufficientCredits then BillingRuleNotConfigured then generic BillingError priority
- [x] cover single-face 3GS, pano-to-3GS, and panorama generation task-start routes
- [x] provide a stable redacted 409 billing-identity error
- [x] validate unknown stage steps before manager, progress, cancellation, or task-function side effects
- [x] execute all seven legal dispatch branches in the CE drift guard
- [x] verify existing acknowledge-no-refund cancellation behavior

## Validation

- backend focused and adjacent regression suite: 296 passed
- frontend paid-task cancellation suite: 5 passed
- Ruff passed for all changed files
- Black passed for the seven scoped files already formatted by staging; the current staging version of freezone.py has existing whole-file Black debt
- git diff check passed
- DCO sign-off present

## Rollout

This CE repair must be merged and deployed before EE Release B activates operation-level stage_asset charging. EE Release A only registers the four price keys and remains behavior-neutral.
