### PR TITLE
fix: scope narrator voice config to project state dir

### DIFF
--- a/license-inventory.csv
+++ b/license-inventory.csv
@@ -1918,6 +1918,7 @@ tests/test_openapi_edition_contract.py,Elastic-2.0,2026 SuperTale contributors,R
 tests/test_openresty_upload_limit.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_org_relay_failure_diagnosability.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_org_relay_granted_prefix.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
+tests/test_org_scoped_narrator_voice.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_oss_presign_builder.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_p0_gray_execution_boundaries.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_p0_gray_shared_egress_seam.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation

--- a/src/novelvideo/api/routes/freezone.py
+++ b/src/novelvideo/api/routes/freezone.py
@@ -275,8 +275,8 @@ from novelvideo.freezone.video_node import (
 )
 from novelvideo.models import CharacterIdentity, beat_scene_id
 from novelvideo.project_config import (
-    load_effective_narration_style_for_voice,
-    load_narrator_reference_audio,
+    load_effective_narration_style_for_voice_from_state_dir,
+    load_narrator_reference_audio_from_state_dir,
 )
 from novelvideo.project_context import (
     ProjectContext,
@@ -6799,8 +6799,8 @@ async def freezone_audio_references(
     ctx, username, project_name, project_dir, _output_dir = await _resolve_freezone_project(
         project, user, required_role="viewer"
     )
-    narrator_descriptor = load_narrator_reference_audio(username, project_name)
-    narration_style = load_effective_narration_style_for_voice(username, project_name)
+    narrator_descriptor = load_narrator_reference_audio_from_state_dir(ctx.state_dir)
+    narration_style = load_effective_narration_style_for_voice_from_state_dir(ctx.state_dir)
     requester_username = ctx.requester_username or username
     user_voices = _attach_user_voice_media_urls(
         project,

--- a/src/novelvideo/api/routes/generation.py
+++ b/src/novelvideo/api/routes/generation.py
@@ -1355,6 +1355,7 @@ def _seedance2_status_response(
         next_beat=ctx["next_beat"],
         characters=ctx["characters"],
         prop_menu=ctx["prop_menu"],
+        state_dir=str(getattr(ctx["store"], "state_dir", "") or "") or None,
     )
     assets = state.assets
     selected_assets = [asset for asset in assets if asset.selected]

--- a/src/novelvideo/api/routes/generation.py
+++ b/src/novelvideo/api/routes/generation.py
@@ -934,6 +934,7 @@ async def _prepare_seedance2_api_beat(
     )
     prepared = await prepare_seedance2_generation_inputs(
         project_output=output_dir,
+        state_dir=Path(store.state_dir),
         episode=episode,
         beat=beat,
         next_beat=all_beats[index + 1] if index + 1 < len(all_beats) else None,
@@ -966,6 +967,7 @@ async def _prepare_seedance2_api_beat(
 async def _prepare_happyhorse_api_beat(
     *,
     output_dir: str | Path,
+    state_dir: str | Path,
     episode: int,
     beat: dict[str, Any],
     next_beat: dict[str, Any] | None,
@@ -1016,6 +1018,7 @@ async def _prepare_happyhorse_api_beat(
             episode=episode,
             beat=beat,
             mode=Seedance2I2VMode.MULTIMODAL_REFERENCE,
+            state_dir=state_dir,
             next_beat=next_beat,
             prop_menu=prop_menu,
         )
@@ -1046,6 +1049,7 @@ async def _prepare_happyhorse_api_beat(
 async def _prepare_grok_video_api_beat(
     *,
     output_dir: str | Path,
+    state_dir: str | Path,
     episode: int,
     beat: dict[str, Any],
     next_beat: dict[str, Any] | None,
@@ -1096,6 +1100,7 @@ async def _prepare_grok_video_api_beat(
             episode=episode,
             beat=beat,
             mode=Seedance2I2VMode.MULTIMODAL_REFERENCE,
+            state_dir=state_dir,
             next_beat=next_beat,
             prop_menu=prop_menu,
         )
@@ -1355,7 +1360,7 @@ def _seedance2_status_response(
         next_beat=ctx["next_beat"],
         characters=ctx["characters"],
         prop_menu=ctx["prop_menu"],
-        state_dir=str(getattr(ctx["store"], "state_dir", "") or "") or None,
+        state_dir=Path(ctx["store"].state_dir),
     )
     assets = state.assets
     selected_assets = [asset for asset in assets if asset.selected]
@@ -4730,6 +4735,7 @@ async def generate_single_video(
             prop_menu = await _runtime_prop_menu_with_global_props(store, episode_obj, beats)
             prepared = await _prepare_happyhorse_api_beat(
                 output_dir=output_dir,
+                state_dir=Path(store.state_dir),
                 episode=episode_num,
                 beat=beat,
                 next_beat=beats[beat_index + 1] if beat_index + 1 < len(beats) else None,
@@ -4776,6 +4782,7 @@ async def generate_single_video(
             prop_menu = await _runtime_prop_menu_with_global_props(store, episode_obj, beats)
             prepared = await _prepare_grok_video_api_beat(
                 output_dir=output_dir,
+                state_dir=Path(store.state_dir),
                 episode=episode_num,
                 beat=beat,
                 next_beat=beats[beat_index + 1] if beat_index + 1 < len(beats) else None,

--- a/src/novelvideo/api/routes/projects.py
+++ b/src/novelvideo/api/routes/projects.py
@@ -37,12 +37,12 @@ from novelvideo.ports import get_project_access, get_project_registry
 from novelvideo.ports.project import ProjectRecord
 from novelvideo.project_config import (
     default_aspect_ratio_for_spine_template,
-    load_effective_narration_style_for_voice,
-    load_narrator_reference_audio,
+    load_effective_narration_style_for_voice_from_state_dir,
+    load_narrator_reference_audio_from_state_dir,
     load_project_config_file_from_state_dir,
     load_project_config_from_state_dir,
     save_project_config_in_state_dir,
-    set_narrator_reference_audio,
+    set_narrator_reference_audio_in_state_dir,
 )
 from novelvideo.project_context import (
     ProjectContext,
@@ -212,13 +212,16 @@ def _narrator_voice_display_lines(
     }
 
 
-def _effective_narrator_voice_style(username: str, project: str) -> str:
-    return load_effective_narration_style_for_voice(username, project) or DEFAULT_NARRATION_STYLE
+def _effective_narrator_voice_style(ctx: ProjectContext) -> str:
+    return (
+        load_effective_narration_style_for_voice_from_state_dir(ctx.state_dir)
+        or DEFAULT_NARRATION_STYLE
+    )
 
 
 def _narrator_voice_payload(ctx: ProjectContext, store) -> dict:
-    style = _effective_narrator_voice_style(ctx.owner_username, ctx.project_name)
-    stored = load_narrator_reference_audio(ctx.owner_username, ctx.project_name)
+    style = _effective_narrator_voice_style(ctx)
+    stored = load_narrator_reference_audio_from_state_dir(ctx.state_dir)
     resolution = resolve_narrator_source(
         store=store,
         narration_style=style,
@@ -257,16 +260,15 @@ def _narrator_voice_payload(ctx: ProjectContext, store) -> dict:
     }
 
 
-def _ensure_third_person_narrator(username: str, project: str) -> None:
-    style = _effective_narrator_voice_style(username, project)
+def _ensure_third_person_narrator(ctx: ProjectContext) -> None:
+    style = _effective_narrator_voice_style(ctx)
     if style == "first_person":
         raise ValueError(NARRATOR_VOICE_MODE_EXPLANATION)
 
 
 def _persist_narrator_voice_content(
     *,
-    username: str,
-    project: str,
+    state_dir: str | Path,
     project_dir: Path,
     filename: str,
     content: bytes,
@@ -285,9 +287,8 @@ def _persist_narrator_voice_content(
                 existing.with_name(f"{existing.stem}_{int(time.time())}{existing.suffix}")
             )
     target.write_bytes(content)
-    set_narrator_reference_audio(
-        username,
-        project,
+    set_narrator_reference_audio_in_state_dir(
+        state_dir,
         relative_path=_project_relative_path(project_dir, target),
         sha256=voice_content_sha256(content),
     )
@@ -296,13 +297,12 @@ def _persist_narrator_voice_content(
 
 def _trim_narrator_voice_content(
     *,
-    username: str,
-    project: str,
+    state_dir: str | Path,
     project_dir: Path,
     start_seconds: float,
     duration_seconds: float,
 ) -> Path:
-    stored = load_narrator_reference_audio(username, project)
+    stored = load_narrator_reference_audio_from_state_dir(state_dir)
     source = Path(stored.get("path", ""))
     if not str(source):
         raise ValueError("请先上传解说声线")
@@ -333,9 +333,8 @@ def _trim_narrator_voice_content(
         if sibling.exists():
             sibling.replace(sibling.with_name(f"{sibling.stem}_{int(time.time())}{sibling.suffix}"))
     target.write_bytes(content)
-    set_narrator_reference_audio(
-        username,
-        project,
+    set_narrator_reference_audio_in_state_dir(
+        state_dir,
         relative_path=_project_relative_path(project_dir, target),
         sha256=voice_content_sha256(content),
     )
@@ -617,11 +616,10 @@ async def upload_narrator_voice(
     ctx = await resolve_project_context(user=user, project_id=project, required_role="editor")
     store = await make_sqlite_store_for_context(ctx)
     try:
-        _ensure_third_person_narrator(ctx.owner_username, ctx.project_name)
+        _ensure_third_person_narrator(ctx)
         content = await file.read()
         _persist_narrator_voice_content(
-            username=ctx.owner_username,
-            project=ctx.project_name,
+            state_dir=ctx.state_dir,
             project_dir=ctx.output_dir,
             filename=file.filename or "",
             content=content,
@@ -644,11 +642,10 @@ async def record_narrator_voice(
     ctx = await resolve_project_context(user=user, project_id=project, required_role="editor")
     store = await make_sqlite_store_for_context(ctx)
     try:
-        _ensure_third_person_narrator(ctx.owner_username, ctx.project_name)
+        _ensure_third_person_narrator(ctx)
         content, extension = decode_recorded_audio_data_url(body.data_url)
         _persist_narrator_voice_content(
-            username=ctx.owner_username,
-            project=ctx.project_name,
+            state_dir=ctx.state_dir,
             project_dir=ctx.output_dir,
             filename=f"recorded{extension}",
             content=content,
@@ -671,7 +668,7 @@ async def copy_project_audio_as_narrator_voice(
     ctx = await resolve_project_context(user=user, project_id=project, required_role="editor")
     store = await make_sqlite_store_for_context(ctx)
     try:
-        _ensure_third_person_narrator(ctx.owner_username, ctx.project_name)
+        _ensure_third_person_narrator(ctx)
         raw_path = Path(body.source_path)
         source_path = raw_path if raw_path.is_absolute() else ctx.output_dir / raw_path
         source_path = source_path.resolve()
@@ -679,8 +676,7 @@ async def copy_project_audio_as_narrator_voice(
         if not source_path.exists() or source_path.suffix.lower() not in VOICE_SAMPLE_EXTENSIONS:
             return {"ok": False, "error": "请选择项目内有效的音频文件"}
         _persist_narrator_voice_content(
-            username=ctx.owner_username,
-            project=ctx.project_name,
+            state_dir=ctx.state_dir,
             project_dir=ctx.output_dir,
             filename=source_path.name,
             content=source_path.read_bytes(),
@@ -703,10 +699,9 @@ async def trim_narrator_voice(
     ctx = await resolve_project_context(user=user, project_id=project, required_role="editor")
     store = await make_sqlite_store_for_context(ctx)
     try:
-        _ensure_third_person_narrator(ctx.owner_username, ctx.project_name)
+        _ensure_third_person_narrator(ctx)
         _trim_narrator_voice_content(
-            username=ctx.owner_username,
-            project=ctx.project_name,
+            state_dir=ctx.state_dir,
             project_dir=ctx.output_dir,
             start_seconds=body.start_seconds,
             duration_seconds=body.duration_seconds,
@@ -727,14 +722,14 @@ async def delete_narrator_voice(
     """移除第三人称项目解说声线。"""
     ctx = await resolve_project_context(user=user, project_id=project, required_role="editor")
     store = await make_sqlite_store_for_context(ctx)
-    stored = load_narrator_reference_audio(ctx.owner_username, ctx.project_name)
+    stored = load_narrator_reference_audio_from_state_dir(ctx.state_dir)
     target = Path(stored.get("path", ""))
     if str(target):
         if not target.is_absolute():
             target = ctx.output_dir / target
         if target.exists():
             target.replace(target.with_name(f"{target.stem}_{int(time.time())}{target.suffix}"))
-    set_narrator_reference_audio(ctx.owner_username, ctx.project_name, relative_path="", sha256="")
+    set_narrator_reference_audio_in_state_dir(ctx.state_dir, relative_path="", sha256="")
     return {
         "ok": True,
         "data": _narrator_voice_payload(ctx, store),

--- a/src/novelvideo/api/routes/scripts.py
+++ b/src/novelvideo/api/routes/scripts.py
@@ -571,6 +571,7 @@ async def generate_seedance2_prompt(
 
         saved_json = await generate_seedance2_prompt_for_panel(
             store=store,
+            state_dir=Path(resolved.state_dir),
             episode=episode_num,
             beat=target,
             project_dir=project_dir,

--- a/src/novelvideo/audio/indextts2_beat_audio_task.py
+++ b/src/novelvideo/audio/indextts2_beat_audio_task.py
@@ -171,10 +171,7 @@ def _audio_usage_request_id(
 
 def _is_narrated_project(store, username: str, project: str) -> bool:
     project_config = importlib.import_module("novelvideo.project_config")
-    state_dir = str(getattr(store, "state_dir", "") or "")
-    if state_dir:
-        return project_config.is_narrated_project_from_state_dir(state_dir)
-    return project_config.is_narrated_project(username, project)
+    return project_config.is_narrated_project_from_state_dir(store.state_dir)
 
 
 def _resolve_beat_uploaded_narration_voice(
@@ -250,21 +247,11 @@ async def _resolve_narrator_voice(
     project: str,
 ) -> tuple[Path | None, str, str, str]:
     project_config = importlib.import_module("novelvideo.project_config")
-    state_dir = str(getattr(store, "state_dir", "") or "")
-    if state_dir:
-        narration_style = (
-            project_config.load_effective_narration_style_for_voice_from_state_dir(state_dir)
-        )
-    else:
-        narration_style = project_config.load_effective_narration_style_for_voice(
-            username, project
-        )
-    if state_dir:
-        narrator_reference = project_config.load_narrator_reference_audio_from_state_dir(
-            state_dir
-        )
-    else:
-        narrator_reference = project_config.load_narrator_reference_audio(username, project)
+    state_dir = store.state_dir
+    narration_style = project_config.load_effective_narration_style_for_voice_from_state_dir(
+        state_dir
+    )
+    narrator_reference = project_config.load_narrator_reference_audio_from_state_dir(state_dir)
     characters = await store.list_characters()
     resolution = resolve_narrator_source(
         store=store,
@@ -293,8 +280,10 @@ async def _resolve_narration_voice_for_beat(
         beat_voice = _resolve_beat_uploaded_narration_voice(beat, store.project_dir)
         if beat_voice is not None:
             project_config = importlib.import_module("novelvideo.project_config")
-            narration_style = project_config.load_effective_narration_style_for_voice(
-                username, project
+            narration_style = (
+                project_config.load_effective_narration_style_for_voice_from_state_dir(
+                    store.state_dir
+                )
             )
             return beat_voice, file_sha256(beat_voice), narration_style, ""
     return await _resolve_narrator_voice(

--- a/src/novelvideo/audio/indextts2_beat_audio_task.py
+++ b/src/novelvideo/audio/indextts2_beat_audio_task.py
@@ -169,8 +169,11 @@ def _audio_usage_request_id(
     return f"indextts2:{uuid.uuid5(uuid.NAMESPACE_URL, stable).hex}"
 
 
-def _is_narrated_project(username: str, project: str) -> bool:
+def _is_narrated_project(store, username: str, project: str) -> bool:
     project_config = importlib.import_module("novelvideo.project_config")
+    state_dir = str(getattr(store, "state_dir", "") or "")
+    if state_dir:
+        return project_config.is_narrated_project_from_state_dir(state_dir)
     return project_config.is_narrated_project(username, project)
 
 
@@ -247,10 +250,21 @@ async def _resolve_narrator_voice(
     project: str,
 ) -> tuple[Path | None, str, str, str]:
     project_config = importlib.import_module("novelvideo.project_config")
-    narration_style = project_config.load_effective_narration_style_for_voice(
-        username, project
-    )
-    narrator_reference = project_config.load_narrator_reference_audio(username, project)
+    state_dir = str(getattr(store, "state_dir", "") or "")
+    if state_dir:
+        narration_style = (
+            project_config.load_effective_narration_style_for_voice_from_state_dir(state_dir)
+        )
+    else:
+        narration_style = project_config.load_effective_narration_style_for_voice(
+            username, project
+        )
+    if state_dir:
+        narrator_reference = project_config.load_narrator_reference_audio_from_state_dir(
+            state_dir
+        )
+    else:
+        narrator_reference = project_config.load_narrator_reference_audio(username, project)
     characters = await store.list_characters()
     resolution = resolve_narrator_source(
         store=store,
@@ -275,7 +289,7 @@ async def _resolve_narration_voice_for_beat(
     username: str,
     project: str,
 ) -> tuple[Path | None, str, str, str]:
-    if not _is_narrated_project(username, project):
+    if not _is_narrated_project(store, username, project):
         beat_voice = _resolve_beat_uploaded_narration_voice(beat, store.project_dir)
         if beat_voice is not None:
             project_config = importlib.import_module("novelvideo.project_config")
@@ -332,7 +346,7 @@ async def build_indextts2_audio_generation_plan(
 
         if is_narration:
             beat_voice = None
-            if not _is_narrated_project(username, project):
+            if not _is_narrated_project(store, username, project):
                 beat_voice = _resolve_beat_uploaded_narration_voice(
                     beat, store.project_dir
                 )

--- a/src/novelvideo/freezone/audio_node.py
+++ b/src/novelvideo/freezone/audio_node.py
@@ -26,8 +26,8 @@ from novelvideo.generators.tts_generator import (
 )
 from novelvideo.ports.model_credentials import ModelCredentialError
 from novelvideo.project_config import (
-    load_effective_narration_style_for_voice,
-    load_narrator_reference_audio,
+    load_effective_narration_style_for_voice_from_state_dir,
+    load_narrator_reference_audio_from_state_dir,
 )
 from novelvideo.seedance2_i2v.voice_clone import (
     build_reference_audio_url,
@@ -473,7 +473,9 @@ async def resolve_speech_voice(
     visible.
     """
     if projection is None:
-        narration_style = load_effective_narration_style_for_voice(username, project)
+        narration_style = load_effective_narration_style_for_voice_from_state_dir(
+            store.state_dir
+        )
         voice_characters = None
         narrator_store = store
     else:
@@ -491,7 +493,7 @@ async def resolve_speech_voice(
     )
     if selected_voice is None:
         if projection is None:
-            descriptor = load_narrator_reference_audio(username, project)
+            descriptor = load_narrator_reference_audio_from_state_dir(store.state_dir)
             characters = (
                 await store.list_characters() if narration_style == "first_person" else None
             )

--- a/src/novelvideo/project_config.py
+++ b/src/novelvideo/project_config.py
@@ -444,17 +444,38 @@ def update_regen_file_map(
     return dict(updated.get("regen_file_map") or {})
 
 
-def load_narration_style(username: str, project: str) -> str:
-    """Return the project-level narration style ("first_person" / "third_person")."""
-    config = load_project_config_file(username, project)
+def _load_narration_style_from_config(config: dict) -> str:
     style = str(config.get(NARRATION_STYLE_KEY) or "").strip()
     return style if style in _VALID_NARRATION_STYLES else DEFAULT_NARRATION_STYLE
 
 
+def _is_narrated_project_from_config(config: dict) -> bool:
+    return str(config.get("spine_template") or "drama").strip() == "narrated"
+
+
+def _load_effective_narration_style_for_voice_from_config(config: dict) -> str:
+    style = _load_narration_style_from_config(config)
+    return style if _is_narrated_project_from_config(config) else DEFAULT_NARRATION_STYLE
+
+
+def load_narration_style(username: str, project: str) -> str:
+    """Return the project-level narration style ("first_person" / "third_person")."""
+    return _load_narration_style_from_config(load_project_config_file(username, project))
+
+
+def load_narration_style_from_state_dir(state_dir: str | Path) -> str:
+    """Return the narration style stored in an explicitly resolved state directory."""
+    return _load_narration_style_from_config(load_project_config_file_from_state_dir(state_dir))
+
+
 def is_narrated_project(username: str, project: str) -> bool:
     """Return whether the project uses the narrated screenplay spine."""
-    config = load_project_config_file(username, project)
-    return str(config.get("spine_template") or "drama").strip() == "narrated"
+    return _is_narrated_project_from_config(load_project_config_file(username, project))
+
+
+def is_narrated_project_from_state_dir(state_dir: str | Path) -> bool:
+    """Return whether the project at an explicitly resolved state directory is narrated."""
+    return _is_narrated_project_from_config(load_project_config_file_from_state_dir(state_dir))
 
 
 def load_effective_narration_style_for_voice(username: str, project: str) -> str:
@@ -463,8 +484,24 @@ def load_effective_narration_style_for_voice(username: str, project: str) -> str
     Drama projects may carry legacy ``first_person`` values, but narration voice
     resolution for drama must use the project narrator instead of protagonist voice.
     """
-    style = load_narration_style(username, project)
-    return style if is_narrated_project(username, project) else DEFAULT_NARRATION_STYLE
+    return _load_effective_narration_style_for_voice_from_config(
+        load_project_config_file(username, project)
+    )
+
+
+def load_effective_narration_style_for_voice_from_state_dir(state_dir: str | Path) -> str:
+    """Return the effective voice style from an explicitly resolved state directory."""
+    return _load_effective_narration_style_for_voice_from_config(
+        load_project_config_file_from_state_dir(state_dir)
+    )
+
+
+def _load_narrator_reference_audio_from_config(config: dict) -> dict[str, str]:
+    return {
+        "path": str(config.get(NARRATOR_AUDIO_PATH_KEY) or "").strip(),
+        "sha256": str(config.get(NARRATOR_AUDIO_SHA256_KEY) or "").strip(),
+        "updated_at": str(config.get(NARRATOR_AUDIO_UPDATED_AT_KEY) or "").strip(),
+    }
 
 
 def load_narrator_reference_audio(username: str, project: str) -> dict[str, str]:
@@ -474,12 +511,16 @@ def load_narrator_reference_audio(username: str, project: str) -> dict[str, str]
     ``narrator_reference_audio_path``, ``..._sha256``, ``..._updated_at``.
     Missing fields come back as empty strings.
     """
-    config = load_project_config_file(username, project)
-    return {
-        "path": str(config.get(NARRATOR_AUDIO_PATH_KEY) or "").strip(),
-        "sha256": str(config.get(NARRATOR_AUDIO_SHA256_KEY) or "").strip(),
-        "updated_at": str(config.get(NARRATOR_AUDIO_UPDATED_AT_KEY) or "").strip(),
-    }
+    return _load_narrator_reference_audio_from_config(
+        load_project_config_file(username, project)
+    )
+
+
+def load_narrator_reference_audio_from_state_dir(state_dir: str | Path) -> dict[str, str]:
+    """Return narrator reference audio from an explicitly resolved state directory."""
+    return _load_narrator_reference_audio_from_config(
+        load_project_config_file_from_state_dir(state_dir)
+    )
 
 
 def set_narrator_reference_audio(
@@ -503,6 +544,29 @@ def set_narrator_reference_audio(
         config[NARRATOR_AUDIO_UPDATED_AT_KEY] = str(stamp or "").strip()
 
     updated = update_project_config_file(username, project, _apply)
+    return {
+        "path": str(updated.get(NARRATOR_AUDIO_PATH_KEY) or ""),
+        "sha256": str(updated.get(NARRATOR_AUDIO_SHA256_KEY) or ""),
+        "updated_at": str(updated.get(NARRATOR_AUDIO_UPDATED_AT_KEY) or ""),
+    }
+
+
+def set_narrator_reference_audio_in_state_dir(
+    state_dir: str | Path,
+    *,
+    relative_path: str,
+    sha256: str,
+    updated_at: str | None = None,
+) -> dict[str, str]:
+    """Persist narrator reference metadata in an explicitly resolved state directory."""
+    stamp = updated_at if updated_at is not None else datetime.now(timezone.utc).isoformat()
+
+    def _apply(config: dict) -> None:
+        config[NARRATOR_AUDIO_PATH_KEY] = str(relative_path or "").strip()
+        config[NARRATOR_AUDIO_SHA256_KEY] = str(sha256 or "").strip()
+        config[NARRATOR_AUDIO_UPDATED_AT_KEY] = str(stamp or "").strip()
+
+    updated = update_project_config_file_in_state_dir(state_dir, _apply)
     return {
         "path": str(updated.get(NARRATOR_AUDIO_PATH_KEY) or ""),
         "sha256": str(updated.get(NARRATOR_AUDIO_SHA256_KEY) or ""),

--- a/src/novelvideo/seedance2_i2v/assets.py
+++ b/src/novelvideo/seedance2_i2v/assets.py
@@ -21,9 +21,7 @@ from novelvideo.models import (
     resolve_scene_plate,
 )
 from novelvideo.project_config import (
-    load_effective_narration_style_for_voice,
     load_effective_narration_style_for_voice_from_state_dir,
-    load_narrator_reference_audio,
     load_narrator_reference_audio_from_state_dir,
 )
 from novelvideo.seedance2_i2v.character_voice_storage import probe_voice_sample_duration_seconds
@@ -792,25 +790,14 @@ def _dialogue_voice_assets(
     return refs
 
 
-def _project_owner_from_output(project_output: Path) -> tuple[str, str]:
-    project = _text(project_output.name)
-    username = _text(project_output.parent.name)
-    return username, project
-
-
 def _narration_voice_asset(
     *,
     project_output: Path,
     characters: list[Any],
-    state_dir: str | Path | None = None,
+    state_dir: str | Path,
 ) -> dict[str, Any]:
-    username, project = _project_owner_from_output(project_output)
     try:
-        style = (
-            load_effective_narration_style_for_voice_from_state_dir(state_dir)
-            if state_dir
-            else load_effective_narration_style_for_voice(username, project)
-        )
+        style = load_effective_narration_style_for_voice_from_state_dir(state_dir)
     except Exception:
         style = DEFAULT_NARRATION_STYLE
 
@@ -827,11 +814,7 @@ def _narration_voice_asset(
             }
 
     try:
-        descriptor = (
-            load_narrator_reference_audio_from_state_dir(state_dir)
-            if state_dir
-            else load_narrator_reference_audio(username, project)
-        )
+        descriptor = load_narrator_reference_audio_from_state_dir(state_dir)
     except Exception:
         descriptor = {}
     stored_path = _text(descriptor.get("path")) if isinstance(descriptor, dict) else ""
@@ -854,10 +837,10 @@ def build_seedance2_project_assets(
     episode: int,
     beat: dict[str, Any],
     mode: Seedance2I2VMode,
+    state_dir: str | Path,
     next_beat: dict[str, Any] | None = None,
     characters: list[Any] | None = None,
     prop_menu: list[Any] | None = None,
-    state_dir: str | Path | None = None,
 ) -> list[Seedance2ResolvedAsset]:
     """Resolve project assets in the order used for Seedance 2.0 requests."""
 

--- a/src/novelvideo/seedance2_i2v/assets.py
+++ b/src/novelvideo/seedance2_i2v/assets.py
@@ -22,7 +22,9 @@ from novelvideo.models import (
 )
 from novelvideo.project_config import (
     load_effective_narration_style_for_voice,
+    load_effective_narration_style_for_voice_from_state_dir,
     load_narrator_reference_audio,
+    load_narrator_reference_audio_from_state_dir,
 )
 from novelvideo.seedance2_i2v.character_voice_storage import probe_voice_sample_duration_seconds
 from novelvideo.seedance2_i2v.models import Seedance2I2VMode
@@ -800,10 +802,15 @@ def _narration_voice_asset(
     *,
     project_output: Path,
     characters: list[Any],
+    state_dir: str | Path | None = None,
 ) -> dict[str, Any]:
     username, project = _project_owner_from_output(project_output)
     try:
-        style = load_effective_narration_style_for_voice(username, project)
+        style = (
+            load_effective_narration_style_for_voice_from_state_dir(state_dir)
+            if state_dir
+            else load_effective_narration_style_for_voice(username, project)
+        )
     except Exception:
         style = DEFAULT_NARRATION_STYLE
 
@@ -820,7 +827,11 @@ def _narration_voice_asset(
             }
 
     try:
-        descriptor = load_narrator_reference_audio(username, project)
+        descriptor = (
+            load_narrator_reference_audio_from_state_dir(state_dir)
+            if state_dir
+            else load_narrator_reference_audio(username, project)
+        )
     except Exception:
         descriptor = {}
     stored_path = _text(descriptor.get("path")) if isinstance(descriptor, dict) else ""
@@ -846,6 +857,7 @@ def build_seedance2_project_assets(
     next_beat: dict[str, Any] | None = None,
     characters: list[Any] | None = None,
     prop_menu: list[Any] | None = None,
+    state_dir: str | Path | None = None,
 ) -> list[Seedance2ResolvedAsset]:
     """Resolve project assets in the order used for Seedance 2.0 requests."""
 
@@ -1106,6 +1118,7 @@ def build_seedance2_project_assets(
         voice_asset = _narration_voice_asset(
             project_output=project_output,
             characters=resolved_characters,
+            state_dir=state_dir,
         )
         add_audio(
             key=voice_asset["key"],

--- a/src/novelvideo/seedance2_i2v/narration_audio_task.py
+++ b/src/novelvideo/seedance2_i2v/narration_audio_task.py
@@ -6,8 +6,8 @@ from dataclasses import dataclass, field
 
 from novelvideo.config import INDEXTTS2_RECORD_MODEL, INDEXTTS2_RECORD_PROVIDER
 from novelvideo.project_config import (
-    load_effective_narration_style_for_voice,
-    load_narrator_reference_audio,
+    load_effective_narration_style_for_voice_from_state_dir,
+    load_narrator_reference_audio_from_state_dir,
 )
 from novelvideo.seedance2_i2v.voice_audio_records import (
     upsert_seedance2_voice_audio_record,
@@ -48,8 +48,8 @@ class Seedance2NarrationAudioTaskResult:
 
 
 async def _resolve_for_run(store, username: str, project: str) -> NarratorResolution:
-    style = load_effective_narration_style_for_voice(username, project)
-    descriptor = load_narrator_reference_audio(username, project)
+    style = load_effective_narration_style_for_voice_from_state_dir(store.state_dir)
+    descriptor = load_narrator_reference_audio_from_state_dir(store.state_dir)
     characters = await store.list_characters() if style == "first_person" else None
     return resolve_narrator_source(
         store=store,

--- a/src/novelvideo/seedance2_i2v/panel_service.py
+++ b/src/novelvideo/seedance2_i2v/panel_service.py
@@ -10,7 +10,10 @@ from pathlib import Path
 from typing import Any
 
 from novelvideo.manual_shots import resolve_target_video_duration
-from novelvideo.project_config import load_project_config_file, set_narrator_reference_audio
+from novelvideo.project_config import (
+    load_project_config_file,
+    set_narrator_reference_audio_in_state_dir,
+)
 from novelvideo.seedance2_i2v.assets import (
     Seedance2ResolvedAsset,
     apply_prompt_audio_selection,
@@ -385,10 +388,11 @@ async def trim_seedance2_audio_to_reference(
         target.parent.mkdir(parents=True, exist_ok=True)
         _archive_narrator_voice_siblings(target)
         target.write_bytes(content)
-        username, project = _project_owner_from_output(Path(project_dir))
-        set_narrator_reference_audio(
-            username,
-            project,
+        state_dir = str(getattr(store, "state_dir", "") or "")
+        if not state_dir:
+            raise ValueError("项目 state_dir 未解析，无法保存解说声线")
+        set_narrator_reference_audio_in_state_dir(
+            state_dir,
             relative_path=_project_relative_path(Path(project_dir), target),
             sha256=voice_content_sha256(content),
         )
@@ -453,6 +457,7 @@ def build_seedance2_video_panel_state(
     next_beat: dict[str, Any] | None = None,
     characters: list[Any] | None = None,
     prop_menu: list[Any] | None = None,
+    state_dir: str | Path | None = None,
 ) -> Seedance2VideoPanelState:
     config = parse_seedance2_config(beat.get("seedance2_config_json"))
     duration_floor = _seedance2_duration_floor(
@@ -469,6 +474,7 @@ def build_seedance2_video_panel_state(
         next_beat=next_beat,
         characters=characters,
         prop_menu=prop_menu,
+        state_dir=state_dir,
     )
     _append_seedance2_user_reference_assets(assets, config)
     prompt_source = config.prompt_source or "saved"

--- a/src/novelvideo/seedance2_i2v/panel_service.py
+++ b/src/novelvideo/seedance2_i2v/panel_service.py
@@ -10,10 +10,7 @@ from pathlib import Path
 from typing import Any
 
 from novelvideo.manual_shots import resolve_target_video_duration
-from novelvideo.project_config import (
-    load_project_config_file,
-    set_narrator_reference_audio_in_state_dir,
-)
+from novelvideo.project_config import set_narrator_reference_audio_in_state_dir
 from novelvideo.seedance2_i2v.assets import (
     Seedance2ResolvedAsset,
     apply_prompt_audio_selection,
@@ -75,6 +72,7 @@ class Seedance2VideoPanelState:
 async def save_seedance2_video_panel_config(
     *,
     store: Any,
+    state_dir: str | Path,
     episode: int,
     beat: dict[str, Any],
     mode: str | None = None,
@@ -123,6 +121,7 @@ async def save_seedance2_video_panel_config(
             project_dir=project_dir,
             episode=episode,
             beat=beat,
+            state_dir=state_dir,
             next_beat=next_beat,
             prop_menu=prop_menu,
         )
@@ -167,6 +166,7 @@ async def append_seedance2_prompt_guidance_template(
 async def generate_seedance2_prompt_for_panel(
     *,
     store: Any,
+    state_dir: str | Path,
     episode: int,
     beat: dict[str, Any],
     project_dir: Path,
@@ -184,6 +184,7 @@ async def generate_seedance2_prompt_for_panel(
         episode=episode,
         beat=beat,
         mode=config.mode,
+        state_dir=state_dir,
         next_beat=next_beat,
         prop_menu=prop_menu,
     )
@@ -384,13 +385,13 @@ async def trim_seedance2_audio_to_reference(
     )
 
     if str(asset_key or "").strip() == "voice:narrator":
+        state_dir = str(getattr(store, "state_dir", "") or "")
+        if not state_dir:
+            raise ValueError("项目 state_dir 未解析，无法保存解说声线")
         target = Path(project_dir) / "assets" / "narrator" / "voice.mp3"
         target.parent.mkdir(parents=True, exist_ok=True)
         _archive_narrator_voice_siblings(target)
         target.write_bytes(content)
-        state_dir = str(getattr(store, "state_dir", "") or "")
-        if not state_dir:
-            raise ValueError("项目 state_dir 未解析，无法保存解说声线")
         set_narrator_reference_audio_in_state_dir(
             state_dir,
             relative_path=_project_relative_path(Path(project_dir), target),
@@ -454,10 +455,10 @@ def build_seedance2_video_panel_state(
     project_dir: Path,
     episode: int,
     beat: dict[str, Any],
+    state_dir: str | Path,
     next_beat: dict[str, Any] | None = None,
     characters: list[Any] | None = None,
     prop_menu: list[Any] | None = None,
-    state_dir: str | Path | None = None,
 ) -> Seedance2VideoPanelState:
     config = parse_seedance2_config(beat.get("seedance2_config_json"))
     duration_floor = _seedance2_duration_floor(
@@ -534,54 +535,13 @@ def _unique_paths(values: list[str]) -> list[str]:
     return result
 
 
-def _project_owner_from_output(project_dir: Path) -> tuple[str, str]:
-    return str(project_dir.parent.name or "").strip(), str(project_dir.name or "").strip()
-
-
-def _is_narrated_project(project_dir: Path) -> bool:
-    username, project = _project_owner_from_output(project_dir)
-    config = load_project_config_file(username, project)
-    return str(config.get("spine_template") or "drama") == "narrated"
-
-
-def _existing_user_audio_paths(config: Any, project_dir: Path) -> list[str]:
-    result: list[str] = []
-    for value in list(config.reference_audio_paths):
-        path = Path(str(value or "").strip())
-        if not str(path):
-            continue
-        resolved = path if path.is_absolute() else project_dir / path
-        if resolved.exists():
-            result.append(str(value))
-    return result
-
-
-def _drop_auto_narration_audio_when_user_audio_selected(
-    *,
-    assets: list[Seedance2ResolvedAsset],
-    config: Any,
-    project_dir: Path,
-    beat: dict[str, Any],
-) -> list[Seedance2ResolvedAsset]:
-    if _is_narrated_project(project_dir):
-        return assets
-    if normalize_seedance2_audio_type(beat) != "narration":
-        return assets
-    if not _existing_user_audio_paths(config, project_dir):
-        return assets
-    return [
-        asset
-        for asset in assets
-        if not (asset.media_type == "audio" and str(asset.key).startswith("voice:"))
-    ]
-
-
 def _sync_seedance2_asset_paths(
     *,
     config: Any,
     project_dir: Path,
     episode: int,
     beat: dict[str, Any],
+    state_dir: str | Path,
     next_beat: dict[str, Any] | None = None,
     prop_menu: list[Any] | None = None,
 ) -> None:
@@ -590,6 +550,7 @@ def _sync_seedance2_asset_paths(
         episode=episode,
         beat=beat,
         mode=config.mode,
+        state_dir=state_dir,
         next_beat=next_beat,
         prop_menu=prop_menu,
     )

--- a/src/novelvideo/seedance2_i2v/pipeline.py
+++ b/src/novelvideo/seedance2_i2v/pipeline.py
@@ -180,6 +180,7 @@ def _validate_dialogue_final_prompt(
 def collect_seedance2_video_prereq_errors(
     *,
     project_output: str | Path,
+    state_dir: str | Path,
     episode: int,
     beats: list[dict[str, Any]],
     characters: list[Any] | None = None,
@@ -197,6 +198,7 @@ def collect_seedance2_video_prereq_errors(
             episode=episode,
             beat=beat,
             mode=config.mode,
+            state_dir=state_dir,
             next_beat=next_beat,
             characters=characters,
             prop_menu=prop_menu,
@@ -242,6 +244,7 @@ def collect_seedance2_video_prereq_errors(
 async def prepare_seedance2_generation_inputs(
     *,
     project_output: str | Path,
+    state_dir: str | Path,
     episode: int,
     beat: dict[str, Any],
     video_mode: str,
@@ -266,6 +269,7 @@ async def prepare_seedance2_generation_inputs(
         episode=episode,
         beat=beat,
         mode=config.mode,
+        state_dir=state_dir,
         next_beat=next_beat,
         characters=characters,
         prop_menu=prop_menu,

--- a/src/novelvideo/seedance2_i2v/voice_reference_service.py
+++ b/src/novelvideo/seedance2_i2v/voice_reference_service.py
@@ -10,7 +10,9 @@ from typing import Any
 from novelvideo.models import real_detected_identities
 from novelvideo.project_config import (
     load_effective_narration_style_for_voice,
+    load_effective_narration_style_for_voice_from_state_dir,
     load_narrator_reference_audio,
+    load_narrator_reference_audio_from_state_dir,
 )
 from novelvideo.seedance2_i2v.spoken_dialogue import (
     speaker_display_name,
@@ -86,8 +88,19 @@ def resolve_narrator_reference_status(
     username: str,
     project: str,
 ) -> NarratorReferenceStatus:
-    style = load_effective_narration_style_for_voice(username, project) or DEFAULT_NARRATION_STYLE
-    stored = load_narrator_reference_audio(username, project)
+    state_dir = str(getattr(store, "state_dir", "") or "")
+    if state_dir:
+        style = (
+            load_effective_narration_style_for_voice_from_state_dir(state_dir)
+            or DEFAULT_NARRATION_STYLE
+        )
+        stored = load_narrator_reference_audio_from_state_dir(state_dir)
+    else:
+        style = (
+            load_effective_narration_style_for_voice(username, project)
+            or DEFAULT_NARRATION_STYLE
+        )
+        stored = load_narrator_reference_audio(username, project)
     resolution = resolve_narrator_source(
         store=store,
         narration_style=style,

--- a/src/novelvideo/seedance2_i2v/voice_reference_service.py
+++ b/src/novelvideo/seedance2_i2v/voice_reference_service.py
@@ -9,9 +9,7 @@ from typing import Any
 
 from novelvideo.models import real_detected_identities
 from novelvideo.project_config import (
-    load_effective_narration_style_for_voice,
     load_effective_narration_style_for_voice_from_state_dir,
-    load_narrator_reference_audio,
     load_narrator_reference_audio_from_state_dir,
 )
 from novelvideo.seedance2_i2v.spoken_dialogue import (
@@ -88,19 +86,12 @@ def resolve_narrator_reference_status(
     username: str,
     project: str,
 ) -> NarratorReferenceStatus:
-    state_dir = str(getattr(store, "state_dir", "") or "")
-    if state_dir:
-        style = (
-            load_effective_narration_style_for_voice_from_state_dir(state_dir)
-            or DEFAULT_NARRATION_STYLE
-        )
-        stored = load_narrator_reference_audio_from_state_dir(state_dir)
-    else:
-        style = (
-            load_effective_narration_style_for_voice(username, project)
-            or DEFAULT_NARRATION_STYLE
-        )
-        stored = load_narrator_reference_audio(username, project)
+    state_dir = Path(store.state_dir)
+    style = (
+        load_effective_narration_style_for_voice_from_state_dir(state_dir)
+        or DEFAULT_NARRATION_STYLE
+    )
+    stored = load_narrator_reference_audio_from_state_dir(state_dir)
     resolution = resolve_narrator_source(
         store=store,
         narration_style=style,

--- a/src/novelvideo/task_backend/projection.py
+++ b/src/novelvideo/task_backend/projection.py
@@ -231,21 +231,13 @@ async def _build_director_control_sketch_fields(
 
 async def _build_audio_speech_fields(store: Any, config: Mapping[str, Any]) -> dict[str, Any]:
     from novelvideo.project_config import (
-        load_effective_narration_style_for_voice,
         load_effective_narration_style_for_voice_from_state_dir,
-        load_narrator_reference_audio,
         load_narrator_reference_audio_from_state_dir,
     )
 
-    username = config["username"]
-    project_name = config["project_name"]
-    state_dir = str(getattr(store, "state_dir", "") or "")
-    if state_dir:
-        narration_style = load_effective_narration_style_for_voice_from_state_dir(state_dir)
-        narrator_reference_audio = load_narrator_reference_audio_from_state_dir(state_dir)
-    else:
-        narration_style = load_effective_narration_style_for_voice(username, project_name)
-        narrator_reference_audio = load_narrator_reference_audio(username, project_name)
+    state_dir = store.state_dir
+    narration_style = load_effective_narration_style_for_voice_from_state_dir(state_dir)
+    narrator_reference_audio = load_narrator_reference_audio_from_state_dir(state_dir)
 
     voice_ref = config.get("voice_ref")
     wanted_name = ""

--- a/src/novelvideo/task_backend/projection.py
+++ b/src/novelvideo/task_backend/projection.py
@@ -232,12 +232,20 @@ async def _build_director_control_sketch_fields(
 async def _build_audio_speech_fields(store: Any, config: Mapping[str, Any]) -> dict[str, Any]:
     from novelvideo.project_config import (
         load_effective_narration_style_for_voice,
+        load_effective_narration_style_for_voice_from_state_dir,
         load_narrator_reference_audio,
+        load_narrator_reference_audio_from_state_dir,
     )
 
     username = config["username"]
     project_name = config["project_name"]
-    narration_style = load_effective_narration_style_for_voice(username, project_name)
+    state_dir = str(getattr(store, "state_dir", "") or "")
+    if state_dir:
+        narration_style = load_effective_narration_style_for_voice_from_state_dir(state_dir)
+        narrator_reference_audio = load_narrator_reference_audio_from_state_dir(state_dir)
+    else:
+        narration_style = load_effective_narration_style_for_voice(username, project_name)
+        narrator_reference_audio = load_narrator_reference_audio(username, project_name)
 
     voice_ref = config.get("voice_ref")
     wanted_name = ""
@@ -258,7 +266,7 @@ async def _build_audio_speech_fields(store: Any, config: Mapping[str, Any]) -> d
             _character_to_dict(main_character) if main_character else None
         ),
         "narration_style": narration_style,
-        "narrator_reference_audio": load_narrator_reference_audio(username, project_name),
+        "narrator_reference_audio": narrator_reference_audio,
     }
 
 

--- a/src/novelvideo/task_backend/runners/video.py
+++ b/src/novelvideo/task_backend/runners/video.py
@@ -163,6 +163,7 @@ async def _run_single_video_async(
 
         prepared = await prepare_seedance2_generation_inputs(
             project_output=output_dir,
+            state_dir=ctx.state_dir,
             episode=episode,
             beat={**beat, "seedance2_config_json": seedance2_config or "{}"},
             next_beat=config.get("next_beat"),

--- a/tests/test_api_audio_indextts2_cutover.py
+++ b/tests/test_api_audio_indextts2_cutover.py
@@ -29,6 +29,7 @@ class _FakeSeedance2Store:
     def __init__(self, beats):
         self.beats = beats
         self.updated = []
+        self.state_dir = "/state/alice/demo"
 
     async def get_beats_as_dicts(self, episode: int):
         assert episode == 3

--- a/tests/test_api_narrator_voice.py
+++ b/tests/test_api_narrator_voice.py
@@ -59,14 +59,13 @@ def _client(monkeypatch, tmp_path):
     app = FastAPI()
     app.include_router(projects.router)
     app.dependency_overrides[projects.get_api_user] = lambda: {"username": "admin"}
-    return TestClient(app), project_config, project_dir
+    return TestClient(app), project_config, project_dir, fake_ctx.state_dir
 
 
 def test_narrator_voice_upload_persists_project_reference(monkeypatch, tmp_path):
-    client, project_config, project_dir = _client(monkeypatch, tmp_path)
-    project_config.set_narrator_reference_audio(
-        "admin",
-        "demo",
+    client, project_config, project_dir, state_dir = _client(monkeypatch, tmp_path)
+    project_config.set_narrator_reference_audio_in_state_dir(
+        state_dir,
         relative_path="",
         sha256="",
     )
@@ -83,14 +82,14 @@ def test_narrator_voice_upload_persists_project_reference(monkeypatch, tmp_path)
     assert payload["data"]["reference_url"].startswith(
         "/static/admin/demo/assets/narrator/voice.wav"
     )
-    saved = project_config.load_narrator_reference_audio("admin", "demo")
+    saved = project_config.load_narrator_reference_audio_from_state_dir(state_dir)
     assert saved["path"] == "assets/narrator/voice.wav"
     assert saved["sha256"]
     assert (project_dir / "assets/narrator/voice.wav").read_bytes() == b"voice-bytes"
 
 
 def test_narrator_voice_record_accepts_data_url(monkeypatch, tmp_path):
-    client, project_config, project_dir = _client(monkeypatch, tmp_path)
+    client, project_config, project_dir, state_dir = _client(monkeypatch, tmp_path)
     encoded = base64.b64encode(b"recorded-voice").decode("ascii")
 
     response = client.post(
@@ -102,14 +101,14 @@ def test_narrator_voice_record_accepts_data_url(monkeypatch, tmp_path):
     payload = response.json()
     assert payload["ok"] is True
     assert payload["data"]["reference_path"] == "assets/narrator/voice.wav"
-    assert project_config.load_narrator_reference_audio("admin", "demo")["path"] == (
+    assert project_config.load_narrator_reference_audio_from_state_dir(state_dir)["path"] == (
         "assets/narrator/voice.wav"
     )
     assert (project_dir / "assets/narrator/voice.wav").read_bytes() == b"recorded-voice"
 
 
 def test_narrator_voice_sources_and_copy(monkeypatch, tmp_path):
-    client, project_config, project_dir = _client(monkeypatch, tmp_path)
+    client, project_config, project_dir, state_dir = _client(monkeypatch, tmp_path)
     source = project_dir / "audio/ep001/beat_01.mp3"
     source.parent.mkdir(parents=True)
     source.write_bytes(b"source-voice")
@@ -131,20 +130,19 @@ def test_narrator_voice_sources_and_copy(monkeypatch, tmp_path):
 
     assert response.status_code == 200
     assert response.json()["ok"] is True
-    assert project_config.load_narrator_reference_audio("admin", "demo")["path"] == (
+    assert project_config.load_narrator_reference_audio_from_state_dir(state_dir)["path"] == (
         "assets/narrator/voice.mp3"
     )
     assert (project_dir / "assets/narrator/voice.mp3").read_bytes() == b"source-voice"
 
 
 def test_narrator_voice_delete_renames_file_and_clears_metadata(monkeypatch, tmp_path):
-    client, project_config, project_dir = _client(monkeypatch, tmp_path)
+    client, project_config, project_dir, state_dir = _client(monkeypatch, tmp_path)
     target = project_dir / "assets/narrator/voice.wav"
     target.parent.mkdir(parents=True)
     target.write_bytes(b"voice")
-    project_config.set_narrator_reference_audio(
-        "admin",
-        "demo",
+    project_config.set_narrator_reference_audio_in_state_dir(
+        state_dir,
         relative_path="assets/narrator/voice.wav",
         sha256="sha",
     )
@@ -153,6 +151,6 @@ def test_narrator_voice_delete_renames_file_and_clears_metadata(monkeypatch, tmp
 
     assert response.status_code == 200
     assert response.json()["ok"] is True
-    assert project_config.load_narrator_reference_audio("admin", "demo")["path"] == ""
+    assert project_config.load_narrator_reference_audio_from_state_dir(state_dir)["path"] == ""
     assert not target.exists()
     assert list((project_dir / "assets/narrator").glob("voice_*.wav"))

--- a/tests/test_freezone_audio_backend.py
+++ b/tests/test_freezone_audio_backend.py
@@ -49,8 +49,9 @@ def _isolate_settings_db(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Non
 
 
 class FakeProjectStore:
-    def __init__(self, project_dir: Path):
+    def __init__(self, project_dir: Path, state_dir: Path | None = None):
         self.project_dir = str(project_dir)
+        self.state_dir = str(state_dir or project_dir)
 
     async def list_characters(self):
         from novelvideo.models import CharacterIdentity, NovelCharacter
@@ -338,7 +339,7 @@ async def test_freezone_audio_speech_drama_first_person_uses_project_narrator(
     )
 
     result = await audio_node.generate_freezone_audio_speech(
-        store=FakeProjectStore(project_dir),
+            store=FakeProjectStore(project_dir, tmp_path / "state" / "alice" / "demo"),
         username="alice",
         project="demo",
         project_dir=project_dir,

--- a/tests/test_freezone_audio_backend.py
+++ b/tests/test_freezone_audio_backend.py
@@ -221,6 +221,7 @@ async def test_freezone_audio_references_use_requester_account_voices(
         owner_username="owner",
         project_name="demo",
         requester_username="viewer",
+        state_dir=tmp_path / "state" / "owner" / "demo",
     )
 
     async def fake_resolve(*_args, **_kwargs):
@@ -250,12 +251,12 @@ async def test_freezone_audio_references_use_requester_account_voices(
     monkeypatch.setattr(freezone_routes, "list_user_audio_voices", fake_list_user_audio_voices)
     monkeypatch.setattr(
         freezone_routes,
-        "load_narrator_reference_audio",
+        "load_narrator_reference_audio_from_state_dir",
         lambda *_args, **_kwargs: {},
     )
     monkeypatch.setattr(
         freezone_routes,
-        "load_effective_narration_style_for_voice",
+        "load_effective_narration_style_for_voice_from_state_dir",
         lambda *_args, **_kwargs: {},
     )
 

--- a/tests/test_freezone_audio_enqueue_projection.py
+++ b/tests/test_freezone_audio_enqueue_projection.py
@@ -39,6 +39,7 @@ class _FakeCharacterStore:
     """Stands in for the project SQLite store on the enqueue side."""
 
     def __init__(self, characters) -> None:
+        self.state_dir = "/state/alice/demo"
         self._characters = list(characters)
         self.list_characters_calls = 0
 
@@ -102,12 +103,12 @@ def speech_harness(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
     monkeypatch.setattr(freezone, "make_sqlite_store_for_context", fake_store_for_context)
     monkeypatch.setattr(freezone, "_project_job_response", lambda **kwargs: {"ok": True})
     monkeypatch.setattr(
-        "novelvideo.project_config.load_effective_narration_style_for_voice",
-        lambda username, project: "first_person",
+        "novelvideo.project_config.load_effective_narration_style_for_voice_from_state_dir",
+        lambda state_dir: "first_person",
     )
     monkeypatch.setattr(
-        "novelvideo.project_config.load_narrator_reference_audio",
-        lambda username, project: {
+        "novelvideo.project_config.load_narrator_reference_audio_from_state_dir",
+        lambda state_dir: {
             "path": "assets/voices/narrator.wav",
             "sha256": "sha-narrator",
             "updated_at": "2026-08-13T00:00:00+00:00",

--- a/tests/test_freezone_audio_node_placement.py
+++ b/tests/test_freezone_audio_node_placement.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import re
 import sys
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -58,7 +59,8 @@ class FakeTTSGenerator:
 class FakeCharacterStore:
     """只提供 `list_characters` 的项目 store 替身（对应真实的项目 SQLite）。"""
 
-    def __init__(self, characters) -> None:
+    def __init__(self, characters, state_dir: Path | str = "/state/alice/demo") -> None:
+        self.state_dir = str(state_dir)
         self._characters = list(characters)
         self.list_characters_calls = 0
 
@@ -112,7 +114,9 @@ def _character(name: str, *, is_main: bool = False) -> NovelCharacter:
 def _character_project(tmp_path: Path) -> tuple[Path, FakeCharacterStore]:
     project_dir = tmp_path / "output" / "alice" / "demo"
     _voice_file(project_dir, "小明")
-    return project_dir, FakeCharacterStore([_character("小明")])
+    return project_dir, FakeCharacterStore(
+        [_character("小明")], tmp_path / "state" / "alice" / "demo"
+    )
 
 
 def _projection_fields(
@@ -169,8 +173,10 @@ async def test_generate_speech_consumes_projection_without_project_state(
     def _explode(*_a, **_k):  # pragma: no cover - 触发即失败
         raise AssertionError("project-local state must not be read")
 
-    monkeypatch.setattr(audio_node, "load_effective_narration_style_for_voice", _explode)
-    monkeypatch.setattr(audio_node, "load_narrator_reference_audio", _explode)
+    monkeypatch.setattr(
+        audio_node, "load_effective_narration_style_for_voice_from_state_dir", _explode
+    )
+    monkeypatch.setattr(audio_node, "load_narrator_reference_audio_from_state_dir", _explode)
     _stub_tts(monkeypatch)
 
     payload = _projection_payload(_projection_fields(voice_character=_character("小明")))
@@ -202,8 +208,10 @@ async def test_generate_speech_resolves_the_narrator_main_from_the_projection(
     def _explode(*_a, **_k):  # pragma: no cover - 触发即失败
         raise AssertionError("project-local state must not be read")
 
-    monkeypatch.setattr(audio_node, "load_effective_narration_style_for_voice", _explode)
-    monkeypatch.setattr(audio_node, "load_narrator_reference_audio", _explode)
+    monkeypatch.setattr(
+        audio_node, "load_effective_narration_style_for_voice_from_state_dir", _explode
+    )
+    monkeypatch.setattr(audio_node, "load_narrator_reference_audio_from_state_dir", _explode)
     _stub_tts(monkeypatch)
 
     payload = _projection_payload(
@@ -251,7 +259,7 @@ async def test_generate_speech_without_projection_still_reads_project_store(
     project_dir, store = _character_project(tmp_path)
     monkeypatch.setattr(
         audio_node,
-        "load_effective_narration_style_for_voice",
+        "load_effective_narration_style_for_voice_from_state_dir",
         lambda *_a, **_k: "third_person",
     )
     _stub_tts(monkeypatch)
@@ -280,7 +288,7 @@ async def test_account_level_voice_never_touches_the_project_store(
     voice_path.write_bytes(b"account-voice")
     monkeypatch.setattr(
         audio_node,
-        "load_effective_narration_style_for_voice",
+        "load_effective_narration_style_for_voice_from_state_dir",
         lambda *_a, **_k: "third_person",
     )
     monkeypatch.setattr(
@@ -293,7 +301,7 @@ async def test_account_level_voice_never_touches_the_project_store(
     _stub_tts(monkeypatch)
 
     result = await audio_node.generate_freezone_audio_speech(
-        store=ExplodingStore(),
+        store=SimpleNamespace(state_dir=tmp_path / "state" / "alice" / "demo"),
         username="alice",
         project="demo",
         account_voice_username="bob",

--- a/tests/test_indextts2_beat_audio_task.py
+++ b/tests/test_indextts2_beat_audio_task.py
@@ -15,7 +15,7 @@ def test_indextts2_resolves_project_config_from_current_module(monkeypatch):
     from novelvideo.audio import indextts2_beat_audio_task as task
 
     current_project_config = SimpleNamespace(
-        is_narrated_project=lambda _username, _project: True,
+        is_narrated_project_from_state_dir=lambda _state_dir: True,
     )
     monkeypatch.setitem(
         sys.modules,
@@ -23,7 +23,9 @@ def test_indextts2_resolves_project_config_from_current_module(monkeypatch):
         current_project_config,
     )
 
-    assert task._is_narrated_project(SimpleNamespace(), "alice", "demo") is True
+    assert task._is_narrated_project(
+        SimpleNamespace(state_dir="/state/alice/demo"), "alice", "demo"
+    ) is True
 
 
 class _ForeignBillingError(BillingError):

--- a/tests/test_indextts2_beat_audio_task.py
+++ b/tests/test_indextts2_beat_audio_task.py
@@ -23,7 +23,7 @@ def test_indextts2_resolves_project_config_from_current_module(monkeypatch):
         current_project_config,
     )
 
-    assert task._is_narrated_project("alice", "demo") is True
+    assert task._is_narrated_project(SimpleNamespace(), "alice", "demo") is True
 
 
 class _ForeignBillingError(BillingError):
@@ -119,6 +119,7 @@ class FakeStore:
     def __init__(self, project_dir, db_path, beats, *, include_dialogue_voice=True):
         self.project_dir = str(project_dir)
         self.db_path = str(db_path)
+        self.state_dir = str(Path(db_path).parent)
         self._beats = list(beats)
         self.include_dialogue_voice = include_dialogue_voice
 

--- a/tests/test_org_scoped_narrator_voice.py
+++ b/tests/test_org_scoped_narrator_voice.py
@@ -226,6 +226,98 @@ async def test_org_scoped_missing_voice_is_not_swallowed_as_attribute_error(
     assert "项目解说人声线未配置" in errors[0]
 
 
+def test_seedance2_narrator_status_reads_store_state_dir(tmp_path: Path) -> None:
+    from novelvideo.project_config import save_project_config_in_state_dir
+    from novelvideo.seedance2_i2v.voice_reference_service import (
+        resolve_narrator_reference_status,
+    )
+
+    suffix = Path("_scopes") / "scope_123" / "alice" / "demo"
+    project_dir = tmp_path / "output" / suffix
+    state_dir = tmp_path / "state" / suffix
+    narrator = project_dir / "assets" / "narrator" / "voice.wav"
+    narrator.parent.mkdir(parents=True, exist_ok=True)
+    narrator.write_bytes(b"narrator")
+    save_project_config_in_state_dir(
+        state_dir,
+        spine_template="narrated",
+        narration_style="third_person",
+        narrator_reference_audio_path="assets/narrator/voice.wav",
+    )
+    store = SimpleNamespace(
+        project_dir=str(project_dir),
+        state_dir=str(state_dir),
+        get_all_characters=lambda: [],
+    )
+
+    status = resolve_narrator_reference_status(
+        store=store,
+        username="alice",
+        project="demo",
+    )
+
+    assert status.active_reference_path == narrator
+
+
+@pytest.mark.asyncio
+async def test_seedance2_narrator_trim_writes_only_store_state_dir(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from novelvideo import project_config
+    from novelvideo.seedance2_i2v import panel_service
+
+    suffix = Path("_scopes") / "scope_123" / "alice" / "demo"
+    project_dir = tmp_path / "output" / suffix
+    state_root = tmp_path / "state"
+    state_dir = state_root / suffix
+    source = project_dir / "audio" / "source.wav"
+    source.parent.mkdir(parents=True, exist_ok=True)
+    source.write_bytes(b"source")
+    monkeypatch.setattr(
+        panel_service,
+        "trim_voice_sample_content",
+        lambda *_args, **_kwargs: (b"trimmed", "voice.mp3"),
+    )
+    monkeypatch.setattr(project_config, "OUTPUT_DIR", state_root)
+    store = SimpleNamespace(state_dir=str(state_dir))
+
+    target = await panel_service.trim_seedance2_audio_to_reference(
+        store=store,
+        episode=1,
+        beat={"beat_number": 1},
+        project_dir=project_dir,
+        asset_key="voice:narrator",
+        source_path=source,
+    )
+
+    assert target is not None
+    assert project_config.load_narrator_reference_audio_from_state_dir(state_dir)["path"]
+    assert not (state_root / "alice" / "demo" / "project_config.json").exists()
+
+
+def test_seedance2_narration_asset_reads_explicit_state_dir(tmp_path: Path) -> None:
+    from novelvideo.project_config import save_project_config_in_state_dir
+    from novelvideo.seedance2_i2v.assets import _narration_voice_asset
+
+    suffix = Path("_scopes") / "scope_123" / "alice" / "demo"
+    project_dir = tmp_path / "output" / suffix
+    state_dir = tmp_path / "state" / suffix
+    save_project_config_in_state_dir(
+        state_dir,
+        spine_template="narrated",
+        narration_style="third_person",
+        narrator_reference_audio_path="assets/narrator/scoped.wav",
+    )
+
+    asset = _narration_voice_asset(
+        project_output=project_dir,
+        characters=[],
+        state_dir=state_dir,
+    )
+
+    assert asset["path"] == project_dir / "assets" / "narrator" / "scoped.wav"
+
+
 @pytest.mark.asyncio
 async def test_org_scoped_third_person_narrator_uses_project_reference(tmp_path: Path) -> None:
     from novelvideo.audio.indextts2_beat_audio_task import (

--- a/tests/test_org_scoped_narrator_voice.py
+++ b/tests/test_org_scoped_narrator_voice.py
@@ -319,6 +319,84 @@ def test_seedance2_narration_asset_reads_explicit_state_dir(tmp_path: Path) -> N
 
 
 @pytest.mark.asyncio
+async def test_seedance2_prepare_uses_org_state_dir_when_personal_config_conflicts(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from novelvideo import project_config
+    from novelvideo.seedance2_i2v.pipeline import prepare_seedance2_generation_inputs
+
+    suffix = Path("_orgs") / "org_123" / "alice" / "demo"
+    project_dir = tmp_path / "output" / suffix
+    state_root = tmp_path / "state"
+    state_dir = state_root / suffix
+    scoped_voice = project_dir / "assets" / "narrator" / "scoped.wav"
+    scoped_voice.parent.mkdir(parents=True, exist_ok=True)
+    scoped_voice.write_bytes(b"scoped")
+    monkeypatch.setattr(project_config, "OUTPUT_DIR", state_root)
+    project_config.save_project_config_in_state_dir(
+        state_root / "alice" / "demo",
+        spine_template="narrated",
+        narration_style="first_person",
+    )
+    project_config.save_project_config_in_state_dir(
+        state_dir,
+        spine_template="narrated",
+        narration_style="third_person",
+        narrator_reference_audio_path="assets/narrator/scoped.wav",
+    )
+
+    prepared = await prepare_seedance2_generation_inputs(
+        project_output=project_dir,
+        state_dir=state_dir,
+        episode=1,
+        beat={
+            "beat_number": 1,
+            "audio_type": "narration",
+            "seedance2_config_json": '{"final_prompt":"使用@音频1"}',
+        },
+        video_mode="first_frame",
+        prompt="unused",
+        duration=4,
+    )
+
+    narration = next(asset for asset in prepared.assets if asset.key == "voice:narrator")
+    assert narration.path == scoped_voice
+
+
+@pytest.mark.asyncio
+async def test_seedance2_narrator_trim_without_state_dir_has_no_file_side_effects(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from novelvideo.seedance2_i2v import panel_service
+
+    project_dir = tmp_path / "output" / "alice" / "demo"
+    source = project_dir / "audio" / "source.wav"
+    target = project_dir / "assets" / "narrator" / "voice.mp3"
+    source.parent.mkdir(parents=True, exist_ok=True)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    source.write_bytes(b"source")
+    target.write_bytes(b"existing")
+    monkeypatch.setattr(
+        panel_service,
+        "trim_voice_sample_content",
+        lambda *_args, **_kwargs: (b"trimmed", "voice.mp3"),
+    )
+
+    with pytest.raises(ValueError, match="state_dir"):
+        await panel_service.trim_seedance2_audio_to_reference(
+            store=SimpleNamespace(),
+            episode=1,
+            beat={"beat_number": 1},
+            project_dir=project_dir,
+            asset_key="voice:narrator",
+            source_path=source,
+        )
+
+    assert target.read_bytes() == b"existing"
+    assert list(target.parent.glob("voice_*")) == []
+
+
+@pytest.mark.asyncio
 async def test_org_scoped_third_person_narrator_uses_project_reference(tmp_path: Path) -> None:
     from novelvideo.audio.indextts2_beat_audio_task import (
         collect_indextts2_voice_prereq_errors,

--- a/tests/test_org_scoped_narrator_voice.py
+++ b/tests/test_org_scoped_narrator_voice.py
@@ -1,0 +1,260 @@
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+
+class ScopedVoiceStore:
+    def __init__(self, project_dir: Path, state_dir: Path, characters: list) -> None:
+        self.project_dir = str(project_dir)
+        self.state_dir = str(state_dir)
+        self.db_path = str(state_dir / "data.db")
+        self._characters = characters
+
+    async def get_beats_as_dicts(self, episode: int) -> list[dict]:
+        assert episode == 1
+        return [
+            {
+                "beat_number": 1,
+                "audio_type": "narration",
+                "speaker": "",
+                "narration_segment": "第一人称解说。",
+            }
+        ]
+
+    async def list_characters(self) -> list:
+        return self._characters
+
+
+def _main_character_with_identity_voice(project_dir: Path):
+    from novelvideo.models import CharacterIdentity, NovelCharacter
+
+    voice_path = project_dir / "assets" / "characters" / "林夏" / "identity.wav"
+    voice_path.parent.mkdir(parents=True, exist_ok=True)
+    voice_path.write_bytes(b"identity-voice")
+    character = NovelCharacter(name="林夏", gender="女", is_main=True)
+    character.identities = [
+        CharacterIdentity(
+            identity_id="林夏_成年",
+            character_name="林夏",
+            identity_name="成年",
+            reference_audio_path="assets/characters/林夏/identity.wav",
+            reference_audio_sha256="identity-sha",
+        )
+    ]
+    return character
+
+
+@pytest.mark.asyncio
+async def test_org_scoped_first_person_narrator_uses_main_identity_voice(tmp_path: Path) -> None:
+    from novelvideo.audio.indextts2_beat_audio_task import (
+        collect_indextts2_voice_prereq_errors,
+    )
+    from novelvideo.project_config import save_project_config_in_state_dir
+
+    suffix = Path("_scopes") / "scope_123" / "alice" / "demo"
+    project_dir = tmp_path / "output" / suffix
+    state_dir = tmp_path / "state" / suffix
+    save_project_config_in_state_dir(
+        state_dir,
+        spine_template="narrated",
+        narration_style="first_person",
+    )
+    store = ScopedVoiceStore(
+        project_dir,
+        state_dir,
+        [_main_character_with_identity_voice(project_dir)],
+    )
+
+    errors = await collect_indextts2_voice_prereq_errors(
+        store=store,
+        username="alice",
+        project="demo",
+        episode=1,
+        beat_numbers=[1],
+        mode="redo_selected",
+    )
+
+    assert errors == []
+
+
+def test_personal_state_dir_voice_config_matches_legacy_wrappers(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from novelvideo import project_config
+
+    state_root = tmp_path / "state"
+    state_dir = state_root / "alice" / "demo"
+    monkeypatch.setattr(project_config, "OUTPUT_DIR", state_root)
+    project_config.save_project_config_in_state_dir(
+        state_dir,
+        spine_template="narrated",
+        narration_style="first_person",
+        narrator_reference_audio_path="assets/narrator/voice.wav",
+        narrator_reference_audio_sha256="voice-sha",
+        narrator_reference_audio_updated_at="2026-08-19T00:00:00+00:00",
+    )
+
+    assert project_config.load_narration_style_from_state_dir(
+        state_dir
+    ) == project_config.load_narration_style("alice", "demo")
+    assert project_config.is_narrated_project_from_state_dir(
+        state_dir
+    ) == project_config.is_narrated_project("alice", "demo")
+    assert project_config.load_effective_narration_style_for_voice_from_state_dir(
+        state_dir
+    ) == project_config.load_effective_narration_style_for_voice("alice", "demo")
+    assert project_config.load_narrator_reference_audio_from_state_dir(
+        state_dir
+    ) == project_config.load_narrator_reference_audio("alice", "demo")
+
+
+def test_org_scoped_narrator_upload_writes_only_resolved_state_dir(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from novelvideo import project_config
+    from novelvideo.api.routes import projects
+
+    suffix = Path("_scopes") / "scope_123" / "alice" / "demo"
+    output_dir = tmp_path / "output" / suffix
+    state_root = tmp_path / "state"
+    state_dir = state_root / suffix
+    output_dir.mkdir(parents=True)
+    project_config.save_project_config_in_state_dir(
+        state_dir,
+        spine_template="narrated",
+        narration_style="third_person",
+    )
+    monkeypatch.setattr(project_config, "OUTPUT_DIR", state_root)
+    ctx = SimpleNamespace(
+        project_id="project_123",
+        project_name="demo",
+        owner_username="alice",
+        owner_project_label="alice/demo",
+        output_dir=output_dir,
+        state_dir=state_dir,
+        is_home_node=True,
+    )
+
+    async def resolve_context(*, user, project_id, required_role="viewer"):
+        return ctx
+
+    store = SimpleNamespace(project_dir=str(output_dir), get_all_characters=lambda: [])
+
+    async def make_store(_ctx):
+        return store
+
+    monkeypatch.setattr(projects, "resolve_project_context", resolve_context)
+    monkeypatch.setattr(projects, "make_sqlite_store_for_context", make_store)
+    monkeypatch.setattr(
+        projects,
+        "make_static_url_for_context",
+        lambda _ctx, relative_path, local_path=None: f"/static/{relative_path}",
+    )
+    app = FastAPI()
+    app.include_router(projects.router)
+    app.dependency_overrides[projects.get_api_user] = lambda: {"username": "alice"}
+
+    response = TestClient(app).post(
+        "/projects/project_123/narrator-voice/upload",
+        files={"file": ("voice.wav", b"voice-bytes", "audio/wav")},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["ok"] is True
+    scoped = project_config.load_project_config_file_from_state_dir(state_dir)
+    assert scoped["narrator_reference_audio_path"] == "assets/narrator/voice.wav"
+    assert not (state_root / "alice" / "demo" / "project_config.json").exists()
+
+
+@pytest.mark.asyncio
+async def test_org_scoped_audio_projection_uses_resolved_voice_config(tmp_path: Path) -> None:
+    from novelvideo.project_config import save_project_config_in_state_dir
+    from novelvideo.task_backend.projection import build_projection
+
+    state_dir = tmp_path / "state" / "_scopes" / "scope_123" / "alice" / "demo"
+    save_project_config_in_state_dir(
+        state_dir,
+        spine_template="narrated",
+        narration_style="first_person",
+        narrator_reference_audio_path="assets/narrator/voice.wav",
+        narrator_reference_audio_sha256="voice-sha",
+    )
+    store = ScopedVoiceStore(tmp_path / "output", state_dir, [])
+
+    projection = await build_projection(
+        store,
+        {"username": "alice", "project_name": "demo"},
+        task_type="freezone_audio_speech",
+    )
+
+    assert projection is not None
+    fields = projection["fields"]
+    assert fields["narration_style"] == "first_person"
+    assert fields["narrator_reference_audio"]["path"] == "assets/narrator/voice.wav"
+
+
+@pytest.mark.asyncio
+async def test_org_scoped_missing_voice_is_not_swallowed_as_attribute_error(
+    tmp_path: Path,
+) -> None:
+    from novelvideo.api.routes.generation import _collect_audio_prereq_errors
+    from novelvideo.project_config import save_project_config_in_state_dir
+
+    state_dir = tmp_path / "state" / "_scopes" / "scope_123" / "alice" / "demo"
+    save_project_config_in_state_dir(
+        state_dir,
+        spine_template="narrated",
+        narration_style="third_person",
+    )
+    store = ScopedVoiceStore(tmp_path / "output", state_dir, [])
+
+    errors = await _collect_audio_prereq_errors(
+        store=store,
+        username="alice",
+        project="demo",
+        episode=1,
+        beat_numbers=[1],
+        mode="redo_selected",
+    )
+
+    assert errors
+    assert "项目解说人声线未配置" in errors[0]
+
+
+@pytest.mark.asyncio
+async def test_org_scoped_third_person_narrator_uses_project_reference(tmp_path: Path) -> None:
+    from novelvideo.audio.indextts2_beat_audio_task import (
+        collect_indextts2_voice_prereq_errors,
+    )
+    from novelvideo.project_config import save_project_config_in_state_dir
+
+    suffix = Path("_scopes") / "scope_123" / "alice" / "demo"
+    project_dir = tmp_path / "output" / suffix
+    state_dir = tmp_path / "state" / suffix
+    narrator = project_dir / "assets" / "narrator" / "voice.wav"
+    narrator.parent.mkdir(parents=True, exist_ok=True)
+    narrator.write_bytes(b"narrator-voice")
+    save_project_config_in_state_dir(
+        state_dir,
+        spine_template="narrated",
+        narration_style="third_person",
+        narrator_reference_audio_path="assets/narrator/voice.wav",
+        narrator_reference_audio_sha256="narrator-sha",
+    )
+    store = ScopedVoiceStore(project_dir, state_dir, [])
+
+    errors = await collect_indextts2_voice_prereq_errors(
+        store=store,
+        username="alice",
+        project="demo",
+        episode=1,
+        beat_numbers=[1],
+        mode="redo_selected",
+    )
+
+    assert errors == []

--- a/tests/test_seedance2_assets.py
+++ b/tests/test_seedance2_assets.py
@@ -44,6 +44,7 @@ def test_multimodal_assets_use_scene_ref_identity_and_audio(tmp_path, monkeypatc
 
     assets = build_seedance2_project_assets(
         project_output=project_dir,
+        state_dir=tmp_path / "state" / "alice" / "project",
         episode=1,
         beat={
             "beat_number": 1,
@@ -80,6 +81,7 @@ def test_multimodal_assets_resolve_scene_variant_to_derived_scene_master(tmp_pat
 
     assets = build_seedance2_project_assets(
         project_output=project_dir,
+        state_dir=tmp_path / "state" / "alice" / "project",
         episode=1,
         beat={
             "beat_number": 1,
@@ -112,6 +114,7 @@ def test_multimodal_assets_resolve_time_of_day_to_time_plate(tmp_path):
 
     assets = build_seedance2_project_assets(
         project_output=project_dir,
+        state_dir=tmp_path / "state" / "alice" / "project",
         episode=1,
         beat={
             "beat_number": 1,
@@ -147,6 +150,7 @@ def test_multimodal_assets_resolve_variant_time_to_variant_time_plate(tmp_path):
 
     assets = build_seedance2_project_assets(
         project_output=project_dir,
+        state_dir=tmp_path / "state" / "alice" / "project",
         episode=1,
         beat={
             "beat_number": 1,
@@ -183,6 +187,7 @@ def test_multimodal_assets_fall_back_to_base_scene_master_when_variant_image_mis
 
     assets = build_seedance2_project_assets(
         project_output=project_dir,
+        state_dir=tmp_path / "state" / "alice" / "project",
         episode=1,
         beat={
             "beat_number": 1,
@@ -211,6 +216,7 @@ async def test_prepare_seedance2_generation_inputs_preserves_config_duration(tmp
 
     prepared = await prepare_seedance2_generation_inputs(
         project_output=project_dir,
+        state_dir=tmp_path / "state" / "alice" / "project",
         episode=1,
         beat={
             "beat_number": 1,
@@ -239,6 +245,7 @@ def test_multimodal_assets_merge_detected_identities_with_visual_markers(tmp_pat
     project_dir = tmp_path / "project"
     assets = build_seedance2_project_assets(
         project_output=project_dir,
+        state_dir=tmp_path / "state" / "alice" / "project",
         episode=1,
         beat={
             "beat_number": 29,
@@ -289,6 +296,7 @@ def test_multimodal_dialogue_assets_use_character_voice_reference_not_beat_audio
 
     assets = build_seedance2_project_assets(
         project_output=project_dir,
+        state_dir=tmp_path / "state" / "alice" / "project",
         episode=1,
         beat={
             "beat_number": 1,
@@ -338,6 +346,7 @@ def test_multimodal_dialogue_assets_follow_multi_speaker_text_order(tmp_path):
 
     assets = build_seedance2_project_assets(
         project_output=project_dir,
+        state_dir=tmp_path / "state" / "alice" / "project",
         episode=1,
         beat={
             "beat_number": 1,
@@ -386,6 +395,7 @@ def test_multimodal_narration_assets_use_project_narrator_voice_not_beat_audio(
 
     assets = build_seedance2_project_assets(
         project_output=project_dir,
+        state_dir=tmp_path / "state" / "alice" / "project",
         episode=1,
         beat={
             "beat_number": 1,
@@ -430,6 +440,7 @@ def test_multimodal_narration_keeps_project_narrator_mentionable_when_duration_n
 
     assets = build_seedance2_project_assets(
         project_output=project_dir,
+        state_dir=tmp_path / "state" / "alice" / "project",
         episode=1,
         beat={
             "beat_number": 1,
@@ -465,6 +476,7 @@ def test_prompt_audio_selection_sends_only_referenced_audio(tmp_path):
 
     assets = build_seedance2_project_assets(
         project_output=project_dir,
+        state_dir=tmp_path / "state" / "alice" / "project",
         episode=1,
         beat={
             "beat_number": 1,
@@ -535,6 +547,7 @@ def test_drama_narration_assets_ignore_first_person_protagonist_voice(tmp_path, 
 
     assets = build_seedance2_project_assets(
         project_output=project_dir,
+        state_dir=tmp_path / "state" / "alice" / "project",
         episode=1,
         beat={
             "beat_number": 1,
@@ -570,6 +583,7 @@ def test_multimodal_assets_skip_auto_audio_for_silence_beat(tmp_path):
 
     assets = build_seedance2_project_assets(
         project_output=project_dir,
+        state_dir=tmp_path / "state" / "alice" / "project",
         episode=1,
         beat={
             "beat_number": 1,
@@ -601,6 +615,7 @@ def test_multimodal_assets_skip_auto_audio_for_legacy_action_beat(tmp_path):
 
     assets = build_seedance2_project_assets(
         project_output=project_dir,
+        state_dir=tmp_path / "state" / "alice" / "project",
         episode=1,
         beat={"beat_number": 1, "audio_type": "action"},
         mode=Seedance2I2VMode.MULTIMODAL_REFERENCE,
@@ -621,6 +636,7 @@ def test_first_frame_mode_only_sends_current_frame(tmp_path):
 
     assets = build_seedance2_project_assets(
         project_output=project_dir,
+        state_dir=tmp_path / "state" / "alice" / "project",
         episode=1,
         beat={"beat_number": 2, "detected_identities": ["秦_青年"]},
         mode=Seedance2I2VMode.FIRST_FRAME,
@@ -665,6 +681,7 @@ def test_first_frame_mode_uses_matching_video_input_override(tmp_path):
 
     assets = build_seedance2_project_assets(
         project_output=project_dir,
+        state_dir=tmp_path / "state" / "alice" / "project",
         episode=1,
         beat={"beat_number": 2},
         mode=Seedance2I2VMode.FIRST_FRAME,
@@ -689,6 +706,7 @@ def test_first_last_frame_mode_sends_both_frame_slots(tmp_path):
 
     assets = build_seedance2_project_assets(
         project_output=project_dir,
+        state_dir=tmp_path / "state" / "alice" / "project",
         episode=1,
         beat={"beat_number": 2},
         next_beat={"beat_number": 3},
@@ -721,6 +739,7 @@ def test_first_last_frame_mode_uses_matching_video_input_overrides(tmp_path):
 
     assets = build_seedance2_project_assets(
         project_output=project_dir,
+        state_dir=tmp_path / "state" / "alice" / "project",
         episode=1,
         beat={"beat_number": 2},
         next_beat={"beat_number": 3},

--- a/tests/test_seedance2_panel_service_narration_audio.py
+++ b/tests/test_seedance2_panel_service_narration_audio.py
@@ -50,6 +50,7 @@ def test_drama_narration_panel_sends_audio_only_when_prompt_references_it(
 
     state = build_seedance2_video_panel_state(
         project_dir=project_dir,
+        state_dir=tmp_path / "state" / "alice" / "project",
         episode=1,
         beat={
             "beat_number": 1,
@@ -74,6 +75,7 @@ def test_drama_narration_panel_sends_audio_only_when_prompt_references_it(
 
     state = build_seedance2_video_panel_state(
         project_dir=project_dir,
+        state_dir=tmp_path / "state" / "alice" / "project",
         episode=1,
         beat={
             "beat_number": 1,

--- a/tests/test_seedance2_voice_audio_task.py
+++ b/tests/test_seedance2_voice_audio_task.py
@@ -157,6 +157,7 @@ class FakeNarrationStore:
     def __init__(self, project_dir, db_path):
         self.project_dir = str(project_dir)
         self.db_path = str(db_path)
+        self.state_dir = str(Path(db_path).parent)
 
     async def get_beats_as_dicts(self, episode):
         assert episode == 1

--- a/tests/test_task_payload_projection.py
+++ b/tests/test_task_payload_projection.py
@@ -36,6 +36,7 @@ class _FakeStore:
     """Minimal stand-in exposing only the reads the projection performs."""
 
     def __init__(self) -> None:
+        self.state_dir = "/state/u/p"
         self.characters = [_FakeCharacter("阿茶", is_main=True)]
         self.scenes = [_FakeScene("皇宫·大殿")]
 
@@ -88,13 +89,13 @@ def stub_project_config(monkeypatch: pytest.MonkeyPatch) -> None:
     )
     monkeypatch.setattr(
         project_config,
-        "load_effective_narration_style_for_voice",
-        lambda username, project: "first_person",
+        "load_effective_narration_style_for_voice_from_state_dir",
+        lambda state_dir: "first_person",
     )
     monkeypatch.setattr(
         project_config,
-        "load_narrator_reference_audio",
-        lambda username, project: {
+        "load_narrator_reference_audio_from_state_dir",
+        lambda state_dir: {
             "path": "assets/narrator/voice.mp3",
             "sha256": "",
             "updated_at": "",


### PR DESCRIPTION
## Summary
- add state-dir narrator voice config readers and writer while preserving legacy wrappers
- route IndexTTS2, narrator voice endpoints, and task projection through registry-resolved project state
- add org-scoped first-person, third-person, upload, projection, and error-boundary regression coverage

## Test plan
- [x] `uv run pytest tests/test_org_scoped_narrator_voice.py tests/test_indextts2_beat_audio_task.py tests/test_task_runner_state_dir.py tests/test_api_narrator_voice.py tests/test_task_payload_projection.py -q` — 55 passed
- [x] `uv run ruff check src/ tests/` — All checks passed
- [ ] `uv run pytest` — 1 failed, 3246 passed, 16 skipped, 2 deselected; the only failure is `tests/test_api_project_summary_paths.py::test_project_summary_counts_from_registered_state_dir`, which passes when rerun alone and is outside this diff

Closes #313