### PR TITLE
fix(api): split shared-pool limit wording and log task-limit rejections

### DIFF
--- a/license-inventory.csv
+++ b/license-inventory.csv
@@ -1623,6 +1623,7 @@ src/novelvideo/task_backend/cancel.py,Elastic-2.0,2026 SuperTale contributors,RE
 src/novelvideo/task_backend/client.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 src/novelvideo/task_backend/consumer.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 src/novelvideo/task_backend/envelope.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
+src/novelvideo/task_backend/limit_logging.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 src/novelvideo/task_backend/limits.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 src/novelvideo/task_backend/producer.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 src/novelvideo/task_backend/projection.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation

--- a/src/novelvideo/api/app.py
+++ b/src/novelvideo/api/app.py
@@ -90,6 +90,38 @@ def _record_resource_request(resource_key: str) -> tuple[int, int]:
         return _RESOURCE_REQUEST_TOTAL, _RESOURCE_REQUEST_COUNTS[resource_key]
 
 
+_TASK_LIMIT_LOG_FIELDS = (
+    "limit_scope",
+    "scope_kind",
+    "org_id",
+    "queue_kind",
+    "limit",
+    "active",
+    "queued",
+    "requester_user_id",
+    "project_id",
+)
+
+
+def _limit_log_value(value: object) -> str:
+    return "-" if value is None else str(value)
+
+
+def _log_task_limit_rejection(**fields: object) -> None:
+    """把一次限流拒绝写成一行可 grep 的日志。
+
+    ``limit_scope`` 此前只活在 429 返回体里,日志一个字不记 —— 线上撞闸后
+    无法归因是五道闸里的哪一道。这五个 handler 是唯一能统一覆盖全部闸门的
+    接缝(三道项目级 + 两道渠道级),所以日志落在这里,而不是任何单个预留
+    调用点。只记业务 ID,不记用户名/项目名。
+    """
+    rendered = " ".join(
+        "%s=%s" % (name, _limit_log_value(fields.get(name)))
+        for name in _TASK_LIMIT_LOG_FIELDS
+    )
+    logger.warning("task lane limit rejected %s", rendered)
+
+
 def create_app() -> FastAPI:
     register_verification_routes()
 
@@ -102,6 +134,13 @@ def create_app() -> FastAPI:
         exc: ProjectTaskLimitExceeded,
     ) -> JSONResponse:
         _ = request
