### PR TITLE
fix: close scene pano model injection

### DIFF
--- a/frontend/src/api/ops.ts
+++ b/frontend/src/api/ops.ts
@@ -1772,8 +1772,7 @@ export interface FreezoneScene360Payload {
  * **单图 360 (simple pipeline)** — 老路径,只把一张图当 reference 走通用
  * 图编辑生成 panorama。不做 master/reverse overlap 分析、空间合约、缝合,
  * 适合 freezone 自由画布上 \"拿任一张图试试 360\" 的快速生成。
- * Asset-scoped scene 360 generation uses
- * {@link submitFreezoneScene360FromMaster} (复杂工作流),不是这条。
+ * Asset-scoped scene 360 generation uses the scenes asset API (复杂工作流),不是这条。
  */
 export async function submitFreezoneScene360(
   project: string,
@@ -1797,75 +1796,6 @@ export async function submitFreezoneScene360(
       },
     },
   );
-}
-
-// /scenes/{name}/pano/generate-async --------------------------------------- //
-
-export interface ScenePanoFromMasterPayload {
-  sceneId: string;
-  /** 后端会自动 fallback 到 text 如果 master 不存在;FE 默认传 'master'。 */
-  source?: "master" | "text";
-  style?: string;
-  provider?: string;
-  model?: string;
-  imageSize?: string;
-  quality?: string;
-  timeoutSeconds?: number;
-}
-
-/**
- * **复杂场景 360 工作流 (complex pipeline)** — 走 stage_asset
- * `pano_from_master` step:
- *  - 读 scene 的 master + reverse_master 文件
- *  - 跑 overlap analyzer (master/reverse 边缘融合分析)
- *  - 跑 spatial contract analyzer (空间合约)
- *  - 调 BuilderGPT/supertale_scene_360_gpt_image2.py 生成 pano_360.png
- *  - 写到 stage_manifest canonical 路径 (跟资产画布 pano viewer 同一份文件)
- *
- * Asset-scoped scene 360 generation uses this complex path, not the simple
- * `/freezone/scene-360` endpoint.
- *
- * 注: 走的是 scenes 路由 (不是 freezone 路由),所以返回的是
- * `{ok, task_type:"stage_asset", task_key, scope, task_id, backend}` 结构 —
- * cast 成 FreezoneJobRef shape (task_key + job_id + task_type) 给上层用。
- */
-export async function submitFreezoneScene360FromMaster(
-  project: string,
-  payload: ScenePanoFromMasterPayload,
-): Promise<FreezoneJobRef> {
-  const sceneId = payload.sceneId;
-  if (!sceneId) throw new Error("submitFreezoneScene360FromMaster: missing sceneId");
-  const result = await apiCall<{
-    ok: boolean;
-    task_type: string;
-    task_key: string;
-    task_id?: string;
-    scope?: string;
-    backend?: string;
-    error?: string;
-  }>(
-    `projects/${encodeURIComponent(project)}/scenes/${encodeURIComponent(sceneId)}/pano/generate-async`,
-    {
-      method: "POST",
-      json: {
-        source: payload.source ?? "master",
-        ...(payload.style ? { style: payload.style } : {}),
-        ...(payload.provider ? { provider: payload.provider } : {}),
-        ...(payload.model ? { model: payload.model } : {}),
-        ...(payload.imageSize ? { image_size: payload.imageSize } : {}),
-        ...(payload.quality ? { quality: payload.quality } : {}),
-        ...(payload.timeoutSeconds ? { timeout_seconds: payload.timeoutSeconds } : {}),
-      },
-    },
-  );
-  if (!result.ok || result.error) {
-    throw new Error(result.error ?? "scene 360 from master failed");
-  }
-  return {
-    task_key: result.task_key,
-    job_id: result.task_id ?? result.scope ?? sceneId,
-    task_type: "stage_asset",
-  } as FreezoneJobRef;
 }
 
 // /freezone/template-edit ------------------------------------------------- //

