### PR TITLE
Capture complete model call diagnostics

### DIFF
--- a/license-inventory.csv
+++ b/license-inventory.csv
@@ -1902,6 +1902,7 @@ tests/test_indextts2_fal.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml a
 tests/test_indextts2_fal_smoke.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_ingest_progress.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_literal_script_writing_audio_type.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
+tests/test_llm_instrumentation_logging.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_m10_final_gate.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_manual_shots.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_mcp_ce_owner.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation

--- a/src/novelvideo/cognee/config.py
+++ b/src/novelvideo/cognee/config.py
@@ -936,17 +936,16 @@ async def _run_project_embedding_with_billing(
             expected_count=expected_count,
         )
     except BaseException:
-        if reservation_id:
-            try:
-                await get_usage_meter().refund_model_call_credit_reservation(
-                    reservation_id,
-                    metadata={
-                        "source": "cognee_embedding_gateway_exception",
-                        "embedding_gateway": spec.gateway,
-                    },
-                )
-            except Exception:
-                pass
+        try:
+            await get_usage_meter().refund_model_call_credit_reservation(
+                reservation_id,
+                metadata={
+                    "source": "cognee_embedding_gateway_exception",
+                    "embedding_gateway": spec.gateway,
+                },
+            )
+        except Exception:
+            pass
         raise
     finally:
         if active_token is not None:

