### PR TITLE
fix(egress): avoid organization context for platform tasks

### DIFF
--- a/license-inventory.csv
+++ b/license-inventory.csv
@@ -1869,6 +1869,7 @@ tests/test_freezone_canvas_store.py,Elastic-2.0,2026 SuperTale contributors,REUS
 tests/test_freezone_generation_history_prompt.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_freezone_image_backend.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_freezone_image_node_backend.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
+tests/test_freezone_leaf_egress.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_freezone_mainline_enqueue_projection.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_freezone_mark_backend.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_freezone_mark_detect_egress.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation

--- a/src/novelvideo/task_backend/runners/freezone.py
+++ b/src/novelvideo/task_backend/runners/freezone.py
@@ -156,7 +156,11 @@ def _call_freezone_leaf(
         if rule.egress is LeafEgress.LOCAL:
             return leaf(**kwargs)
         if rule.egress is LeafEgress.NETWORK:
-            return leaf(egress_context=context, **kwargs)
+            # 组织任务必须携带受信任的组织身份以走网关；平台与个人任务
+            # 保持无组织上下文的既有直连语义，不能误触发组织出网闸门。
+            if context is not None and context.is_organization:
+                return leaf(egress_context=context, **kwargs)
+            return leaf(**kwargs)
     # 未分类与 DENIED 同待遇：默认 fail-closed。
     if context is not None and context.is_organization:
         raise InvalidTaskEnvelope() from None

--- a/tests/test_freezone_image_backend.py
+++ b/tests/test_freezone_image_backend.py
@@ -3502,17 +3502,14 @@ async def test_freezone_celery_text_runner_records_project_node_history(
     ctx = _project_ctx(tmp_path)
     project_dir = ctx.output_dir
 
-    # 真 leaf 出网，签名里有 egress_context（`freezone/text_node.py`）。个人信封下
-    # 它是 None，但仍会传进来——分发按分类注入，不再看替身的签名长什么样。
+    # 普通任务不传组织身份；组织任务才由分发层注入 egress_context。
     async def fake_translate_freezone_text(
         *,
         text: str,
         node_type: str,
-        egress_context,
     ):
         assert text == "你好"
         assert node_type == "text"
-        assert egress_context is None
         return "hello", "zh", "en"
 
     class FakeTaskManager:
@@ -3563,11 +3560,9 @@ async def test_freezone_celery_text_generate_runner_records_project_node_history
     ctx = _project_ctx(tmp_path)
     project_dir = ctx.output_dir
 
-    # 真 leaf 出网，签名里有 egress_context（`freezone/text_node.py`）。个人信封下
-    # 它是 None，但仍会传进来——分发按分类注入，不再看替身的签名长什么样。
-    async def fake_generate_freezone_text(*, prompt: str, egress_context):
+    # 普通任务不传组织身份；组织任务才由分发层注入 egress_context。
+    async def fake_generate_freezone_text(*, prompt: str):
         assert prompt == "写一段雨夜重逢"
-        assert egress_context is None
         return "DC-freezone-text-writer-LLM", "雨夜里，他们在旧站台重逢。"
 
     class FakeTaskManager:

--- a/tests/test_freezone_leaf_egress.py
+++ b/tests/test_freezone_leaf_egress.py
@@ -1,0 +1,33 @@
+from types import SimpleNamespace
+
+from novelvideo.task_backend.runners import freezone
+
+
+def test_network_leaf_uses_organization_context_only(monkeypatch):
+    platform_context = SimpleNamespace(is_organization=False)
+    monkeypatch.setattr(
+        freezone,
+        "_extract_trusted_egress_context",
+        lambda _envelope: platform_context,
+    )
+
+    def leaf(**kwargs):
+        return kwargs
+
+    assert freezone._call_freezone_leaf({}, leaf, "generate_freezone_audio_eleven_music") == {}
+
+
+def test_network_leaf_passes_organization_context(monkeypatch):
+    organization_context = SimpleNamespace(is_organization=True)
+    monkeypatch.setattr(
+        freezone,
+        "_extract_trusted_egress_context",
+        lambda _envelope: organization_context,
+    )
+
+    def leaf(**kwargs):
+        return kwargs
+
+    assert freezone._call_freezone_leaf(
+        {}, leaf, "generate_freezone_audio_eleven_music"
+    ) == {"egress_context": organization_context}


### PR DESCRIPTION
## PR 类型 / Type of PR
- [x] 🐞 Bug 修复 / Bug fix

## 改动说明 / What this PR does and why
普通/平台任务在 Freezone 网络叶子分发时也被注入了 `egress_context`，音乐节点会将该非组织身份判为非法组织出网身份，导致任务报 `ORG_EGRESS_DENIED`。

本 PR 仅在组织任务中注入受信任的组织出网上下文；平台和个人任务保持无组织上下文的既有直连路径。同时补齐回归测试、既有测试桩和许可证清单。

## 关联 issue / Linked issues
N/A

## 给 reviewer 的说明 / Notes for the reviewer
组织任务仍携带上下文，继续走网关、组织凭证与组织账本；普通任务不再误触发组织闸门。

## 面向用户的变更 / User-facing change
```release-note
修复普通用户生成音乐时错误提示 ORG_EGRESS_DENIED 的问题。
```

## 自检 / Checklist
- [x] 已自测，相关 pytest 通过 / Self-tested
- [x] 必要的文档已更新 / Docs updated where needed
- [x] 提交信息清晰（建议 Conventional Commits）/ Clear commits
- [x] 每个 commit 都已 `git commit -s` 附 DCO 签署 / Every commit signed off with DCO
- [x] 我已阅读并同意贡献者协议 / I agree to contributor terms