--- a/src/novelvideo/api/routes/freezone.py
+++ b/src/novelvideo/api/routes/freezone.py
@@ -2018,6 +2018,7 @@ async def _start_or_enqueue_mainline_scene_360_candidate_job(
     canvas_id: str | None,
     node_id: str | None,
     catalog_id: str | None = None,
+    execution_catalog_id: str | None = None,
     task_display: dict[str, str] | None = None,
 ) -> dict:
     return await _start_or_enqueue_mainline_scene_360_task(
@@ -2033,6 +2034,7 @@ async def _start_or_enqueue_mainline_scene_360_candidate_job(
         canvas_id=canvas_id,
         node_id=node_id,
         catalog_id=catalog_id,
+        execution_catalog_id=execution_catalog_id,
         auto_commit=False,
         task_display=task_display,
     )
@@ -2052,6 +2054,7 @@ async def _start_or_enqueue_mainline_scene_360_task(
     canvas_id: str | None,
     node_id: str | None,
     catalog_id: str | None = None,
+    execution_catalog_id: str | None = None,
     auto_commit: bool = True,
     task_display: dict[str, str] | None = None,
 ) -> dict:
@@ -2125,6 +2128,20 @@ async def _start_or_enqueue_mainline_scene_360_task(
             "canvas_id": canvas_id or "",
             "node_id": node_id or "",
             "billing": billing,
+            **(
+                {
+                    "scene_360_model_authority": {
+                        "kind": "catalog",
+                        "catalog_id": execution_catalog_id,
+                        "provider": resolved_provider or "newapi",
+                        "model": resolved_model
+                        or model
+                        or FREEZONE_DEFAULT_IMAGE_MODEL,
+                    }
+                }
+                if execution_catalog_id
+                else {}
+            ),
             "task_family": "mainline_skill",
             "task_label": "生成 360 全景",
             "display_name": f"生成 360 全景 · {scene_id}",
@@ -4685,6 +4702,10 @@ async def freezone_scene_360(
         "quality": body.quality,
         # 计费身份以目录条目为准，不采信 body —— 它直接决定按哪条目录规则扣费。
         "catalog_id": _catalog_entry_id(catalog_entry) or body.catalog_id or None,
+        # Only an entry resolved by the server catalog may authorize a dynamic
+        # execution model. A client-supplied legacy catalog_id is billing data,
+        # not model authority.
+        "execution_catalog_id": _catalog_entry_id(catalog_entry) or None,
         "canvas_id": body.canvas_id or None,
         "node_id": body.node_id or None,
         "task_display": {

--- a/src/novelvideo/api/routes/freezone.py
+++ b/src/novelvideo/api/routes/freezone.py
@@ -2085,6 +2085,19 @@ async def _start_or_enqueue_mainline_scene_360_task(
         "newapi",
         model or FREEZONE_DEFAULT_IMAGE_MODEL,
     )
+    if not execution_catalog_id:
+        from novelvideo.stage_asset_tasks import (
+            Scene360ImageModelSelectionError,
+            resolve_scene_360_image_model,
+        )
+
+        try:
+            resolve_scene_360_image_model(
+                resolved_provider or "newapi",
+                resolved_model or model or FREEZONE_DEFAULT_IMAGE_MODEL,
+            )
+        except Scene360ImageModelSelectionError as exc:
+            raise HTTPException(400, str(exc)) from exc
     from novelvideo.api.routes.model_credits import freezone_image_task_billing
 
     billing = freezone_image_task_billing(

--- a/src/novelvideo/api/routes/scenes.py
+++ b/src/novelvideo/api/routes/scenes.py
@@ -1535,13 +1535,9 @@ async def generate_scene_pano(
 
     params: dict[str, Any] = {
         "description": _scene_360_description(scene),
-        "style": body.style or _project_style(username, project_name),
-        "timeout_seconds": body.timeout_seconds,
+        "style": _project_style(username, project_name),
+        "timeout_seconds": 1800,
     }
-    for key in ("provider", "model", "image_size", "quality"):
-        value = getattr(body, key)
-        if value:
-            params[key] = value
 
     try:
         scope, queued = await _start_or_enqueue_scene_pano(

--- a/src/novelvideo/api/schemas.py
+++ b/src/novelvideo/api/schemas.py
@@ -1979,13 +1979,9 @@ class SceneUpdate(BaseModel):
 
 
 class ScenePanoGenerateRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
     source: Literal["master", "text"] = "master"
-    style: Optional[str] = None
-    provider: Optional[str] = None
-    model: Optional[str] = None
-    image_size: Optional[str] = None
-    quality: Optional[str] = None
-    timeout_seconds: int = 1800
 
 
 class SceneReferenceGenerateRequest(BaseModel):

--- a/src/novelvideo/stage_asset_tasks.py
+++ b/src/novelvideo/stage_asset_tasks.py
@@ -22,6 +22,7 @@ import shutil
 import subprocess
 import sys
 import threading
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Callable
@@ -233,6 +234,21 @@ def resolve_scene_360_image_provider(provider: str = "") -> str:
 
 class Scene360ImageModelSelectionError(ValueError):
     """Raised when a scene 360 model selection is unknown or uses another provider."""
+
+
+@dataclass(frozen=True, slots=True)
+class Scene360CatalogModelAuthority:
+    """Catalog model identity recovered from a verified task envelope."""
+
+    catalog_id: str
+    provider: str
+    model: str
+
+    def __post_init__(self) -> None:
+        for field_name in ("catalog_id", "provider", "model"):
+            value = getattr(self, field_name)
+            if type(value) is not str or not value.strip():
+                raise ValueError(f"{field_name} is required")
 
 
 def resolve_scene_360_image_model(provider: str = "", model: str = "") -> str:
@@ -1187,6 +1203,7 @@ def run_scene_360(
     update_manifest: bool = True,
     timeout_seconds: int = 1800,
     progress_callback: Callable[[float, str], None] | None = None,
+    model_authority: Scene360CatalogModelAuthority | None = None,
     _manage_model_credit: bool = True,
     egress_context: TrustedEgressContext | None = None,
 ) -> dict[str, Any]:
@@ -1219,7 +1236,25 @@ def run_scene_360(
     generation_dir.mkdir(parents=True, exist_ok=True)
 
     provider = resolve_scene_360_image_provider(provider)
-    resolved_model = resolve_scene_360_image_model(provider=provider, model=model)
+    requested_model = str(model or "").strip()
+    if model_authority is None:
+        resolved_model = resolve_scene_360_image_model(
+            provider=provider,
+            model=requested_model,
+        )
+    else:
+        if type(model_authority) is not Scene360CatalogModelAuthority:
+            raise TypeError(
+                "model_authority must be a Scene360CatalogModelAuthority"
+            )
+        if (
+            model_authority.provider.strip().lower() != provider
+            or model_authority.model.strip() != requested_model
+        ):
+            raise Scene360ImageModelSelectionError(
+                "scene 360 catalog model authority does not match execution model"
+            )
+        resolved_model = model_authority.model.strip()
     style = (style or os.environ.get("SCENE_360_STYLE") or "realistic").strip()
     image_size = (image_size or os.environ.get("SCENE_360_IMAGE_SIZE") or "2K").strip()
     quality = (

--- a/src/novelvideo/stage_asset_tasks.py
+++ b/src/novelvideo/stage_asset_tasks.py
@@ -231,6 +231,10 @@ def resolve_scene_360_image_provider(provider: str = "") -> str:
     )
 
 
+class Scene360ImageModelSelectionError(ValueError):
+    """Raised when a scene 360 model selection is unknown or uses another provider."""
+
+
 def resolve_scene_360_image_model(provider: str = "", model: str = "") -> str:
     """Return the model used by scene 360 image generation."""
     resolved_provider = resolve_scene_360_image_provider(provider)
@@ -239,9 +243,24 @@ def resolve_scene_360_image_model(provider: str = "", model: str = "") -> str:
         from novelvideo.config import IMAGE_GENERATION_SELECTIONS
 
         selection = IMAGE_GENERATION_SELECTIONS.get(resolved_model)
-        if selection and selection.get("provider") == resolved_provider:
+        if selection is not None:
+            selection_provider = str(selection.get("provider") or "").strip().lower()
+            if selection_provider != resolved_provider:
+                raise Scene360ImageModelSelectionError(
+                    f"scene 360 image model selection {resolved_model} does not use provider "
+                    f"{resolved_provider}"
+                )
             return str(selection.get("model") or "").strip()
-        return resolved_model
+
+        for registered in IMAGE_GENERATION_SELECTIONS.values():
+            registered_provider = str(registered.get("provider") or "").strip().lower()
+            registered_model = str(registered.get("model") or "").strip()
+            if registered_provider == resolved_provider and registered_model == resolved_model:
+                return registered_model
+
+        raise Scene360ImageModelSelectionError(
+            f"unknown scene 360 image model selection: {resolved_model}"
+        )
     if resolved_provider in {"huimeng", "huimengi"}:
         return (
             os.environ.get("SCENE_360_HUIMENG_MODEL")

--- a/src/novelvideo/task_backend/runners/stage_asset.py
+++ b/src/novelvideo/task_backend/runners/stage_asset.py
@@ -190,6 +190,37 @@ def run_stage_asset(
     elif step in {"pano_from_master", "pano_from_text"}:
         source = "master" if step == "pano_from_master" else "text"
         artifact_dir = params.get("artifact_dir")
+        authority_payload = payload.get("scene_360_model_authority")
+        model_authority = None
+        if authority_payload is not None:
+            if (
+                type(envelope) is not TrustedRunnerEnvelope
+                or type(authority_payload) is not dict
+                or set(authority_payload)
+                != {"kind", "catalog_id", "provider", "model"}
+                or authority_payload.get("kind") != "catalog"
+            ):
+                raise InvalidTaskEnvelope() from None
+            catalog_id = authority_payload.get("catalog_id")
+            authority_provider = authority_payload.get("provider")
+            authority_model = authority_payload.get("model")
+            if any(
+                type(value) is not str or not value.strip()
+                for value in (catalog_id, authority_provider, authority_model)
+            ):
+                raise InvalidTaskEnvelope() from None
+            if (
+                authority_provider.strip().lower()
+                != str(params.get("provider") or "").strip().lower()
+                or authority_model.strip()
+                != str(params.get("model") or "").strip()
+            ):
+                raise InvalidTaskEnvelope() from None
+            model_authority = stage_asset_tasks.Scene360CatalogModelAuthority(
+                catalog_id=catalog_id.strip(),
+                provider=authority_provider.strip().lower(),
+                model=authority_model.strip(),
+            )
         result = stage_asset_tasks.run_scene_360(
             project_dir,
             scene_name,
@@ -214,6 +245,7 @@ def run_stage_asset(
                 int(params.get("timeout_seconds", 1800))
             ),
             progress_callback=update,
+            model_authority=model_authority,
             egress_context=_extract_trusted_egress_context(envelope),
         )
     else:

--- a/tests/contract/test_m05_route_contracts.py
+++ b/tests/contract/test_m05_route_contracts.py
@@ -465,6 +465,53 @@ def _assert_task_shape(payload: dict, *, backend: str, task_type: str):
     assert "celery_queue" not in payload
 
 
+@pytest.mark.parametrize(
+    "removed_field,value",
+    [
+        ("provider", "newapi"),
+        ("model", "newapi_gpt_image2"),
+        ("image_size", "4K"),
+        ("quality", "high"),
+        ("style", "cinematic"),
+        ("timeout_seconds", 7200),
+    ],
+)
+def test_scene_pano_rejects_removed_execution_fields_before_enqueue(
+    m05_client_factory, removed_field, value
+):
+    client, task_backend, _project_dir, _store = m05_client_factory()
+
+    response = client.post(
+        f"/api/v1/projects/{_PROJECT}/scenes/{_SCENE}/pano/generate-async",
+        json={"source": "text", removed_field: value},
+    )
+
+    assert response.status_code == 422
+    assert task_backend.calls == []
+
+
+@pytest.mark.parametrize(
+    ("master_exists", "expected_step"),
+    [(True, "pano_from_master"), (False, "pano_from_text")],
+)
+def test_scene_pano_derives_source_from_server_asset_state(
+    m05_client_factory, master_exists, expected_step
+):
+    client, task_backend, project_dir, _store = m05_client_factory()
+    master_path = project_dir / "assets" / "scenes" / _SCENE / "master.png"
+    if master_exists:
+        master_path.parent.mkdir(parents=True, exist_ok=True)
+        master_path.write_bytes(_png_bytes())
+
+    response = client.post(
+        f"/api/v1/projects/{_PROJECT}/scenes/{_SCENE}/pano/generate-async",
+        json={"source": "master"},
+    )
+
+    assert response.status_code == 200
+    assert task_backend.calls[-1]["payload"]["step"] == expected_step
+
+
 def _seed_labels(project_dir: Path) -> None:
     labels_dir = project_dir / "verify_reports" / "ep001"
     labels_dir.mkdir(parents=True, exist_ok=True)

--- a/tests/test_freezone_image_backend.py
+++ b/tests/test_freezone_image_backend.py
@@ -46,6 +46,7 @@ from novelvideo.shared.billing_errors import (
     BillingRuleNotConfiguredError,
     InsufficientCreditsError,
 )
+from novelvideo.stage_asset_tasks import resolve_scene_360_image_model
 from novelvideo.task_backend.limits import ProjectUserTaskLimitExceeded
 from novelvideo.task_state import get_task_manager
 
@@ -6775,6 +6776,10 @@ async def test_skill_run_scene_360_uses_reverse_master_and_scene_slot_target(
     assert captured["payload"]["step"] == "pano_from_master"
     assert captured["payload"]["params"]["provider"] == "newapi"
     assert captured["payload"]["params"]["model"] == NEWAPI_IMAGE_MODEL
+    assert resolve_scene_360_image_model(
+        provider=captured["payload"]["params"]["provider"],
+        model=captured["payload"]["params"]["model"],
+    ) == NEWAPI_IMAGE_MODEL
     assert captured["payload"]["params"]["image_size"] == "2K"
     assert captured["payload"]["params"]["update_manifest"] is False
     assert captured["payload"]["params"]["master_path"].endswith("/assets/scenes/小区/master.png")

--- a/tests/test_freezone_image_backend.py
+++ b/tests/test_freezone_image_backend.py
@@ -4134,7 +4134,23 @@ async def test_scene_360_endpoint_keeps_image_size_below_the_cap(
             queue="node.node_a.world",
         )
 
+    async def fake_resolve_catalog_request(*_args, **_kwargs):
+        return (
+            {},
+            {},
+            {
+                "catalogId": "cat-77",
+                "providerId": "newapi",
+                "apiModel": "google/gemini-2.5-flash-image-preview",
+            },
+        )
+
     monkeypatch.setattr(freezone_routes, "_resolve_freezone_project", fake_resolve_freezone_project)
+    monkeypatch.setattr(
+        freezone_routes,
+        "_resolve_catalog_request",
+        fake_resolve_catalog_request,
+    )
     monkeypatch.setattr(
         freezone_routes,
         "get_task_backend",
@@ -4271,7 +4287,7 @@ async def test_scene_360_takes_model_and_billing_identity_from_the_catalog(
 
 
 @pytest.mark.asyncio
-async def test_scene_360_does_not_trust_client_catalog_id_as_model_authority(
+async def test_scene_360_rejects_client_model_without_catalog_authority_before_enqueue(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -4285,17 +4301,22 @@ async def test_scene_360_does_not_trust_client_catalog_id_as_model_authority(
         freezone_routes, "_resolve_catalog_request", fake_resolve_catalog_request
     )
 
-    await freezone_routes.freezone_scene_360(
-        project="proj_freezone",
-        body=freezone_routes.FreezoneScene360Request(
-            reference_url="/api/v1/projects/proj_freezone/media/assets/scenes/小区/master.png",
-            model="attacker-controlled-model",
-            catalog_id="forged-catalog",
-        ),
-        user={"username": "admin"},
-    )
+    with pytest.raises(HTTPException) as exc_info:
+        await freezone_routes.freezone_scene_360(
+            project="proj_freezone",
+            body=freezone_routes.FreezoneScene360Request(
+                reference_url=(
+                    "/api/v1/projects/proj_freezone/media/assets/scenes/小区/master.png"
+                ),
+                model="attacker-controlled-model",
+                catalog_id="forged-catalog",
+            ),
+            user={"username": "admin"},
+        )
 
-    assert "scene_360_model_authority" not in captured["payload"]
+    assert exc_info.value.status_code == 400
+    assert "scene 360 image model" in str(exc_info.value.detail)
+    assert not captured
 
 
 @pytest.mark.asyncio

--- a/tests/test_freezone_image_backend.py
+++ b/tests/test_freezone_image_backend.py
@@ -4260,8 +4260,42 @@ async def test_scene_360_takes_model_and_billing_identity_from_the_catalog(
     )
 
     assert captured["payload"]["params"]["model"] == "real-pano-model"
+    assert captured["payload"]["scene_360_model_authority"] == {
+        "kind": "catalog",
+        "catalog_id": "cat-real",
+        "provider": "newapi",
+        "model": "real-pano-model",
+    }
     assert captured["payload"]["billing"]["catalog_id"] == "cat-real"
     assert captured["payload"]["billing"]["pricing_model"] == "real-pano-model"
+
+
+@pytest.mark.asyncio
+async def test_scene_360_does_not_trust_client_catalog_id_as_model_authority(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict = {}
+    _patch_scene_360_enqueue(monkeypatch, tmp_path, captured)
+
+    async def fake_resolve_catalog_request(*_args, **_kwargs):
+        return {}, {}, None
+
+    monkeypatch.setattr(
+        freezone_routes, "_resolve_catalog_request", fake_resolve_catalog_request
+    )
+
+    await freezone_routes.freezone_scene_360(
+        project="proj_freezone",
+        body=freezone_routes.FreezoneScene360Request(
+            reference_url="/api/v1/projects/proj_freezone/media/assets/scenes/小区/master.png",
+            model="attacker-controlled-model",
+            catalog_id="forged-catalog",
+        ),
+        user={"username": "admin"},
+    )
+
+    assert "scene_360_model_authority" not in captured["payload"]
 
 
 @pytest.mark.asyncio

--- a/tests/test_p0g4l_scene_360_subprocess_egress.py
+++ b/tests/test_p0g4l_scene_360_subprocess_egress.py
@@ -630,6 +630,140 @@ def test_stage_asset_runner_passes_envelope_context_through(
     assert seen == [context]
 
 
+def test_stage_asset_runner_passes_signed_catalog_model_authority(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    from novelvideo import stage_asset_tasks
+
+    runner_module = _quiet_runner(monkeypatch)
+    context = _egress_context(kind="organization")
+    seen: list[object] = []
+
+    def spy(*_args, **kwargs):
+        seen.append(kwargs.get("model_authority"))
+        return {"ok": True, "scene_id": "scene-360"}
+
+    monkeypatch.setattr(stage_asset_tasks, "run_scene_360", spy)
+
+    runner_module.run_stage_asset(
+        _envelope(
+            {
+                "scene_name": "scene-360",
+                "step": "pano_from_text",
+                "params": {
+                    "provider": "newapi",
+                    "model": "organization-authorized-pano-model",
+                },
+                "scene_360_model_authority": {
+                    "kind": "catalog",
+                    "catalog_id": "catalog-pano",
+                    "provider": "newapi",
+                    "model": "organization-authorized-pano-model",
+                },
+                "project_dir": str(tmp_path),
+            },
+            context,
+        ),
+        _ctx(tmp_path),
+    )
+
+    assert len(seen) == 1
+    authority = seen[0]
+    assert authority is not None
+    assert (
+        authority.catalog_id,
+        authority.provider,
+        authority.model,
+    ) == (
+        "catalog-pano",
+        "newapi",
+        "organization-authorized-pano-model",
+    )
+
+
+def test_stage_asset_runner_rejects_catalog_authority_from_plain_envelope(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    from novelvideo import stage_asset_tasks
+    from novelvideo.task_backend.envelope import InvalidTaskEnvelope
+
+    runner_module = _quiet_runner(monkeypatch)
+    monkeypatch.setattr(
+        stage_asset_tasks,
+        "run_scene_360",
+        lambda *_args, **_kwargs: {"ok": True, "scene_id": "scene-360"},
+    )
+    payload = {
+        "scene_name": "scene-360",
+        "step": "pano_from_text",
+        "params": {
+            "provider": "newapi",
+            "model": "attacker-controlled-model",
+        },
+        "scene_360_model_authority": {
+            "kind": "catalog",
+            "catalog_id": "forged-catalog",
+            "provider": "newapi",
+            "model": "attacker-controlled-model",
+        },
+        "project_dir": str(tmp_path),
+    }
+
+    with pytest.raises(InvalidTaskEnvelope):
+        runner_module.run_stage_asset(
+            {"scope": "scene-360", "payload": payload},
+            _ctx(tmp_path),
+        )
+
+
+@pytest.mark.parametrize(
+    ("authority_provider", "authority_model"),
+    [
+        ("openai", "organization-authorized-pano-model"),
+        ("newapi", "different-authorized-pano-model"),
+    ],
+)
+def test_stage_asset_runner_rejects_catalog_authority_execution_mismatch(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    authority_provider: str,
+    authority_model: str,
+) -> None:
+    from novelvideo import stage_asset_tasks
+    from novelvideo.task_backend.envelope import InvalidTaskEnvelope
+
+    runner_module = _quiet_runner(monkeypatch)
+    context = _egress_context(kind="organization")
+    monkeypatch.setattr(
+        stage_asset_tasks,
+        "run_scene_360",
+        lambda *_args, **_kwargs: {"ok": True, "scene_id": "scene-360"},
+    )
+
+    with pytest.raises(InvalidTaskEnvelope):
+        runner_module.run_stage_asset(
+            _envelope(
+                {
+                    "scene_name": "scene-360",
+                    "step": "pano_from_text",
+                    "params": {
+                        "provider": "newapi",
+                        "model": "organization-authorized-pano-model",
+                    },
+                    "scene_360_model_authority": {
+                        "kind": "catalog",
+                        "catalog_id": "catalog-pano",
+                        "provider": authority_provider,
+                        "model": authority_model,
+                    },
+                    "project_dir": str(tmp_path),
+                },
+                context,
+            ),
+            _ctx(tmp_path),
+        )
+
+
 def test_scene_pano_generation_runner_passes_envelope_context_through(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:

--- a/tests/test_stage_asset_scene_360_credit.py
+++ b/tests/test_stage_asset_scene_360_credit.py
@@ -122,6 +122,7 @@ def test_scene_360_refunds_reserved_credit_on_subprocess_failure(monkeypatch, tm
 
 def test_scene_360_candidate_artifact_does_not_update_manifest(monkeypatch, tmp_path):
     from novelvideo import stage_asset_tasks
+    from novelvideo.config import NEWAPI_IMAGE_MODEL
 
     project_dir = tmp_path / "project"
     master = project_dir / "assets" / "scenes" / "Hall" / "master.png"
@@ -166,7 +167,7 @@ def test_scene_360_candidate_artifact_does_not_update_manifest(monkeypatch, tmp_
         "Hall",
         source="master",
         provider="newapi",
-        model="gpt-image-2",
+        model=NEWAPI_IMAGE_MODEL,
         master_path_override=master,
         reverse_master_path_override=reverse,
         artifact_dir=artifact_dir,

--- a/tests/test_stage_asset_scene_360_provider.py
+++ b/tests/test_stage_asset_scene_360_provider.py
@@ -1,3 +1,6 @@
+import pytest
+
+
 def test_scene_360_provider_defaults_to_newapi_when_env_is_empty(monkeypatch):
     from novelvideo import stage_asset_tasks
 
@@ -6,3 +9,42 @@ def test_scene_360_provider_defaults_to_newapi_when_env_is_empty(monkeypatch):
     monkeypatch.setenv("NANOBANANA_PROVIDER", "")
 
     assert stage_asset_tasks.resolve_scene_360_image_provider() == "newapi"
+
+
+def test_scene_360_model_accepts_registered_gateway_model_for_provider():
+    from novelvideo import stage_asset_tasks
+    from novelvideo.config import NEWAPI_IMAGE_MODEL
+
+    assert (
+        stage_asset_tasks.resolve_scene_360_image_model(
+            provider="newapi",
+            model=NEWAPI_IMAGE_MODEL,
+        )
+        == NEWAPI_IMAGE_MODEL
+    )
+
+
+def test_scene_360_model_rejects_unknown_selection_instead_of_raw_passthrough():
+    from novelvideo import stage_asset_tasks
+
+    with pytest.raises(
+        stage_asset_tasks.Scene360ImageModelSelectionError,
+        match="unknown scene 360 image model selection",
+    ):
+        stage_asset_tasks.resolve_scene_360_image_model(
+            provider="newapi",
+            model="attacker-controlled-model",
+        )
+
+
+def test_scene_360_model_rejects_provider_mismatch_instead_of_raw_passthrough():
+    from novelvideo import stage_asset_tasks
+
+    with pytest.raises(
+        stage_asset_tasks.Scene360ImageModelSelectionError,
+        match="does not use provider",
+    ):
+        stage_asset_tasks.resolve_scene_360_image_model(
+            provider="openai",
+            model="newapi_gpt_image2",
+        )

--- a/tests/test_stage_asset_scene_360_provider.py
+++ b/tests/test_stage_asset_scene_360_provider.py
@@ -1,3 +1,5 @@
+from types import SimpleNamespace
+
 import pytest
 
 
@@ -48,3 +50,45 @@ def test_scene_360_model_rejects_provider_mismatch_instead_of_raw_passthrough():
             provider="openai",
             model="newapi_gpt_image2",
         )
+
+
+def test_scene_360_runs_catalog_model_with_verified_authority(monkeypatch, tmp_path):
+    from novelvideo import stage_asset_tasks
+
+    model = "organization-authorized-pano-model"
+    monkeypatch.setattr(
+        stage_asset_tasks,
+        "_reserve_scene_360_model_call",
+        lambda *_args, **_kwargs: "",
+    )
+    monkeypatch.setattr(
+        stage_asset_tasks,
+        "_confirm_scene_360_model_call",
+        lambda **_kwargs: None,
+    )
+
+    def fake_run(cmd, **_kwargs):
+        output_dir = stage_asset_tasks.Path(cmd[cmd.index("--output-dir") + 1])
+        output_dir.mkdir(parents=True, exist_ok=True)
+        (output_dir / "scene_panorama_2to1.png").write_bytes(b"png")
+        return SimpleNamespace(returncode=0, stdout="ok", stderr="")
+
+    monkeypatch.setattr(stage_asset_tasks, "run_project_subprocess", fake_run)
+
+    result = stage_asset_tasks.run_scene_360(
+        tmp_path / "project",
+        "Hall",
+        source="text",
+        provider="newapi",
+        model=model,
+        artifact_dir=tmp_path / "candidate",
+        update_manifest=False,
+        model_authority=stage_asset_tasks.Scene360CatalogModelAuthority(
+            catalog_id="catalog-pano",
+            provider="newapi",
+            model=model,
+        ),
+    )
+
+    assert result["ok"] is True
+    assert result["model"] == model


### PR DESCRIPTION
## Summary

- restrict scene panorama API inputs to server-controlled model settings
- reject untrusted raw model passthrough in the worker parser
- preserve server-authorized dynamic catalog models through a signed task authority envelope
- remove the unused frontend free-form scene panorama submission helper

## Verification

- `uv run pytest -q -p no:cacheprovider tests/test_freezone_image_backend.py tests/test_p0g4l_scene_360_subprocess_egress.py tests/test_stage_asset_scene_360_credit.py tests/test_stage_asset_scene_360_provider.py` (228 passed)
- focused related suite (355 passed)
- Ruff checks passed
- `git diff --check` passed

## Scope

OI-51 P0 partial: input convergence and parser rejection of raw passthrough.