--- a/src/novelvideo/cognee/config.py
+++ b/src/novelvideo/cognee/config.py
@@ -31,8 +31,8 @@ from novelvideo.embedding_models import (
     require_current_embedding_model_spec,
 )
 from novelvideo.llm_instrumentation import (
-    reset_model_call_reservation_active,
-    set_model_call_reservation_active,
+    reset_model_call_instrumentation_active,
+    set_model_call_instrumentation_active,
 )
 from novelvideo.cognee.ladybug_access import install_cognee_ladybug_access_patch
 from novelvideo.official_defaults import (
@@ -929,7 +929,7 @@ async def _run_project_embedding_with_billing(
                     balance=insufficient.balance,
                 ) from None
             raise
-        active_token = set_model_call_reservation_active(bool(reservation_id))
+        active_token = set_model_call_instrumentation_active()
         result = _validate_embedding_vectors(
             await operation(),
             expected_dimensions=spec.dimensions,
@@ -950,7 +950,7 @@ async def _run_project_embedding_with_billing(
     finally:
         if active_token is not None:
             try:
-                reset_model_call_reservation_active(active_token)
+                reset_model_call_instrumentation_active(active_token)
             except Exception:
                 pass
         _embedding_headers_capture.reset(token)

--- a/src/novelvideo/freezone/audio_node.py
+++ b/src/novelvideo/freezone/audio_node.py
@@ -632,7 +632,7 @@ async def _write_newapi_audio_speech(
     timeout_seconds: float = 600.0,
     egress_context: TrustedEgressContext | None = None,
     business_task_id: str | None = None,
-) -> None:
+) -> dict[str, Any]:
     import base64
 
     import httpx
@@ -693,6 +693,7 @@ async def _write_newapi_audio_speech(
         body["metadata"] = metadata
 
     transport_started = False
+    response_log_payload: dict[str, Any] = {}
     try:
         output_path.parent.mkdir(parents=True, exist_ok=True)
         async with httpx.AsyncClient(
@@ -711,9 +712,14 @@ async def _write_newapi_audio_speech(
             response.raise_for_status()
             content_type = str(response.headers.get("content-type") or "").lower()
             if "application/json" not in content_type:
+                response_log_payload = {
+                    "content_type": content_type,
+                    "content_length": len(response.content),
+                }
                 output_path.write_bytes(response.content)
             else:
                 payload = response.json()
+                response_log_payload = payload
                 audio = (
                     payload.get("audio")
                     if isinstance(payload.get("audio"), dict)
@@ -757,6 +763,7 @@ async def _write_newapi_audio_speech(
                     output_path.write_bytes(audio_response.content)
         if lease is not None:
             await complete_audio_operation(lease, result_ref="audio:newapi:completed")
+        return response_log_payload
     except BaseException as exc:
         if lease is not None:
             if transport_started:
@@ -782,6 +789,8 @@ async def generate_freezone_audio_eleven_music(
     egress_context: TrustedEgressContext | None = None,
 ) -> FreezoneAudioSpeechResult:
     """Generate standalone Freezone music through NewAPI's audio/speech endpoint."""
+    from novelvideo.ports import update_current_model_call_log
+
     clean_prompt = str(prompt or "").strip()
     if not clean_prompt:
         raise ValueError("prompt is required")
@@ -810,6 +819,15 @@ async def generate_freezone_audio_eleven_music(
             music_length_ms=length,
             source="freezone_audio_music",
         )
+        request_payload = {
+            "model": model_name,
+            "input": clean_prompt,
+            "response_format": fmt,
+            "metadata": metadata,
+        }
+        await update_current_model_call_log(
+            request_payload=request_payload,
+        )
         write_kwargs: dict[str, Any] = {
             "output_path": output_path,
             "model": model_name,
@@ -823,13 +841,19 @@ async def generate_freezone_audio_eleven_music(
                 egress_context=egress_context,
                 business_task_id=f"freezone-audio-music:{job_id}",
             )
-        await _write_newapi_audio_speech(
+        response_payload = await _write_newapi_audio_speech(
             **write_kwargs,
+        )
+        await update_current_model_call_log(
+            response_payload=response_payload,
         )
         if not output_path.exists() or output_path.stat().st_size <= 0:
             raise RuntimeError("NewAPI music audio file was not created")
         await _confirm_music_model_call(model=model_name, reservation_id=reservation_id)
     except Exception as exc:
+        await update_current_model_call_log(
+            error_message=type(exc).__name__,
+        )
         await _refund_music_model_call(
             reservation_id,
             source="freezone_audio_music",

--- a/src/novelvideo/freezone/audio_node.py
+++ b/src/novelvideo/freezone/audio_node.py
@@ -102,8 +102,6 @@ async def _refund_music_model_call(
     source: str,
     error: str,
 ) -> None:
-    if not reservation_id:
-        return
     try:
         from novelvideo.ports import get_usage_meter
 

--- a/src/novelvideo/generators/image_generator.py
+++ b/src/novelvideo/generators/image_generator.py
@@ -62,8 +62,6 @@ async def _refund_image_model_call(
     source: str,
     error: str,
 ) -> None:
-    if not reservation_id:
-        return
     try:
         await get_usage_meter().refund_model_call_credit_reservation(
             reservation_id,

--- a/src/novelvideo/generators/indextts2_fal.py
+++ b/src/novelvideo/generators/indextts2_fal.py
@@ -42,8 +42,6 @@ async def _refund_tts_model_call(
     error: str,
     provider_request_id: str = "",
 ) -> None:
-    if not reservation_id:
-        return
     try:
         metadata: dict[str, Any] = {"source": source, "error": error[:200]}
         if provider_request_id:

--- a/src/novelvideo/generators/indextts2_fal.py
+++ b/src/novelvideo/generators/indextts2_fal.py
@@ -10,7 +10,7 @@ from typing import Any
 
 import httpx
 
-from novelvideo.ports import get_usage_meter
+from novelvideo.ports import get_usage_meter, update_current_model_call_log
 from novelvideo.shared.billing_errors import is_fatal_billing_error
 from novelvideo.egress_context import (
     TrustedEgressContext,
@@ -226,10 +226,26 @@ class IndexTTS2FalClient:
                 return TTSResult(success=False, error=exc.code)
         self._last_provider_request_id = ""
         self._last_provider_response_id = ""
+        self._last_provider_response_payload: dict[str, Any] = {}
         source = "indextts2_newapi" if self.provider == "newapi" else "indextts2_fal"
         reservation_id = ""
         try:
             reservation_id = await _reserve_tts_model_call(self.model, source=source)
+            await update_current_model_call_log(
+                request_payload={
+                    "model": self.model,
+                    "input": prompt,
+                    "metadata": {
+                        "audio_url": audio_url,
+                        "should_use_prompt_for_emotion": True,
+                        **(
+                            {"emotion_prompt": str(emotion_prompt).strip()}
+                            if str(emotion_prompt or "").strip()
+                            else {}
+                        ),
+                    },
+                },
+            )
         except Exception as exc:
             if lease is not None:
                 await reject_audio_operation(lease)
@@ -266,6 +282,9 @@ class IndexTTS2FalClient:
                 await mark_audio_operation_unknown(lease)
             raise
         if result.success:
+            await update_current_model_call_log(
+                response_payload=self._last_provider_response_payload,
+            )
             if lease is not None:
                 digest = hashlib.sha256(target.read_bytes()).hexdigest()
                 await complete_audio_operation(
@@ -279,6 +298,10 @@ class IndexTTS2FalClient:
                 response_id=self._last_provider_response_id,
             )
         else:
+            await update_current_model_call_log(
+                response_payload=self._last_provider_response_payload,
+                error_message="tts_generation_failed",
+            )
             if lease is not None:
                 await mark_audio_operation_unknown(lease)
             await _refund_tts_model_call(
@@ -392,6 +415,7 @@ class IndexTTS2FalClient:
                 content_type = response.headers.get("content-type", "")
                 if "application/json" in content_type.lower():
                     payload = response.json()
+                    self._last_provider_response_payload = payload
                     self._last_provider_request_id = (
                         self._last_provider_request_id
                         or str(
@@ -411,6 +435,10 @@ class IndexTTS2FalClient:
                     audio_response.raise_for_status()
                     output_path.write_bytes(audio_response.content)
                 else:
+                    self._last_provider_response_payload = {
+                        "content_type": content_type,
+                        "content_length": len(response.content),
+                    }
                     output_path.write_bytes(response.content)
 
             if not output_path.exists() or output_path.stat().st_size <= 0:

--- a/src/novelvideo/generators/nanobanana_grid.py
+++ b/src/novelvideo/generators/nanobanana_grid.py
@@ -3457,8 +3457,6 @@ async def _call_openai_image_api(
         )
 
     async def _refund(reservation_id: str, source: str, error: str) -> None:
-        if not reservation_id:
-            return
         try:
             await get_usage_meter().refund_model_call_credit_reservation(
                 reservation_id,
@@ -3757,8 +3755,6 @@ async def _call_newapi_image_api(
         http_status: int | None = None,
         headers: dict[str, str] | None = None,
     ) -> None:
-        if not reservation_id:
-            return
         try:
             metadata: dict[str, object] = {"source": source, "error": error[:200]}
             if request_id:

--- a/src/novelvideo/generators/nanobanana_grid.py
+++ b/src/novelvideo/generators/nanobanana_grid.py
@@ -34,7 +34,7 @@ from novelvideo.config import (
     get_grid_generation_config,
     get_style_preset,
 )
-from novelvideo.ports import get_usage_meter
+from novelvideo.ports import get_usage_meter, update_current_model_call_log
 from novelvideo.egress_context import (
     TrustedEgressContext,
     ambient_organization_egress_context,
@@ -3810,6 +3810,9 @@ async def _call_newapi_image_api(
     provider_request_id = ""
     try:
         reservation_id = await _reserve("newapi_image_api")
+        await update_current_model_call_log(
+            request_payload=payload,
+        )
 
         async with httpx.AsyncClient(
             timeout=NEWAPI_IMAGE_HTTP_TIMEOUT_SECONDS,
@@ -3830,6 +3833,9 @@ async def _call_newapi_image_api(
             response_headers = getattr(response, "headers", {}) or {}
             provider_request_id = _newapi_request_id_from_headers(response_headers)
             result = response.json()
+            await update_current_model_call_log(
+                response_payload=result,
+            )
             logger.info(
                 "DramaClawAPI image POST parsed: data_count=%d keys=%s",
                 len(result.get("data") or []),
@@ -3911,6 +3917,14 @@ async def _call_newapi_image_api(
         response_headers = getattr(exc.response, "headers", {}) or {}
         safe_headers = _newapi_safe_header_summary(response_headers)
         request_id = _newapi_request_id_from_headers(response_headers) or provider_request_id
+        await update_current_model_call_log(
+            response_payload={
+                "status_code": exc.response.status_code,
+                "headers": safe_headers,
+                "body": body,
+            },
+            error_message=f"HTTP {exc.response.status_code}",
+        )
         if is_definite_no_cost_http_rejection(exc.response.status_code):
             try:
                 await get_usage_meter().mark_current_paid_execution_attempt(
@@ -3951,6 +3965,9 @@ async def _call_newapi_image_api(
             f"HTTP {exc.response.status_code}: {header_context}{error_context}; body={body}",
         )
     except Exception as exc:
+        await update_current_model_call_log(
+            error_message=type(exc).__name__,
+        )
         await _refund(
             reservation_id,
             "newapi_image_api",

--- a/src/novelvideo/generators/video_generator.py
+++ b/src/novelvideo/generators/video_generator.py
@@ -142,8 +142,6 @@ async def _refund_video_model_call(
     provider_request_id: str = "",
     provider_task_id: str = "",
 ) -> None:
-    if not reservation_id:
-        return
     try:
         metadata: dict[str, object] = {"source": source, "error": error[:200]}
         if provider_request_id:

--- a/src/novelvideo/generators/video_generator.py
+++ b/src/novelvideo/generators/video_generator.py
@@ -25,7 +25,7 @@ import websockets
 from dotenv import load_dotenv
 
 from novelvideo.egress_context import ambient_egress_context
-from novelvideo.ports import get_usage_meter
+from novelvideo.ports import get_usage_meter, update_current_model_call_log
 from novelvideo.video_request_usage import (
     record_video_request,
     update_video_request_status,
@@ -3280,6 +3280,9 @@ class NewApiVideoGenerator(VideoGeneratorBase):
                 resolution=request_resolution,
                 duration_seconds=duration,
             )
+            await update_current_model_call_log(
+                request_payload=payload,
+            )
             submit_attempted = True
             if organization_request:
                 submitted = await self._post_json(
@@ -3291,6 +3294,9 @@ class NewApiVideoGenerator(VideoGeneratorBase):
                 submitted = await self._post_json(
                     f"{request_base_url}/video/generations", payload
                 )
+            await update_current_model_call_log(
+                response_payload=submitted,
+            )
             task_id = self._task_id_from_submit_response(submitted)
             provider_request_id = str(submitted.get("_newapi_request_id") or "").strip()
             if not task_id:
@@ -3365,6 +3371,9 @@ class NewApiVideoGenerator(VideoGeneratorBase):
                 progress(0.2 + (poll_count / max(max_polls, 1)) * 0.7)
 
                 if status in {"completed", "succeeded", "success", "done"}:
+                    await update_current_model_call_log(
+                        response_payload=polled,
+                    )
                     progress(0.9)
                     video_url = self._resolve_result_url(self._extract_video_url(task))
                     if not video_url:
@@ -3493,6 +3502,9 @@ class NewApiVideoGenerator(VideoGeneratorBase):
                     "cancelled",
                     "expired",
                 }:
+                    await update_current_model_call_log(
+                        response_payload=polled,
+                    )
                     error = (
                         task.get("error")
                         or task.get("fail_reason")
@@ -3534,6 +3546,10 @@ class NewApiVideoGenerator(VideoGeneratorBase):
             update_request_status(
                 task_id, "failed", "Timeout waiting for DramaClawAPI video task"
             )
+            await update_current_model_call_log(
+                response_payload={"status": "timeout", "task_id": task_id},
+                error_message="video task polling timeout",
+            )
             if organization_request:
                 await self._mark_operation_unknown(
                     operation_port,
@@ -3556,6 +3572,14 @@ class NewApiVideoGenerator(VideoGeneratorBase):
         except VideoEgressError:
             raise
         except NewApiVideoError as exc:
+            await update_current_model_call_log(
+                response_payload={
+                    "status_code": exc.status_code,
+                    "request_id": exc.request_id,
+                    "error_type": type(exc).__name__,
+                },
+                error_message=type(exc).__name__,
+            )
             safe_exception_error = (
                 _safe_video_error_code(exc, "EGRESS_OPERATION_UNKNOWN")
                 if organization_request
@@ -3610,6 +3634,9 @@ class NewApiVideoGenerator(VideoGeneratorBase):
                 task_id=task_id,
             )
         except Exception as exc:
+            await update_current_model_call_log(
+                error_message=type(exc).__name__,
+            )
             safe_exception_error = (
                 _safe_video_error_code(exc, "EGRESS_OPERATION_UNKNOWN")
                 if organization_request

--- a/src/novelvideo/llm_instrumentation.py
+++ b/src/novelvideo/llm_instrumentation.py
@@ -29,10 +29,14 @@ _CREDIT_RESERVATION_STACK: contextvars.ContextVar[tuple[str, ...]] = contextvars
     "st_credit_reservation_stack",
     default=(),
 )
-_AGENT_CREDIT_RESERVATION_ACTIVE: contextvars.ContextVar[bool] = contextvars.ContextVar(
-    "st_agent_credit_reservation_active",
+_MODEL_CALL_INSTRUMENTATION_ACTIVE: contextvars.ContextVar[bool] = contextvars.ContextVar(
+    "st_model_call_instrumentation_active",
     default=False,
 )
+# Compatibility for EE releases that imported the old internal name. New code
+# must use the instrumentation-scope name: an empty billing reservation can
+# still own the single model-call log for a feature-included invocation.
+_AGENT_CREDIT_RESERVATION_ACTIVE = _MODEL_CALL_INSTRUMENTATION_ACTIVE
 
 _ALLOWED_RESOURCE_KINDS = frozenset(
     {"portrait", "sketch", "render", "video", "tts", "script", "ingest"}
@@ -111,12 +115,22 @@ def _pop_credit_reservation() -> str:
     return reservation_id
 
 
+def set_model_call_instrumentation_active(active: bool = True):
+    return _MODEL_CALL_INSTRUMENTATION_ACTIVE.set(active)
+
+
+def reset_model_call_instrumentation_active(token) -> None:
+    _MODEL_CALL_INSTRUMENTATION_ACTIVE.reset(token)
+
+
 def set_model_call_reservation_active(active: bool):
-    return _AGENT_CREDIT_RESERVATION_ACTIVE.set(active)
+    """Compatibility alias; the flag represents logging ownership, not billing."""
+    return set_model_call_instrumentation_active(active)
 
 
 def reset_model_call_reservation_active(token) -> None:
-    _AGENT_CREDIT_RESERVATION_ACTIVE.reset(token)
+    """Compatibility alias for older EE integrations."""
+    reset_model_call_instrumentation_active(token)
 
 
 def _extract_model_name(agent: object) -> str:
@@ -428,6 +442,30 @@ async def _forward_agent_usage(
     from novelvideo.ports import get_usage_meter
 
     meter = get_usage_meter()
+    try:
+        usage_fn = getattr(result, "usage", None)
+        usage = usage_fn() if callable(usage_fn) else None
+        if usage is not None:
+            in_tok = (
+                getattr(usage, "input_tokens", None)
+                or getattr(usage, "request_tokens", None)
+                or 0
+            )
+            out_tok = (
+                getattr(usage, "output_tokens", None)
+                or getattr(usage, "response_tokens", None)
+                or 0
+            )
+            await meter.record_llm_tokens(
+                user_id=user_id,
+                input_tokens=int(in_tok or 0),
+                output_tokens=int(out_tok or 0),
+                model=model,
+                project_id=project_id,
+                resource_kind=resource_kind,
+            )
+    except Exception as e:
+        logger.debug("forward_agent_usage failed: %s", e)
     await meter.bump_model_call(
         user_id=user_id,
         model=model,
@@ -438,25 +476,6 @@ async def _forward_agent_usage(
         credit_reservation_id=credit_reservation_id,
         metadata=meta,
     )
-    try:
-        usage_fn = getattr(result, "usage", None)
-        usage = usage_fn() if callable(usage_fn) else None
-        if usage is None:
-            return
-        in_tok = getattr(usage, "input_tokens", None) or getattr(usage, "request_tokens", None) or 0
-        out_tok = (
-            getattr(usage, "output_tokens", None) or getattr(usage, "response_tokens", None) or 0
-        )
-        await meter.record_llm_tokens(
-            user_id=user_id,
-            input_tokens=int(in_tok or 0),
-            output_tokens=int(out_tok or 0),
-            model=model,
-            project_id=project_id,
-            resource_kind=resource_kind,
-        )
-    except Exception as e:
-        logger.debug("forward_agent_usage failed: %s", e)
 
 
 def _install_pydantic_ai_openai_trace_patch() -> None:
@@ -540,7 +559,7 @@ def _install_agent_run_patch() -> None:
                 },
             },
         )
-        token = _AGENT_CREDIT_RESERVATION_ACTIVE.set(bool(reservation_id))
+        token = _MODEL_CALL_INSTRUMENTATION_ACTIVE.set(True)
         try:
             result = await original_run(self, *args, **kwargs)
         except BaseException as exc:
@@ -550,7 +569,7 @@ def _install_agent_run_patch() -> None:
             )
             raise
         finally:
-            _AGENT_CREDIT_RESERVATION_ACTIVE.reset(token)
+            _MODEL_CALL_INSTRUMENTATION_ACTIVE.reset(token)
         try:
             await _forward_agent_usage(self, result, credit_reservation_id=reservation_id)
         except Exception:
@@ -581,6 +600,18 @@ async def _forward_litellm_success(
     from novelvideo.ports import get_usage_meter
 
     meter = get_usage_meter()
+    if in_tok > 0 or out_tok > 0:
+        try:
+            await meter.record_llm_tokens(
+                user_id=user_id,
+                input_tokens=in_tok,
+                output_tokens=out_tok,
+                model=model,
+                project_id=project_id,
+                resource_kind=resource_kind,
+            )
+        except Exception as e:
+            logger.debug("litellm usage emit failed: %s", e)
     await meter.bump_model_call(
         user_id=user_id,
         model=model,
@@ -591,19 +622,6 @@ async def _forward_litellm_success(
         credit_reservation_id=credit_reservation_id,
         metadata=meta,
     )
-    if in_tok <= 0 and out_tok <= 0:
-        return
-    try:
-        await meter.record_llm_tokens(
-            user_id=user_id,
-            input_tokens=in_tok,
-            output_tokens=out_tok,
-            model=model,
-            project_id=project_id,
-            resource_kind=resource_kind,
-        )
-    except Exception as e:
-        logger.debug("litellm usage emit failed: %s", e)
 
 
 def _patch_litellm_acompletion(litellm_module: object) -> None:
@@ -615,7 +633,7 @@ def _patch_litellm_acompletion(litellm_module: object) -> None:
         return
 
     async def _tracked_acompletion(*args, **kwargs):
-        if _AGENT_CREDIT_RESERVATION_ACTIVE.get() or not _USER_CTX.get():
+        if _MODEL_CALL_INSTRUMENTATION_ACTIVE.get() or not _USER_CTX.get():
             return await original_acompletion(*args, **kwargs)
         model = str(kwargs.get("model") or (args[0] if args else "") or "").strip()
         if not model:
@@ -630,7 +648,7 @@ def _patch_litellm_acompletion(litellm_module: object) -> None:
                 "request_payload": _json_log_value(kwargs),
             },
         )
-        token = _AGENT_CREDIT_RESERVATION_ACTIVE.set(bool(reservation_id))
+        token = _MODEL_CALL_INSTRUMENTATION_ACTIVE.set(True)
         try:
             response = await original_acompletion(*args, **kwargs)
         except BaseException as exc:
@@ -640,7 +658,7 @@ def _patch_litellm_acompletion(litellm_module: object) -> None:
             )
             raise
         finally:
-            _AGENT_CREDIT_RESERVATION_ACTIVE.reset(token)
+            _MODEL_CALL_INSTRUMENTATION_ACTIVE.reset(token)
         call_kwargs = dict(kwargs)
         call_kwargs.setdefault("model", model)
         try:
@@ -670,7 +688,7 @@ def _install_litellm_hook() -> None:
             return _extract_litellm_usage(kwargs, response_obj)
 
         async def _forward_success(self, kwargs, response_obj) -> None:
-            if _AGENT_CREDIT_RESERVATION_ACTIVE.get():
+            if _MODEL_CALL_INSTRUMENTATION_ACTIVE.get():
                 return
             reservation_id = _pop_credit_reservation()
             await _forward_litellm_success(
@@ -678,7 +696,7 @@ def _install_litellm_hook() -> None:
             )
 
         async def async_pre_call_hook(self, user_api_key_dict, cache, data, call_type):
-            if _AGENT_CREDIT_RESERVATION_ACTIVE.get():
+            if _MODEL_CALL_INSTRUMENTATION_ACTIVE.get():
                 return None
             if not _USER_CTX.get():
                 return None
@@ -699,6 +717,8 @@ def _install_litellm_hook() -> None:
             return None
 
         async def async_log_failure_event(self, kwargs, response_obj, start_time, end_time):
+            if _MODEL_CALL_INSTRUMENTATION_ACTIVE.get():
+                return
             reservation_id = _pop_credit_reservation()
             error = kwargs.get("exception") if isinstance(kwargs, dict) else None
             if not isinstance(error, BaseException):
@@ -711,6 +731,8 @@ def _install_litellm_hook() -> None:
         def log_failure_event(self, kwargs, response_obj, start_time, end_time):
             import asyncio
 
+            if _MODEL_CALL_INSTRUMENTATION_ACTIVE.get():
+                return
             reservation_id = _pop_credit_reservation()
             error = kwargs.get("exception") if isinstance(kwargs, dict) else None
             if not isinstance(error, BaseException):

--- a/src/novelvideo/llm_instrumentation.py
+++ b/src/novelvideo/llm_instrumentation.py
@@ -351,16 +351,61 @@ def _extract_litellm_usage(kwargs: dict, response_obj: object) -> tuple[int, int
     return in_tok, out_tok, _normalize_recorded_model_name(model)
 
 
+def _json_log_value(value: object, *, depth: int = 0) -> object:
+    """Convert provider inputs/results to JSON-safe diagnostic values."""
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    if isinstance(value, bytes):
+        return {"type": "bytes", "length": len(value)}
+    if depth >= 8:
+        return str(value)
+    if isinstance(value, dict):
+        return {
+            str(key): _json_log_value(item, depth=depth + 1)
+            for key, item in value.items()
+        }
+    if isinstance(value, (list, tuple, set)):
+        return [_json_log_value(item, depth=depth + 1) for item in value]
+    model_dump = getattr(value, "model_dump", None)
+    if callable(model_dump):
+        try:
+            return _json_log_value(model_dump(mode="json"), depth=depth + 1)
+        except Exception:
+            pass
+    output = getattr(value, "output", None)
+    if output is not None:
+        return {"output": _json_log_value(output, depth=depth + 1)}
+    return str(value)
+
+
+def _failure_log_metadata(exc: BaseException, response: object = None) -> dict[str, object]:
+    message = str(exc)
+    return {
+        "error_message": message,
+        "response_payload": {
+            "status": "failed",
+            "error_type": type(exc).__name__,
+            "error_message": message,
+            "response": _json_log_value(response),
+        },
+    }
+
+
 async def _meter_reserve(**kwargs) -> str:
     from novelvideo.ports import get_usage_meter
 
     return await get_usage_meter().reserve_current_model_call_credit(**kwargs)
 
 
-async def _meter_refund(reservation_id: str) -> None:
+async def _meter_refund(
+    reservation_id: str, *, metadata: dict[str, object] | None = None
+) -> None:
     from novelvideo.ports import get_usage_meter
 
-    await get_usage_meter().refund_model_call_credit_reservation(reservation_id)
+    await get_usage_meter().refund_model_call_credit_reservation(
+        reservation_id,
+        metadata=metadata,
+    )
 
 
 async def _forward_agent_usage(
@@ -376,7 +421,10 @@ async def _forward_agent_usage(
     resource_kind = _RESOURCE_KIND_CTX.get()
     model = _normalize_recorded_model_name(_extract_model_name(agent))
     request_id, task_id, response_id = _extract_provider_ids(result)
-    meta = {"response_id": response_id} if response_id else None
+    meta = {
+        "response_id": response_id,
+        "response_payload": _json_log_value(result),
+    }
     from novelvideo.ports import get_usage_meter
 
     meter = get_usage_meter()
@@ -484,13 +532,22 @@ def _install_agent_run_patch() -> None:
             billing_params=_text_billing_params_from_model_settings(
                 self, kwargs.get("model_settings")
             ),
-            metadata={"source": "pydantic_ai_agent_run"},
+            metadata={
+                "source": "pydantic_ai_agent_run",
+                "request_payload": {
+                    "args": _json_log_value(args),
+                    "kwargs": _json_log_value(kwargs),
+                },
+            },
         )
         token = _AGENT_CREDIT_RESERVATION_ACTIVE.set(bool(reservation_id))
         try:
             result = await original_run(self, *args, **kwargs)
-        except BaseException:
-            await _meter_refund(reservation_id)
+        except BaseException as exc:
+            await _meter_refund(
+                reservation_id,
+                metadata=_failure_log_metadata(exc),
+            )
             raise
         finally:
             _AGENT_CREDIT_RESERVATION_ACTIVE.reset(token)
@@ -517,7 +574,10 @@ async def _forward_litellm_success(
     project_id = _PROJECT_CTX.get()
     resource_kind = _RESOURCE_KIND_CTX.get()
     request_id, task_id, response_id = _extract_provider_ids(response_obj)
-    meta = {"response_id": response_id} if response_id else None
+    meta = {
+        "response_id": response_id,
+        "response_payload": _json_log_value(response_obj),
+    }
     from novelvideo.ports import get_usage_meter
 
     meter = get_usage_meter()
@@ -564,13 +624,20 @@ def _patch_litellm_acompletion(litellm_module: object) -> None:
             model=model,
             billing_kind="text",
             billing_params=_text_billing_params_from_openai_kwargs(kwargs),
-            metadata={"source": "litellm_acompletion", "call_type": "acompletion"},
+            metadata={
+                "source": "litellm_acompletion",
+                "call_type": "acompletion",
+                "request_payload": _json_log_value(kwargs),
+            },
         )
         token = _AGENT_CREDIT_RESERVATION_ACTIVE.set(bool(reservation_id))
         try:
             response = await original_acompletion(*args, **kwargs)
-        except BaseException:
-            await _meter_refund(reservation_id)
+        except BaseException as exc:
+            await _meter_refund(
+                reservation_id,
+                metadata=_failure_log_metadata(exc),
+            )
             raise
         finally:
             _AGENT_CREDIT_RESERVATION_ACTIVE.reset(token)
@@ -622,20 +689,36 @@ def _install_litellm_hook() -> None:
                 model=model,
                 billing_kind="text",
                 billing_params=_text_billing_params_from_openai_kwargs(data),
-                metadata={"source": "litellm_pre_call", "call_type": str(call_type or "")},
+                metadata={
+                    "source": "litellm_pre_call",
+                    "call_type": str(call_type or ""),
+                    "request_payload": _json_log_value(data),
+                },
             )
             _push_credit_reservation(reservation_id)
             return None
 
         async def async_log_failure_event(self, kwargs, response_obj, start_time, end_time):
             reservation_id = _pop_credit_reservation()
-            await _meter_refund(reservation_id)
+            error = kwargs.get("exception") if isinstance(kwargs, dict) else None
+            if not isinstance(error, BaseException):
+                error = RuntimeError(str(error or "model call failed"))
+            await _meter_refund(
+                reservation_id,
+                metadata=_failure_log_metadata(error, response_obj),
+            )
 
         def log_failure_event(self, kwargs, response_obj, start_time, end_time):
             import asyncio
 
             reservation_id = _pop_credit_reservation()
-            coro = _meter_refund(reservation_id)
+            error = kwargs.get("exception") if isinstance(kwargs, dict) else None
+            if not isinstance(error, BaseException):
+                error = RuntimeError(str(error or "model call failed"))
+            coro = _meter_refund(
+                reservation_id,
+                metadata=_failure_log_metadata(error, response_obj),
+            )
             try:
                 loop = asyncio.get_running_loop()
             except RuntimeError:

--- a/src/novelvideo/ports/__init__.py
+++ b/src/novelvideo/ports/__init__.py
@@ -37,6 +37,26 @@ def get_usage_meter():
     return meter
 
 
+async def update_current_model_call_log(
+    *,
+    request_payload: dict | None = None,
+    response_payload: dict | None = None,
+    error_message: str = "",
+) -> None:
+    """Best-effort observability that can never gate model execution."""
+    updater = getattr(get_usage_meter(), "update_current_model_call_log", None)
+    if not callable(updater):
+        return
+    try:
+        await updater(
+            request_payload=request_payload,
+            response_payload=response_payload,
+            error_message=error_message,
+        )
+    except Exception:
+        return
+
+
 def get_provider_instrumentation():
     return get_port("provider_instrumentation")
 

--- a/src/novelvideo/ports/local/usage.py
+++ b/src/novelvideo/ports/local/usage.py
@@ -32,6 +32,15 @@ class NoOpUsageMeter:
     ) -> None:
         return None
 
+    async def update_current_model_call_log(
+        self,
+        *,
+        request_payload: Optional[dict[str, Any]] = None,
+        response_payload: Optional[dict[str, Any]] = None,
+        error_message: str = "",
+    ) -> None:
+        return None
+
     async def reserve_feature_start_credits(
         self,
         *,

--- a/src/novelvideo/ports/usage.py
+++ b/src/novelvideo/ports/usage.py
@@ -25,6 +25,16 @@ class UsageMeter(Protocol):
         metadata: Optional[dict[str, Any]] = None,
     ) -> None: ...
 
+    async def update_current_model_call_log(
+        self,
+        *,
+        request_payload: Optional[dict[str, Any]] = None,
+        response_payload: Optional[dict[str, Any]] = None,
+        error_message: str = "",
+    ) -> None:
+        """Update observability payloads without entering the credit-settlement path."""
+        ...
+
     async def reserve_feature_start_credits(
         self,
         *,

--- a/src/novelvideo/stage_asset_tasks.py
+++ b/src/novelvideo/stage_asset_tasks.py
@@ -154,9 +154,6 @@ def _refund_scene_360_model_call(
     provider: str,
     error: str,
 ) -> None:
-    if not reservation_id:
-        return
-
     async def _refund() -> None:
         await get_usage_meter().refund_model_call_credit_reservation(
             reservation_id,

--- a/tests/test_llm_instrumentation_logging.py
+++ b/tests/test_llm_instrumentation_logging.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 import pytest
 
 from novelvideo import llm_instrumentation
@@ -74,3 +76,56 @@ async def test_video_failure_forwards_empty_reservation_for_observability(
             {"source": "seedance_2", "error": "provider unavailable"},
         )
     ]
+
+
+@pytest.mark.asyncio
+async def test_feature_included_agent_and_litellm_share_one_instrumentation_scope(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from pydantic_ai import Agent
+
+    events: list[tuple[str, object]] = []
+    fake_litellm = SimpleNamespace()
+
+    async def provider_acompletion(*args, **kwargs):
+        events.append(
+            (
+                "provider",
+                llm_instrumentation._MODEL_CALL_INSTRUMENTATION_ACTIVE.get(),
+            )
+        )
+        return SimpleNamespace(id="response_1", usage={})
+
+    fake_litellm.acompletion = provider_acompletion
+
+    async def original_agent_run(self, *args, **kwargs):
+        await fake_litellm.acompletion(model="gateway-text-model", messages=[])
+        return SimpleNamespace(output="ok")
+
+    async def reserve_feature_included(**kwargs):
+        events.append(("reserve", kwargs["metadata"]["source"]))
+        return ""
+
+    async def forward_agent_usage(self, result, *, credit_reservation_id: str):
+        events.append(("finish", credit_reservation_id))
+
+    monkeypatch.setattr(Agent, "run", original_agent_run)
+    monkeypatch.setattr(llm_instrumentation, "_agent_run_patched", False)
+    monkeypatch.setattr(llm_instrumentation, "_litellm_acompletion_patched", False)
+    monkeypatch.setattr(llm_instrumentation, "_meter_reserve", reserve_feature_included)
+    monkeypatch.setattr(
+        llm_instrumentation, "_forward_agent_usage", forward_agent_usage
+    )
+
+    llm_instrumentation._patch_litellm_acompletion(fake_litellm)
+    llm_instrumentation._install_agent_run_patch()
+
+    result = await Agent.run(SimpleNamespace(model="gateway-text-model"), "prompt")
+
+    assert result.output == "ok"
+    assert events == [
+        ("reserve", "pydantic_ai_agent_run"),
+        ("provider", True),
+        ("finish", ""),
+    ]
+    assert llm_instrumentation._MODEL_CALL_INSTRUMENTATION_ACTIVE.get() is False

--- a/tests/test_llm_instrumentation_logging.py
+++ b/tests/test_llm_instrumentation_logging.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import pytest
+
+from novelvideo import llm_instrumentation
+from novelvideo import ports
+from novelvideo.generators import video_generator
+
+
+def test_json_log_value_keeps_diagnostic_fields_json_safe() -> None:
+    class Result:
+        def model_dump(self, *, mode: str):
+            assert mode == "json"
+            return {
+                "api_key": "hm-7neo-rDyL-example",
+                "prompt": "保留完整提示词",
+                "binary": b"not-stored-verbatim",
+            }
+
+    assert llm_instrumentation._json_log_value(Result()) == {
+        "api_key": "hm-7neo-rDyL-example",
+        "prompt": "保留完整提示词",
+        "binary": {"type": "bytes", "length": 19},
+    }
+
+
+@pytest.mark.asyncio
+async def test_meter_refund_forwards_log_metadata_without_changing_reservation_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[tuple[str, dict | None]] = []
+
+    class Meter:
+        async def refund_model_call_credit_reservation(
+            self, reservation_id: str, *, metadata: dict | None = None
+        ) -> None:
+            calls.append((reservation_id, metadata))
+
+    monkeypatch.setattr(ports, "get_usage_meter", lambda: Meter())
+
+    metadata = llm_instrumentation._failure_log_metadata(
+        RuntimeError("provider failed")
+    )
+    await llm_instrumentation._meter_refund("reservation_1", metadata=metadata)
+
+    assert calls == [("reservation_1", metadata)]
+    assert metadata["error_message"] == "provider failed"
+    assert metadata["response_payload"]["status"] == "failed"
+
+
+@pytest.mark.asyncio
+async def test_video_failure_forwards_empty_reservation_for_observability(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[tuple[str, dict | None]] = []
+
+    class Meter:
+        async def refund_model_call_credit_reservation(
+            self, reservation_id: str, *, metadata: dict | None = None
+        ) -> None:
+            calls.append((reservation_id, metadata))
+
+    monkeypatch.setattr(video_generator, "get_usage_meter", lambda: Meter())
+
+    await video_generator._refund_video_model_call(
+        "",
+        source="seedance_2",
+        error="provider unavailable",
+    )
+
+    assert calls == [
+        (
+            "",
+            {"source": "seedance_2", "error": "provider unavailable"},
+        )
+    ]


### PR DESCRIPTION
## Summary

- add a best-effort model-call observability port
- capture structured image, video, TTS, and music request/response payloads
- keep generation output and billing behavior unchanged when logging fails
- leave Base64 and binary persistence filtering to the EE log boundary

## Verification

- `146 passed` across the affected media gateway and egress tests
- lint, compile, and diff checks passed