### PR TITLE
fix(ci): update freezone route guard count

### DIFF
--- a/tests/test_freezone_canvas_route_home_node_guard.py
+++ b/tests/test_freezone_canvas_route_home_node_guard.py
@@ -256,8 +256,8 @@ def test_only_canvas_routes_opt_out_of_the_home_node_guard() -> None:
         and _opts_out_of_the_guard(call)
     }
 
-    # 取证口径（`TCP-P60`）：freezone 76 条路由全过同一个解析器，画布只占 13 条。
-    assert router_decorators == 76
+    # 取证口径（`TCP-P60`）：freezone 77 条路由全过同一个解析器，画布只占 13 条。
+    assert router_decorators == 77
     assert len(canvas_routes) == 13
 
     # 正向：13 条画布路由必须全部、且每一处调用都 opt-out。


### PR DESCRIPTION
## Summary

- update the Freezone route-count guard from 76 to 77
- keep the canvas route opt-out count fixed at 13
- align the evidence comment with the new asset-library rename route merged from main

## Cause

The staging CI failed after `PATCH /projects/{project}/freezone/video/character-library/{item_id}` increased the total router decorator count. The new route already calls `_resolve_freezone_project()` with the default home-node guard; only the hard-coded test count was stale.

## Verification

- `pytest -q tests/test_freezone_canvas_route_home_node_guard.py`: 7 passed
- `git diff --check`: passed
