### PR TITLE
harden Hermes sandbox and runtime

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,3 +30,26 @@ Recent history uses short conventional prefixes such as `fix:`, `feat(scope):`, 
 ## Security & Configuration Tips
 
 Do not commit provider keys, signed URLs, credentials, or generated secrets. Configure model access through environment variables such as `MODEL_PROVIDER` and `MODEL_API_KEY`. Run the gitleaks pre-commit hook before sharing changes that touch configuration, provisioning, backup, or gateway code.
+
+## Hermes Sandbox & the CE Unsandboxed Fallback
+
+Hermes workers run inside an OS sandbox (`sandbox_wrap.py`): macOS uses the system
+`sandbox-exec`; Linux uses `codex-linux-sandbox` (bubblewrap-based). When no sandbox
+binary is available the wrapper **fails closed** — it refuses to run rather than drop
+isolation silently.
+
+CE deployment posture (interim, tracked in **#346**):
+
+- The vendored Linux binaries ship in the image (`Dockerfile` does `COPY deploy ./deploy`,
+  so they land under `deploy/sandbox/linux-{amd64,arm64}/codex-linux-sandbox`) but are **not
+  yet installed onto `PATH`**, and bubblewrap is not installed. Until #346 wires the per-arch
+  install + a controlled model/API egress, the Linux sandbox cannot actually run.
+- Because CE is **single-tenant self-hosted**, the four CE compose files therefore set
+  `SUPERTALE_ALLOW_UNSANDBOXED=1` explicitly. This restores the pre-hardening default
+  (run Hermes unsandboxed on Linux) instead of crashing the first worker on `docker compose up`.
+- This opt-in is **local/CE only**. When `SUPERTALE_ENV=production` or `ST_CONTROL_PLANE_DSN`
+  is non-empty (EE / multi-tenant), `_fallback_or_raise` still refuses to run unsandboxed —
+  the flag cannot override it. `tests/test_compose_ce_unsandboxed_gate.py` pins both halves.
+
+Do not remove the compose opt-in without either installing a working Linux sandbox (#346) or
+accepting that the default CE image will fail closed on Linux.

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,13 +15,16 @@ ENV ST_EDITION=ce \
     UV_COMPILE_BYTECODE=1 \
     UV_LINK_MODE=copy \
     UV_PROJECT_ENVIRONMENT=/app/.venv \
-    HERMES_CLI_PATH=/root/.local/bin/hermes
+    HERMES_CLI_PATH=/usr/local/bin/hermes \
+    HOME=/home/dramaclaw
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends ffmpeg \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
+RUN groupadd --system --gid 10001 dramaclaw \
+    && useradd --system --uid 10001 --gid 10001 --create-home --home-dir /home/dramaclaw dramaclaw
 COPY pyproject.toml uv.lock README.md ./
 # license 正文按 REUSE 惯例只存于 LICENSES/(pyproject license-files 指向它),
 # hatchling 构建 wheel 时需要这份文件在上下文中。
@@ -86,9 +89,14 @@ RUN set -eux; \
     python3 deploy/patch_hermes_acp_toolsets.py; \
     hermes --version; \
     python3 deploy/verify_hermes_fork.py; \
+    chown -R dramaclaw:dramaclaw /data /home/dramaclaw; \
     apt-get purge -y git; apt-get autoremove -y
 
-ENV PATH="/app/.venv/bin:/root/.local/bin:$PATH"
+ENV PATH="/app/.venv/bin:/usr/local/bin:$PATH"
+
+# Hermes and the API never need root at runtime. Compose may still override
+# the user explicitly, but the image itself is safe-by-default.
+USER dramaclaw:dramaclaw
 
 EXPOSE 8780
 HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 CMD python -c "import sys, urllib.request; sys.exit(0 if urllib.request.urlopen('http://127.0.0.1:8780/api/v1/config', timeout=2).status == 200 else 1)"

--- a/deploy/patch_hermes_acp_toolsets.py
+++ b/deploy/patch_hermes_acp_toolsets.py
@@ -27,10 +27,17 @@ CANDIDATE_PATTERNS = [
     # the source stays where it was cloned rather than landing in site-packages.
     "/opt/hermes-agent/acp_adapter/session.py",
     str(Path(os.environ.get("HERMES_SOURCE_DIR", "/nonexistent")) / "acp_adapter/session.py"),
+    "/home/dramaclaw/.local/share/uv/tools/hermes-agent/lib/python*/site-packages/acp_adapter/session.py",
 ]
 if override := os.environ.get("HERMES_AGENT_SESSION_PY"):
     CANDIDATE_PATTERNS.insert(0, override)
-CANDIDATES = sorted({candidate for pattern in CANDIDATE_PATTERNS for candidate in glob.glob(pattern)})
+source_candidate = Path(os.environ.get("HERMES_SOURCE_DIR", "/nonexistent")) / "acp_adapter/session.py"
+if source_candidate.is_file():
+    # Editable installs import the fork directly from its clone. Prefer that
+    # source over any unrelated stock Hermes left in a uv tool environment.
+    CANDIDATES = [str(source_candidate)]
+else:
+    CANDIDATES = sorted({candidate for pattern in CANDIDATE_PATTERNS for candidate in glob.glob(pattern)})
 if len(CANDIDATES) != 1:
     sys.exit(f"PATCH FAIL: expected 1 acp_adapter/session.py, found {CANDIDATES}")
 path = CANDIDATES[0]

--- a/docker-compose.release.yml
+++ b/docker-compose.release.yml
@@ -8,6 +8,15 @@
 #   INSTALL_WORLD=1 docker compose up --build(见 docker-compose.yml)。
 services:
   api:
+    user: "10001:10001"
+    read_only: true
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+    tmpfs:
+      - /tmp:rw,noexec,nosuid,nodev,size=256m
+      - /run:rw,noexec,nosuid,nodev,size=16m
     image: claymorelab/dramaclaw:${DRAMACLAW_VERSION:-latest}
     # 运行时从宿主 .env 注入 model/LLM key;镜像版允许没有 .env(全部走网页设置)。
     # environment: 块仍覆盖此处同名变量,保持 CE inline 模式强制不变。
@@ -25,7 +34,7 @@ services:
       NOVELVIDEO_STATE_DIR: /data/state
       NOVELVIDEO_RUNTIME_DIR: /data/runtime
       DRAMACLAW_CHAT_BACKEND: hermes
-      HERMES_CLI_PATH: /root/.local/bin/hermes
+      HERMES_CLI_PATH: /usr/local/bin/hermes
       # 默认「官方 DC key」路径:模型网关地址/密钥来自 .env(NEWAPI_BASE_URL / NEWAPI_API_KEY),
       # 或启动后到网页「设置 → 模型配置 → 官方渠道」粘贴 DC key 保存即用。
       # 不在此处硬写 NEWAPI_BASE_URL —— 留给 .env / 网页设置驱动,避免覆盖用户配置。

--- a/docker-compose.release.yml
+++ b/docker-compose.release.yml
@@ -41,6 +41,12 @@ services:
       XDG_CACHE_HOME: /data/cache
       DRAMACLAW_CHAT_BACKEND: hermes
       HERMES_CLI_PATH: /usr/local/bin/hermes
+      # CE 单租户自托管:Linux 镜像暂未把 deploy/sandbox 下的 codex-linux-sandbox
+      # 装到 PATH(留待 #346),此处显式声明 CE 沿用无沙箱运行——保留本 PR 之前的
+      # 默认行为,避免 fail-close 让默认 compose 首次起 Hermes worker 即崩。
+      # 仅对本地/CE 生效:production 或 ST_CONTROL_PLANE_DSN 非空时,
+      # sandbox_wrap._fallback_or_raise 仍严格拒绝裸跑,兜底不会扩散到多租户。
+      SUPERTALE_ALLOW_UNSANDBOXED: "1"
       # 默认「官方 DC key」路径:模型网关地址/密钥来自 .env(NEWAPI_BASE_URL / NEWAPI_API_KEY),
       # 或启动后到网页「设置 → 模型配置 → 官方渠道」粘贴 DC key 保存即用。
       # 不在此处硬写 NEWAPI_BASE_URL —— 留给 .env / 网页设置驱动,避免覆盖用户配置。

--- a/docker-compose.release.yml
+++ b/docker-compose.release.yml
@@ -33,6 +33,12 @@ services:
       NOVELVIDEO_OUTPUT_DIR: /data/output
       NOVELVIDEO_STATE_DIR: /data/state
       NOVELVIDEO_RUNTIME_DIR: /data/runtime
+      # read_only root fs + non-root user: ML libs (HF/torch) otherwise try to
+      # write $HOME/.cache and crash. Redirect their caches into the writable
+      # ce-data volume so weights persist across restarts instead of re-download.
+      HF_HOME: /data/cache/huggingface
+      TORCH_HOME: /data/cache/torch
+      XDG_CACHE_HOME: /data/cache
       DRAMACLAW_CHAT_BACKEND: hermes
       HERMES_CLI_PATH: /usr/local/bin/hermes
       # 默认「官方 DC key」路径:模型网关地址/密钥来自 .env(NEWAPI_BASE_URL / NEWAPI_API_KEY),

--- a/docker-compose.selfhosted.release.yml
+++ b/docker-compose.selfhosted.release.yml
@@ -9,6 +9,15 @@
 #   INSTALL_WORLD=1 docker compose -f docker-compose.selfhosted.yml up --build。
 services:
   api:
+    user: "10001:10001"
+    read_only: true
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+    tmpfs:
+      - /tmp:rw,noexec,nosuid,nodev,size=256m
+      - /run:rw,noexec,nosuid,nodev,size=16m
     image: claymorelab/dramaclaw:${DRAMACLAW_VERSION:-latest}
     # 运行时从宿主 .env 注入 model/LLM key;镜像版允许没有 .env(首启后再补也行)。
     # environment: 块仍覆盖此处同名变量,保持 CE inline 模式强制不变。
@@ -26,7 +35,7 @@ services:
       NOVELVIDEO_STATE_DIR: /data/state
       NOVELVIDEO_RUNTIME_DIR: /data/runtime
       DRAMACLAW_CHAT_BACKEND: hermes
-      HERMES_CLI_PATH: /root/.local/bin/hermes
+      HERMES_CLI_PATH: /usr/local/bin/hermes
       # 内置 newapi 网关:后端服务端调用走容器内网,覆盖 .env 里的外部网关地址,
       # 让整套自包含、开箱即跑。要 BYO 自己的 OpenAI 兼容网关:删掉下面两行,
       # 改在 .env 里填 NEWAPI_BASE_URL / NEWAPI_API_KEY。

--- a/docker-compose.selfhosted.release.yml
+++ b/docker-compose.selfhosted.release.yml
@@ -34,6 +34,12 @@ services:
       NOVELVIDEO_OUTPUT_DIR: /data/output
       NOVELVIDEO_STATE_DIR: /data/state
       NOVELVIDEO_RUNTIME_DIR: /data/runtime
+      # read_only root fs + non-root user: ML libs (HF/torch) otherwise try to
+      # write $HOME/.cache and crash. Redirect their caches into the writable
+      # ce-data volume so weights persist across restarts instead of re-download.
+      HF_HOME: /data/cache/huggingface
+      TORCH_HOME: /data/cache/torch
+      XDG_CACHE_HOME: /data/cache
       DRAMACLAW_CHAT_BACKEND: hermes
       HERMES_CLI_PATH: /usr/local/bin/hermes
       # 内置 newapi 网关:后端服务端调用走容器内网,覆盖 .env 里的外部网关地址,

--- a/docker-compose.selfhosted.release.yml
+++ b/docker-compose.selfhosted.release.yml
@@ -42,6 +42,12 @@ services:
       XDG_CACHE_HOME: /data/cache
       DRAMACLAW_CHAT_BACKEND: hermes
       HERMES_CLI_PATH: /usr/local/bin/hermes
+      # CE 单租户自托管:Linux 镜像暂未把 deploy/sandbox 下的 codex-linux-sandbox
+      # 装到 PATH(留待 #346),此处显式声明 CE 沿用无沙箱运行——保留本 PR 之前的
+      # 默认行为,避免 fail-close 让默认 compose 首次起 Hermes worker 即崩。
+      # 仅对本地/CE 生效:production 或 ST_CONTROL_PLANE_DSN 非空时,
+      # sandbox_wrap._fallback_or_raise 仍严格拒绝裸跑,兜底不会扩散到多租户。
+      SUPERTALE_ALLOW_UNSANDBOXED: "1"
       # 内置 newapi 网关:后端服务端调用走容器内网,覆盖 .env 里的外部网关地址,
       # 让整套自包含、开箱即跑。要 BYO 自己的 OpenAI 兼容网关:删掉下面两行,
       # 改在 .env 里填 NEWAPI_BASE_URL / NEWAPI_API_KEY。

--- a/docker-compose.selfhosted.yml
+++ b/docker-compose.selfhosted.yml
@@ -47,6 +47,12 @@ services:
       XDG_CACHE_HOME: /data/cache
       DRAMACLAW_CHAT_BACKEND: hermes
       HERMES_CLI_PATH: /usr/local/bin/hermes
+      # CE 单租户自托管:Linux 镜像暂未把 deploy/sandbox 下的 codex-linux-sandbox
+      # 装到 PATH(留待 #346),此处显式声明 CE 沿用无沙箱运行——保留本 PR 之前的
+      # 默认行为,避免 fail-close 让默认 compose 首次起 Hermes worker 即崩。
+      # 仅对本地/CE 生效:production 或 ST_CONTROL_PLANE_DSN 非空时,
+      # sandbox_wrap._fallback_or_raise 仍严格拒绝裸跑,兜底不会扩散到多租户。
+      SUPERTALE_ALLOW_UNSANDBOXED: "1"
       # 内置 newapi 网关：后端服务端调用走容器内网，覆盖 .env 里的外部网关地址，
       # 让整套自包含、开箱即跑。要 BYO 自己的 OpenAI 兼容网关：删掉下面两行，
       # 改在 .env 里填 NEWAPI_BASE_URL / NEWAPI_API_KEY。

--- a/docker-compose.selfhosted.yml
+++ b/docker-compose.selfhosted.yml
@@ -39,6 +39,12 @@ services:
       NOVELVIDEO_OUTPUT_DIR: /data/output
       NOVELVIDEO_STATE_DIR: /data/state
       NOVELVIDEO_RUNTIME_DIR: /data/runtime
+      # read_only root fs + non-root user: ML libs (HF/torch) otherwise try to
+      # write $HOME/.cache and crash. Redirect their caches into the writable
+      # ce-data volume so weights persist across restarts instead of re-download.
+      HF_HOME: /data/cache/huggingface
+      TORCH_HOME: /data/cache/torch
+      XDG_CACHE_HOME: /data/cache
       DRAMACLAW_CHAT_BACKEND: hermes
       HERMES_CLI_PATH: /usr/local/bin/hermes
       # 内置 newapi 网关：后端服务端调用走容器内网，覆盖 .env 里的外部网关地址，

--- a/docker-compose.selfhosted.yml
+++ b/docker-compose.selfhosted.yml
@@ -5,6 +5,15 @@
 # 想改用「官方 DC key」路径(更简单、填一个 key 即用):改用默认 docker-compose.yml。
 services:
   api:
+    user: "10001:10001"
+    read_only: true
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+    tmpfs:
+      - /tmp:rw,noexec,nosuid,nodev,size=256m
+      - /run:rw,noexec,nosuid,nodev,size=16m
     build:
       context: .
       dockerfile: Dockerfile
@@ -14,7 +23,8 @@ services:
       args:
         INSTALL_WORLD: "${INSTALL_WORLD:-0}"
         # 默认装 fork 的 brainclaw/evidence-plane 分支；要固定到某个提交时传 SHA。
-        HERMES_INSTALL_SPEC: "${HERMES_INSTALL_SPEC:-}"
+        HERMES_REPO: "${HERMES_REPO:-https://github.com/dramaclaw/hermes-agent.git}"
+        HERMES_REF: "${HERMES_REF:-brainclaw/evidence-plane}"
     # 运行时从宿主 .env 注入 model/LLM key（.env 不进镜像，由 .dockerignore 排除）。
     # environment: 块仍覆盖此处同名变量，保持 CE inline 模式强制不变。
     env_file:
@@ -30,7 +40,7 @@ services:
       NOVELVIDEO_STATE_DIR: /data/state
       NOVELVIDEO_RUNTIME_DIR: /data/runtime
       DRAMACLAW_CHAT_BACKEND: hermes
-      HERMES_CLI_PATH: /root/.local/bin/hermes
+      HERMES_CLI_PATH: /usr/local/bin/hermes
       # 内置 newapi 网关：后端服务端调用走容器内网，覆盖 .env 里的外部网关地址，
       # 让整套自包含、开箱即跑。要 BYO 自己的 OpenAI 兼容网关：删掉下面两行，
       # 改在 .env 里填 NEWAPI_BASE_URL / NEWAPI_API_KEY。

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,6 +41,12 @@ services:
       NOVELVIDEO_OUTPUT_DIR: /data/output
       NOVELVIDEO_STATE_DIR: /data/state
       NOVELVIDEO_RUNTIME_DIR: /data/runtime
+      # read_only root fs + non-root user: ML libs (HF/torch) otherwise try to
+      # write $HOME/.cache and crash. Redirect their caches into the writable
+      # ce-data volume so weights persist across restarts instead of re-download.
+      HF_HOME: /data/cache/huggingface
+      TORCH_HOME: /data/cache/torch
+      XDG_CACHE_HOME: /data/cache
       DRAMACLAW_CHAT_BACKEND: hermes
       HERMES_CLI_PATH: /usr/local/bin/hermes
       # 默认「官方 DC key」路径:模型网关地址/密钥来自 .env(NEWAPI_BASE_URL / NEWAPI_API_KEY),

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,6 +49,12 @@ services:
       XDG_CACHE_HOME: /data/cache
       DRAMACLAW_CHAT_BACKEND: hermes
       HERMES_CLI_PATH: /usr/local/bin/hermes
+      # CE 单租户自托管:Linux 镜像暂未把 deploy/sandbox 下的 codex-linux-sandbox
+      # 装到 PATH(留待 #346),此处显式声明 CE 沿用无沙箱运行——保留本 PR 之前的
+      # 默认行为,避免 fail-close 让默认 compose 首次起 Hermes worker 即崩。
+      # 仅对本地/CE 生效:production 或 ST_CONTROL_PLANE_DSN 非空时,
+      # sandbox_wrap._fallback_or_raise 仍严格拒绝裸跑,兜底不会扩散到多租户。
+      SUPERTALE_ALLOW_UNSANDBOXED: "1"
       # 默认「官方 DC key」路径:模型网关地址/密钥来自 .env(NEWAPI_BASE_URL / NEWAPI_API_KEY),
       # 或启动后到网页「设置 → 模型配置 → 官方渠道」粘贴 DC key 保存即用。
       # 不在此处硬写 NEWAPI_BASE_URL —— 留给 .env / 网页设置驱动,避免覆盖用户配置。

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,15 @@
 #   docker compose -f docker-compose.selfhosted.yml up
 services:
   api:
+    user: "10001:10001"
+    read_only: true
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+    tmpfs:
+      - /tmp:rw,noexec,nosuid,nodev,size=256m
+      - /run:rw,noexec,nosuid,nodev,size=16m
     build:
       context: .
       dockerfile: Dockerfile
@@ -16,7 +25,8 @@ services:
       args:
         INSTALL_WORLD: "${INSTALL_WORLD:-0}"
         # 默认装 fork 的 brainclaw/evidence-plane 分支；要固定到某个提交时传 SHA。
-        HERMES_INSTALL_SPEC: "${HERMES_INSTALL_SPEC:-}"
+        HERMES_REPO: "${HERMES_REPO:-https://github.com/dramaclaw/hermes-agent.git}"
+        HERMES_REF: "${HERMES_REF:-brainclaw/evidence-plane}"
     # 运行时从宿主 .env 注入 model/LLM key（.env 不进镜像，由 .dockerignore 排除）。
     # environment: 块仍覆盖此处同名变量，保持 CE inline 模式强制不变。
     env_file:
@@ -32,7 +42,7 @@ services:
       NOVELVIDEO_STATE_DIR: /data/state
       NOVELVIDEO_RUNTIME_DIR: /data/runtime
       DRAMACLAW_CHAT_BACKEND: hermes
-      HERMES_CLI_PATH: /root/.local/bin/hermes
+      HERMES_CLI_PATH: /usr/local/bin/hermes
       # 默认「官方 DC key」路径:模型网关地址/密钥来自 .env(NEWAPI_BASE_URL / NEWAPI_API_KEY),
       # 或启动后到网页「设置 → 模型配置 → 官方渠道」粘贴 DC key 保存即用。
       # 不在此处硬写 NEWAPI_BASE_URL —— 留给 .env / 网页设置驱动,避免覆盖用户配置。

--- a/docs/security/linux-docker-sandbox.md
+++ b/docs/security/linux-docker-sandbox.md
@@ -1,0 +1,36 @@
+# Linux/Docker Hermes 沙箱部署要求
+
+本项目的 Hermes 子进程会使用 `codex-linux-sandbox`。Linux 沙箱可以限制写入目录和网络，
+但当前 `workspace-write` 运行模型对挂载进程可见的根文件系统保持只读可见。因此，**容器
+挂载整个共享 `/data` 时，不能把它当作跨租户读取隔离**。
+
+## 默认镜像加固
+
+API 镜像默认使用非 root 用户 `dramaclaw:10001`。Compose 配置还会启用：
+
+- 只读容器根文件系统；
+- `cap_drop: ALL`；
+- `no-new-privileges`；
+- 仅为临时文件提供 `tmpfs`；
+- Hermes CLI 放在非 root 用户的 home 下。
+
+已有命名卷如果是 root 创建的，升级后需要在停机窗口修正一次权限，或者迁移到新卷：
+
+```bash
+docker compose run --rm --user root api sh -lc \
+  'chown -R 10001:10001 /data'
+```
+
+## EE/多租户要求
+
+EE 多租户部署不能把所有租户的 `state/output/runtime` 作为同一个可读卷挂载给 Hermes。
+应使用以下任一方式：
+
+1. 每个租户/任务独立 Hermes 容器，并只挂载该租户目录；或
+2. Kubernetes/容器运行时为每个 Hermes worker 提供只包含当前租户目录的 mount namespace。
+
+共享资源（代码、内置技能、公共只读资产）可以单独只读挂载。禁止挂载 Docker Socket，
+禁止 `privileged: true`，并为 Hermes/API 配置网络出口白名单。
+
+如果部署环境无法提供按租户挂载隔离，不应将当前 Linux 沙箱宣传为完整的多租户文件读取隔离；
+应用层项目权限校验和 Hermes 高风险工具禁用仍然必须保留。

--- a/frontend/src/features/superchat/use-superchat.ts
+++ b/frontend/src/features/superchat/use-superchat.ts
@@ -135,6 +135,14 @@ function resolveChatWsUrl(): string {
   return url.toString();
 }
 
+// Development-only transport diagnostics. Never log prompt text, attachments,
+// cookies, or gateway credentials; these events are enough to locate a stalled
+// turn between the browser, WebSocket, API, and Hermes.
+const SUPERCHAT_DEBUG = import.meta.env.DEV;
+function superchatDebug(event: string, details?: Record<string, unknown>) {
+  if (SUPERCHAT_DEBUG) console.info(`[superchat] ${event}`, details ?? "");
+}
+
 function scopeForProject(
   project?: string,
   surface: ProjectChatSurface = "director",
@@ -1896,8 +1904,16 @@ export function useSuperChat({
     const ws = wsRef.current;
     if (ws?.readyState === WebSocket.OPEN) {
       ws.send(JSON.stringify(frame));
+      superchatDebug("send", {
+        type: frame.type,
+        turn_id: "turn_id" in frame ? frame.turn_id : undefined,
+      });
       return true;
     }
+    superchatDebug("send_skipped_socket_not_open", {
+      type: frame.type,
+      readyState: ws?.readyState ?? null,
+    });
     return false;
   }, []);
 
@@ -2757,25 +2773,39 @@ export function useSuperChat({
 
     const ws = new WebSocket(resolveChatWsUrl());
     wsRef.current = ws;
+    superchatDebug("connecting", { url: resolveChatWsUrl() });
     ws.onopen = () => {
       if (connectionIdRef.current !== connectionId || wsRef.current !== ws) return;
+      superchatDebug("open");
       sendFrame({ type: "scope.set", scope: desiredScopeRef.current });
     };
     ws.onmessage = (event) => {
       if (connectionIdRef.current !== connectionId || wsRef.current !== ws) return;
       try {
-        handleFrameRef.current(JSON.parse(String(event.data)) as ServerFrame);
+        const frame = JSON.parse(String(event.data)) as ServerFrame;
+        superchatDebug("receive", {
+          type: typeof frame === "object" && frame !== null && "type" in frame
+            ? frame.type
+            : "unknown",
+          turn_id: typeof frame === "object" && frame !== null && "turn_id" in frame
+            ? frame.turn_id
+            : undefined,
+        });
+        handleFrameRef.current(frame);
       } catch {
+        superchatDebug("receive_invalid_json");
         // Ignore malformed frames from development proxies.
       }
     };
     ws.onerror = () => {
       if (connectionIdRef.current !== connectionId || wsRef.current !== ws) return;
+      superchatDebug("error");
       setError("WebSocket connection failed");
       setConnecting(false);
     };
     ws.onclose = (event) => {
       if (connectionIdRef.current !== connectionId || wsRef.current !== ws) return;
+      superchatDebug("close", { code: event.code, reason: event.reason });
       wsRef.current = null;
       setConnected(false);
       const hasActiveTurn = Boolean(activeTurnIdRef.current ?? pendingClientTurnIdRef.current);

--- a/scripts/setup-hermes.sh
+++ b/scripts/setup-hermes.sh
@@ -20,11 +20,15 @@ mode="${1:-install}"
 HERMES_REPO="${HERMES_REPO:-https://github.com/dramaclaw/hermes-agent.git}"
 HERMES_REF="${HERMES_REF:-brainclaw/evidence-plane}"
 HERMES_SOURCE_DIR="${HERMES_SOURCE_DIR:-$root_dir/.cache/hermes-agent}"
+HERMES_PYTHON="${HERMES_PYTHON:-$root_dir/.venv/bin/python}"
+if [ ! -x "$HERMES_PYTHON" ]; then
+  HERMES_PYTHON="$(command -v python3)"
+fi
 
 # The property this deployment actually depends on: does `_meta` survive the
 # ACP router? Probed in the interpreter that will run the worker.
 fork_is_installed() {
-  python3 - <<'PY' 2>/dev/null
+  "$HERMES_PYTHON" - <<'PY' 2>/dev/null
 import sys
 try:
     from acp_adapter.server import _recover_turn_meta
@@ -63,14 +67,14 @@ if [ -d "$HERMES_SOURCE_DIR/.git" ]; then
   git -C "$HERMES_SOURCE_DIR" checkout --quiet FETCH_HEAD
 else
   echo "Cloning $HERMES_REPO@$HERMES_REF ..."
-  git clone --quiet --branch "$HERMES_REF" "$HERMES_REPO" "$HERMES_SOURCE_DIR" \
-    || { git clone --quiet "$HERMES_REPO" "$HERMES_SOURCE_DIR"
+  git clone --progress --branch "$HERMES_REF" "$HERMES_REPO" "$HERMES_SOURCE_DIR" \
+    || { git clone --progress "$HERMES_REPO" "$HERMES_SOURCE_DIR"
          git -C "$HERMES_SOURCE_DIR" checkout --quiet "$HERMES_REF"; }
 fi
 
 installed_sha="$(git -C "$HERMES_SOURCE_DIR" rev-parse HEAD)"
-uv pip install --system -e "$HERMES_SOURCE_DIR[acp]"
-HERMES_SOURCE_DIR="$HERMES_SOURCE_DIR" python3 "$root_dir/deploy/patch_hermes_acp_toolsets.py"
+uv pip install --python "$HERMES_PYTHON" -e "$HERMES_SOURCE_DIR[acp]"
+HERMES_SOURCE_DIR="$HERMES_SOURCE_DIR" "$HERMES_PYTHON" "$root_dir/deploy/patch_hermes_acp_toolsets.py"
 
 if ! fork_is_installed; then
   echo "Install finished, but the result is not the fork — _meta does not" >&2

--- a/src/novelvideo/api/__init__.py
+++ b/src/novelvideo/api/__init__.py
@@ -47,6 +47,7 @@ from novelvideo.api.routes import (  # noqa: E402
     chat,
     config,
     content,
+    diagnostics,
     episodes,
     files,
     freezone,
@@ -97,6 +98,7 @@ if not runtime_env.is_ce_effective():
     for ep in entry_points(group="novelvideo.api_routes"):
         ep.load()(api_router)
 api_router.include_router(config.router, tags=["config"])
+api_router.include_router(diagnostics.router, tags=["diagnostics"])
 api_router.include_router(product_surfaces.router, tags=["product-surfaces"])
 api_router.include_router(chat.router, tags=["chat"])
 api_router.include_router(projects.router, tags=["projects"])

--- a/src/novelvideo/api/auth.py
+++ b/src/novelvideo/api/auth.py
@@ -224,6 +224,7 @@ def require_scope(needed: str) -> Callable[[dict], dict]:
             )
         return user
 
+    _check._required_scope = needed  # introspection hook for route-wiring tests
     return _check
 
 

--- a/src/novelvideo/api/auth.py
+++ b/src/novelvideo/api/auth.py
@@ -27,7 +27,19 @@ logger = logging.getLogger("novelvideo.api.auth")
 AUTH_COOKIE_NAME = "st_session"
 
 UNSAFE_METHODS = {"POST", "PUT", "PATCH", "DELETE"}
-AGENT_WRITE_SCOPES = {"projects:write", "tasks:submit"}
+# Scopes that satisfy the central agent write-boundary backstop. This set must
+# include every precise write scope a route may require, otherwise a token that
+# legitimately holds only that precise scope (e.g. [projects:read,
+# projects:purge]) is rejected here — before its route's own require_scope check
+# ever runs — for lacking the generic write scope. The route-level require_scope
+# still enforces the exact scope, so listing these here only lifts the redundant
+# backstop, it does not widen what any single route accepts.
+AGENT_WRITE_SCOPES = {
+    "projects:write",
+    "tasks:submit",
+    "projects:lifecycle",
+    "projects:purge",
+}
 PROJECT_PATH_RE = re.compile(r"/projects/([^/]+)")
 LOCAL_TRUST_HOSTS = {"127.0.0.1", "::1", "localhost"}
 UNSUPPORTED_QUERY_CREDENTIALS = {"token", "access_token", "api_key"}

--- a/src/novelvideo/api/routes/chat.py
+++ b/src/novelvideo/api/routes/chat.py
@@ -3097,9 +3097,11 @@ async def _stream_home_turn(
 @router.websocket("/chat/ws")
 async def chat_ws(websocket: WebSocket) -> None:
     await websocket.accept()
+    logger.info("chat websocket accepted client=%s", websocket.client)
     try:
         user = await _authenticate_ws(websocket)
     except Exception:
+        logger.warning("chat websocket authentication failed client=%s", websocket.client)
         await _close_ws_unauthorized(websocket)
         return
 
@@ -3115,6 +3117,12 @@ async def chat_ws(websocket: WebSocket) -> None:
         return
     if current_scope is None:
         return
+    logger.info(
+        "chat websocket ready username=%s scope=%s:%s",
+        username,
+        current_scope.kind,
+        current_scope.id or "",
+    )
     await register_chat_websocket(websocket, username=username, scope=current_scope)
     # Do not pre-warm the default home scope on connect. The React client often
     # immediately sends scope.set for the active project; warming home first
@@ -3137,6 +3145,7 @@ async def chat_ws(websocket: WebSocket) -> None:
                     return
                 raise
             event_type = str(raw.get("type") or "")
+            logger.info("chat websocket received type=%s username=%s", event_type, username)
             if event_type == "scope.set":
                 msg = ScopeSetIn.model_validate(raw)
                 requested_scope = _scope_from_model(msg.scope)
@@ -3239,6 +3248,14 @@ async def chat_ws(websocket: WebSocket) -> None:
             turn_id = (msg.turn_id or "").strip() or uuid.uuid4().hex
             text = msg.text.strip()
             user_text = (msg.user_text or "").strip() or text
+            logger.info(
+                "chat message accepted username=%s turn_id=%s scope=%s:%s text_len=%d",
+                username,
+                turn_id,
+                scope.kind,
+                scope.id or "",
+                len(text),
+            )
             if not text:
                 await _send_json_best_effort(
                     websocket,
@@ -3294,6 +3311,12 @@ async def chat_ws(websocket: WebSocket) -> None:
                     )
             except Exception as exc:  # noqa: BLE001
                 message = str(exc)
+                logger.exception(
+                    "chat turn failed username=%s turn_id=%s error_type=%s",
+                    username,
+                    turn_id,
+                    type(exc).__name__,
+                )
                 if "当前用户已有 AI 对话正在处理中" in message:
                     await _send_json_best_effort(
                         websocket,
@@ -3347,6 +3370,7 @@ async def chat_ws(websocket: WebSocket) -> None:
                     websocket, {"type": "error", "turn_id": turn_id, "message": message}
                 )
     except WebSocketDisconnect:
+        logger.info("chat websocket disconnected username=%s", username)
         pass
     finally:
         await unregister_chat_websocket(websocket)

--- a/src/novelvideo/api/routes/diagnostics.py
+++ b/src/novelvideo/api/routes/diagnostics.py
@@ -1,0 +1,43 @@
+"""Read-only diagnostics for the evidence plane.
+
+``evidence_metrics`` counts each per-turn capability outcome in process memory
+only — nothing persists it and nothing emits it, so a running backend cannot be
+asked "did this turn mint a capability?". This endpoint exposes those counters
+so the answer is observable with a single ``curl`` after a message is sent.
+
+Only names and counts are returned. The ``evidence_metrics`` module is designed
+so these carry no key, capability, project, trajectory or prompt — safe to
+expose wherever the process already logs, so no auth gate is needed (mirrors the
+public ``/config`` route).
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter
+from fastapi.responses import JSONResponse
+
+from novelvideo.chat import evidence_metrics
+
+router = APIRouter()
+
+
+@router.get("/diagnostics/evidence")
+async def get_evidence_counters():
+    """Return the in-process evidence-plane counters and any halting outcomes."""
+    counters = evidence_metrics.counters()
+    halting = evidence_metrics.halting_counts()
+    return JSONResponse(
+        {
+            "ok": True,
+            "data": {
+                # capability_issued > 0 proves a project-scoped turn minted a
+                # capability with the configured K1/K3 keys since process start.
+                "counters": counters,
+                # Any non-empty halting map means rollout must stop — a turn
+                # produced untrustworthy evidence or tried to leave for a host it
+                # had no business reaching.
+                "halting": halting,
+                "capability_issued": counters.get("capability_issued", 0),
+            },
+        }
+    )

--- a/src/novelvideo/api/routes/projects.py
+++ b/src/novelvideo/api/routes/projects.py
@@ -36,6 +36,10 @@ from novelvideo.embedding_models import (
 )
 from novelvideo.ports import get_project_access, get_project_registry
 from novelvideo.ports.project import ProjectRecord
+from novelvideo.security import (
+    ProjectStorageOwnershipError,
+    assert_owned_project_storage,
+)
 from novelvideo.project_config import (
     default_aspect_ratio_for_spine_template,
     load_effective_narration_style_for_voice,
@@ -173,23 +177,32 @@ def _narrator_voice_sample_path(project_dir: str | Path, filename: str) -> Path:
     return Path(project_dir) / "assets" / "narrator" / f"voice{ext}"
 
 
-def _cleanup_uncommitted_project_dirs(record: ProjectRecord) -> None:
-    for path in (Path(record.output_dir), Path(record.state_dir), Path(record.runtime_dir)):
-        if path.exists():
-            shutil.rmtree(path)
+def _validated_owned_dirs(record: ProjectRecord) -> list[Path]:
+    """校验三类目录确属 owner,返回去重后的真实路径;校验失败直接抛出。
 
-
-def _unique_project_storage_paths(paths) -> list[Path]:
+    这是所有对项目整树的移动/删除的唯一入口,任一目录不在
+    ``<root>/<owner>/`` 下即拒绝,禁止碰任何目录。
+    """
+    validated = assert_owned_project_storage(
+        owner_username=record.owner_username,
+        output_dir=record.output_dir,
+        state_dir=record.state_dir,
+        runtime_dir=record.runtime_dir,
+    )
     unique: list[Path] = []
     seen: set[Path] = set()
-    for raw_path in paths:
-        path = Path(raw_path)
-        resolved = path.resolve(strict=False)
-        if resolved in seen:
+    for path in validated.as_tuple():
+        if path in seen:
             continue
-        seen.add(resolved)
+        seen.add(path)
         unique.append(path)
     return unique
+
+
+def _cleanup_uncommitted_project_dirs(record: ProjectRecord) -> None:
+    for path in _validated_owned_dirs(record):
+        if path.exists():
+            shutil.rmtree(path)
 
 
 def _restore_quarantined_project_dirs(quarantined: list[tuple[Path, Path]]) -> None:
@@ -197,21 +210,33 @@ def _restore_quarantined_project_dirs(quarantined: list[tuple[Path, Path]]) -> N
         if not quarantine.exists():
             continue
         if original.exists():
-            shutil.rmtree(original)
+            # 恢复隔离目录时,若原位置已被并发创建/重建占用,绝不递归删除它 ——
+            # 那可能是另一个操作合法写入的新数据。保留双方并报警,交由人工处置。
+            logger.error(
+                "cannot restore isolated dir %s: original path already exists; "
+                "leaving quarantine %s in place for manual recovery",
+                original,
+                quarantine,
+            )
+            continue
         quarantine.replace(original)
 
 
 def _quarantine_project_dirs(
-    paths,
+    record: ProjectRecord,
     *,
     project_id: str,
     reason: str,
 ) -> list[tuple[Path, Path]]:
-    """Atomically detach project directories before releasing their registry name."""
+    """Atomically detach project directories before releasing their registry name.
+
+    仅在 ``record`` 的三类目录全部通过归属校验后才移动;任一目录不属于
+    ``record.owner_username`` 时抛出,不移动任何目录。
+    """
     quarantined: list[tuple[Path, Path]] = []
     token = uuid.uuid4().hex
     try:
-        for original in _unique_project_storage_paths(paths):
+        for original in _validated_owned_dirs(record):
             if not original.exists():
                 continue
             quarantine = original.with_name(
@@ -516,10 +541,9 @@ async def create_project(
                 detail=f"Project '{body.name}' already exists",
             ) from exc
         raise
-    project_dirs = (record.output_dir, record.state_dir, record.runtime_dir)
     try:
         orphaned_dirs = _quarantine_project_dirs(
-            project_dirs,
+            record,
             project_id=record.id,
             reason="orphaned",
         )
@@ -528,10 +552,12 @@ async def create_project(
             await registry.delete_uncommitted_project(record.id)
         except Exception:
             logger.warning("failed to compensate uncommitted project registry row", exc_info=True)
-        raise HTTPException(
-            status_code=500,
-            detail="Existing project data could not be isolated. Project was not created.",
-        ) from exc
+        detail = (
+            "Existing project data failed ownership validation; nothing was touched."
+            if isinstance(exc, ProjectStorageOwnershipError)
+            else "Existing project data could not be isolated. Project was not created."
+        )
+        raise HTTPException(status_code=500, detail=detail) from exc
     try:
         ensure_project_dirs_at_paths(
             output_dir=record.output_dir,
@@ -860,7 +886,7 @@ async def _set_project_status(
 @router.post("/projects/{project}/archive")
 async def archive_project(
     project: str,
-    user: dict = Depends(require_scope("projects:write")),
+    user: dict = Depends(require_scope("projects:lifecycle")),
 ):
     ctx = await resolve_project_context(user=user, project_id=project, required_role="owner")
     return await _set_project_status(
@@ -875,7 +901,7 @@ async def archive_project(
 @router.post("/projects/{project}/unarchive")
 async def unarchive_project(
     project: str,
-    user: dict = Depends(require_scope("projects:write")),
+    user: dict = Depends(require_scope("projects:lifecycle")),
 ):
     ctx = await resolve_project_context(user=user, project_id=project, required_role="owner")
     return await _set_project_status(ctx, "active", audit_action="project.unarchive")
@@ -884,7 +910,7 @@ async def unarchive_project(
 @router.post("/projects/{project}/delete")
 async def soft_delete_project(
     project: str,
-    user: dict = Depends(require_scope("projects:write")),
+    user: dict = Depends(require_scope("projects:lifecycle")),
 ):
     ctx = await resolve_project_context(user=user, project_id=project, required_role="owner")
     return await _set_project_status(
@@ -899,7 +925,7 @@ async def soft_delete_project(
 @router.post("/projects/{project}/restore")
 async def restore_project(
     project: str,
-    user: dict = Depends(require_scope("projects:write")),
+    user: dict = Depends(require_scope("projects:lifecycle")),
 ):
     ctx = await resolve_project_context(user=user, project_id=project, required_role="owner")
     record = await get_project_registry().get_project(ctx.project_id)
@@ -911,14 +937,12 @@ async def restore_project(
 @router.post("/projects/{project}/purge")
 async def purge_project(
     project: str,
-    user: dict = Depends(require_scope("projects:write")),
+    user: dict = Depends(require_scope("projects:purge")),
 ):
     """永久删除项目目录；只允许对已进入回收站的项目执行。"""
     ctx = await resolve_project_context(user=user, project_id=project, required_role="owner")
     require_project_home_node(ctx, operation="purge project files")
-    from novelvideo.utils.project_paths import ProjectPaths
 
-    paths = ProjectPaths.from_context(ctx)
     registry = get_project_registry()
     record = await registry.get_project(ctx.project_id)
     if record is None or record.status != "deleted":
@@ -930,15 +954,17 @@ async def purge_project(
         raise HTTPException(status_code=400, detail="Project has already been purged.")
     try:
         quarantined_dirs = _quarantine_project_dirs(
-            (paths.output_dir, paths.state_dir, paths.runtime_dir),
+            record,
             project_id=ctx.project_id,
             reason="purging",
         )
     except Exception as exc:
-        raise HTTPException(
-            status_code=500,
-            detail="Project files could not be isolated. Nothing was permanently deleted.",
-        ) from exc
+        detail = (
+            "Project files failed ownership validation; nothing was permanently deleted."
+            if isinstance(exc, ProjectStorageOwnershipError)
+            else "Project files could not be isolated. Nothing was permanently deleted."
+        )
+        raise HTTPException(status_code=500, detail=detail) from exc
     try:
         record = await registry.mark_project_purged(ctx.project_id)
     except Exception:

--- a/src/novelvideo/chat/hermes_pool.py
+++ b/src/novelvideo/chat/hermes_pool.py
@@ -949,7 +949,9 @@ class HermesPool:
             "NOVELVIDEO_RUNTIME_DIR": str(config.RUNTIME_DIR),
             "ST_EDITION": os.environ.get("ST_EDITION", "ce"),
             "DRAMACLAW_FREEZONE_TOOL_RESULT_DIR": str(home / "tmp" / "freezone-tool-results"),
-            "ST_CONTROL_PLANE_DSN": os.environ.get("ST_CONTROL_PLANE_DSN", ""),
+            # 绝不把控制面数据库凭据传进 Hermes 子进程:worker 只经短期 agent token
+            # 走 HTTP API,拿到 DSN 会让插件/依赖的任意代码执行缺陷绕开业务鉴权直连库。
+            # (凭据化启动路径 build_hermes_child_env 本就不带 DSN,这里对齐旧分支。)
             "DRAMACLAW_USER": username,
             "DRAMACLAW_AGENT_TOKEN": token.value,
             "DRAMACLAW_AGENT_TOKEN_TYPE": "Bearer",

--- a/src/novelvideo/chat/hermes_sdk.py
+++ b/src/novelvideo/chat/hermes_sdk.py
@@ -782,9 +782,21 @@ def _issue_turn_capability(
             trajectory_id=trajectory_id, project_id=project_id, turn_id=turn_id
         )
         evidence_metrics.observe("capability_issued")
+        # One greppable success line per minted turn. Names only — no key,
+        # capability or prompt — so it is safe in api.log. Lets an operator
+        # confirm the K1/K3 keys are live without a debugger or an endpoint.
+        _log.info(
+            "capability_issued turn=%s (evidence plane active)", turn_id
+        )
         return capability
     except Exception:
-        _log.debug("could not issue an egress capability for this turn", exc_info=True)
+        # Elevated from debug: a mint failure is a HALTING evidence outcome —
+        # it must be visible in the normal log, not only under debug.
+        _log.warning(
+            "capability_issue_failure turn=%s — evidence plane HALT",
+            turn_id,
+            exc_info=True,
+        )
         evidence_metrics.observe("capability_issue_failure")
         return None
 

--- a/src/novelvideo/security/__init__.py
+++ b/src/novelvideo/security/__init__.py
@@ -6,10 +6,22 @@ Public API:
     - build_macos_profile: helper for direct sandbox-exec testing (used by PoC)
 """
 
+from novelvideo.security.project_storage import (
+    ProjectStorageOwnershipError,
+    ValidatedProjectStorage,
+    assert_owned_project_storage,
+)
 from novelvideo.security.sandbox_wrap import (
     SandboxSpec,
     build_macos_profile,
     wrap_command,
 )
 
-__all__ = ["SandboxSpec", "build_macos_profile", "wrap_command"]
+__all__ = [
+    "ProjectStorageOwnershipError",
+    "SandboxSpec",
+    "ValidatedProjectStorage",
+    "assert_owned_project_storage",
+    "build_macos_profile",
+    "wrap_command",
+]

--- a/src/novelvideo/security/project_storage.py
+++ b/src/novelvideo/security/project_storage.py
@@ -1,0 +1,136 @@
+"""统一的项目存储目录归属校验。
+
+所有对项目 output/state/runtime **整树**的移动或删除,必须先经过本模块。
+目的:即使数据库记录被篡改、旧迁移写坏路径、或程序缺陷导致路径异常,也绝不
+能移动或删除属于其他用户(或数据根、用户根等宽泛目录)的文件。
+
+规范布局: ``<root>/<owner_username>/<project>`` ,其中三类 root 分别是
+``config.OUTPUT_DIR`` / ``config.STATE_DIR`` / ``config.RUNTIME_DIR`` 。
+
+校验规则(任一不满足即拒绝,调用方必须放弃移动/删除任何目录):
+
+1. 路径规范化( ``resolve()`` )后必须恰好位于 ``<root>/<owner>/`` 下一层;
+2. 三类目录各自只能落在对应的数据根内;
+3. owner 目录本身不能是符号链接,目标目录本身不能是符号链接
+   (防止用可写目录里的软链接把删除引到别处);
+4. 路径不得等于数据根或 owner 用户根;
+5. 三个目录必须互不相同,且互不为对方的祖先。
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from novelvideo import config
+
+
+class ProjectStorageOwnershipError(Exception):
+    """项目存储目录未通过归属校验;禁止移动或删除。"""
+
+
+@dataclass(frozen=True, slots=True)
+class ValidatedProjectStorage:
+    """通过校验后的三类目录(均为 resolve 后的真实路径)。"""
+
+    output_dir: Path
+    state_dir: Path
+    runtime_dir: Path
+
+    def as_tuple(self) -> tuple[Path, Path, Path]:
+        return (self.output_dir, self.state_dir, self.runtime_dir)
+
+
+def _roots() -> dict[str, Path]:
+    # 动态读取,而非 import 时绑定:根目录可被配置或测试改写。
+    return {
+        "output": Path(config.OUTPUT_DIR),
+        "state": Path(config.STATE_DIR),
+        "runtime": Path(config.RUNTIME_DIR),
+    }
+
+
+def _validate_one(kind: str, root: Path, owner_username: str, raw: Path) -> Path:
+    root_real = root.resolve(strict=False)
+    owner_dir = root / owner_username
+    # owner 目录本身若是软链接,resolve 会把它指到别处 —— 直接拒,不给软链接机会。
+    if owner_dir.is_symlink():
+        raise ProjectStorageOwnershipError(
+            f"{kind}: owner directory {owner_dir} is a symlink; refusing"
+        )
+    owner_real = owner_dir.resolve(strict=False)
+    if owner_real.parent != root_real:
+        raise ProjectStorageOwnershipError(
+            f"{kind}: owner directory {owner_real} is not directly under root {root_real}"
+        )
+
+    # 叶子目录本身若是软链接,即便解析后落在 owner 内也拒绝:软链接可在两次操作
+    # 之间被换指向(TOCTOU),不作为可信边界。
+    if raw.is_symlink():
+        raise ProjectStorageOwnershipError(
+            f"{kind}: project directory {raw} is a symlink; refusing"
+        )
+    real = raw.resolve(strict=False)
+    if real == root_real:
+        raise ProjectStorageOwnershipError(f"{kind}: path equals data root {root_real}")
+    if real == owner_real:
+        raise ProjectStorageOwnershipError(
+            f"{kind}: path equals owner root {owner_real}"
+        )
+    if real.parent != owner_real:
+        raise ProjectStorageOwnershipError(
+            f"{kind}: path {real} is not directly under owner directory {owner_real}"
+        )
+    return real
+
+
+def _assert_disjoint(paths: dict[str, Path]) -> None:
+    items = list(paths.items())
+    for i, (kind_a, a) in enumerate(items):
+        for kind_b, b in items[i + 1 :]:
+            if a == b:
+                raise ProjectStorageOwnershipError(
+                    f"{kind_a} and {kind_b} resolve to the same directory {a}"
+                )
+            if a in b.parents or b in a.parents:
+                raise ProjectStorageOwnershipError(
+                    f"{kind_a} ({a}) and {kind_b} ({b}) are nested"
+                )
+
+
+def assert_owned_project_storage(
+    *,
+    owner_username: str,
+    output_dir: str | Path,
+    state_dir: str | Path,
+    runtime_dir: str | Path,
+) -> ValidatedProjectStorage:
+    """校验三类项目目录归属;通过则返回 resolve 后的真实路径,否则抛出。
+
+    调用方必须只在本函数成功返回后才移动/删除返回的路径,任一校验失败都不得
+    对任何目录执行破坏性操作。
+    """
+    owner = (owner_username or "").strip()
+    if not owner or "/" in owner or "\\" in owner or owner in (".", ".."):
+        raise ProjectStorageOwnershipError(
+            f"invalid owner username for storage validation: {owner_username!r}"
+        )
+    roots = _roots()
+    validated = {
+        "output": _validate_one("output", roots["output"], owner, Path(output_dir)),
+        "state": _validate_one("state", roots["state"], owner, Path(state_dir)),
+        "runtime": _validate_one("runtime", roots["runtime"], owner, Path(runtime_dir)),
+    }
+    _assert_disjoint(validated)
+    return ValidatedProjectStorage(
+        output_dir=validated["output"],
+        state_dir=validated["state"],
+        runtime_dir=validated["runtime"],
+    )
+
+
+__all__ = [
+    "ProjectStorageOwnershipError",
+    "ValidatedProjectStorage",
+    "assert_owned_project_storage",
+]

--- a/src/novelvideo/security/sandbox_wrap.py
+++ b/src/novelvideo/security/sandbox_wrap.py
@@ -35,7 +35,13 @@ SEATBELT_NETWORK_POLICY = SANDBOX_PROFILES_DIR / "seatbelt_network_policy.sbpl"
 def _data_dir(kind: str) -> Path:
     env = os.environ.get(f"NOVELVIDEO_{kind.upper()}_DIR", "").strip()
     if env:
-        return Path(env).expanduser()
+        p = Path(env).expanduser()
+        # A relative override (e.g. NOVELVIDEO_OUTPUT_DIR=output) MUST be
+        # anchored to SUPERTALE_ROOT — mirroring the no-override default below.
+        # A relative path here would reach the Seatbelt profile as
+        # `(subpath "output")`, which Seatbelt silently never matches, leaving
+        # the wholesale peer-read deny disabled for that tree. Always absolute.
+        return p if p.is_absolute() else (SUPERTALE_ROOT / p)
     return SUPERTALE_ROOT / kind
 
 
@@ -74,20 +80,14 @@ class SandboxSpec:
         ]
         return paths
 
-    def other_user_paths(self) -> list[Path]:
-        """All other users' state/output/runtime trees — must be denied."""
-        result: list[Path] = []
-        for top in ("state", "output", "runtime"):
-            top_dir = _data_dir(top)
-            if not top_dir.is_dir():
-                continue
-            for child in top_dir.iterdir():
-                if not child.is_dir():
-                    continue
-                if child.name in (self.user, "_shared"):
-                    continue
-                result.append(child)
-        return result
+    def data_roots(self) -> list[Path]:
+        """The per-user data roots (state/output/runtime tops).
+
+        The macOS profile denies reads on these wholesale and then allows back
+        only this user's own slice + ``_shared`` — so every peer (existing or
+        created mid-session) is denied without enumeration.
+        """
+        return [_data_dir("state"), _data_dir("output"), _data_dir("runtime")]
 
 
 def wrap_command(cmd: list[str], spec: SandboxSpec) -> list[str]:
@@ -171,6 +171,14 @@ def _expand_aliases(paths: Iterable[Path]) -> list[Path]:
     out: list[Path] = []
     seen: set[str] = set()
     for p in paths:
+        # Fail loud, never silent: Seatbelt `(subpath "…")` only matches
+        # absolute paths. A relative one never matches, so a relative deny would
+        # silently leave a tree open (see _data_dir). Refuse to emit one.
+        if not p.is_absolute():
+            raise ValueError(
+                f"sandbox profile path must be absolute, got relative {p!r}; "
+                f"a relative subpath silently disables the Seatbelt rule"
+            )
         for alt in _aliases(p):
             s = str(alt)
             if s not in seen:
@@ -211,13 +219,38 @@ def build_macos_profile(spec: SandboxSpec) -> str:
 
     # --- READ allow: broad ((subpath "/") — same as codex workspace-write mode) ---
     # Rationale: macOS dyld needs many paths to launch even `cat`; strict
-    # subpath whitelist is unmaintainable. Defense relies on explicit DENY
-    # of host secrets + other-user dirs below, which override this broad allow.
+    # subpath whitelist is unmaintainable. Defense relies on the specific DENY
+    # rules below (per-user data roots + host secrets), which override this
+    # broad allow via Seatbelt last-match-wins.
     parts.append(";; READ: broad allow; specific denies below override\n")
     parts.append("(allow file-read* (subpath \"/\"))\n")
 
-    # --- READ deny: host secrets (specific denies override broad allow) ---
-    parts.append("\n;; READ deny: host secrets — overrides broad allow\n")
+    # --- READ deny: per-user data roots, WHOLESALE ---
+    # Deny reads on the entire state/output/runtime roots rather than
+    # enumerating sibling users at session start. Enumeration (iterdir) only
+    # captured users that existed when the profile was built, so a peer dir
+    # created mid-session stayed readable (TOCTOU). Denying the roots then
+    # allowing back only this user's own slice + _shared closes that gap and
+    # covers all future peers with no enumeration.
+    parts.append(
+        "\n;; READ deny: per-user data roots wholesale "
+        "(blocks all peers incl. future — no enumeration)\n"
+    )
+    parts.append(_deny_read_block(_expand_aliases(spec.data_roots())))
+
+    # --- READ allow-back: this user's own trees + shared read-only resources ---
+    # Comes AFTER the data-root deny so last-match-wins re-opens only the
+    # current user's slice and the shared resources.
+    allow_back = _expand_aliases(
+        [*spec.self_business_paths(), *spec.shared_read_paths()]
+    )
+    parts.append(
+        "\n;; READ allow-back: own dirs + shared resources override root deny\n"
+    )
+    parts.append(_allow_read_block(allow_back))
+
+    # --- READ deny: host secrets (LAST so nothing above can re-open them) ---
+    parts.append("\n;; READ deny: host secrets — overrides every allow above\n")
     parts.append(_deny_read_block(_expand_aliases([
         Path.home() / ".ssh",
         Path.home() / ".gnupg",
@@ -229,17 +262,9 @@ def build_macos_profile(spec: SandboxSpec) -> str:
         Path("/etc/sudoers.d"),
     ])))
 
-    # --- READ deny: other users ---
-    other = list(spec.other_user_paths())
-    if other:
-        parts.append("\n;; READ deny: other users' state/output/runtime\n")
-        parts.append(_deny_read_block(other))
-
-    # --- WRITE deny: explicit host /tmp + other users (must come BEFORE allow HERMES_HOME) ---
-    #     (base profile already `deny default`, but be explicit about /tmp and other users)
-    if other:
-        parts.append("\n;; WRITE deny: other users' state/output/runtime\n")
-        parts.append(_deny_write_block(other))
+    # --- WRITE: base profile is `deny default`, so peer/other-user writes
+    #     (existing AND future) are already denied without enumeration. Only
+    #     HERMES_HOME is allowed, last, so it wins over the /tmp deny. ---
     parts.append("\n;; WRITE deny: host /tmp (must use $TMPDIR=$HERMES_HOME/tmp)\n")
     parts.append(_deny_write_block(_expand_aliases([Path("/tmp")])))
 
@@ -283,10 +308,51 @@ def _deny_write_block(paths: Iterable[Path]) -> str:
     return "\n".join(lines)
 
 
+def _sandbox_required() -> bool:
+    """多租户/生产必须强制沙箱,不允许裸跑。
+
+    两个独立触发条件,满足其一即视为"必须沙箱":
+    - ``SUPERTALE_ENV=production`` —— 显式生产标记;
+    - ``ST_CONTROL_PLANE_DSN`` 非空 —— EE 控制面已接入,即多用户模式。
+
+    刻意不只依赖容易漏配的 ``SUPERTALE_ENV``:只要连了控制面(EE),哪怕忘了设
+    生产标记,也必须 fail-close。
+    """
+    if os.environ.get("SUPERTALE_ENV", "").strip().lower() == "production":
+        return True
+    if os.environ.get("ST_CONTROL_PLANE_DSN", "").strip():
+        return True
+    return False
+
+
+def _dev_unsandboxed_opt_in() -> bool:
+    """本地无沙箱开发必须走醒目的显式开关,而不是静默降级。"""
+    return os.environ.get("SUPERTALE_ALLOW_UNSANDBOXED", "").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
+
+
 def _fallback_or_raise(cmd: list[str], reason: str) -> list[str]:
-    if os.environ.get("SUPERTALE_ENV", "").lower() == "production":
-        raise RuntimeError(f"sandbox required in production but {reason}")
-    msg = f"sandbox unavailable ({reason}); running unsandboxed — dev only"
+    if _sandbox_required():
+        raise RuntimeError(
+            f"sandbox required (production or EE control-plane) but {reason}; "
+            f"refusing to run Hermes worker unsandboxed"
+        )
+    if not _dev_unsandboxed_opt_in():
+        # CE 本地开发也默认 fail-close:必须显式开 SUPERTALE_ALLOW_UNSANDBOXED=1
+        # 才允许裸跑,杜绝"漏配就静默无沙箱"。
+        raise RuntimeError(
+            f"sandbox unavailable ({reason}) and SUPERTALE_ALLOW_UNSANDBOXED is not "
+            f"set; refusing to run unsandboxed. Set SUPERTALE_ALLOW_UNSANDBOXED=1 to "
+            f"explicitly allow unsandboxed workers in local development only"
+        )
+    msg = (
+        f"sandbox unavailable ({reason}); running UNSANDBOXED because "
+        f"SUPERTALE_ALLOW_UNSANDBOXED is set — dev only, never in multi-user"
+    )
     _log.warning(msg)
     warnings.warn(msg, RuntimeWarning, stacklevel=3)
     return cmd

--- a/tests/sandbox_linux_check.sh
+++ b/tests/sandbox_linux_check.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Run the Linux Hermes sandbox isolation check inside a throwaway Linux
+# container, driving the real codex-linux-sandbox binary vendored in this repo.
+#
+# Companion to tests/sandbox_smoke.sh (which covers the macOS Seatbelt path).
+# The binary + the sandbox code under test both live in this CE repo, so the
+# check lives here too.
+#
+# Usage:   bash tests/sandbox_linux_check.sh
+#
+# Requires a running Docker/OrbStack daemon. On macOS the arm64/amd64 Linux
+# binary is picked to match your host. --privileged is used ONLY so bubblewrap
+# can create user namespaces inside the container (mirrors the "host kernel must
+# support user namespaces" production requirement); it does not affect the
+# sandbox semantics under test.
+set -euo pipefail
+
+# repo root = one level up from this script (tests/..)
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# codex-linux-sandbox is vendored per arch under deploy/sandbox/
+case "$(uname -m)" in
+  arm64|aarch64) ARCH=arm64 ;;
+  x86_64|amd64)  ARCH=amd64 ;;
+  *) echo "unsupported host arch: $(uname -m)" >&2; exit 1 ;;
+esac
+
+BIN="$ROOT/deploy/sandbox/linux-${ARCH}/codex-linux-sandbox"
+CHECK="$ROOT/tests/sandbox_linux_isolation.py"
+[ -f "$BIN" ]   || { echo "missing sandbox binary: $BIN" >&2; exit 1; }
+[ -f "$CHECK" ] || { echo "missing check script: $CHECK" >&2; exit 1; }
+
+if ! docker version >/dev/null 2>&1; then
+  echo "Docker daemon not reachable. Start OrbStack/Docker Desktop first." >&2
+  exit 1
+fi
+
+echo "arch=${ARCH}  binary=$BIN"
+exec docker run --rm --platform "linux/${ARCH}" --privileged \
+  -v "$BIN:/opt/cls-src:ro" \
+  -v "$CHECK:/check.py:ro" \
+  python:3.12-slim-bookworm \
+  sh -c '
+    set -e
+    apt-get update -qq >/dev/null 2>&1
+    apt-get install -y -qq bubblewrap >/dev/null 2>&1
+    # codex re-execs itself inside the sandbox, so it must be a real file under
+    # a bind-mounted tree, not a nested docker volume mount point.
+    cp /opt/cls-src /usr/local/bin/codex-linux-sandbox
+    chmod +x /usr/local/bin/codex-linux-sandbox
+    python3 /check.py
+  '

--- a/tests/sandbox_linux_isolation.py
+++ b/tests/sandbox_linux_isolation.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""Linux Hermes sandbox isolation check — runs INSIDE a Linux container.
+
+Drives the real codex-linux-sandbox binary (the same one the image installs)
+to empirically verify the three isolation dimensions a multi-tenant Hermes
+worker relies on:
+
+  WRITE  — a user may write only its own HERMES_HOME; peers + own non-home dirs
+           must be read-only.
+  READ   — broad-read is codex's workspace-write model; peers ARE readable at
+           this layer, so cross-user read confidentiality must come from the
+           deployment topology (mount only state/<user>), NOT from the profile.
+  NETWORK — `restricted` must block egress (external AND loopback).
+
+Exit 0 iff the security-critical expectations hold:
+  - own HERMES_HOME writable
+  - peer dir NOT writable
+  - own non-home dir NOT writable
+  - restricted network blocks egress
+The READ peer check is reported (not failed on): it documents the known
+workspace-write broad-read, which is closed at the deployment layer.
+
+Run it via tests/sandbox_linux_check.sh (handles Docker + bwrap).
+"""
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+BIN = shutil.which("codex-linux-sandbox") or "/usr/local/bin/codex-linux-sandbox"
+
+WORK = Path("/work")
+STATE = WORK / "state"
+ALICE = STATE / "alice"
+SHARED = STATE / "_shared"
+BOB = STATE / "bob"
+HOME = ALICE / ".hermes"
+
+
+def setup() -> None:
+    for p in (ALICE, SHARED, BOB, HOME):
+        p.mkdir(parents=True, exist_ok=True)
+    (ALICE / "mine.txt").write_text("alice-own-data")
+    (SHARED / "shared.txt").write_text("shared-data")
+    (BOB / "bob.txt").write_text("bob-secret")
+
+
+def _profile(network: str) -> dict:
+    return {
+        "type": "managed",
+        "file_system": {
+            "type": "restricted",
+            "entries": [
+                {"path": {"type": "special", "value": {"kind": "root"}}, "access": "read"},
+                {"path": {"type": "path", "path": str(HOME)}, "access": "write"},
+            ],
+        },
+        "network": network,
+    }
+
+
+def _run(cmd: list[str], network: str = "restricted") -> tuple[int, str]:
+    args = [
+        BIN,
+        "--sandbox-policy-cwd", str(HOME),
+        "--command-cwd", str(HOME),
+        "--permission-profile", json.dumps(_profile(network), separators=(",", ":")),
+        "--", *cmd,
+    ]
+    r = subprocess.run(args, capture_output=True, text=True, timeout=30)
+    return r.returncode, (r.stdout or r.stderr).strip().replace("\n", " ")[:100]
+
+
+def main() -> int:
+    if not Path(BIN).exists():
+        print(f"FATAL: {BIN} not found", file=sys.stderr)
+        return 2
+    setup()
+    v = subprocess.run([BIN, "--help"], capture_output=True, text=True)
+    if v.returncode != 0:
+        print(f"FATAL: codex-linux-sandbox --help rc={v.returncode}: {v.stderr[:200]}", file=sys.stderr)
+        return 2
+
+    ok = True
+
+    def expect(label: str, got_rc: int, want_zero: bool, detail: str) -> None:
+        nonlocal ok
+        passed = (got_rc == 0) == want_zero
+        ok = ok and passed
+        verdict = "PASS" if passed else "FAIL"
+        print(f"  [{verdict}] {label:34s} rc={got_rc}  {detail}")
+
+    print("== WRITE isolation (security-critical) ==")
+    rc, d = _run(["/bin/sh", "-c", f"echo x > {HOME}/ok.txt"])
+    expect("write own HERMES_HOME -> allow", rc, True, d)
+    rc, d = _run(["/bin/sh", "-c", f"echo x > {BOB}/hack.txt"])
+    expect("write peer dir -> DENY", rc, False, d)
+    rc, d = _run(["/bin/sh", "-c", f"echo x > {ALICE}/nope.txt"])
+    expect("write own non-home dir -> DENY", rc, False, d)
+
+    print("== NETWORK isolation (security-critical) ==")
+    net_probe = ("import socket,sys; s=socket.socket(); s.settimeout(4)\n"
+                 "try:\n s.connect(('1.1.1.1',53)); print('CONNECTED'); sys.exit(0)\n"
+                 "except Exception as e:\n print('blocked:'+type(e).__name__); sys.exit(7)")
+    rc, d = _run(["python3", "-c", net_probe], network="restricted")
+    expect("restricted blocks external egress", rc, False, d)
+
+    print("== READ (documented workspace-write broad-read; deployment closes it) ==")
+    rc, d = _run(["/bin/cat", str(BOB / "bob.txt")])
+    note = "peer READABLE (expected at sandbox layer — mount only state/<user> to close)"
+    print(f"  [NOTE] {'read peer dir':34s} rc={rc}  {note}")
+    rc, d = _run(["/bin/cat", str(ALICE / "mine.txt")])
+    print(f"  [NOTE] {'read own dir':34s} rc={rc}  {d}")
+
+    print("\nRESULT:", "OK — write+network isolation hold" if ok else "FAIL — a critical check regressed")
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/sandbox_smoke.sh
+++ b/tests/sandbox_smoke.sh
@@ -20,6 +20,10 @@ HOME_DIR="${HERMES_HOME:-/tmp/hermes-poc}"
 mkdir -p "$HOME_DIR/tmp"
 chmod 700 "$HOME_DIR"
 
+# Resolve the hermes CLI from PATH / HERMES_CLI_PATH rather than a hardcoded
+# per-machine home (T13). Falls back to the image default.
+HERMES_BIN="${HERMES_CLI_PATH:-$(command -v hermes 2>/dev/null || echo /root/.local/bin/hermes)}"
+
 # Build profile via Python (writes to a temp file, then exports as $PROFILE)
 PROFILE=$(.venv/bin/python3 - <<PY
 from novelvideo.security import SandboxSpec, build_macos_profile
@@ -142,7 +146,7 @@ expect_pass "T12  import ssl + sqlite3 + json" \
 # T13: import hermes_agent — hermes is in uv tool's own venv, not SuperTale .venv;
 # this verifies sandbox lets us at least *run* /usr/local/bin/hermes which is what matters.
 expect_pass "T13  exec hermes --version" \
-    /usr/bin/sandbox-exec -p "$PROFILE" -- /Users/eric/.local/bin/hermes --version
+    /usr/bin/sandbox-exec -p "$PROFILE" -- "$HERMES_BIN" --version
 
 # T14: tempfile uses TMPDIR=$HERMES_HOME/tmp
 expect_pass "T14  tempfile honors TMPDIR" \

--- a/tests/test_compose_ce_unsandboxed_gate.py
+++ b/tests/test_compose_ce_unsandboxed_gate.py
@@ -1,0 +1,66 @@
+"""CE 默认 compose 缺 Linux sandbox binary 时仍能起 Hermes worker;EE/production 仍拒绝。
+
+回应 #333 review:本 PR 把"无沙箱"从 fallback 改为 fail-close。默认 CE 镜像既未把
+``deploy/sandbox`` 下的 codex-linux-sandbox 装到 PATH,四份 compose 也无 opt-in,导致
+默认 ``docker compose up`` 首次创建 Hermes worker 即崩。四份 CE compose 现显式设
+``SUPERTALE_ALLOW_UNSANDBOXED=1``。本测试把 compose 配置与运行时行为钉在一起:
+CE(单租户、DSN 空)放行,worker 可创建;而一旦连上控制面(EE/多租户)仍严格拒绝。
+
+完整的 Linux binary 安装 / bubblewrap / 受控出口留在 #346。
+"""
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from novelvideo.security.sandbox_wrap import _fallback_or_raise
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CE_COMPOSE_FILES = [
+    "docker-compose.yml",
+    "docker-compose.release.yml",
+    "docker-compose.selfhosted.yml",
+    "docker-compose.selfhosted.release.yml",
+]
+
+
+def _api_env(compose_name: str) -> dict:
+    data = yaml.safe_load((REPO_ROOT / compose_name).read_text(encoding="utf-8"))
+    env = data["services"]["api"]["environment"]
+    assert isinstance(env, dict), f"{compose_name}: api.environment 必须是 map 形式"
+    return env
+
+
+@pytest.mark.parametrize("compose_name", CE_COMPOSE_FILES)
+def test_ce_compose_opts_into_unsandboxed_and_stays_single_tenant(compose_name: str) -> None:
+    env = _api_env(compose_name)
+    # CE 显式声明沿用无沙箱运行(Linux 镜像暂无 PATH 上的 binary,见 #346)。
+    assert str(env.get("SUPERTALE_ALLOW_UNSANDBOXED")) == "1", (
+        f"{compose_name}: 缺 SUPERTALE_ALLOW_UNSANDBOXED=1,默认 compose 会 fail-close 崩"
+    )
+    # 且必须是单租户 CE:DSN 显式为空,否则控制面兜底会覆盖该 opt-in(见下)。
+    assert env.get("ST_CONTROL_PLANE_DSN", "") == "", f"{compose_name}: CE 的 DSN 必须为空"
+    assert env.get("ST_EDITION") == "ce", f"{compose_name}: 必须是 CE"
+
+
+def test_ce_compose_env_lets_worker_start_without_binary(monkeypatch: pytest.MonkeyPatch) -> None:
+    # 用默认 compose 的真实 env 值驱动 fallback:缺 binary 时 CE 放行,worker 可创建。
+    env = _api_env("docker-compose.yml")
+    monkeypatch.delenv("SUPERTALE_ENV", raising=False)
+    monkeypatch.setenv("ST_CONTROL_PLANE_DSN", env.get("ST_CONTROL_PLANE_DSN", ""))
+    monkeypatch.setenv(
+        "SUPERTALE_ALLOW_UNSANDBOXED", str(env["SUPERTALE_ALLOW_UNSANDBOXED"])
+    )
+    with pytest.warns(RuntimeWarning, match="UNSANDBOXED"):
+        result = _fallback_or_raise(["hermes", "run"], "no linux sandbox binary on PATH")
+    assert result == ["hermes", "run"]
+
+
+def test_same_optin_still_fails_closed_under_control_plane(monkeypatch: pytest.MonkeyPatch) -> None:
+    # 同样的 opt-in,一旦连上控制面(EE/多租户)仍必须拒绝——兜底不扩散到多租户。
+    monkeypatch.delenv("SUPERTALE_ENV", raising=False)
+    monkeypatch.setenv("SUPERTALE_ALLOW_UNSANDBOXED", "1")
+    monkeypatch.setenv("ST_CONTROL_PLANE_DSN", "postgres://cp/db")
+    with pytest.raises(RuntimeError, match="sandbox required"):
+        _fallback_or_raise(["hermes"], "no linux sandbox binary on PATH")

--- a/tests/test_docker_hardening.py
+++ b/tests/test_docker_hardening.py
@@ -1,0 +1,26 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_api_image_drops_root_at_runtime() -> None:
+    dockerfile = (ROOT / "Dockerfile").read_text(encoding="utf-8")
+    assert "useradd --system --uid 10001" in dockerfile
+    assert "USER dramaclaw:dramaclaw" in dockerfile
+    assert "HERMES_CLI_PATH=/usr/local/bin/hermes" in dockerfile
+
+
+def test_all_api_compose_variants_are_hardened() -> None:
+    for name in (
+        "docker-compose.yml",
+        "docker-compose.release.yml",
+        "docker-compose.selfhosted.yml",
+        "docker-compose.selfhosted.release.yml",
+    ):
+        text = (ROOT / name).read_text(encoding="utf-8")
+        api = text.split("\n  web:", 1)[0]
+        assert 'user: "10001:10001"' in api, name
+        assert "read_only: true" in api, name
+        assert "- ALL" in api, name
+        assert "no-new-privileges:true" in api, name

--- a/tests/test_hermes_pool_session_resume.py
+++ b/tests/test_hermes_pool_session_resume.py
@@ -103,9 +103,10 @@ def _patch_fake_hermes_pool(
     )
     monkeypatch.setattr(
         hermes_pool,
-        "effective_gateway_fingerprint",
+        "gateway_origin_fingerprint",
         lambda: gateway["fingerprint"],
     )
+    monkeypatch.setattr(hermes_pool, "require_hermes_fork", lambda *_args, **_kwargs: None)
     monkeypatch.setattr(hermes_pool, "HermesSdkClient", FakeHermesSdkClient)
 
     pool = hermes_pool.HermesPool(max_workers=5)
@@ -148,8 +149,10 @@ def test_hermes_worker_receives_effective_newapi_key_without_mutating_host_env(
         project_id=None,
     )
 
-    assert env["NEWAPI_API_KEY"] == "worker-only-key"
-    assert env["OPENAI_API_KEY"] == "worker-only-key"
+    # The real gateway key is delivered per turn through ACP metadata; the
+    # long-lived worker only receives a non-secret placeholder.
+    assert env["NEWAPI_API_KEY"] == "dramaclaw-per-turn-placeholder"
+    assert env["OPENAI_API_KEY"] == "dramaclaw-per-turn-placeholder"
     assert "NEWAPI_API_KEY" not in os.environ
     assert "OPENAI_API_KEY" not in os.environ
 
@@ -158,6 +161,8 @@ def test_hermes_worker_defaults_to_ce_edition(tmp_path: Path, monkeypatch: pytes
     from novelvideo.chat import hermes_pool
 
     monkeypatch.delenv("ST_EDITION", raising=False)
+    # 即便宿主进程有控制面 DSN,也绝不能泄漏进 worker 子进程环境。
+    monkeypatch.setenv("ST_CONTROL_PLANE_DSN", "postgres://cp/db")
     monkeypatch.setattr(hermes_pool, "effective_gateway_credentials", lambda: ("", ""))
     token = AgentSessionToken(
         value="agent-token",
@@ -178,6 +183,7 @@ def test_hermes_worker_defaults_to_ce_edition(tmp_path: Path, monkeypatch: pytes
     )
 
     assert env["ST_EDITION"] == "ce"
+    assert "ST_CONTROL_PLANE_DSN" not in env
 
 
 def test_hermes_worker_receives_novelvideo_data_roots(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -341,6 +347,7 @@ async def test_hermes_pool_freezone_profile_uses_isolated_home_and_canvas_env(
     monkeypatch.setattr(registry, "_PORTS", dict(registry._PORTS))
     registry.register_port("auth_session", fake_auth)
     monkeypatch.setattr(hermes_pool, "_hermes_cli_path", lambda: fake_cli)
+    monkeypatch.setattr(hermes_pool, "require_hermes_fork", lambda *_args, **_kwargs: None)
     monkeypatch.setattr(hermes_pool, "ensure_user_hermes_workspace", fake_workspace)
     monkeypatch.setattr(hermes_pool, "HermesSdkClient", FakeHermesSdkClient)
 
@@ -437,9 +444,10 @@ async def test_hermes_pool_starts_fresh_session_when_resume_fails(
     )
     monkeypatch.setattr(
         hermes_pool,
-        "effective_gateway_fingerprint",
+        "gateway_origin_fingerprint",
         lambda: "gateway-1",
     )
+    monkeypatch.setattr(hermes_pool, "require_hermes_fork", lambda *_args, **_kwargs: None)
     monkeypatch.setattr(hermes_pool, "HermesSdkClient", FakeHermesSdkClient)
 
     pool = hermes_pool.HermesPool(max_workers=5)
@@ -500,9 +508,10 @@ async def test_hermes_pool_surfaces_error_when_resume_and_fresh_start_fail(
     )
     monkeypatch.setattr(
         hermes_pool,
-        "effective_gateway_fingerprint",
+        "gateway_origin_fingerprint",
         lambda: "gateway-1",
     )
+    monkeypatch.setattr(hermes_pool, "require_hermes_fork", lambda *_args, **_kwargs: None)
     monkeypatch.setattr(hermes_pool, "HermesSdkClient", FakeHermesSdkClient)
 
     pool = hermes_pool.HermesPool(max_workers=5)
@@ -563,9 +572,10 @@ async def test_hermes_pool_does_not_restore_stale_session_after_rotation_fallbac
     )
     monkeypatch.setattr(
         hermes_pool,
-        "effective_gateway_fingerprint",
+        "gateway_origin_fingerprint",
         lambda: "gateway-1",
     )
+    monkeypatch.setattr(hermes_pool, "require_hermes_fork", lambda *_args, **_kwargs: None)
     monkeypatch.setattr(hermes_pool, "HermesSdkClient", FakeHermesSdkClient)
 
     pool = hermes_pool.HermesPool(max_workers=5)

--- a/tests/test_project_lifecycle_storage.py
+++ b/tests/test_project_lifecycle_storage.py
@@ -3,21 +3,31 @@ from types import SimpleNamespace
 
 import pytest
 
+from novelvideo import config
 from novelvideo.ports.project import ProjectRecord
 from novelvideo.project_context import ProjectContext
 
 
-def _record(tmp_path, *, status: str = "active") -> ProjectRecord:
+def _patch_roots(monkeypatch, tmp_path) -> None:
+    """把三类数据根指向 tmp_path,让归属校验器认得测试目录。"""
+    monkeypatch.setattr(config, "OUTPUT_DIR", tmp_path / "output")
+    monkeypatch.setattr(config, "STATE_DIR", tmp_path / "state")
+    monkeypatch.setattr(config, "RUNTIME_DIR", tmp_path / "runtime")
+
+
+def _record(
+    tmp_path, *, status: str = "active", owner: str = "alice"
+) -> ProjectRecord:
     return ProjectRecord(
         id="01PROJECT",
         owner_type="user",
         owner_id="local",
-        owner_username="alice",
+        owner_username=owner,
         name="demo",
         home_node_id="local",
-        output_dir=str(tmp_path / "output" / "alice" / "demo"),
-        state_dir=str(tmp_path / "state" / "alice" / "demo"),
-        runtime_dir=str(tmp_path / "runtime" / "alice" / "demo"),
+        output_dir=str(tmp_path / "output" / owner / "demo"),
+        state_dir=str(tmp_path / "state" / owner / "demo"),
+        runtime_dir=str(tmp_path / "runtime" / owner / "demo"),
         status=status,
     )
 
@@ -45,6 +55,7 @@ def _context(record: ProjectRecord) -> ProjectContext:
 async def test_create_project_does_not_reuse_orphaned_same_name_data(monkeypatch, tmp_path):
     from novelvideo.api.routes import projects
 
+    _patch_roots(monkeypatch, tmp_path)
     record = _record(tmp_path)
     old_canvas = tmp_path / "state" / "alice" / "demo" / "freezone" / "canvases"
     old_canvas.mkdir(parents=True)
@@ -100,6 +111,7 @@ async def test_create_project_does_not_reuse_orphaned_same_name_data(monkeypatch
 async def test_purge_detaches_files_before_releasing_project_name(monkeypatch, tmp_path):
     from novelvideo.api.routes import projects
 
+    _patch_roots(monkeypatch, tmp_path)
     record = _record(tmp_path, status="deleted")
     for raw_path in (record.output_dir, record.state_dir, record.runtime_dir):
         path = projects.Path(raw_path)
@@ -147,6 +159,7 @@ async def test_purge_detaches_files_before_releasing_project_name(monkeypatch, t
 async def test_purge_restores_files_when_registry_purge_fails(monkeypatch, tmp_path):
     from novelvideo.api.routes import projects
 
+    _patch_roots(monkeypatch, tmp_path)
     record = _record(tmp_path, status="deleted")
     for raw_path in (record.output_dir, record.state_dir, record.runtime_dir):
         path = projects.Path(raw_path)
@@ -174,3 +187,158 @@ async def test_purge_restores_files_when_registry_purge_fails(monkeypatch, tmp_p
         path = projects.Path(raw_path)
         assert (path / "retained.txt").read_text(encoding="utf-8") == "old"
         assert not list(path.parent.glob(".demo.purging-*"))
+
+
+# --------------------------------------------------------------------------- #
+# 存储归属校验器:用户操作必须互相隔离,绝不移动/删除他人目录                     #
+# --------------------------------------------------------------------------- #
+
+
+def _valid_dirs(tmp_path, owner="alice"):
+    return dict(
+        owner_username=owner,
+        output_dir=str(tmp_path / "output" / owner / "demo"),
+        state_dir=str(tmp_path / "state" / owner / "demo"),
+        runtime_dir=str(tmp_path / "runtime" / owner / "demo"),
+    )
+
+
+def test_validator_accepts_owned_dirs(monkeypatch, tmp_path):
+    from novelvideo.security import assert_owned_project_storage
+
+    _patch_roots(monkeypatch, tmp_path)
+    validated = assert_owned_project_storage(**_valid_dirs(tmp_path))
+    assert validated.state_dir == (tmp_path / "state" / "alice" / "demo").resolve()
+
+
+def test_validator_rejects_other_users_directory(monkeypatch, tmp_path):
+    from novelvideo.security import (
+        ProjectStorageOwnershipError,
+        assert_owned_project_storage,
+    )
+
+    _patch_roots(monkeypatch, tmp_path)
+    # state_dir 指向 bob 的目录,owner 是 alice —— 必须拒绝。
+    args = _valid_dirs(tmp_path)
+    args["state_dir"] = str(tmp_path / "state" / "bob" / "demo")
+    with pytest.raises(ProjectStorageOwnershipError):
+        assert_owned_project_storage(**args)
+
+
+@pytest.mark.parametrize(
+    "override_key, override_value_fn",
+    [
+        # 指向数据根本身
+        ("output_dir", lambda t: str(t / "output")),
+        # 指向 owner 用户根(会连带删掉该用户全部项目)
+        ("state_dir", lambda t: str(t / "state" / "alice")),
+        # 路径穿越到别的用户
+        ("runtime_dir", lambda t: str(t / "runtime" / "alice" / ".." / "bob" / "demo")),
+    ],
+)
+def test_validator_rejects_dangerous_paths(
+    monkeypatch, tmp_path, override_key, override_value_fn
+):
+    from novelvideo.security import (
+        ProjectStorageOwnershipError,
+        assert_owned_project_storage,
+    )
+
+    _patch_roots(monkeypatch, tmp_path)
+    args = _valid_dirs(tmp_path)
+    args[override_key] = override_value_fn(tmp_path)
+    with pytest.raises(ProjectStorageOwnershipError):
+        assert_owned_project_storage(**args)
+
+
+def test_validator_rejects_symlinked_project_dir(monkeypatch, tmp_path):
+    from novelvideo.security import (
+        ProjectStorageOwnershipError,
+        assert_owned_project_storage,
+    )
+
+    _patch_roots(monkeypatch, tmp_path)
+    # alice 的 state 目录里放一个软链接指向 bob 的目录。
+    (tmp_path / "state" / "bob" / "demo").mkdir(parents=True)
+    alice_state = tmp_path / "state" / "alice"
+    alice_state.mkdir(parents=True)
+    link = alice_state / "demo"
+    link.symlink_to(tmp_path / "state" / "bob" / "demo")
+    args = _valid_dirs(tmp_path)
+    args["state_dir"] = str(link)
+    with pytest.raises(ProjectStorageOwnershipError):
+        assert_owned_project_storage(**args)
+
+
+def test_validator_rejects_nested_dirs(monkeypatch, tmp_path):
+    from novelvideo.security import (
+        ProjectStorageOwnershipError,
+        assert_owned_project_storage,
+    )
+
+    _patch_roots(monkeypatch, tmp_path)
+    args = _valid_dirs(tmp_path)
+    # runtime 嵌在 state 下 —— 移动/删除会互相牵连,拒绝。
+    args["runtime_dir"] = str(tmp_path / "state" / "alice" / "demo" / "runtime")
+    with pytest.raises(ProjectStorageOwnershipError):
+        assert_owned_project_storage(**args)
+
+
+@pytest.mark.asyncio
+async def test_purge_refuses_when_record_points_at_other_user(monkeypatch, tmp_path):
+    """数据库记录被篡改指向别人目录时,purge 必须拒绝且不动任何文件。"""
+    from novelvideo.api.routes import projects
+
+    _patch_roots(monkeypatch, tmp_path)
+    record = _record(tmp_path, status="deleted")
+    # 篡改:把 alice 项目的 state_dir 指到 bob 的真实数据。
+    bob_state = tmp_path / "state" / "bob" / "demo"
+    bob_state.mkdir(parents=True)
+    (bob_state / "keep.txt").write_text("bob's data", encoding="utf-8")
+    record = replace(record, state_dir=str(bob_state))
+    for raw_path in (record.output_dir, record.runtime_dir):
+        projects.Path(raw_path).mkdir(parents=True)
+    ctx = _context(record)
+
+    class Registry:
+        async def get_project(self, _project_id):
+            return record
+
+        async def mark_project_purged(self, _project_id):
+            raise AssertionError("must not reach purge after validation failure")
+
+    async def resolve_context(**_kwargs):
+        return ctx
+
+    monkeypatch.setattr(projects, "resolve_project_context", resolve_context)
+    monkeypatch.setattr(projects, "get_project_registry", lambda: Registry())
+
+    with pytest.raises(projects.HTTPException) as exc_info:
+        await projects.purge_project("01PROJECT", user={"username": "alice"})
+
+    assert exc_info.value.status_code == 500
+    # bob 的数据毫发无损,alice 自己的目录也没被移动。
+    assert (bob_state / "keep.txt").read_text(encoding="utf-8") == "bob's data"
+    assert not list(bob_state.parent.glob(".demo.purging-*"))
+    for raw_path in (record.output_dir, record.runtime_dir):
+        assert projects.Path(raw_path).exists()
+
+
+def test_restore_never_deletes_a_reoccupied_original(monkeypatch, tmp_path, caplog):
+    """恢复隔离目录时,若原位置已被并发重建占用,绝不递归删除新数据。"""
+    from novelvideo.api.routes import projects
+
+    _patch_roots(monkeypatch, tmp_path)
+    original = tmp_path / "state" / "alice" / "demo"
+    quarantine = original.with_name(".demo.purging-x")
+    quarantine.mkdir(parents=True)
+    (quarantine / "old.txt").write_text("quarantined", encoding="utf-8")
+    # 原位置在隔离之后被重新创建,写入了新数据。
+    original.mkdir(parents=True)
+    (original / "new.txt").write_text("fresh", encoding="utf-8")
+
+    projects._restore_quarantined_project_dirs([(original, quarantine)])
+
+    # 新数据保留,隔离目录也保留(留给人工处置),都没被删。
+    assert (original / "new.txt").read_text(encoding="utf-8") == "fresh"
+    assert (quarantine / "old.txt").read_text(encoding="utf-8") == "quarantined"

--- a/tests/test_project_scope_split.py
+++ b/tests/test_project_scope_split.py
@@ -10,7 +10,9 @@ from __future__ import annotations
 import pytest
 from fastapi import HTTPException
 
-from novelvideo.api.auth import require_scope
+from types import SimpleNamespace
+
+from novelvideo.api.auth import _enforce_agent_request_boundary, require_scope
 
 LIFECYCLE_SCOPE = "projects:lifecycle"
 PURGE_SCOPE = "projects:purge"
@@ -66,6 +68,74 @@ async def test_lifecycle_scope_does_not_imply_purge() -> None:
 async def test_explicitly_scoped_agent_is_allowed() -> None:
     user = _agent_user("projects:read", PURGE_SCOPE)
     assert await _run(PURGE_SCOPE, user) is user
+
+
+def _request(method: str, path: str) -> SimpleNamespace:
+    # _enforce_agent_request_boundary only touches request.method and
+    # request.url.path — a namespace is enough and keeps the test hermetic.
+    return SimpleNamespace(method=method, url=SimpleNamespace(path=path))
+
+
+def test_central_guard_admits_purge_only_agent_on_unsafe_write() -> None:
+    """Regression for the AGENT_WRITE_SCOPES gap.
+
+    ``_enforce_agent_request_boundary`` runs inside ``get_api_user`` *before* the
+    route's own ``require_scope`` check. It rejects any agent unsafe write whose
+    scopes are disjoint from ``AGENT_WRITE_SCOPES``. When that set only listed
+    ``projects:write``/``tasks:submit``, a token holding exactly the scope the
+    purge route requires — ``[projects:read, projects:purge]`` — was 403'd here
+    before its route ever ran. The per-route ``require_scope`` tests stayed green
+    and never saw this, which is why the bug shipped. This asserts the central
+    guard now lets the correctly-scoped token through.
+    """
+    user = {
+        "credential_kind": "agent_session",
+        "username": "alice",
+        "scopes": ["projects:read", PURGE_SCOPE],
+        "current_scope_kind": "project",
+        "current_project_id": "demo",
+    }
+    # Must not raise: the guard admits it, the route-level scope check enforces
+    # the exact scope afterwards.
+    _enforce_agent_request_boundary(_request("DELETE", "/api/v1/projects/demo/purge"), user)
+
+
+def test_central_guard_admits_lifecycle_only_agent_on_unsafe_write() -> None:
+    user = {
+        "credential_kind": "agent_session",
+        "username": "alice",
+        "scopes": ["projects:read", LIFECYCLE_SCOPE],
+        "current_scope_kind": "project",
+        "current_project_id": "demo",
+    }
+    _enforce_agent_request_boundary(
+        _request("POST", "/api/v1/projects/demo/archive"), user
+    )
+
+
+def test_central_guard_still_rejects_agent_without_any_write_scope() -> None:
+    # A read-only agent token must still be blocked by the backstop on writes.
+    user = {
+        "credential_kind": "agent_session",
+        "username": "alice",
+        "scopes": ["projects:read"],
+        "current_scope_kind": "project",
+        "current_project_id": "demo",
+    }
+    with pytest.raises(HTTPException) as excinfo:
+        _enforce_agent_request_boundary(
+            _request("DELETE", "/api/v1/projects/demo/purge"), user
+        )
+    assert excinfo.value.status_code == 403
+
+
+def test_agent_write_scopes_covers_every_split_route_scope() -> None:
+    # If a future split adds a new precise write scope to a route but forgets the
+    # central backstop, that route becomes unreachable for its own token. Pin the
+    # invariant: every scope the split routes require is admitted by the backstop.
+    from novelvideo.api.auth import AGENT_WRITE_SCOPES
+
+    assert {LIFECYCLE_SCOPE, PURGE_SCOPE} <= AGENT_WRITE_SCOPES
 
 
 def test_default_agent_scope_lists_exclude_lifecycle_and_purge() -> None:

--- a/tests/test_project_scope_split.py
+++ b/tests/test_project_scope_split.py
@@ -1,0 +1,103 @@
+"""P0-3: 项目生命周期/永久删除必须与 projects:write 拆分为独立 scope。
+
+安全目标:Hermes / 外部 agent 默认只持有读写与任务 scope,永不持有
+``projects:lifecycle`` 或 ``projects:purge``。因此 agent 请求归档/删除/恢复/
+purge 时必须收到明确的 403,而浏览器用户(无 scopes)照常放行。
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import HTTPException
+
+from novelvideo.api.auth import require_scope
+
+LIFECYCLE_SCOPE = "projects:lifecycle"
+PURGE_SCOPE = "projects:purge"
+
+
+def _agent_user(*scopes: str) -> dict:
+    return {
+        "credential_kind": "agent_session",
+        "username": "alice",
+        "scopes": list(scopes),
+        "current_scope_kind": "project",
+        "current_project_id": "demo",
+    }
+
+
+def _browser_user() -> dict:
+    # 浏览器会话不带 scopes 字段,由常规项目访问校验授权。
+    return {"credential_kind": "browser", "username": "alice"}
+
+
+async def _run(scope: str, user: dict) -> dict:
+    check = require_scope(scope)
+    return await check(user=user)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("scope", [LIFECYCLE_SCOPE, PURGE_SCOPE])
+async def test_write_scoped_agent_is_rejected_for_lifecycle_and_purge(scope: str) -> None:
+    user = _agent_user("projects:read", "projects:write", "tasks:submit")
+    with pytest.raises(HTTPException) as excinfo:
+        await _run(scope, user)
+    assert excinfo.value.status_code == 403
+    assert scope in str(excinfo.value.detail)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("scope", [LIFECYCLE_SCOPE, PURGE_SCOPE])
+async def test_browser_session_passes_lifecycle_and_purge(scope: str) -> None:
+    user = _browser_user()
+    assert await _run(scope, user) is user
+
+
+@pytest.mark.asyncio
+async def test_lifecycle_scope_does_not_imply_purge() -> None:
+    # 持有 lifecycle 的 token 仍不能 purge:两个 scope 相互独立。
+    user = _agent_user("projects:read", "projects:write", LIFECYCLE_SCOPE)
+    with pytest.raises(HTTPException) as excinfo:
+        await _run(PURGE_SCOPE, user)
+    assert excinfo.value.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_explicitly_scoped_agent_is_allowed() -> None:
+    user = _agent_user("projects:read", PURGE_SCOPE)
+    assert await _run(PURGE_SCOPE, user) is user
+
+
+def test_default_agent_scope_lists_exclude_lifecycle_and_purge() -> None:
+    from novelvideo.chat.hermes_pool import HERMES_DEFAULT_SCOPES
+    from novelvideo.chat.service import PAGE_AGENT_SCOPES
+    from novelvideo.ports.auth_contract import DEFAULT_EXTERNAL_AGENT_SCOPES
+
+    for scopes in (
+        HERMES_DEFAULT_SCOPES,
+        PAGE_AGENT_SCOPES,
+        DEFAULT_EXTERNAL_AGENT_SCOPES,
+    ):
+        assert LIFECYCLE_SCOPE not in scopes
+        assert PURGE_SCOPE not in scopes
+
+
+def test_lifecycle_and_purge_routes_use_split_scopes() -> None:
+    # 直接从路由依赖里读回 scope,防止有人把守卫改回 projects:write。
+    from novelvideo.api.routes import projects as projects_routes
+
+    wanted = {
+        "archive_project": LIFECYCLE_SCOPE,
+        "unarchive_project": LIFECYCLE_SCOPE,
+        "soft_delete_project": LIFECYCLE_SCOPE,
+        "restore_project": LIFECYCLE_SCOPE,
+        "purge_project": PURGE_SCOPE,
+    }
+    routes = {r.name: r for r in projects_routes.router.routes if getattr(r, "name", None) in wanted}
+    assert set(routes) == set(wanted), f"missing routes: {set(wanted) - set(routes)}"
+    for name, scope in wanted.items():
+        scopes = {
+            getattr(dep.call, "_required_scope", None)
+            for dep in routes[name].dependant.dependencies
+        }
+        assert scope in scopes, f"{name} should require {scope}, got {scopes}"

--- a/tests/test_sandbox_roots.py
+++ b/tests/test_sandbox_roots.py
@@ -1,12 +1,18 @@
 """Sandbox data roots follow configured NOVELVIDEO_*_DIR values."""
 
 import json
+from pathlib import Path
+
+import pytest
 
 from novelvideo.security.sandbox_wrap import (
     SUPERTALE_ROOT,
     SandboxSpec,
     _data_dir,
+    _expand_aliases,
+    _fallback_or_raise,
     _wrap_linux,
+    build_macos_profile,
 )
 
 
@@ -19,7 +25,26 @@ def test_data_dir_prefers_env(monkeypatch, tmp_path):
     assert _data_dir("state") == SUPERTALE_ROOT / "state"
 
 
-def test_other_user_paths_use_configured_data_roots(monkeypatch, tmp_path):
+def test_data_dir_absolutizes_relative_env(monkeypatch):
+    """Regression: a relative NOVELVIDEO_*_DIR must anchor to SUPERTALE_ROOT.
+
+    A relative value (e.g. `.env` had NOVELVIDEO_OUTPUT_DIR=output) previously
+    reached the Seatbelt profile as `(subpath "output")`, which Seatbelt never
+    matches — silently leaving that data root's peer-read deny disabled.
+    """
+    monkeypatch.setenv("NOVELVIDEO_OUTPUT_DIR", "output")
+    got = _data_dir("output")
+    assert got.is_absolute()
+    assert got == SUPERTALE_ROOT / "output"
+
+
+def test_expand_aliases_rejects_relative_path():
+    """Belt-and-suspenders: no relative path may ever reach a subpath block."""
+    with pytest.raises(ValueError, match="must be absolute"):
+        _expand_aliases([Path("output")])
+
+
+def test_data_roots_and_self_paths_use_configured_data_roots(monkeypatch, tmp_path):
     state = tmp_path / "state"
     output = tmp_path / "output"
     runtime = tmp_path / "runtime"
@@ -31,7 +56,6 @@ def test_other_user_paths_use_configured_data_roots(monkeypatch, tmp_path):
     monkeypatch.setenv("NOVELVIDEO_RUNTIME_DIR", str(runtime))
 
     spec = SandboxSpec(user="alice")
-    others = set(spec.other_user_paths())
 
     assert spec.resolved_hermes_home() == state / "alice" / ".hermes"
     assert set(spec.self_business_paths()) == {
@@ -39,9 +63,46 @@ def test_other_user_paths_use_configured_data_roots(monkeypatch, tmp_path):
         output / "alice",
         runtime / "alice",
     }
-    assert {state / "bob", output / "bob", runtime / "bob"} <= others
-    assert state / "alice" not in others
-    assert state / "_shared" not in others
+    assert set(spec.data_roots()) == {state, output, runtime}
+
+
+def test_macos_profile_denies_peer_roots_wholesale(monkeypatch, tmp_path):
+    """P0/H3: peer reads are denied by root, not by session-start enumeration.
+
+    A sibling user dir created AFTER the profile was built must still be
+    unreadable — the earlier iterdir() approach missed those (TOCTOU).
+    """
+    state = tmp_path / "state"
+    output = tmp_path / "output"
+    runtime = tmp_path / "runtime"
+    for root in (state, output, runtime):
+        (root / "alice").mkdir(parents=True)
+        (root / "_shared").mkdir(parents=True)
+    monkeypatch.setenv("NOVELVIDEO_STATE_DIR", str(state))
+    monkeypatch.setenv("NOVELVIDEO_OUTPUT_DIR", str(output))
+    monkeypatch.setenv("NOVELVIDEO_RUNTIME_DIR", str(runtime))
+
+    profile = build_macos_profile(SandboxSpec(user="alice"))
+
+    # The whole data roots are denied for read...
+    assert f'(deny file-read*\n  (subpath "{state}")' in profile
+    assert f'(subpath "{output}")' in profile
+    assert f'(subpath "{runtime}")' in profile
+    # ...then this user's own slice + _shared are allowed back.
+    assert f'(subpath "{state / "alice"}")' in profile
+    assert f'(subpath "{state / "_shared"}")' in profile
+
+    # Deny of the root must precede the allow-back (last-match-wins re-opens
+    # only alice's slice); and no peer dir is ever named explicitly.
+    deny_root_at = profile.index(f'(deny file-read*\n  (subpath "{state}")')
+    allow_self_at = profile.rindex(f'(subpath "{state / "alice"}")')
+    assert deny_root_at < allow_self_at
+    assert "bob" not in profile  # a future/other peer is covered by root deny, never listed
+
+    # Host secrets are denied LAST so nothing re-opens them.
+    assert profile.rstrip().count("file-read*")  # sanity: read rules present
+    ssh_deny_at = profile.rindex(str(Path.home() / ".ssh"))
+    assert ssh_deny_at > allow_self_at
 
 
 def test_linux_wrapper_uses_current_codex_sandbox_cli(monkeypatch, tmp_path):
@@ -72,3 +133,51 @@ def test_linux_wrapper_uses_current_codex_sandbox_cli(monkeypatch, tmp_path):
         "path": {"type": "path", "path": str(hermes_home)},
         "access": "write",
     } in profile["file_system"]["entries"]
+
+
+def _clear_sandbox_env(monkeypatch) -> None:
+    for name in (
+        "SUPERTALE_ENV",
+        "ST_CONTROL_PLANE_DSN",
+        "SUPERTALE_ALLOW_UNSANDBOXED",
+    ):
+        monkeypatch.delenv(name, raising=False)
+
+
+def test_fallback_fails_closed_in_production(monkeypatch):
+    _clear_sandbox_env(monkeypatch)
+    monkeypatch.setenv("SUPERTALE_ENV", "production")
+    with pytest.raises(RuntimeError, match="sandbox required"):
+        _fallback_or_raise(["hermes"], "no backend")
+
+
+def test_fallback_fails_closed_when_control_plane_connected(monkeypatch):
+    # EE 多租户:连了控制面即使没设 production,也必须拒绝裸跑。
+    _clear_sandbox_env(monkeypatch)
+    monkeypatch.setenv("ST_CONTROL_PLANE_DSN", "postgres://cp/db")
+    with pytest.raises(RuntimeError, match="sandbox required"):
+        _fallback_or_raise(["hermes"], "no backend")
+
+
+def test_fallback_fails_closed_in_dev_without_optin(monkeypatch):
+    # 本地 CE 开发默认也 fail-close,除非显式开开关。
+    _clear_sandbox_env(monkeypatch)
+    with pytest.raises(RuntimeError, match="SUPERTALE_ALLOW_UNSANDBOXED"):
+        _fallback_or_raise(["hermes"], "no backend")
+
+
+def test_fallback_allows_dev_with_explicit_optin(monkeypatch):
+    _clear_sandbox_env(monkeypatch)
+    monkeypatch.setenv("SUPERTALE_ALLOW_UNSANDBOXED", "1")
+    with pytest.warns(RuntimeWarning, match="UNSANDBOXED"):
+        result = _fallback_or_raise(["hermes", "run"], "no backend")
+    assert result == ["hermes", "run"]
+
+
+def test_dev_optin_cannot_override_required_sandbox(monkeypatch):
+    # 开关只对本地开发生效;生产/EE 下即便设了也必须拒绝。
+    _clear_sandbox_env(monkeypatch)
+    monkeypatch.setenv("SUPERTALE_ALLOW_UNSANDBOXED", "1")
+    monkeypatch.setenv("ST_CONTROL_PLANE_DSN", "postgres://cp/db")
+    with pytest.raises(RuntimeError, match="sandbox required"):
+        _fallback_or_raise(["hermes"], "no backend")


### PR DESCRIPTION
## 摘要\n- 加强 Hermes 沙箱路径与项目作用域隔离，避免跨租户访问或删除数据\n- 补充 Linux/Docker 运行时隔离与启动配置\n- 修复 Hermes 运行时接入、会话恢复及相关前端/后端诊断日志\n- 保留 freezone-canvas 现有功能，未包含本地 start-ce.sh\n\n## 验证\n- 48 个针对性测试通过\n- Docker Compose 配置校验通过\n- 本地 Hermes 0.20.4 启动及消息收发已验证\n\n## 备注\n这是独立于现有稳定基线的草稿 PR，供审核后合并。