+        _log_task_limit_rejection(
+            limit_scope="project",
+            queue_kind=exc.queue_kind,
+            limit=exc.limit,
+            active=exc.active,
+            project_id=exc.project_id,
+        )
         return JSONResponse(
             status_code=429,
             content={
@@ -123,6 +162,14 @@ def create_app() -> FastAPI:
         exc: ProjectUserTaskLimitExceeded,
     ) -> JSONResponse:
         _ = request
+        _log_task_limit_rejection(
+            limit_scope="user",
+            queue_kind=exc.queue_kind,
+            limit=exc.limit,
+            active=exc.active,
+            requester_user_id=exc.requester_user_id,
+            project_id=exc.project_id,
+        )
         return JSONResponse(
             status_code=429,
             content={
@@ -148,6 +195,13 @@ def create_app() -> FastAPI:
         exc: GlobalLaneQueueLimitExceeded,
     ) -> JSONResponse:
         _ = request
+        _log_task_limit_rejection(
+            limit_scope="global_lane_queue",
+            queue_kind=exc.queue_kind,
+            limit=exc.limit,
+            queued=exc.queued,
+            project_id=exc.project_id,
+        )
         return JSONResponse(
             status_code=429,
             content={
@@ -169,20 +223,36 @@ def create_app() -> FastAPI:
         exc: ChannelTaskLimitExceeded,
     ) -> JSONResponse:
         _ = request
+        limit_scope = "platform" if exc.scope_kind == "platform" else "channel"
+        _log_task_limit_rejection(
+            limit_scope=limit_scope,
+            scope_kind=exc.scope_kind,
+            org_id=exc.org_id,
+            queue_kind=exc.queue_kind,
+            limit=exc.limit,
+            active=exc.active,
+        )
+        if exc.scope_kind == "platform":
+            # 共享池(``org_id is None``)拦下的是不归属任何渠道的请求,对他们
+            # 说"渠道"没有对应概念;而池子是全平台共享的,"等待已有任务完成"
+            # 也无从等起 —— 撞闸的人自己可能一个任务都没在跑。
+            message = f"当前平台 {exc.queue_kind} 队列任务已满，请稍后再试"
+        else:
+            message = (
+                f"当前渠道 {exc.queue_kind} 队列任务已满，请等待已有任务完成后再提交"
+            )
         return JSONResponse(
             status_code=429,
             content={
                 "ok": False,
-                "error": f"当前渠道 {exc.queue_kind} 队列任务已满，请等待已有任务完成后再提交",
+                "error": message,
                 "data": {
                     "scope_kind": exc.scope_kind,
                     "org_id": exc.org_id,
                     "queue_kind": exc.queue_kind,
                     "limit": exc.limit,
                     "active": exc.active,
-                    "limit_scope": (
-                        "platform" if exc.scope_kind == "platform" else "channel"
-                    ),
+                    "limit_scope": limit_scope,
                 },
             },
         )
@@ -193,6 +263,13 @@ def create_app() -> FastAPI:
         exc: UserTaskLimitExceeded,
     ) -> JSONResponse:
         _ = request
+        _log_task_limit_rejection(
+            limit_scope="user",
+            queue_kind=exc.queue_kind,
+            limit=exc.limit,
+            active=exc.active,
+            requester_user_id=exc.requester_user_id,
+        )
         return JSONResponse(
             status_code=429,
             content={

--- a/src/novelvideo/api/app.py
+++ b/src/novelvideo/api/app.py
@@ -29,6 +29,7 @@ from novelvideo.shared.billing_errors import (
     insufficient_credits_payload,
 )
 from novelvideo.shared.api_coverage import mount_api_coverage_middleware
+from novelvideo.task_backend.limit_logging import log_task_limit_rejection
 from novelvideo.task_backend.limits import (
     ChannelTaskLimitExceeded,
     GlobalLaneQueueLimitExceeded,
@@ -90,38 +91,6 @@ def _record_resource_request(resource_key: str) -> tuple[int, int]:
         return _RESOURCE_REQUEST_TOTAL, _RESOURCE_REQUEST_COUNTS[resource_key]
 
 
-_TASK_LIMIT_LOG_FIELDS = (
-    "limit_scope",
-    "scope_kind",
-    "org_id",
-    "queue_kind",
-    "limit",
-    "active",
-    "queued",
-    "requester_user_id",
-    "project_id",
-)
-
-
-def _limit_log_value(value: object) -> str:
-    return "-" if value is None else str(value)
-
-
-def _log_task_limit_rejection(**fields: object) -> None:
-    """把一次限流拒绝写成一行可 grep 的日志。
-
-    ``limit_scope`` 此前只活在 429 返回体里,日志一个字不记 —— 线上撞闸后
-    无法归因是五道闸里的哪一道。这五个 handler 是唯一能统一覆盖全部闸门的
-    接缝(三道项目级 + 两道渠道级),所以日志落在这里,而不是任何单个预留
-    调用点。只记业务 ID,不记用户名/项目名。
-    """
-    rendered = " ".join(
-        "%s=%s" % (name, _limit_log_value(fields.get(name)))
-        for name in _TASK_LIMIT_LOG_FIELDS
-    )
-    logger.warning("task lane limit rejected %s", rendered)
-
-
 def create_app() -> FastAPI:
     register_verification_routes()
 
@@ -134,13 +103,7 @@ def create_app() -> FastAPI:
         exc: ProjectTaskLimitExceeded,
     ) -> JSONResponse:
         _ = request
-        _log_task_limit_rejection(
-            limit_scope="project",
-            queue_kind=exc.queue_kind,
-            limit=exc.limit,
-            active=exc.active,
-            project_id=exc.project_id,
-        )
+        log_task_limit_rejection(exc, limit_scope="project")
         return JSONResponse(
             status_code=429,
             content={
@@ -162,14 +125,7 @@ def create_app() -> FastAPI:
         exc: ProjectUserTaskLimitExceeded,
     ) -> JSONResponse:
         _ = request
-        _log_task_limit_rejection(
-            limit_scope="user",
-            queue_kind=exc.queue_kind,
-            limit=exc.limit,
-            active=exc.active,
-            requester_user_id=exc.requester_user_id,
-            project_id=exc.project_id,
-        )
+        log_task_limit_rejection(exc, limit_scope="user")
         return JSONResponse(
             status_code=429,
             content={
@@ -195,13 +151,7 @@ def create_app() -> FastAPI:
         exc: GlobalLaneQueueLimitExceeded,
     ) -> JSONResponse:
         _ = request
-        _log_task_limit_rejection(
-            limit_scope="global_lane_queue",
-            queue_kind=exc.queue_kind,
-            limit=exc.limit,
-            queued=exc.queued,
-            project_id=exc.project_id,
-        )
+        log_task_limit_rejection(exc, limit_scope="global_lane_queue")
         return JSONResponse(
             status_code=429,
             content={
@@ -224,14 +174,7 @@ def create_app() -> FastAPI:
     ) -> JSONResponse:
         _ = request
         limit_scope = "platform" if exc.scope_kind == "platform" else "channel"
-        _log_task_limit_rejection(
-            limit_scope=limit_scope,
-            scope_kind=exc.scope_kind,
-            org_id=exc.org_id,
-            queue_kind=exc.queue_kind,
-            limit=exc.limit,
-            active=exc.active,
-        )
+        log_task_limit_rejection(exc, limit_scope=limit_scope)
         if exc.scope_kind == "platform":
             # 共享池(``org_id is None``)拦下的是不归属任何渠道的请求,对他们
             # 说"渠道"没有对应概念;而池子是全平台共享的,"等待已有任务完成"
@@ -263,13 +206,7 @@ def create_app() -> FastAPI:
         exc: UserTaskLimitExceeded,
     ) -> JSONResponse:
         _ = request
-        _log_task_limit_rejection(
-            limit_scope="user",
-            queue_kind=exc.queue_kind,
-            limit=exc.limit,
-            active=exc.active,
-            requester_user_id=exc.requester_user_id,
-        )
+        log_task_limit_rejection(exc, limit_scope="user")
         return JSONResponse(
             status_code=429,
             content={

--- a/src/novelvideo/api/routes/generation.py
+++ b/src/novelvideo/api/routes/generation.py
@@ -71,6 +71,7 @@ from novelvideo.seedance2_i2v.voice_clone import normalize_seedance2_audio_type
 from novelvideo.project_config import load_project_config, save_project_config
 from novelvideo.project_context import ProjectContext
 from novelvideo.ports import get_credit_quote, get_task_backend, get_usage_meter
+from novelvideo.task_backend.limit_logging import log_task_limit_rejection
 from novelvideo.task_backend.limits import (
     ChannelTaskLimitExceeded,
     ProjectTaskLimitExceeded,
@@ -447,34 +448,45 @@ _FANOUT_ACTIVE_LIMIT_ERRORS = (
 )
 
 
-def _task_limit_rejection(
-    scope: str,
-    exc: (
-        ChannelTaskLimitExceeded
-        | UserTaskLimitExceeded
-        | ProjectTaskLimitExceeded
-        | ProjectUserTaskLimitExceeded
-    ),
-) -> dict[str, Any]:
-    """把撞闸异常翻成扇出响应里的一条 ``rejected``（M8 §8.2 冻结形状）。
+_FanoutLimitError = (
+    ChannelTaskLimitExceeded
+    | UserTaskLimitExceeded
+    | ProjectTaskLimitExceeded
+    | ProjectUserTaskLimitExceeded
+)
 
-    ``reason`` 的分支必须与 ``api/app.py`` 的 ``limit_scope`` 逐字同源
-    （``:183-185`` 渠道闸 / ``:209`` 人闸）—— 两侧同算法是跨 EU 的漂移探测器，
-    故三处扇出循环共用这一个 helper，而不是各自内联一份。
+
+def _task_limit_reason(exc: _FanoutLimitError) -> str:
+    """撞闸异常 → 作用域词。
+
+    分支必须与 ``api/app.py`` 的 ``limit_scope`` 逐字同源（``:226`` 渠道闸 /
+    ``:206`` 与 ``:271`` 人闸）—— 两侧同算法是跨 EU 的漂移探测器，故三处扇出
+    循环共用这一个 helper，而不是各自内联一份。
     """
     if isinstance(exc, ProjectTaskLimitExceeded):
-        reason = "project"
-    elif isinstance(exc, ChannelTaskLimitExceeded):
-        reason = "platform" if exc.scope_kind == "platform" else "channel"
-    elif isinstance(exc, (ProjectUserTaskLimitExceeded, UserTaskLimitExceeded)):
-        reason = "user"
-    else:  # pragma: no cover - the precise catch tuple keeps this unreachable
-        raise TypeError(
-            f"unsupported fanout task-limit exception: {type(exc).__name__}"
-        )
+        return "project"
+    if isinstance(exc, ChannelTaskLimitExceeded):
+        return "platform" if exc.scope_kind == "platform" else "channel"
+    if isinstance(exc, (ProjectUserTaskLimitExceeded, UserTaskLimitExceeded)):
+        return "user"
+    # pragma: no cover - the precise catch tuple keeps this unreachable
+    raise TypeError(f"unsupported fanout task-limit exception: {type(exc).__name__}")
+
+
+def _log_partial_dispatch_rejection(exc: _FanoutLimitError) -> None:
+    """已投出 k > 0 个后撞闸：异常就地被吞、响应是 200，走不到 ``api/app.py``
+    的 handler，日志得在这里补 —— 否则「投了一半撞闸」在面板上不存在。
+
+    一次撞闸记一行（按捕获到的那个异常），不按后面合成的每条 ``rejected`` 记。
+    """
+    log_task_limit_rejection(exc, limit_scope=_task_limit_reason(exc))
+
+
+def _task_limit_rejection(scope: str, exc: _FanoutLimitError) -> dict[str, Any]:
+    """把撞闸异常翻成扇出响应里的一条 ``rejected``（M8 §8.2 冻结形状）。"""
     return {
         "scope": scope,
-        "reason": reason,
+        "reason": _task_limit_reason(exc),
         "limit": exc.limit,
         "active": exc.active,
     }
@@ -2201,6 +2213,7 @@ async def generate_sketches(
                     # 一个都没投出去＝纯粹超限：裸抛，交 api/app.py 的 handler
                     # 渲染 429 ＋ 正确的 limit_scope（M8 不变量 7）。
                     raise
+                _log_partial_dispatch_rejection(exc)
                 # 闸是全局的，后面每一个都必然被拒 —— 所以**只投这一次**（break），
                 # 但要把「当前这条 ＋ 后面还没尝试的」全部如实记进 rejected：
                 # 契约要 N−k 条（M8 :722 / :755），下游按尾段长度对齐
@@ -3178,6 +3191,7 @@ async def render_execute(
                 if not dispatched_task_ids:
                     # k == 0：裸抛交 handler 渲染 429（M8 不变量 7）。
                     raise
+                _log_partial_dispatch_rejection(exc)
                 # 只投这一次，但把未投的尾段逐条如实上报（N−k 条，M8 :722 / :755）。
                 for pending in execution_plan[position:]:
                     pending_beats = [int(beat) for beat in pending.beat_numbers]
@@ -4567,6 +4581,7 @@ async def generate_missing_manual_sketches(
                 if not dispatched_scopes:
                     # k == 0：裸抛交 handler 渲染 429（M8 不变量 7）。
                     raise
+                _log_partial_dispatch_rejection(exc)
                 # 只投这一次，但把未投的尾段逐条如实上报（N−k 条，M8 :722 / :755）。
                 for pending in segments[position:]:
                     pending_beats = [int(n) for n in pending]

--- a/src/novelvideo/task_backend/limit_logging.py
+++ b/src/novelvideo/task_backend/limit_logging.py
@@ -1,0 +1,52 @@
+"""限流拒绝的统一日志接缝。
+
+住在这里而不是 ``api/app.py``:撞闸有两条出口 —— 全局 exception handler
+(渲染 429),以及扇出循环的本地捕获(已投出 k > 0 个时吞掉异常、返回 200 ＋
+``rejected``)。日志只挂在前者就漏掉后者,而后者恰是最值得看的一类事件:
+用户拿到 200、面板上一条记录都没有。
+
+本模块只依赖 ``limits`` 里的异常定义,两条出口都能 import,不会绕成环。
+"""
+
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+# 字段顺序固定,便于 grep 与按 pattern 切分;缺失的填 "-" 而不是省略,
+# 免得下游按位置解析时错位。除 ``limit_scope`` 外全部逐字对应异常的属性名。
+_LOG_FIELDS = (
+    "limit_scope",
+    "scope_kind",
+    "org_id",
+    "queue_kind",
+    "limit",
+    "active",
+    "queued",
+    "requester_user_id",
+    "project_id",
+)
+
+
+def _render(value: object) -> str:
+    return "-" if value is None else str(value)
+
+
+def log_task_limit_rejection(exc: BaseException, *, limit_scope: str) -> None:
+    """把一次撞闸写成一行可 grep 的 WARNING。
+
+    ``limit_scope`` 由调用方给:它在两条出口各有一份算法(handler 的
+    ``limit_scope`` 与扇出的 ``rejected.reason``),两侧同算法是它们之间的
+    漂移探测器,不能在这里合并掉。其余字段一律从异常自身取,故两条出口
+    记出来的行逐字同形。只记业务 ID,不记用户名/项目名。
+    """
+    rendered = " ".join(
+        "%s=%s"
+        % (
+            name,
+            _render(limit_scope if name == "limit_scope" else getattr(exc, name, None)),
+        )
+        for name in _LOG_FIELDS
+    )
+    logger.warning("task lane limit rejected %s", rendered)

--- a/tests/test_channel_task_limit_error_surface.py
+++ b/tests/test_channel_task_limit_error_surface.py
@@ -516,10 +516,13 @@ def test_message_split_leaves_channel_handler_data_untouched() -> None:
     }
 
 
+_LIMIT_LOGGER = "novelvideo.task_backend.limit_logging"
+
 # ---------------------------------------------------------------------------
 # 5. 限流日志
 #    429 的 limit_scope 此前只活在返回体里，日志一个字不记 —— 生产上撞闸后
-#    无法归因是五道闸里的哪一道。这五个 handler 是唯一能统一覆盖全部闸门的接缝。
+#    无法归因是五道闸里的哪一道。这五个 handler 覆盖「异常逃到 HTTP 层」这条出口；
+#    扇出循环吞掉异常的那条出口另见 tests/test_fanout_partial_dispatch.py。
 # ---------------------------------------------------------------------------
 
 _LIMIT_LOG_CASES = (
@@ -620,14 +623,14 @@ def test_every_limit_handler_emits_one_attributable_warning(
     exc: RuntimeError,
     expected_fragments: tuple[str, ...],
 ) -> None:
-    caplog.set_level(logging.WARNING, logger="novelvideo.api.app")
+    caplog.set_level(logging.WARNING, logger=_LIMIT_LOGGER)
 
     _client_raising(exc).get("/_test/task-limit")
 
     records = [
         record
         for record in caplog.records
-        if record.name == "novelvideo.api.app"
+        if record.name == _LIMIT_LOGGER
         and "task lane limit rejected" in record.getMessage()
     ]
     assert len(records) == 1, "每次拒绝恰好一条，不多不少"
@@ -642,7 +645,7 @@ def test_limit_log_never_carries_names_only_ids(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """可记业务 ID，不记用户名/项目名。"""
-    caplog.set_level(logging.WARNING, logger="novelvideo.api.app")
+    caplog.set_level(logging.WARNING, logger=_LIMIT_LOGGER)
 
     _client_raising(
         ChannelTaskLimitExceeded(

--- a/tests/test_channel_task_limit_error_surface.py
+++ b/tests/test_channel_task_limit_error_surface.py
@@ -16,6 +16,7 @@
 
 from __future__ import annotations
 
+import logging
 from dataclasses import fields, is_dataclass
 from pathlib import Path
 from types import SimpleNamespace
@@ -430,3 +431,233 @@ def test_existing_limit_exceptions_are_not_downgraded_to_503_on_real_route(
     assert response.status_code != 503
     assert response.status_code == 429
     assert response.json()["data"]["limit_scope"] == expected_scope
+
+
+# ---------------------------------------------------------------------------
+# 4. 文案按作用域分叉
+#    共享池（``scope_kind == "platform"``）拦下的是不归属任何渠道的请求，
+#    对他们说"渠道"没有对应概念，配套的等待指引也无从执行。
+# ---------------------------------------------------------------------------
+
+
+def test_platform_scope_message_avoids_channel_wording() -> None:
+    response = _client_raising(
+        ChannelTaskLimitExceeded(
+            scope_kind="platform",
+            org_id=None,
+            queue_kind="default",
+            limit=32,
+            active=32,
+        )
+    ).get("/_test/task-limit")
+
+    message = response.json()["error"]
+    assert "渠道" not in message
+    assert "组织" not in message
+    assert "平台" in message
+    assert "default" in message
+    # 共享池是全平台共用的，撞闸的人自己可能一个任务都没在跑 ——
+    # 让他"等待已有任务完成"是条不可行动的指引。
+    assert "等待已有任务完成" not in message
+
+
+def test_organization_scope_message_keeps_channel_wording() -> None:
+    response = _client_raising(
+        ChannelTaskLimitExceeded(
+            scope_kind="organization",
+            org_id="org_9",
+            queue_kind="video",
+            limit=2,
+            active=2,
+        )
+    ).get("/_test/task-limit")
+
+    assert response.json()["error"] == (
+        "当前渠道 video 队列任务已满，请等待已有任务完成后再提交"
+    )
+
+
+def test_message_split_leaves_channel_handler_data_untouched() -> None:
+    """分叉只动 error 文案，data 两个作用域都逐字未变。"""
+    platform = _client_raising(
+        ChannelTaskLimitExceeded(
+            scope_kind="platform",
+            org_id=None,
+            queue_kind="world",
+            limit=8,
+            active=8,
+        )
+    ).get("/_test/task-limit")
+    assert platform.json()["data"] == {
+        "scope_kind": "platform",
+        "org_id": None,
+        "queue_kind": "world",
+        "limit": 8,
+        "active": 8,
+        "limit_scope": "platform",
+    }
+
+    organization = _client_raising(
+        ChannelTaskLimitExceeded(
+            scope_kind="organization",
+            org_id="org_9",
+            queue_kind="world",
+            limit=8,
+            active=8,
+        )
+    ).get("/_test/task-limit")
+    assert organization.json()["data"] == {
+        "scope_kind": "organization",
+        "org_id": "org_9",
+        "queue_kind": "world",
+        "limit": 8,
+        "active": 8,
+        "limit_scope": "channel",
+    }
+
+
+# ---------------------------------------------------------------------------
+# 5. 限流日志
+#    429 的 limit_scope 此前只活在返回体里，日志一个字不记 —— 生产上撞闸后
+#    无法归因是五道闸里的哪一道。这五个 handler 是唯一能统一覆盖全部闸门的接缝。
+# ---------------------------------------------------------------------------
+
+_LIMIT_LOG_CASES = (
+    (
+        ProjectTaskLimitExceeded(
+            project_id="proj_1", queue_kind="video", limit=4, active=4
+        ),
+        (
+            "limit_scope=project",
+            "queue_kind=video",
+            "limit=4",
+            "active=4",
+            "project_id=proj_1",
+        ),
+    ),
+    (
+        ProjectUserTaskLimitExceeded(
+            project_id="proj_1",
+            requester_user_id="user_1",
+            queue_kind="video",
+            limit=1,
+            active=1,
+        ),
+        (
+            "limit_scope=user",
+            "requester_user_id=user_1",
+            "project_id=proj_1",
+        ),
+    ),
+    (
+        GlobalLaneQueueLimitExceeded(
+            project_id="proj_1", queue_kind="world", limit=2, queued=2
+        ),
+        (
+            "limit_scope=global_lane_queue",
+            "queued=2",
+            "project_id=proj_1",
+        ),
+    ),
+    (
+        ChannelTaskLimitExceeded(
+            scope_kind="platform",
+            org_id=None,
+            queue_kind="default",
+            limit=32,
+            active=32,
+        ),
+        (
+            "limit_scope=platform",
+            "scope_kind=platform",
+            "org_id=-",
+            "queue_kind=default",
+            "limit=32",
+            "active=32",
+        ),
+    ),
+    (
+        ChannelTaskLimitExceeded(
+            scope_kind="organization",
+            org_id="org_9",
+            queue_kind="video",
+            limit=2,
+            active=2,
+        ),
+        (
+            "limit_scope=channel",
+            "scope_kind=organization",
+            "org_id=org_9",
+        ),
+    ),
+    (
+        UserTaskLimitExceeded(
+            requester_user_id="user_7", queue_kind="default", limit=1, active=1
+        ),
+        (
+            "limit_scope=user",
+            "requester_user_id=user_7",
+            "queue_kind=default",
+        ),
+    ),
+)
+
+
+@pytest.mark.parametrize(
+    ("exc", "expected_fragments"),
+    _LIMIT_LOG_CASES,
+    ids=[
+        "project",
+        "project_user",
+        "global_lane_queue",
+        "channel_platform",
+        "channel_organization",
+        "user",
+    ],
+)
+def test_every_limit_handler_emits_one_attributable_warning(
+    caplog: pytest.LogCaptureFixture,
+    exc: RuntimeError,
+    expected_fragments: tuple[str, ...],
+) -> None:
+    caplog.set_level(logging.WARNING, logger="novelvideo.api.app")
+
+    _client_raising(exc).get("/_test/task-limit")
+
+    records = [
+        record
+        for record in caplog.records
+        if record.name == "novelvideo.api.app"
+        and "task lane limit rejected" in record.getMessage()
+    ]
+    assert len(records) == 1, "每次拒绝恰好一条，不多不少"
+
+    message = records[0].getMessage()
+    assert records[0].levelno == logging.WARNING
+    for fragment in expected_fragments:
+        assert fragment in message, f"{fragment!r} 不在 {message!r} 里"
+
+
+def test_limit_log_never_carries_names_only_ids(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """可记业务 ID，不记用户名/项目名。"""
+    caplog.set_level(logging.WARNING, logger="novelvideo.api.app")
+
+    _client_raising(
+        ChannelTaskLimitExceeded(
+            scope_kind="organization",
+            org_id="org_9",
+            queue_kind="video",
+            limit=2,
+            active=2,
+        )
+    ).get("/_test/task-limit")
+
+    message = next(
+        record.getMessage()
+        for record in caplog.records
+        if "task lane limit rejected" in record.getMessage()
+    )
+    assert "username" not in message
+    assert "project_name" not in message

--- a/tests/test_fanout_partial_dispatch.py
+++ b/tests/test_fanout_partial_dispatch.py
@@ -27,6 +27,7 @@
 
 from __future__ import annotations
 
+import logging
 from types import SimpleNamespace
 
 import pytest
@@ -886,3 +887,117 @@ def test_rejected_reason_matches_the_handler_limit_scope_verbatim(
     from_handler = refused.json()["data"]["limit_scope"]
 
     assert from_loop == from_handler == reason
+
+
+# ---------------------------------------------------------------------------
+# 部分投递撞闸也要留下可归因日志
+#   k > 0 时异常被本地吞掉、响应是 200 ＋ ``rejected``，永远走不到 ``api/app.py``
+#   的 handler。日志若只挂在 handler 上，漏掉的恰是「投了一半撞闸」这类线上事件 ——
+#   用户拿到 200、面板上一条记录都没有。
+# ---------------------------------------------------------------------------
+
+_LIMIT_LOGGER = "novelvideo.task_backend.limit_logging"
+
+
+def _limit_log_records(caplog: pytest.LogCaptureFixture) -> list[logging.LogRecord]:
+    return [
+        record
+        for record in caplog.records
+        if record.name == _LIMIT_LOGGER
+        and "task lane limit rejected" in record.getMessage()
+    ]
+
+
+def _assert_single_rejection_log(
+    caplog: pytest.LogCaptureFixture, exc, reason: str
+) -> None:
+    records = _limit_log_records(caplog)
+    assert len(records) == 1, "按捕获到的那一个异常记一次，不按 rejected 逐条刷屏"
+    message = records[0].getMessage()
+    assert records[0].levelno == logging.WARNING
+    assert f"limit_scope={reason}" in message
+    assert f"queue_kind={exc.queue_kind}" in message
+    assert f"limit={exc.limit}" in message
+
+
+@pytest.mark.parametrize(("exc", "reason", "_scope"), _GATE_CASES, ids=_GATE_IDS)
+def test_loop1_partial_dispatch_logs_one_attributable_rejection(
+    caplog, monkeypatch, tmp_path, exc, reason, _scope
+) -> None:
+    caplog.set_level(logging.WARNING, logger=_LIMIT_LOGGER)
+    backend = _GateBackend(exc, fail_from=4)
+
+    response = _post_sketches(_sketch_client(monkeypatch, tmp_path, backend, grids=6))
+
+    assert response.status_code == 200
+    assert len(response.json()["data"]["rejected"]) == 3
+    _assert_single_rejection_log(caplog, exc, reason)
+
+
+@pytest.mark.parametrize(("exc", "reason", "_scope"), _GATE_CASES, ids=_GATE_IDS)
+def test_loop2_partial_dispatch_logs_one_attributable_rejection(
+    caplog, monkeypatch, tmp_path, exc, reason, _scope
+) -> None:
+    caplog.set_level(logging.WARNING, logger=_LIMIT_LOGGER)
+    backend = _GateBackend(exc, fail_from=4)
+
+    _plan, response = _render_execute(
+        _render_client(monkeypatch, tmp_path, backend), [1, 2, 3, 4, 5, 6]
+    )
+
+    assert response.status_code == 200, response.text
+    assert len(response.json()["data"]["rejected"]) == 3
+    _assert_single_rejection_log(caplog, exc, reason)
+
+
+@pytest.mark.parametrize(("exc", "reason", "_scope"), _GATE_CASES, ids=_GATE_IDS)
+def test_loop3_partial_dispatch_logs_one_attributable_rejection(
+    caplog, monkeypatch, tmp_path, exc, reason, _scope
+) -> None:
+    caplog.set_level(logging.WARNING, logger=_LIMIT_LOGGER)
+    backend = _GateBackend(exc, fail_from=4)
+    segments = [[1], [2], [3], [4], [5], [6]]
+
+    response = _post_missing_manual(
+        _manual_client(monkeypatch, tmp_path, backend, segments)
+    )
+
+    assert response.status_code == 200, response.text
+    assert len(response.json()["data"]["rejected"]) == 3
+    _assert_single_rejection_log(caplog, exc, reason)
+
+
+def test_partial_dispatch_log_carries_the_gate_identity_not_the_tail_length(
+    caplog, monkeypatch, tmp_path
+) -> None:
+    """一次撞闸一行，字段来自异常本身（org_id / active），与 ``rejected`` 条数无关。"""
+    caplog.set_level(logging.WARNING, logger=_LIMIT_LOGGER)
+    backend = _GateBackend(_CHANNEL_GATE, fail_from=2)
+
+    response = _post_sketches(_sketch_client(monkeypatch, tmp_path, backend, grids=6))
+
+    assert response.status_code == 200
+    assert len(response.json()["data"]["rejected"]) == 5
+    records = _limit_log_records(caplog)
+    assert len(records) == 1
+    message = records[0].getMessage()
+    assert "limit_scope=channel" in message
+    assert "scope_kind=organization" in message
+    assert f"org_id={_CHANNEL_GATE.org_id}" in message
+    assert f"active={_CHANNEL_GATE.active}" in message
+
+
+@pytest.mark.parametrize(("exc", "_reason", "scope"), _GATE_CASES, ids=_GATE_IDS)
+def test_k_zero_still_logs_exactly_once_through_the_handler(
+    caplog, monkeypatch, tmp_path, exc, _reason, scope
+) -> None:
+    """k == 0 走裸抛：只有 handler 记那一次，扇出侧不得抢在 ``raise`` 前重复记。"""
+    caplog.set_level(logging.WARNING, logger=_LIMIT_LOGGER)
+    backend = _GateBackend(exc, fail_from=1)
+
+    response = _post_sketches(_sketch_client(monkeypatch, tmp_path, backend, grids=4))
+
+    assert response.status_code == 429
+    records = _limit_log_records(caplog)
+    assert len(records) == 1, "裸抛路径只该由 handler 记一次"
+    assert f"limit_scope={scope}" in records[0].getMessage()


### PR DESCRIPTION
## 背景

限流面两处问题，都只动 `src/novelvideo/api/app.py` 的异常 handler，不改任何限流逻辑、不改 `data` 返回结构。

## 改动 1 · 共享池的 429 文案

`ChannelTaskLimitExceeded` 的 429 文案对两个 `scope_kind` 一视同仁，都写「当前渠道 … 队列任务已满，请等待已有任务完成后再提交」。但共享池（`scope_kind == "platform"`、`org_id is None`）拦下的是**不归属任何渠道**的请求：

- 对他们说「渠道」没有对应概念；
- 池子是全平台共用的，「等待已有任务完成」也无从执行——撞闸的人自己可能一个任务都没在跑。

共享池改为「当前平台 `{lane}` 队列任务已满，请稍后再试」。**另一个作用域的文案逐字不变**，两个作用域的 `data` 返回体也逐字不变。

顺带把重复出现的 `limit_scope` 三元判断收成一个变量，避免文案与作用域两处判断将来漂移。

## 改动 2 · 限流拒绝日志

`limit_scope` 此前只活在 429 返回体里，日志一个字不记——线上撞闸后无法归因是五道闸里的哪一道。现在每次拒绝写一行可 grep 的 WARNING：

```
task lane limit rejected limit_scope=platform scope_kind=platform org_id=- queue_kind=default limit=32 active=32 queued=- requester_user_id=- project_id=-
task lane limit rejected limit_scope=channel scope_kind=organization org_id=… queue_kind=video limit=2 active=2 queued=- requester_user_id=- project_id=-
task lane limit rejected limit_scope=user scope_kind=- org_id=- queue_kind=default limit=1 active=1 queued=- requester_user_id=… project_id=-
```

覆盖全部五个 handler：`project` / `user`（项目内）/ `global_lane_queue` / `platform` / `channel`。字段位置固定、缺失填 `-`，只记业务 ID，不记用户名/项目名（有测试钉住）。

日志落在 handler 而不是任何单个预留调用点：这五个 handler 是唯一能统一覆盖全部闸门的接缝（三道项目级 + 两道渠道级）。

## 测试

`tests/test_channel_task_limit_error_surface.py` 新增两节共 10 条，先 RED（8 failed / 2 passed，通过的 2 条正是「行为不该变」的既有文案与 `data` 逐字断言）后 GREEN：

- 共享池文案不含「渠道 / 组织」、含「平台」、不含「等待已有任务完成」
- 另一作用域文案逐字不变
- 两个作用域的 `data` 逐字不变
- 六个异常实例各自恰好产出一条 `novelvideo.api.app` 的 WARNING，字段片段逐个断言
- 日志只带 ID、不带名称

本地：目标文件 26 passed；`test_freezone_image_backend` / `test_scene_task_start_errors` / `test_fanout_partial_dispatch` 共 266 passed；`ruff check` 干净（两个文件都不在 per-file-ignores 里）；`ce_allowlist` / `lint_ee_terms` / `lint_banned_words` / `lint_ce_imports` 四个守栏本地全过。

## 部署顺序

改动 2 的日志行是限流可观测面板的数据源，面板要等这个版本部署后才有数据。
