### PR TITLE
feat: default UI/Hermes chat language to English

### DIFF
--- a/.hermes/plugins/dramaclaw/__init__.py
+++ b/.hermes/plugins/dramaclaw/__init__.py
@@ -125,8 +125,9 @@ def _with_chat_error_hints(value: Any) -> Any:
         result.setdefault(
             "agent_instruction",
             (
-                "Reply to the user with chat_error in natural Chinese. Make clear the audio task "
-                "was not started. Tell the user they can go to 虾塘 to upload or record the missing "
+                "Reply to the user with chat_error in the user's UI language "
+                "(default English). Make clear the audio task "
+                "was not started. Tell the user they can go to Freezone (虾塘) to upload or record the missing "
                 "voice lines, then continue. Do not start another tool in this turn."
             ),
         )
@@ -139,9 +140,10 @@ def _with_chat_error_hints(value: Any) -> Any:
         result.setdefault(
             "agent_instruction",
             (
-                "Reply to the user with chat_error in natural Chinese. Make clear the render "
+                "Reply to the user with chat_error in the user's UI language "
+                "(default English). Make clear the render "
                 "task did not produce usable images because sketches are missing. Tell the user "
-                "to generate or verify sketches in 虾塘 before retrying render. Do not start "
+                "to generate or verify sketches in Freezone (虾塘) before retrying render. Do not start "
                 "another tool in this turn."
             ),
         )
@@ -150,7 +152,8 @@ def _with_chat_error_hints(value: Any) -> Any:
         result.setdefault(
             "agent_instruction",
             (
-                "Reply to the user with chat_error in natural Chinese. Do not quote the raw "
+                "Reply to the user with chat_error in the user's UI language "
+                "(default English). Do not quote the raw "
                 "provider JSON or provider_response_id."
             ),
         )

--- a/.hermes/skills/dramaclaw/SKILL.md
+++ b/.hermes/skills/dramaclaw/SKILL.md
@@ -8,6 +8,11 @@ requires:
 
 # DramaClaw 虾导 — AI 小说转视频 Skill
 
+## Language
+
+- Reply in the user's UI language. Default to **English** when the locale is missing or unclear.
+- Keep product names as DramaClaw / 虾导. Operational docs below may be Chinese; reply language still follows the UI locale.
+
 **Base URL**: `$DRAMACLAW_API_URL/api/v1`  
 **认证**: 所有请求需要 `Authorization: Bearer $DRAMACLAW_AGENT_TOKEN` header。
 

--- a/README.md
+++ b/README.md
@@ -237,9 +237,10 @@ uv run novelvideo api --port 8780   # start the REST API (CE defaults to inline 
 DramaClaw stays model-neutral — all text/image/video/audio models connect through a single **OpenAI-compatible gateway**, in two ways:
 
 - **DramaClaw official key (recommended)**: `docker compose up`, open <http://localhost:8080> → Settings → Model Config → Official, paste your DC key, save. Works instantly — no model mapping needed. Get a key at <https://relayclaw.cdnfg.com>.
-- **Bring your own gateway (BYO)**: point `NEWAPI_BASE_URL` at your own OpenAI-compatible endpoint and map model names (see [Configuring Models](docs/en/getting-started/configuring-models.md)).
+- **Bring your own gateway (BYO)**: use Local NewAPI (`docker-compose.selfhosted.yml`) and map model names in the UI (see [Configuring Models](docs/en/getting-started/configuring-models.md)).
+- **Local LLMs (Ollama / hybrid)**: run text + embeddings on your machine behind Local NewAPI; keep image / video / TTS on a cloud-capable upstream unless you supply compatible media APIs. Step-by-step: [Using DramaClaw with Local LLMs](docs/en/guides/local-llms.md).
 
-> Prefer fully local? Run `docker compose -f docker-compose.selfhosted.yml up` for a bundled `newapi` gateway you configure yourself (prebuilt-image variant: `docker-compose.selfhosted.release.yml`).
+> Prefer a bundled local gateway? Run `docker compose -f docker-compose.selfhosted.yml up` for `newapi` you configure yourself (prebuilt-image variant: `docker-compose.selfhosted.release.yml`).
 
 | Stage                | Connected via gateway                                               |
 |----------------------|---------------------------------------------------------------------|
@@ -293,6 +294,7 @@ The edge isn't "more generation" — it's organizing the whole short-drama produ
 - [Quick Start](./docs/en/getting-started/quickstart.md)
 - [Self-hosting guide](./docs/en/guides/self-hosting.md)
 - [Configuring model providers](./docs/en/getting-started/configuring-models.md)
+- [Local LLMs (Ollama / BYO)](./docs/en/guides/local-llms.md)
 - [More docs &rarr;](./docs/en/README.md)
 
 <br/>

--- a/docs/en/README.md
+++ b/docs/en/README.md
@@ -16,6 +16,7 @@
 | Doc | Contents |
 |---|---|
 | [Product User Manual](https://neo-flying.feishu.cn/docx/JGNTdsjJuo748TxJkxecoYs2nth) | Full-featured UI operation manual (Feishu) |
+| [Local LLMs (Ollama / BYO)](guides/local-llms.md) | Hybrid local text + embeddings behind Local NewAPI |
 | [Self-Hosting Guide](guides/self-hosting.md) | Deploy / upgrade / back up |
 | [ffmpeg Guide](guides/ffmpeg.md) | Install / locate / licensing obligations |
 | [Telemetry Notes](guides/telemetry.md) | No data collected by default / optional tracing |

--- a/docs/en/getting-started/configuring-models.md
+++ b/docs/en/getting-started/configuring-models.md
@@ -17,6 +17,8 @@ After startup, open `http://localhost:8080` and go to **Settings → Models & Ch
 
 Enable the intended mode after configuring it. New jobs read the latest mode, key, and mappings. Jobs already running do not switch gateways midway.
 
+For an end-to-end **Ollama / local LLM** walkthrough (Docker host URLs, example mappings, smoke tests), see [Using DramaClaw with Local LLMs](../guides/local-llms.md).
+
 ## Official mode
 
 Official mode is the shortest setup path:

--- a/docs/en/getting-started/quickstart.md
+++ b/docs/en/getting-started/quickstart.md
@@ -41,9 +41,10 @@ docker compose ps   # both api and web should be running
 
 ## Want to use your own model channels?
 
-Start the local NewAPI bundled with CE via `docker-compose.selfhosted.yml`, then initialize it and configure upstream keys and model mappings under Settings → Model Configuration → Local NewAPI. Its address and runtime token are stored in local `settings.db`, not `.env`. See [Configuring Model Providers](configuring-models.md).
+Start the local NewAPI bundled with CE via `docker-compose.selfhosted.yml`, then initialize it and configure upstream keys and model mappings under Settings → Model Configuration → Local NewAPI. Its address and runtime token are stored in local `settings.db`, not `.env`. See [Configuring Model Providers](configuring-models.md). For Ollama / hybrid local text + embeddings, follow [Using DramaClaw with Local LLMs](../guides/local-llms.md).
 
 ## Next steps
 
 - Full deployment/upgrade/backup: [Self-Hosting Handbook](../guides/self-hosting.md)
 - Connect your own models: [Configuring Model Providers](configuring-models.md)
+- Local LLMs (Ollama / BYO): [Using DramaClaw with Local LLMs](../guides/local-llms.md)

--- a/docs/en/guides/local-llms.md
+++ b/docs/en/guides/local-llms.md
@@ -1,0 +1,184 @@
+<!-- lang-switch -->
+**English** · [简体中文](../../zh/guides/local-llms.md)
+
+# Using DramaClaw with Local LLMs
+
+> End-to-end guide for Ollama (and other OpenAI-compatible local servers) behind Local NewAPI.
+
+DramaClaw does **not** load LLMs on the app host. The API (`:8780`) and web UI (`:8080`) call an **OpenAI-compatible NewAPI gateway**; that gateway talks to upstream providers (cloud or local). Gateway address and token are saved from **Settings → Model Configuration** into local `settings.db` — CE does not read them from `MODEL_API_KEY` / `MODEL_PROVIDER` environment variables.
+
+```mermaid
+flowchart LR
+  UI[Web UI :8080] --> API[DramaClaw API :8780]
+  API --> GW[NewAPI gateway]
+  GW --> Official[RelayClaw cloud]
+  GW --> Ollama[Ollama]
+  GW --> Custom[LM Studio / vLLM / llama.cpp]
+  GW --> Media[Image / video / TTS upstreams]
+```
+
+For channel buttons, embedding batch limits, and media relay, see [Configuring Model Providers](../getting-started/configuring-models.md).
+
+---
+
+## 1. Choose a path
+
+| Goal | Path | Model mapping |
+|---|---|---|
+| Fastest full novel → video pipeline | **Official RelayClaw** (default `docker-compose.yml` + DC key) | None — logical names already exist upstream |
+| Local text + embeddings; cloud image / video / TTS | **Hybrid (recommended for local LLMs)** | Map `DC-*-LLM` and `DC-cognee-embedding` in Local NewAPI |
+| Fully offline novel → finished video | Self-hosted NewAPI + local upstreams for **every** modality | Hard — image / video / TTS APIs are not “an Ollama chat model” |
+
+**Recommendation:** use hybrid local text. Get Hermes + Cognee working on Ollama first; leave media on RelayClaw or another cloud-capable upstream until text mapping is solid.
+
+---
+
+## 2. Wire the gateway
+
+### Official channel (full pipeline, no local models)
+
+```bash
+cp .env.example .env   # set PROMPT_EXPORT_PASSWORD
+docker compose up -d --build
+```
+
+Open `http://localhost:8080` → **Settings → Model Configuration → Official Channel** → paste a DC key from [relayclaw.cdnfg.com](https://relayclaw.cdnfg.com) → **Save and Enable**.
+
+### Local NewAPI (required for Ollama / BYO)
+
+```bash
+cp .env.example .env   # set PROMPT_EXPORT_PASSWORD
+docker compose -f docker-compose.selfhosted.yml up -d --build
+```
+
+This starts `api`, `web`, and bundled `newapi` (`http://localhost:3000`).
+
+1. Open `http://localhost:8080` → **Settings → Model Configuration → Local NewAPI**.
+2. Set a first-time admin password (only used if NewAPI is not initialized yet).
+3. Click **Initialize Local NewAPI**.
+
+The wizard creates or reuses the `dramaclaw-ce-runtime` token, writes it to `settings.db`, and switches the gateway mode to `custom`. Save the NewAPI admin password yourself — DramaClaw does not store it for later logins.
+
+If NewAPI was already initialized, leave the password blank and click Initialize again to only create/reuse the runtime token.
+
+Selfhosted compose already enables the provisioner (`NEWAPI_PROVISIONER_ENABLED` / `NEWAPI_ADMIN_BASE_URL`). Details: [Self-Hosting Handbook](self-hosting.md).
+
+---
+
+## 3. Run a local inference backend
+
+### Ollama (first-class preset)
+
+Install and start [Ollama](https://ollama.com), then pull at least one chat model and one embedding model:
+
+```bash
+# Example chat model — pick a size that fits your GPU / Apple Silicon RAM
+ollama pull qwen2.5:14b
+
+# Embedding model with 1024 dims (matches default COGNEE_EMBEDDING_DIM)
+ollama pull mxbai-embed-large
+
+# Optional: vision model for multimodal slots
+ollama pull qwen2.5vl:7b
+```
+
+**Docker networking:** NewAPI runs inside Docker; Ollama usually runs on the host. Do **not** use `http://localhost:11434` from the container — that points at the container itself.
+
+| Host OS | Base URL for the Ollama channel |
+|---|---|
+| macOS / Windows (Docker Desktop) | `http://host.docker.internal:11434` |
+| Linux | `http://172.17.0.1:11434` or the host IP; or run Ollama in the same compose network |
+
+Ollama often accepts any API key; if the UI requires one, use a placeholder such as `ollama`.
+
+### Other backends (Custom / Xinference)
+
+| Backend | UI preset | Notes |
+|---|---|---|
+| **Ollama** | `ollama` | Default preset base `http://localhost:11434` — override for Docker → host as above |
+| **Xinference** | `xinference` | Set Base URL to your Xinference OpenAI-compatible endpoint |
+| **Custom** | `custom` | LM Studio, vLLM, llama.cpp server, LocalAI — any OpenAI-compatible `/v1` base |
+
+---
+
+## 4. Map logical models
+
+Keep DramaClaw logical names in `.env` (for example `HERMES_MODEL=DC-hermes-LLM`, `COGNEE_LLM_MODEL=DC-cognee-LLM`). Map each name in the UI to a real upstream model ID — do not rename every `*_MODEL` unless you intentionally bypass NewAPI aliases.
+
+### Add the Ollama channel
+
+On **Local NewAPI**:
+
+1. Add provider channel **Ollama**.
+2. Set Base URL (see Docker table above).
+3. **Save channel config**, then **Update NewAPI channel**.
+
+### Text models (`DC-*-LLM`)
+
+1. In the pure-text block, choose the Ollama channel and your chat model (e.g. `qwen2.5:14b`).
+2. Click **Apply to all** for that block, then adjust individual rows if needed.
+3. Click **Save model mappings**.
+
+Hermes defaults expect a large context (`HERMES_MODEL_CONTEXT_LENGTH=131072` in `.env.example`). Set that env to the largest context your local model actually supports.
+
+Sensible chat sizes (approximate VRAM):
+
+| Hardware | Starting point |
+|---|---|
+| 16–24 GB GPU | Qwen2.5 / Qwen3 14B–32B, Llama 3.1/3.3 (quantized), Mistral Small |
+| 8–12 GB GPU | Qwen2.5 7B–14B Q4/Q5, Llama 3.1 8B |
+| Apple Silicon | Same families via Ollama Metal; prefer 7B–32B quantized |
+
+There is no official “tested Ollama tag” list in this repo — pick by instruction-following quality and context length.
+
+### Embeddings (`DC-cognee-embedding`)
+
+Map to a **real embedding model**, not a chat model. Default dimension is **1024** (`COGNEE_EMBEDDING_DIM`).
+
+| Example Ollama tag | Typical dims | Action |
+|---|---|---|
+| `mxbai-embed-large` | 1024 | Matches default — map and keep dim 1024 |
+| `bge-m3` | 1024 | Matches default |
+| `nomic-embed-text` | 768 | Map and set embedding dim to **768** in Local NewAPI / `.env` |
+
+If Cognee returns HTTP 400/422 on import, lower embedding batch size (toward `10`) and confirm dim + mapping. See [Configuring Model Providers](../getting-started/configuring-models.md#embedding-batch-size).
+
+### Vision / multimodal slots
+
+Features that send images (freezone vision, identity color checks, style from reference images, etc.) need a **VLM** (e.g. `qwen2.5vl:7b`). Pure text models will fail those paths.
+
+### Image / video / TTS
+
+Leave these on a cloud-capable channel (or RelayClaw) for hybrid setups. Local chat models cannot fill `LingShan-*`, Seedance, or `index-tts-2` slots.
+
+After gateway or mapping changes: new tasks pick up the new settings. If Cognee already initialized in the current process, **restart DramaClaw** before importing novels again.
+
+---
+
+## 5. Smoke-test checklist
+
+1. `docker compose -f docker-compose.selfhosted.yml up -d --build`
+2. Ollama running; chat + embedding models pulled
+3. Local NewAPI initialized in the UI
+4. Ollama channel Base URL reachable from the `newapi` container
+5. `DC-hermes-LLM` / `DC-cognee-LLM` (and other text roles) → chat model
+6. `DC-cognee-embedding` → embedding model + matching dimension
+7. Open Hermes chat and send a short prompt
+8. Import a short novel chapter (Cognee / knowledge graph)
+9. Keep image / video / TTS on cloud until those upstreams are ready
+
+---
+
+## What not to expect
+
+- Setting `MODEL_PROVIDER` / `MODEL_API_KEY` alone is **not** the CE configuration path.
+- “Fully local” in the README means a **local gateway**, not automatic local Seedance / IndexTTS.
+- CE is single-machine with in-process tasks; multi-tenant scale-out is Enterprise Edition.
+
+## Related docs
+
+- [Configuring Model Providers](../getting-started/configuring-models.md)
+- [Self-Hosting Handbook](self-hosting.md)
+- [Environment Variables Reference](../reference/environment-variables.md)
+- `.env.example` — logical `*_MODEL` defaults
+- `docker-compose.selfhosted.yml` — bundled NewAPI stack

--- a/docs/en/guides/self-hosting.md
+++ b/docs/en/guides/self-hosting.md
@@ -41,7 +41,7 @@ Groups (each item is commented inline in `.env.example`): local NewAPI provision
 Recommended and alternative options (see [Configuring Model Providers](../getting-started/configuring-models.md) for details):
 
 - **A. DC official key (recommended)**: the default compose already uses the official gateway. After bringing the stack up, open `http://localhost:8080` → Settings → Model Configuration → Official Channel → paste your DC key and save to start using it, **no model mapping required**. Get a key at <https://relayclaw.cdnfg.com>.
-- **B. Local NewAPI**: switch to `docker compose -f docker-compose.selfhosted.yml up`, then initialize it and configure upstream channels and model mappings from the Local NewAPI page.
+- **B. Local NewAPI**: switch to `docker compose -f docker-compose.selfhosted.yml up`, then initialize it and configure upstream channels and model mappings from the Local NewAPI page. For Ollama / hybrid local text, follow [Using DramaClaw with Local LLMs](local-llms.md).
 
 Local NewAPI must map DramaClaw's logical models to real upstream models. The reference-image feature needs `OSS_RELAY_AK/SK` (you can skip it for a text-only workflow).
 
@@ -114,4 +114,4 @@ After the formal release this will switch to **pulling published, pinned-version
 
 ## Related
 
-- [Quickstart](../getting-started/quickstart.md) ｜ [Configuring Model Providers](../getting-started/configuring-models.md)
+- [Quickstart](../getting-started/quickstart.md) ｜ [Configuring Model Providers](../getting-started/configuring-models.md) ｜ [Local LLMs](local-llms.md)

--- a/docs/en/guides/troubleshooting.md
+++ b/docs/en/guides/troubleshooting.md
@@ -19,7 +19,7 @@
 | Symptom | Diagnosis |
 |---|---|
 | **Every model call errors** | Under Settings → Model Configuration, confirm the active channel is configured. Check the DC key for the official channel, or the service, runtime token, and upstream channels for Local NewAPI. |
-| **A stage reports "model does not exist"** | Local NewAPI is missing the corresponding logical model mapping, or the target channel is disabled. See [Configuring model providers](../getting-started/configuring-models.md). |
+| **A stage reports "model does not exist"** | Local NewAPI is missing the corresponding logical model mapping, or the target channel is disabled. See [Configuring model providers](../getting-started/configuring-models.md) or [Local LLMs](local-llms.md). |
 | **Text model times out** | Increase `NEWAPI_TEXT_TIMEOUT_SECONDS` (default 120); if a system proxy is intercepting an internal gateway, set `NEWAPI_TEXT_TRUST_ENV=false`. |
 | **Reference-image feature unavailable** | Requires `OSS_RELAY_AK/SK`; the plain text→video pipeline can run without it. |
 

--- a/docs/en/reference/environment-variables.md
+++ b/docs/en/reference/environment-variables.md
@@ -81,4 +81,4 @@ See the [telemetry notes](../guides/telemetry.md) for details. By default none o
 ## Related
 
 - Full list with comments: `.env.example` in the repo root
-- [Quickstart](../getting-started/quickstart.md) ｜ [Configuring Model Providers](../getting-started/configuring-models.md) ｜ [Self-Hosting Manual](../guides/self-hosting.md)
+- [Quickstart](../getting-started/quickstart.md) ｜ [Configuring Model Providers](../getting-started/configuring-models.md) ｜ [Self-Hosting Manual](../guides/self-hosting.md) ｜ [Local LLMs](../guides/local-llms.md)

--- a/docs/zh/README.md
+++ b/docs/zh/README.md
@@ -16,6 +16,7 @@
 | 文档 | 内容 |
 |---|---|
 | [产品使用手册](https://neo-flying.feishu.cn/docx/JGNTdsjJuo748TxJkxecoYs2nth) | 全功能 UI 操作手册（飞书） |
+| [本地 LLM（Ollama / BYO）](guides/local-llms.md) | 混合本机文本 + embedding，经 Local NewAPI 接入 |
 | [自托管手册](guides/self-hosting.md) | 部署 / 升级 / 备份 |
 | [ffmpeg 指南](guides/ffmpeg.md) | 安装 / 定位 / 许可义务 |
 | [遥测说明](guides/telemetry.md) | 默认不收集数据 / 可选追踪 |

--- a/docs/zh/getting-started/configuring-models.md
+++ b/docs/zh/getting-started/configuring-models.md
@@ -17,6 +17,8 @@ DramaClaw CE 通过 NewAPI 兼容网关调用文本、视觉理解、Embedding�
 
 配置完成后点击对应模式的启用按钮。更换模式、Key 或模型后，新任务会读取新配置；正在运行的任务不会中途切换。
 
+本地 Ollama / 混合方案的端到端步骤（Docker 宿主机地址、示例映射、冒烟检查）见[使用本地 LLM 跑 DramaClaw](../guides/local-llms.md)。
+
 ## 官方模式
 
 官方模式是最简单的接入方式：

--- a/docs/zh/getting-started/quickstart.md
+++ b/docs/zh/getting-started/quickstart.md
@@ -41,9 +41,10 @@ docker compose ps   # api、web 均应 running
 
 ## 想使用自己的模型渠道？
 
-使用 `docker-compose.selfhosted.yml` 启动 CE 随附的本地 NewAPI，然后在「设置 → 模型配置 → 本地 NewAPI」中初始化渠道、填写上游 key 并保存模型映射。地址和 runtime token 会写入本机 `settings.db`，不写入 `.env`。详见[配置模型供应商](configuring-models.md)。
+使用 `docker-compose.selfhosted.yml` 启动 CE 随附的本地 NewAPI，然后在「设置 → 模型配置 → 本地 NewAPI」中初始化渠道、填写上游 key 并保存模型映射。地址和 runtime token 会写入本机 `settings.db`，不写入 `.env`。详见[配置模型供应商](configuring-models.md)。Ollama / 混合本机文本见[使用本地 LLM 跑 DramaClaw](../guides/local-llms.md)。
 
 ## 下一步
 
 - 完整部署/升级/备份:[自托管手册](../guides/self-hosting.md)
 - 接入自己的模型:[配置模型供应商](configuring-models.md)
+- 本地 LLM（Ollama / BYO）:[使用本地 LLM 跑 DramaClaw](../guides/local-llms.md)

--- a/docs/zh/guides/local-llms.md
+++ b/docs/zh/guides/local-llms.md
@@ -1,0 +1,177 @@
+<!-- lang-switch -->
+[English](../../en/guides/local-llms.md) · **简体中文**
+
+# 使用本地 LLM 跑 DramaClaw
+
+> 通过 Local NewAPI 接入 Ollama（及其他 OpenAI 兼容本地服务）的端到端指南。
+
+DramaClaw **不会**在应用主机上加载 LLM。API（`:8780`）与网页（`:8080`）只调用 **OpenAI 兼容的 NewAPI 网关**；网关再转发到上游（云端或本机）。网关地址与 token 保存在 **设置 → 模型配置** 写入的本机 `settings.db` 中——CE **不会**从 `MODEL_API_KEY` / `MODEL_PROVIDER` 环境变量读取。
+
+```mermaid
+flowchart LR
+  UI[网页 :8080] --> API[DramaClaw API :8780]
+  API --> GW[NewAPI 网关]
+  GW --> Official[RelayClaw 云端]
+  GW --> Ollama[Ollama]
+  GW --> Custom[LM Studio / vLLM / llama.cpp]
+  GW --> Media[图片 / 视频 / TTS 上游]
+```
+
+渠道按钮含义、embedding 批量上限、媒体 relay 等见[配置模型供应商](../getting-started/configuring-models.md)。
+
+---
+
+## 1. 先选路径
+
+| 目标 | 路径 | 是否需要映射模型 |
+|---|---|---|
+| 最快跑通小说 → 成片 | **官方 RelayClaw**（默认 `docker-compose.yml` + DC key） | 不需要 |
+| 本机文本 + embedding；图片 / 视频 / TTS 仍走云端 | **混合方案（本地 LLM 推荐）** | 在 Local NewAPI 映射 `DC-*-LLM` 与 `DC-cognee-embedding` |
+| 全离线小说 → 成片 | 自托管 NewAPI + **每种模态**都有本地上游 | 难——图 / 视频 / TTS 不是「拉一个 Ollama 聊天模型」就能替代 |
+
+**建议：** 本地优先做混合文本。先让 Hermes + Cognee 在 Ollama 上跑通；媒体继续用 RelayClaw 或其他具备媒体能力的云端上游。
+
+---
+
+## 2. 接入网关
+
+### 官方渠道（完整管线，不跑本地模型）
+
+```bash
+cp .env.example .env   # 修改 PROMPT_EXPORT_PASSWORD
+docker compose up -d --build
+```
+
+打开 `http://localhost:8080` → **设置 → 模型配置 → 官方渠道** → 粘贴 [relayclaw.cdnfg.com](https://relayclaw.cdnfg.com) 的 DC key → **保存并启用**。
+
+### 本地 NewAPI（Ollama / BYO 必需）
+
+```bash
+cp .env.example .env   # 修改 PROMPT_EXPORT_PASSWORD
+docker compose -f docker-compose.selfhosted.yml up -d --build
+```
+
+会启动 `api`、`web` 以及内置 `newapi`（`http://localhost:3000`）。
+
+1. 打开 `http://localhost:8080` → **设置 → 模型配置 → 本地 NewAPI**。
+2. 设置首次管理员密码（仅当 NewAPI 尚未初始化时使用）。
+3. 点击 **初始化本地 NewAPI**。
+
+向导会创建或复用 `dramaclaw-ce-runtime` token，写入 `settings.db`，并把网关模式切到 `custom`。请自行保存 NewAPI 管理员密码——DramaClaw 不会用它做后续登录。
+
+若 NewAPI 已初始化，密码可留空再点初始化，只会创建/复用 runtime token。
+
+selfhosted 编排已启用 provisioner。细节见[自托管手册](self-hosting.md)。
+
+---
+
+## 3. 启动本机推理后端
+
+### Ollama（一等公民预设）
+
+安装并启动 [Ollama](https://ollama.com)，至少拉取一个聊天模型和一个 embedding 模型：
+
+```bash
+ollama pull qwen2.5:14b
+ollama pull mxbai-embed-large
+ollama pull qwen2.5vl:7b   # 可选：多模态槽位
+```
+
+**Docker 网络：** NewAPI 在容器内，Ollama 通常在宿主机。容器里的 `http://localhost:11434` 指向容器自身，不可用。
+
+| 宿主机系统 | Ollama 渠道 Base URL |
+|---|---|
+| macOS / Windows（Docker Desktop） | `http://host.docker.internal:11434` |
+| Linux | `http://172.17.0.1:11434` 或宿主机 IP；或把 Ollama 放进同一 compose 网络 |
+
+Ollama 往往不校验 API key；若 UI 必填，可填占位值如 `ollama`。
+
+### 其他后端（Custom / Xinference）
+
+| 后端 | UI 预设 | 说明 |
+|---|---|---|
+| **Ollama** | `ollama` | 默认 `http://localhost:11434`——Docker → 宿主机时按上表覆盖 |
+| **Xinference** | `xinference` | 填 Xinference 的 OpenAI 兼容地址 |
+| **Custom** | `custom` | LM Studio、vLLM、llama.cpp server、LocalAI 等任意 `/v1` 兼容端点 |
+
+---
+
+## 4. 映射逻辑模型
+
+保持 `.env` 中的逻辑名（如 `HERMES_MODEL=DC-hermes-LLM`），在 UI 里映射到真实上游模型 ID。
+
+### 添加 Ollama 渠道
+
+在 **本地 NewAPI** 页：
+
+1. 添加供应商渠道 **Ollama**。
+2. 设置 Base URL（见上表）。
+3. **保存渠道配置**，再 **更新 NewAPI 渠道**。
+
+### 文本模型（`DC-*-LLM`）
+
+1. 在纯文本区块选择 Ollama 渠道与聊天模型（如 `qwen2.5:14b`）。
+2. 对该区块点 **应用到全部**，再按需微调单行。
+3. 点击 **保存模型映射**。
+
+Hermes 默认期望较大上下文（`.env.example` 中 `HERMES_MODEL_CONTEXT_LENGTH=131072`）。请改成你本机模型真实支持的最大值。
+
+| 硬件 | 起步建议 |
+|---|---|
+| 16–24 GB GPU | Qwen2.5 / Qwen3 14B–32B、量化 Llama 3.1/3.3、Mistral Small |
+| 8–12 GB GPU | Qwen2.5 7B–14B Q4/Q5、Llama 3.1 8B |
+| Apple Silicon | 同系列 + Ollama Metal；优先 7B–32B 量化 |
+
+仓库没有官方「已验证 Ollama 标签」列表——按指令遵循能力与上下文长度选型。
+
+### Embedding（`DC-cognee-embedding`）
+
+必须映射真实 embedding 模型。默认维度 **1024**（`COGNEE_EMBEDDING_DIM`）。
+
+| 示例 Ollama 标签 | 典型维度 | 操作 |
+|---|---|---|
+| `mxbai-embed-large` | 1024 | 与默认一致 |
+| `bge-m3` | 1024 | 与默认一致 |
+| `nomic-embed-text` | 768 | 映射并把维度改为 **768** |
+
+建图若出现 HTTP 400/422，降低 embedding 批量（靠近 `10`），并核对维度与映射。见[配置模型供应商](../getting-started/configuring-models.md#embedding-批量大小)。
+
+### 视觉 / 多模态槽位
+
+会发送图片的功能需要 **VLM**（如 `qwen2.5vl:7b`）。纯文本模型会失败。
+
+### 图片 / 视频 / TTS
+
+混合方案下请继续走云端渠道。本地聊天模型填不了 `LingShan-*`、Seedance、`index-tts-2` 等槽位。
+
+更换网关或映射后：新任务会读新配置。若当前进程里 Cognee 已初始化，**重启 DramaClaw** 后再导入小说。
+
+---
+
+## 5. 冒烟检查清单
+
+1. `docker compose -f docker-compose.selfhosted.yml up -d --build`
+2. Ollama 已启动；聊天 + embedding 模型已拉取
+3. UI 中完成本地 NewAPI 初始化
+4. Ollama 渠道 Base URL 从 `newapi` 容器可达
+5. `DC-hermes-LLM` / `DC-cognee-LLM`（及其他文本角色）→ 聊天模型
+6. `DC-cognee-embedding` → embedding 模型 + 匹配维度
+7. 打开 Hermes 发一条短消息
+8. 导入一小章小说（Cognee / 知识图谱）
+9. 图片 / 视频 / TTS 暂留云端
+
+---
+
+## 不要期望
+
+- 只设 `MODEL_PROVIDER` / `MODEL_API_KEY` **不是** CE 的配置路径。
+- README 里的「完全本地」指 **本地网关**，不等于自动具备本地 Seedance / IndexTTS。
+- CE 是单机、进程内任务；多租户扩缩容属于企业版。
+
+## 相关文档
+
+- [配置模型供应商](../getting-started/configuring-models.md)
+- [自托管手册](self-hosting.md)
+- [环境变量参考](../reference/environment-variables.md)
+- `.env.example` — 逻辑 `*_MODEL` 默认值
+- `docker-compose.selfhosted.yml` — 内置 NewAPI 编排

--- a/docs/zh/guides/self-hosting.md
+++ b/docs/zh/guides/self-hosting.md
@@ -41,7 +41,7 @@ cp .env.example .env
 推荐与备选(详见 [配置模型供应商](../getting-started/configuring-models.md)):
 
 - **A. DC 官方 key(推荐)**：默认 compose 已走官方网关。起栈后开 `http://localhost:8080` → 设置 → 模型配置 → 官方渠道 → 粘贴 DC key 保存即用,**无需映射模型**。到 <https://relayclaw.cdnfg.com> 取 key。
-- **B. 本地 NewAPI**：改用 `docker compose -f docker-compose.selfhosted.yml up`，然后在网页「本地 NewAPI」页初始化并配置上游渠道和模型映射。
+- **B. 本地 NewAPI**：改用 `docker compose -f docker-compose.selfhosted.yml up`，然后在网页「本地 NewAPI」页初始化并配置上游渠道和模型映射。Ollama / 混合本机文本见[使用本地 LLM 跑 DramaClaw](local-llms.md)。
 
 本地 NewAPI 需把 DramaClaw 逻辑模型映射到真实上游模型。参考图功能需要 `OSS_RELAY_AK/SK`（纯文本流程可暂不配）。
 
@@ -114,4 +114,4 @@ docker compose up -d --build
 
 ## 相关
 
-- [快速开始](../getting-started/quickstart.md) ｜ [配置模型供应商](../getting-started/configuring-models.md)
+- [快速开始](../getting-started/quickstart.md) ｜ [配置模型供应商](../getting-started/configuring-models.md) ｜ [本地 LLM](local-llms.md)

--- a/docs/zh/guides/troubleshooting.md
+++ b/docs/zh/guides/troubleshooting.md
@@ -19,7 +19,7 @@
 | 现象 | 排查 |
 |---|---|
 | **模型调用全报错** | 在「设置 → 模型配置」确认当前渠道已配置；官方渠道检查 DC key，本地 NewAPI 检查服务、runtime token 和上游渠道。 |
-| **某个环节报"模型不存在"** | 本地 NewAPI 中没有对应逻辑模型映射，或目标渠道未启用。详见[配置模型供应商](../getting-started/configuring-models.md)。 |
+| **某个环节报"模型不存在"** | 本地 NewAPI 中没有对应逻辑模型映射，或目标渠道未启用。详见[配置模型供应商](../getting-started/configuring-models.md)或[本地 LLM](local-llms.md)。 |
 | **文本模型超时** | 调大 `NEWAPI_TEXT_TIMEOUT_SECONDS`(默认 120);内网网关被系统代理拦截时设 `NEWAPI_TEXT_TRUST_ENV=false`。 |
 | **参考图功能不可用** | 需配 `OSS_RELAY_AK/SK`;纯文本→成片流程可不配。 |
 

--- a/docs/zh/reference/environment-variables.md
+++ b/docs/zh/reference/environment-variables.md
@@ -80,4 +80,4 @@ CE 的渠道选择、网关地址和 token 由网页「设置 → 模型配置�
 ## 相关
 
 - 完整列表与注释:仓库根 `.env.example`
-- [快速开始](../getting-started/quickstart.md) ｜ [配置模型供应商](../getting-started/configuring-models.md) ｜ [自托管手册](../guides/self-hosting.md)
+- [快速开始](../getting-started/quickstart.md) ｜ [配置模型供应商](../getting-started/configuring-models.md) ｜ [自托管手册](../guides/self-hosting.md) ｜ [本地 LLM](../guides/local-llms.md)

--- a/frontend/src/__tests__/lib/queries/release-notifications.test.tsx
+++ b/frontend/src/__tests__/lib/queries/release-notifications.test.tsx
@@ -74,7 +74,7 @@ describe("release notification query", () => {
     expect(seenLocale).toBe("zh");
   });
 
-  it("defaults missing and unknown locales to zh", async () => {
+  it("defaults missing and unknown locales to en", async () => {
     const seenLocales: string[] = [];
     server.use(
       http.get("http://localhost:3000/api/v1/release-notifications", ({ request }) => {
@@ -87,6 +87,6 @@ describe("release notification query", () => {
     await fetchReleaseNotifications("fr-FR");
 
     expect(seenLocales.length).toBeGreaterThanOrEqual(2);
-    expect(seenLocales.every((locale) => locale === "zh")).toBe(true);
+    expect(seenLocales.every((locale) => locale === "en")).toBe(true);
   });
 });

--- a/frontend/src/__tests__/stores/app-store-language.test.ts
+++ b/frontend/src/__tests__/stores/app-store-language.test.ts
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: Elastic-2.0
+// Copyright (c) 2026 ClaymoreLab
+import { describe, expect, it } from "vitest";
+import { normalize } from "@/i18n";
+import { useAppStore } from "@/stores/app-store";
+
+describe("UI language defaults", () => {
+  it("normalizes unknown and missing locales to English", () => {
+    expect(normalize(undefined)).toBe("en");
+    expect(normalize("")).toBe("en");
+    expect(normalize("fr-FR")).toBe("en");
+    expect(normalize("en-US")).toBe("en");
+    expect(normalize("zh-CN")).toBe("zh");
+  });
+
+  it("app store initial language is English", () => {
+    expect(useAppStore.getState().language === "en" || useAppStore.getState().language === "zh").toBe(
+      true,
+    );
+    // Module default in create() is "en"; persisted zh from prior sessions is allowed.
+    const raw = window.localStorage.getItem("supertale-app");
+    if (!raw) {
+      expect(useAppStore.getState().language).toBe("en");
+    }
+  });
+});

--- a/frontend/src/features/superchat/types.ts
+++ b/frontend/src/features/superchat/types.ts
@@ -6,6 +6,7 @@ export type ClientFrame =
       scope?: ChatScope;
       text: string;
       turn_id?: string;
+      language?: "en" | "zh";
       attachments?: ChatAttachment[];
     }
   | { type: "scope.set"; scope: ChatScope };

--- a/frontend/src/features/superchat/use-superchat.ts
+++ b/frontend/src/features/superchat/use-superchat.ts
@@ -19,6 +19,8 @@ import {
 } from "@/features/superchat/message";
 import { hasStructuredContent } from "@/features/superchat/spec-extract";
 import { api } from "@/lib/api";
+import { normalize as normalizeLanguage } from "@/i18n";
+import { useAppStore } from "@/stores/app-store";
 import {
   isStaleByTtl,
   pruneLocalStorageByPrefix,
@@ -969,6 +971,7 @@ export function useSuperChat({
     if (!trimmed || !connected) return false;
     const outboundText = transportText?.trim() || trimmed;
     const turnId = `turn-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    const language = normalizeLanguage(useAppStore.getState().language);
     pendingClientTurnIdRef.current = turnId;
     markTurnActive(turnId);
     setMessages((current) => [...current, buildLocalUserMessage(trimmed, turnId, displayName, attachments)]);
@@ -979,6 +982,7 @@ export function useSuperChat({
       scope: desiredScope,
       text: outboundText,
       turn_id: turnId,
+      language,
       attachments: attachments.length > 0 ? attachments : undefined,
     });
     return true;

--- a/frontend/src/i18n/index.ts
+++ b/frontend/src/i18n/index.ts
@@ -11,7 +11,7 @@ type Supported = (typeof SUPPORTED)[number];
 
 export function normalize(lng: string | undefined): Supported {
   const two = (lng ?? "").slice(0, 2).toLowerCase();
-  return (SUPPORTED as readonly string[]).includes(two) ? (two as Supported) : "zh";
+  return (SUPPORTED as readonly string[]).includes(two) ? (two as Supported) : "en";
 }
 
 function initialLanguage(): Supported {
@@ -19,17 +19,17 @@ function initialLanguage(): Supported {
     const queryLanguage = new URLSearchParams(window.location.search).get("lng");
     if (queryLanguage) return normalize(queryLanguage);
   }
-  return normalize(useAppStore.getState().language || "zh");
+  return normalize(useAppStore.getState().language || "en");
 }
 
 i18n
   .use(HttpBackend)
   .use(initReactI18next)
   .init({
-    // Default to Chinese unless the user explicitly selects another supported
-    // language via URL or the app language setting.
+    // Default to English unless the user explicitly selects another supported
+    // language via URL or the app language setting (persisted zh stays zh).
     lng: initialLanguage(),
-    fallbackLng: "zh",
+    fallbackLng: "en",
     supportedLngs: [...SUPPORTED],
     // `zh-CN` / `en-US` collapse to `zh` / `en`, so the
     // backend loader only has to serve two translation files.

--- a/frontend/src/lib/queries/release-notifications.ts
+++ b/frontend/src/lib/queries/release-notifications.ts
@@ -34,7 +34,7 @@ const RELEASE_FEED_STALE_TIME_MS = 60 * 60 * 1000;
 
 export function normalizeReleaseLocale(locale: string | undefined): "zh" | "en" {
   const two = (locale ?? "").slice(0, 2).toLowerCase();
-  return two === "en" ? "en" : "zh";
+  return two === "zh" ? "zh" : "en";
 }
 
 export function releaseNotificationsQueryOptions(localeInput: string | undefined) {

--- a/frontend/src/stores/app-store.ts
+++ b/frontend/src/stores/app-store.ts
@@ -123,7 +123,7 @@ function persistedCompanionPet(pet: AppState["companionPet"]): AppState["compani
 export const useAppStore = create<AppState>()(
   persist(
     (set) => ({
-      language: "zh",
+      language: "en",
       theme: "dark",
       dashboardTab: "active",
       dashboardView: "card",

--- a/readme/README_zh.md
+++ b/readme/README_zh.md
@@ -236,9 +236,10 @@ uv run novelvideo api --port 8780   # 启动 REST API（CE 默认 inline 任务�
 DramaClaw 对模型侧保持中立 —— 所有文本/图片/视频/音频模型都经一个 **OpenAI 兼容网关**接入，两种方式：
 
 - **DramaClaw 官方 key（推荐）**：`docker compose up`,开 <http://localhost:8080> → 设置 → 模型配置 → 官方渠道,粘贴 DC key 保存即用,**无需映射模型**。到 <https://relayclaw.cdnfg.com> 获取 key。
-- **自带网关（BYO）**：把 `NEWAPI_BASE_URL` 指向你自己的 OpenAI 兼容端点并映射模型名（详见 [配置模型供应商](../docs/zh/getting-started/configuring-models.md)）。
+- **自带网关（BYO）**：使用 Local NewAPI（`docker-compose.selfhosted.yml`）并在 UI 中映射模型名（详见 [配置模型供应商](../docs/zh/getting-started/configuring-models.md)）。
+- **本地 LLM（Ollama / 混合）**：本机跑文本 + embedding，经 Local NewAPI 接入；图片 / 视频 / TTS 仍走具备媒体能力的云端上游，除非你自备兼容的媒体 API。步骤见 [使用本地 LLM 跑 DramaClaw](../docs/zh/guides/local-llms.md)。
 
-> 想完全本地?用 `docker compose -f docker-compose.selfhosted.yml up` 起 selfhosted 版 `newapi` 网关自行配置（免构建镜像版:`docker-compose.selfhosted.release.yml`）。
+> 想用内置本地网关？用 `docker compose -f docker-compose.selfhosted.yml up` 起 selfhosted 版 `newapi` 网关自行配置（免构建镜像版:`docker-compose.selfhosted.release.yml`）。
 
 | 环节              | 经网关接入                                                          |
 |-------------------|---------------------------------------------------------------------|
@@ -292,6 +293,7 @@ DramaClaw 对模型侧保持中立 —— 所有文本/图片/视频/音频模�
 - [快速开始](../docs/zh/getting-started/quickstart.md)
 - [自托管手册](../docs/zh/guides/self-hosting.md)
 - [配置模型供应商](../docs/zh/getting-started/configuring-models.md)
+- [本地 LLM（Ollama / BYO）](../docs/zh/guides/local-llms.md)
 - [更多文档 &rarr;](../docs/zh/README.md)
 
 <br/>

--- a/src/novelvideo/api/routes/chat.py
+++ b/src/novelvideo/api/routes/chat.py
@@ -86,6 +86,7 @@ class ChatMessageIn(BaseModel):
     scope: ChatScopePayload | None = None
     text: str
     turn_id: str | None = None
+    language: str | None = None
     attachments: list[ChatAttachmentIn] = []
 
 
@@ -406,6 +407,7 @@ async def _stream_project_turn(
     text: str,
     attachments: list[ChatAttachmentIn],
     turn_id: str,
+    language: str | None = None,
 ) -> None:
     project = str(scope.id)
     project_ctx = await _project_context_for_scope(user, scope)
@@ -507,6 +509,7 @@ async def _stream_project_turn(
             on_event,
             project_dir=project_dir,
             project_state_dir=project_state_dir,
+            language=language,
         )
     finally:
         heartbeat_task.cancel()
@@ -528,6 +531,7 @@ async def _stream_home_turn(
     text: str,
     attachments: list[ChatAttachmentIn],
     turn_id: str,
+    language: str | None = None,
 ) -> None:
     from novelvideo.chat.hermes_pool import pool as hermes_pool
 
@@ -540,7 +544,10 @@ async def _stream_home_turn(
         ),
         "",
     )
-    agent_text = _text_with_attachment_context(text, attachments)
+    agent_text = chat_service.prepare_home_agent_prompt(
+        _text_with_attachment_context(text, attachments),
+        language=language,
+    )
     chat_store.append_message(
         username,
         scope,
@@ -592,7 +599,11 @@ async def _stream_home_turn(
         send_lock,
     )
     try:
-        async for event in thread.stream(agent_text, current_project=None):
+        async for event in thread.stream(
+            agent_text,
+            current_project=None,
+            language=language,
+        ):
             if event.type == "thread_started":
                 await _send_json_best_effort(
                     websocket,
@@ -648,7 +659,9 @@ async def _stream_home_turn(
             previous_assistant,
             text,
         )
-        assistant_text = assistant_text.strip() or "(agent returned no content)"
+        assistant_text = assistant_text.strip() or chat_service.chat_copy(
+            language, "empty_agent_content"
+        )
         message = chat_store.append_message(username, scope, "assistant", assistant_text)
         persisted = True
         await _send_json_best_effort(
@@ -765,6 +778,7 @@ async def chat_ws(websocket: WebSocket) -> None:
             scope = _scope_from_model(msg.scope) if msg.scope else current_scope
             turn_id = (msg.turn_id or "").strip() or uuid.uuid4().hex
             text = msg.text.strip()
+            language = msg.language
             if not text:
                 await _send_json_best_effort(
                     websocket, {"type": "error", "turn_id": turn_id, "message": "empty message"}
@@ -782,6 +796,7 @@ async def chat_ws(websocket: WebSocket) -> None:
                         text=text,
                         attachments=msg.attachments,
                         turn_id=turn_id,
+                        language=language,
                     )
                 elif scope.kind == "home":
                     await _stream_home_turn(
@@ -791,6 +806,7 @@ async def chat_ws(websocket: WebSocket) -> None:
                         text=text,
                         attachments=msg.attachments,
                         turn_id=turn_id,
+                        language=language,
                     )
                 else:
                     await _send_json_best_effort(

--- a/src/novelvideo/api/routes/release_notifications.py
+++ b/src/novelvideo/api/routes/release_notifications.py
@@ -15,9 +15,9 @@ router = APIRouter()
 
 def normalize_locale(value: str | None) -> str:
     if not value:
-        return "zh"
+        return "en"
     primary = value.split(",", 1)[0].split(";", 1)[0].split("-", 1)[0].strip().lower()
-    return primary if primary in {"zh", "en"} else "zh"
+    return primary if primary in {"zh", "en"} else "en"
 
 
 @router.get("/release-notifications", response_model=OkResponse)

--- a/src/novelvideo/chat/hermes_sdk.py
+++ b/src/novelvideo/chat/hermes_sdk.py
@@ -47,13 +47,66 @@ CONTENT_FILTER_MESSAGE = (
     "请把需求拆得更具体，避免一次性要求完成整集或包含敏感/违规描述；"
     "也可以先让我只列当前制作进度和下一步。"
 )
+CONTENT_FILTER_MESSAGE_EN = (
+    "This reply was blocked by the model gateway content filter, so the assistant "
+    "could not return usable output. Please narrow the request, avoid asking for an "
+    "entire episode at once or sensitive/prohibited content, or ask me to list "
+    "current progress and the next step first."
+)
 DRAMACLAW_ONE_STEP_STOP_MESSAGE = (
     "当前任务已开始处理。请稍后让我查看当前任务进度，或在任务完成后再继续下一步。"
+)
+DRAMACLAW_ONE_STEP_STOP_MESSAGE_EN = (
+    "The current task has started. Ask me to check task progress later, or continue "
+    "after it finishes."
 )
 DRAMACLAW_WRITE_FAILED_STOP_MESSAGE = (
     "刚才这一步没有成功启动任务。请先根据返回的错误补齐前置条件；"
     "如果是配音缺少声线，可以到「虾塘」上传或录制缺失声线后再继续。"
 )
+DRAMACLAW_WRITE_FAILED_STOP_MESSAGE_EN = (
+    "That step failed to start a task. Fix the prerequisites from the error first; "
+    "if voice-over is missing a voice line, upload or record it in Freezone (虾塘), "
+    "then continue."
+)
+DRAMACLAW_TOOL_LIMIT_STOP_MESSAGE = (
+    "本轮操作已停止：虾导连续调用工具过多，可能在自动推进过大范围。"
+    "请缩小指令范围，例如只检查前置条件，或只启动一个具体 beat 的视频任务。"
+)
+DRAMACLAW_TOOL_LIMIT_STOP_MESSAGE_EN = (
+    "This turn stopped because too many tools were called in a row — the assistant "
+    "may have been advancing too much at once. Narrow the request, for example only "
+    "check prerequisites, or start a single beat video task."
+)
+
+
+def _normalize_reply_language(value: str | None) -> str:
+    two = str(value or "").strip().lower()[:2]
+    return "zh" if two == "zh" else "en"
+
+
+def _localized_stop_message(kind: str, language: str | None) -> str:
+    lang = _normalize_reply_language(language)
+    messages = {
+        "content_filter": {
+            "zh": CONTENT_FILTER_MESSAGE,
+            "en": CONTENT_FILTER_MESSAGE_EN,
+        },
+        "one_step": {
+            "zh": DRAMACLAW_ONE_STEP_STOP_MESSAGE,
+            "en": DRAMACLAW_ONE_STEP_STOP_MESSAGE_EN,
+        },
+        "write_failed": {
+            "zh": DRAMACLAW_WRITE_FAILED_STOP_MESSAGE,
+            "en": DRAMACLAW_WRITE_FAILED_STOP_MESSAGE_EN,
+        },
+        "tool_limit": {
+            "zh": DRAMACLAW_TOOL_LIMIT_STOP_MESSAGE,
+            "en": DRAMACLAW_TOOL_LIMIT_STOP_MESSAGE_EN,
+        },
+    }
+    entry = messages.get(kind) or {}
+    return str(entry.get(lang) or entry.get("en") or "")
 
 _DRAMACLAW_WRITE_TOOLS = {
     "dramaclaw_post",
@@ -429,8 +482,13 @@ class HermesSdkThread:
             text="(hermes timed out)",
         )
 
-    async def stream(self, prompt: str, *, current_project: str | None = None) \
-            -> AsyncIterator[ChatBackendEvent]:
+    async def stream(
+        self,
+        prompt: str,
+        *,
+        current_project: str | None = None,
+        language: str | None = None,
+    ) -> AsyncIterator[ChatBackendEvent]:
         """Send a prompt and yield ChatBackendEvent items as hermes streams them.
 
         ``current_project`` is included as a prompt prefix so per-user hermes
@@ -439,6 +497,7 @@ class HermesSdkThread:
         if self._closed:
             raise RuntimeError("HermesSdkThread is closed")
 
+        reply_language = _normalize_reply_language(language)
         await self._prepare()
         try:
             assert self._proc is not None and self._proc.stdout is not None
@@ -504,7 +563,9 @@ class HermesSdkThread:
                             type="complete",
                             thread_id=self.id,
                             turn_id=turn_id,
-                            text=CONTENT_FILTER_MESSAGE,
+                            text=_localized_stop_message(
+                                "content_filter", reply_language
+                            ),
                         )
                         return
                     result = msg.get("result") or {}
@@ -514,7 +575,9 @@ class HermesSdkThread:
                         yield ChatBackendEvent(
                             type="complete", thread_id=self.id, turn_id=turn_id,
                             text=(
-                                CONTENT_FILTER_MESSAGE
+                                _localized_stop_message(
+                                    "content_filter", reply_language
+                                )
                                 if _has_content_filter_signal(err)
                                 else f"error: {err.get('message', err)}"
                             ),
@@ -536,9 +599,13 @@ class HermesSdkThread:
                         active_tool_name = tool_name
                         if _should_stop_after_write_tool(first_write_tool, tool_name):
                             stop_text = (
-                                DRAMACLAW_WRITE_FAILED_STOP_MESSAGE
+                                _localized_stop_message(
+                                    "write_failed", reply_language
+                                )
                                 if first_write_failed
-                                else DRAMACLAW_ONE_STEP_STOP_MESSAGE
+                                else _localized_stop_message(
+                                    "one_step", reply_language
+                                )
                             )
                             _log.warning(
                                 "Hermes turn attempted tool after write task: thread=%s turn=%s "
@@ -572,9 +639,8 @@ class HermesSdkThread:
                                 type="complete",
                                 thread_id=self.id,
                                 turn_id=turn_id,
-                                text=(
-                                    "本轮操作已停止：虾导连续调用工具过多，可能在自动推进过大范围。"
-                                    "请缩小指令范围，例如只检查前置条件，或只启动一个具体 beat 的视频任务。"
+                                text=_localized_stop_message(
+                                    "tool_limit", reply_language
                                 ),
                             )
                             return

--- a/src/novelvideo/chat/hermes_workspace.py
+++ b/src/novelvideo/chat/hermes_workspace.py
@@ -183,16 +183,21 @@ def _default_config_yaml() -> str:
     )
 
 _DEFAULT_SOUL_MD = (
-    "你是虾导。不要自称 Hermes Agent，不要提 Nous Research，"
-    "也不要主动解释底层代理框架。自我介绍时只回答“我是虾导”，"
-    "不要附加“DramaClaw 的小说转视频创作助手”之类的头衔或职能描述。"
-    "你应当直接、清晰、务实，优先帮助用户完成 "
-    "DramaClaw 项目进度查询、任务管理、剧本、配音、图片、视频生成与交付相关工作。\n"
+    "You are 虾导 (Xiaodao), the DramaClaw assistant. Do not call yourself Hermes Agent, "
+    "do not mention Nous Research, and do not volunteer explanations of the underlying "
+    "agent framework. When introducing yourself, answer only \"I am 虾导\" "
+    "(or \"我是虾导\" when the user is speaking Chinese). Do not append titles such as "
+    "\"DramaClaw novel-to-video creation assistant\".\n"
+    "Be direct, clear, and practical. Prioritize helping with DramaClaw project progress, "
+    "tasks, scripts, voice-over, image/video generation, and delivery.\n"
+    "Language: follow the user's UI language for replies. Default to English when unsure.\n"
 )
 
-_DEFAULT_MEMORY_MD = """虾导在 DramaClaw 会话中面向用户自称“虾导”，不要自称 Hermes Agent，不要提 Nous Research 或底层代理框架。自我介绍时只回答“我是虾导”，不要附加“DramaClaw 的小说转视频创作助手”之类的头衔或职能描述。
+_DEFAULT_MEMORY_MD = """In DramaClaw sessions, introduce yourself only as 虾导. Do not call yourself Hermes Agent, and do not mention Nous Research or the underlying agent framework. When asked who you are, answer only "I am 虾导" / "我是虾导" without job-title fluff.
 §
-DramaClaw 管理的虾导会话中 `terminal` 被禁用（在 config.yaml disabled_toolsets 中），curl 等 shell 命令会被直接拒绝。调用 DramaClaw API 时应使用已启用的 `hermes-acp` toolset 中的 DramaClaw 插件工具，不要用 curl。
+Follow the user's UI language for replies; default to English when unsure.
+§
+In DramaClaw-managed 虾导 sessions, `terminal` is disabled (config.yaml disabled_toolsets), so curl and shell commands are rejected. Call DramaClaw APIs via the enabled `hermes-acp` toolset DramaClaw plugin tools, not curl.
 """
 
 _OLD_SOUL_PREFIX = (
@@ -212,10 +217,18 @@ _OLD_IDENTITY_MEMORY_LINE = (
     "的小说转视频创作助手。”"
 )
 
-_IDENTITY_MEMORY_LINE = (
+_PREV_ZH_IDENTITY_MEMORY_LINE = (
     "虾导在 DramaClaw 会话中面向用户自称“虾导”，不要自称 Hermes Agent，"
     "不要提 Nous Research 或底层代理框架。自我介绍时只回答“我是虾导”，"
     "不要附加“DramaClaw 的小说转视频创作助手”之类的头衔或职能描述。"
+)
+
+_IDENTITY_MEMORY_LINE = (
+    "In DramaClaw sessions, introduce yourself only as 虾导. Do not call yourself "
+    "Hermes Agent, and do not mention Nous Research or the underlying agent framework. "
+    "When introducing yourself, answer only \"I am 虾导\" / \"我是虾导\" without "
+    "job-title fluff. Follow the user's UI language for replies; default to English "
+    "when unsure."
 )
 
 _OLD_MEMORY_LINE = (
@@ -224,10 +237,16 @@ _OLD_MEMORY_LINE = (
     "时应使用已启用的 `dramaclaw` 插件 toolset 提供的内置 HTTP 工具，不要用 curl。"
 )
 
-_NEW_MEMORY_LINE = (
+_PREV_ZH_MEMORY_LINE = (
     "DramaClaw 管理的虾导会话中 `terminal` 被禁用（在 config.yaml "
     "disabled_toolsets 中），curl 等 shell 命令会被直接拒绝。调用 DramaClaw API "
     "时应使用已启用的 `hermes-acp` toolset 中的 DramaClaw 插件工具，不要用 curl。"
+)
+
+_NEW_MEMORY_LINE = (
+    "In DramaClaw-managed 虾导 sessions, `terminal` is disabled (config.yaml "
+    "disabled_toolsets), so curl and shell commands are rejected. Call DramaClaw APIs "
+    "via the enabled `hermes-acp` toolset DramaClaw plugin tools, not curl."
 )
 
 _OLD_SOUL_IDENTITY_TEXT = (
@@ -322,7 +341,7 @@ def _ensure_identity_context(home: Path) -> None:
             text = soul_file.read_text(encoding="utf-8")
             if _OLD_SOUL_PREFIX in text:
                 text = text.replace(_OLD_SOUL_PREFIX, _DEFAULT_SOUL_MD.strip(), 1)
-            elif "你是虾导" not in text:
+            elif "你是虾导" not in text and "You are 虾导" not in text:
                 text = _DEFAULT_SOUL_MD.rstrip() + "\n\n" + text
             text = text.replace(_OLD_SOUL_IDENTITY_TEXT, "你是虾导。")
             soul_file.write_text(text.rstrip() + "\n", encoding="utf-8")
@@ -338,7 +357,9 @@ def _ensure_identity_context(home: Path) -> None:
         if memory_file.exists():
             text = memory_file.read_text(encoding="utf-8")
             text = text.replace(_OLD_IDENTITY_MEMORY_LINE, _IDENTITY_MEMORY_LINE)
+            text = text.replace(_PREV_ZH_IDENTITY_MEMORY_LINE, _IDENTITY_MEMORY_LINE)
             text = text.replace(_OLD_MEMORY_LINE, _NEW_MEMORY_LINE)
+            text = text.replace(_PREV_ZH_MEMORY_LINE, _NEW_MEMORY_LINE)
             if _IDENTITY_MEMORY_LINE not in text:
                 text = _IDENTITY_MEMORY_LINE + "\n§\n" + text.lstrip()
             memory_file.write_text(text.rstrip() + "\n", encoding="utf-8")

--- a/src/novelvideo/chat/service.py
+++ b/src/novelvideo/chat/service.py
@@ -95,7 +95,7 @@ _STYLE_SHORT_DRAMA_REQUEST_RE = re.compile(
     re.IGNORECASE,
 )
 _CONTINUE_PIPELINE_RE = re.compile(r"(?:继续|恢复|接着|下一步|当前|已有|已上传|刚才上传)")
-_DRAMACLAW_SCRIPT_UPLOAD_MODEL_REPLY_INSTRUCTIONS = """[DRAMACLAW_SCRIPT_UPLOAD_GUIDANCE]
+_DRAMACLAW_SCRIPT_UPLOAD_MODEL_REPLY_INSTRUCTIONS_ZH = """[DRAMACLAW_SCRIPT_UPLOAD_GUIDANCE]
 用户正在请求创建、生成或编写剧本/短剧，但当前消息没有上传剧本文档。
 
 你必须只用自然中文回复用户，不要调用任何工具，不要创建项目，不要生成剧本，不要构造基础脚本，不要启动摄入或流水线。
@@ -108,6 +108,58 @@ _DRAMACLAW_SCRIPT_UPLOAD_MODEL_REPLY_INSTRUCTIONS = """[DRAMACLAW_SCRIPT_UPLOAD_
 - 只回复 1-2 句，不要列步骤，不要输出 markdown 标题。
 [/DRAMACLAW_SCRIPT_UPLOAD_GUIDANCE]
 """
+_DRAMACLAW_SCRIPT_UPLOAD_MODEL_REPLY_INSTRUCTIONS_EN = """[DRAMACLAW_SCRIPT_UPLOAD_GUIDANCE]
+The user is asking to create, generate, or write a script/short drama, but this message has no uploaded script document.
+
+You must reply to the user in natural English only. Do not call any tools, do not create a project, do not generate a script, do not construct a base script, and do not start ingest or the pipeline.
+
+Reply goals:
+- Sound natural; do not sound like a system error.
+- Make clear that the assistant does not generate scripts.
+- Guide the user to upload an existing script document in Materials (虾料).
+- Explain that after upload you can help with episodes, visuals, voice-over, and delivery.
+- Reply in 1-2 sentences only; no step lists; no markdown headings.
+[/DRAMACLAW_SCRIPT_UPLOAD_GUIDANCE]
+"""
+# Back-compat alias used by older imports/tests.
+_DRAMACLAW_SCRIPT_UPLOAD_MODEL_REPLY_INSTRUCTIONS = (
+    _DRAMACLAW_SCRIPT_UPLOAD_MODEL_REPLY_INSTRUCTIONS_ZH
+)
+_REPLY_LANGUAGE_PREAMBLE = {
+    "en": "[DRAMACLAW_REPLY_LANGUAGE]\nReply to the user in English.\n[/DRAMACLAW_REPLY_LANGUAGE]",
+    "zh": "[DRAMACLAW_REPLY_LANGUAGE]\n请用自然中文回复用户。\n[/DRAMACLAW_REPLY_LANGUAGE]",
+}
+_CHAT_COPY = {
+    "reingest_confirm_clear": {
+        "en": (
+            "Overwrite will clear/rebuild this project's existing characters, episodes, "
+            "scripts, sketches, audio, video, and other pipeline results. Continue?\n\n"
+            "Reply `confirm` or `continue` to proceed with overwrite."
+        ),
+        "zh": (
+            "覆盖会清空/重建当前项目已有角色、分集、脚本、草图、音频、视频等"
+            "流水线结果。是否继续？\n\n请回复 `确定` 或 `继续` 后才会开始覆盖。"
+        ),
+    },
+    "reingest_confirm_overwrite": {
+        "en": (
+            "This project already has ingested content. Continuing will overwrite the "
+            "current project.\n\nReply `overwrite` to proceed to the next confirmation."
+        ),
+        "zh": (
+            "当前项目已有摄入内容，继续会覆盖现有项目。是否要覆盖当前项目？\n\n"
+            "请回复 `覆盖` 进入下一步确认。"
+        ),
+    },
+    "empty_agent_content": {
+        "en": "(agent returned no content)",
+        "zh": "(agent returned no content)",
+    },
+    "user_said_prefix": {
+        "en": "User said: ",
+        "zh": "用户原话：",
+    },
+}
 _HIDDEN_TOOL_MARKERS = (
     "skill_view",
     "skills_list",
@@ -240,10 +292,47 @@ def load_user_preferences(username: str) -> str:
     return path.read_text(encoding="utf-8").strip()
 
 
-def _prompt_with_user_context(username: str, project: str, prompt: str) -> str:
+def normalize_chat_language(value: str | None) -> str:
+    """Normalize UI/chat language to ``en`` or ``zh`` (default English)."""
+    two = str(value or "").strip().lower()[:2]
+    return "zh" if two == "zh" else "en"
+
+
+def chat_copy(language: str | None, key: str) -> str:
+    lang = normalize_chat_language(language)
+    entry = _CHAT_COPY.get(key) or {}
+    return str(entry.get(lang) or entry.get("en") or "")
+
+
+def _reply_language_preamble(language: str | None) -> str:
+    return _REPLY_LANGUAGE_PREAMBLE[normalize_chat_language(language)]
+
+
+def _script_upload_instructions(language: str | None) -> str:
+    if normalize_chat_language(language) == "zh":
+        return _DRAMACLAW_SCRIPT_UPLOAD_MODEL_REPLY_INSTRUCTIONS_ZH
+    return _DRAMACLAW_SCRIPT_UPLOAD_MODEL_REPLY_INSTRUCTIONS_EN
+
+
+def prepare_home_agent_prompt(prompt: str, *, language: str | None = None) -> str:
+    """Apply reply-language + script-upload guidance for home-scope Hermes turns."""
+    lang = normalize_chat_language(language)
+    guided = _script_creation_model_reply_prompt(prompt, language=lang) or prompt
+    return f"{_reply_language_preamble(lang)}\n\n{guided}"
+
+
+def _prompt_with_user_context(
+    username: str,
+    project: str,
+    prompt: str,
+    *,
+    language: str | None = None,
+) -> str:
     preferences = load_user_preferences(username)
     scope = f"project:{project}" if project else "home"
+    lang = normalize_chat_language(language)
     return (
+        f"{_reply_language_preamble(lang)}\n\n"
         "[DRAMACLAW_USER_CONTEXT]\n"
         f"username: {username}\n"
         f"scope: {scope}\n"
@@ -3207,13 +3296,15 @@ async def stream_assistant_reply(
     *,
     project_dir: str | Path | None = None,
     project_state_dir: str | Path | None = None,
+    language: str | None = None,
 ) -> dict[str, Any]:
     run_lock_id = _acquire_chat_run_lock(username, project)
     heartbeat_task = asyncio.create_task(
         _chat_run_lock_heartbeat_loop(username, project, run_lock_id)
     )
     try:
-        deterministic = _frontend_context_reply(prompt)
+        lang = normalize_chat_language(language)
+        deterministic = _frontend_context_reply(prompt, language=lang)
         if deterministic is not None:
             return await _stream_deterministic_assistant_reply(
                 username,
@@ -3223,7 +3314,7 @@ async def stream_assistant_reply(
                 project_dir=project_dir,
                 project_state_dir=project_state_dir,
             )
-        model_prompt = _script_creation_model_reply_prompt(prompt) or prompt
+        model_prompt = _script_creation_model_reply_prompt(prompt, language=lang) or prompt
         backend = _chat_backend()
         if backend == "codex":
             return await _stream_assistant_reply_codex(
@@ -3233,6 +3324,7 @@ async def stream_assistant_reply(
                 on_event,
                 project_dir=project_dir,
                 project_state_dir=project_state_dir,
+                language=lang,
             )
         if backend == "hermes":
             return await _stream_assistant_reply_hermes(
@@ -3242,6 +3334,7 @@ async def stream_assistant_reply(
                 on_event,
                 project_dir=project_dir,
                 project_state_dir=project_state_dir,
+                language=lang,
             )
         if backend != "claude":
             raise RuntimeError(f"Unsupported chat backend: {backend}")
@@ -3252,6 +3345,7 @@ async def stream_assistant_reply(
             on_event,
             project_dir=project_dir,
             project_state_dir=project_state_dir,
+            language=lang,
         )
     finally:
         heartbeat_task.cancel()
@@ -3262,24 +3356,20 @@ async def stream_assistant_reply(
         _release_chat_run_lock(username, project, run_lock_id)
 
 
-def _frontend_context_reply(prompt: str) -> str | None:
+def _frontend_context_reply(prompt: str, *, language: str | None = None) -> str | None:
     confirmation = _REINGEST_CONFIRMATION_BLOCK_RE.search(prompt)
     if confirmation:
         body = confirmation.group(1)
         if re.search(r"(?m)^\s*stage:\s*confirm_clear\s*$", body):
-            return (
-                "覆盖会清空/重建当前项目已有角色、分集、脚本、草图、音频、视频等"
-                "流水线结果。是否继续？\n\n请回复 `确定` 或 `继续` 后才会开始覆盖。"
-            )
-        return (
-            "当前项目已有摄入内容，继续会覆盖现有项目。是否要覆盖当前项目？\n\n"
-            "请回复 `覆盖` 进入下一步确认。"
-        )
+            return chat_copy(language, "reingest_confirm_clear")
+        return chat_copy(language, "reingest_confirm_overwrite")
 
     return None
 
 
-def _script_creation_model_reply_prompt(prompt: str) -> str | None:
+def _script_creation_model_reply_prompt(
+    prompt: str, *, language: str | None = None
+) -> str | None:
     if not prompt:
         return None
     if _DRAMACLAW_INGEST_AUTOMATION_RE.search(prompt):
@@ -3291,9 +3381,10 @@ def _script_creation_model_reply_prompt(prompt: str) -> str | None:
     if _CONTINUE_PIPELINE_RE.search(text):
         return None
     if _SCRIPT_CREATION_REQUEST_RE.search(text) or _STYLE_SHORT_DRAMA_REQUEST_RE.search(text):
+        prefix = chat_copy(language, "user_said_prefix")
         return (
-            f"{_DRAMACLAW_SCRIPT_UPLOAD_MODEL_REPLY_INSTRUCTIONS}"
-            f"\n\n用户原话：{text}"
+            f"{_script_upload_instructions(language)}"
+            f"\n\n{prefix}{text}"
         )
     return None
 
@@ -3351,6 +3442,7 @@ async def _stream_assistant_reply_hermes(
     *,
     project_dir: str | Path | None = None,
     project_state_dir: str | Path | None = None,
+    language: str | None = None,
 ) -> dict[str, Any]:
     """Stream via Hermes ACP subprocess (per-user, sandboxed).
 
@@ -3361,7 +3453,10 @@ async def _stream_assistant_reply_hermes(
     """
     from novelvideo.chat.hermes_pool import pool as _hermes_pool
 
-    agent_prompt = _prompt_with_user_context(username, project, prompt)
+    lang = normalize_chat_language(language)
+    agent_prompt = _prompt_with_user_context(
+        username, project, prompt, language=lang
+    )
     thread = await _hermes_pool.get_for_user(
         username,
         scope_kind="project" if project else "home",
@@ -3428,7 +3523,11 @@ async def _stream_assistant_reply_hermes(
         return persisted_message
 
     try:
-        async for event in thread.stream(agent_prompt, current_project=project or None):
+        async for event in thread.stream(
+            agent_prompt,
+            current_project=project or None,
+            language=lang,
+        ):
             if event.type == "thread_started":
                 await _emit_chat_event_best_effort(
                     on_event,
@@ -3589,6 +3688,7 @@ async def _stream_assistant_reply_claude(
     *,
     project_dir: str | Path | None = None,
     project_state_dir: str | Path | None = None,
+    language: str | None = None,
 ) -> dict[str, Any]:
     try:
         agent_token = await _create_page_agent_session_token(
@@ -3597,7 +3697,9 @@ async def _stream_assistant_reply_claude(
             agent_kind="claude",
         )
         thread = _build_claude_thread(username, project, agent_token)
-        agent_prompt = _prompt_with_user_context(username, project, prompt)
+        agent_prompt = _prompt_with_user_context(
+            username, project, prompt, language=language
+        )
         assistant_text = ""
         tool_text = ""
         async for event in thread.stream(agent_prompt):
@@ -3666,6 +3768,7 @@ async def _stream_assistant_reply_codex(
     *,
     project_dir: str | Path | None = None,
     project_state_dir: str | Path | None = None,
+    language: str | None = None,
 ) -> dict[str, Any]:
     assistant_text = ""
     tool_text = ""
@@ -3675,7 +3778,9 @@ async def _stream_assistant_reply_codex(
         agent_kind="codex",
     )
     thread = _build_codex_thread(username, project, agent_token)
-    agent_prompt = _prompt_with_user_context(username, project, prompt)
+    agent_prompt = _prompt_with_user_context(
+        username, project, prompt, language=language
+    )
     async for event in thread.stream(agent_prompt):
         if event.type == "thread_started":
             thread_id = str(event.thread_id or "").strip() or None

--- a/tests/test_chat_reply_language.py
+++ b/tests/test_chat_reply_language.py
@@ -1,0 +1,95 @@
+"""Chat reply-language helpers and prompt injection."""
+
+from __future__ import annotations
+
+from novelvideo.api.routes.chat import ChatMessageIn
+from novelvideo.chat import hermes_sdk
+from novelvideo.chat import service as chat_service
+
+
+def test_chat_message_in_accepts_language_field() -> None:
+    msg = ChatMessageIn.model_validate(
+        {"type": "chat.message", "text": "hello", "language": "zh"}
+    )
+    assert msg.language == "zh"
+    defaulted = ChatMessageIn.model_validate(
+        {"type": "chat.message", "text": "hello"}
+    )
+    assert defaulted.language is None
+    assert chat_service.normalize_chat_language(defaulted.language) == "en"
+
+
+def test_hermes_stop_messages_default_to_english() -> None:
+    assert "English" not in hermes_sdk._localized_stop_message("one_step", None)
+    assert "started" in hermes_sdk._localized_stop_message("one_step", None).lower()
+    assert "请稍后" in hermes_sdk._localized_stop_message("one_step", "zh")
+    assert hermes_sdk._localized_stop_message("tool_limit", "en") == (
+        hermes_sdk.DRAMACLAW_TOOL_LIMIT_STOP_MESSAGE_EN
+    )
+
+
+def test_normalize_chat_language_defaults_to_english() -> None:
+    assert chat_service.normalize_chat_language(None) == "en"
+    assert chat_service.normalize_chat_language("") == "en"
+    assert chat_service.normalize_chat_language("fr-FR") == "en"
+    assert chat_service.normalize_chat_language("en-US") == "en"
+    assert chat_service.normalize_chat_language("zh-CN") == "zh"
+
+
+def test_script_upload_guidance_is_english_by_default() -> None:
+    guided = chat_service._script_creation_model_reply_prompt("帮我创建一个短剧剧本")
+    assert guided is not None
+    assert "reply to the user in natural english only" in guided.lower()
+    assert "只用自然中文" not in guided
+
+
+def test_script_upload_guidance_is_chinese_when_requested() -> None:
+    guided = chat_service._script_creation_model_reply_prompt(
+        "帮我创建一个短剧剧本",
+        language="zh",
+    )
+    assert guided is not None
+    assert "只用自然中文" in guided
+
+
+def test_prompt_with_user_context_injects_english_reply_language(
+    tmp_path, monkeypatch
+) -> None:
+    prefs = tmp_path / "USER.md"
+    prefs.write_text("prefers short replies\n", encoding="utf-8")
+    monkeypatch.setattr(chat_service, "load_user_preferences", lambda _u: prefs.read_text())
+
+    prompt = chat_service._prompt_with_user_context("admin", "demo", "hello")
+    assert "[DRAMACLAW_REPLY_LANGUAGE]" in prompt
+    assert "Reply to the user in English." in prompt
+
+
+def test_prompt_with_user_context_injects_chinese_reply_language(
+    tmp_path, monkeypatch
+) -> None:
+    prefs = tmp_path / "USER.md"
+    prefs.write_text("喜欢简短回复\n", encoding="utf-8")
+    monkeypatch.setattr(chat_service, "load_user_preferences", lambda _u: prefs.read_text())
+
+    prompt = chat_service._prompt_with_user_context(
+        "admin", "demo", "你好", language="zh"
+    )
+    assert "请用自然中文回复用户。" in prompt
+
+
+def test_prepare_home_agent_prompt_defaults_to_english() -> None:
+    prompt = chat_service.prepare_home_agent_prompt("hello")
+    assert "Reply to the user in English." in prompt
+
+
+def test_reingest_confirm_copy_is_language_aware() -> None:
+    zh = chat_service._frontend_context_reply(
+        "[DRAMACLAW_REINGEST_CONFIRMATION]\nstage: confirm_clear\n[/DRAMACLAW_REINGEST_CONFIRMATION]",
+        language="zh",
+    )
+    en = chat_service._frontend_context_reply(
+        "[DRAMACLAW_REINGEST_CONFIRMATION]\nstage: confirm_clear\n[/DRAMACLAW_REINGEST_CONFIRMATION]",
+        language="en",
+    )
+    assert zh is not None and "确定" in zh
+    assert en is not None and "confirm" in en.lower()

--- a/tests/test_hermes_workspace.py
+++ b/tests/test_hermes_workspace.py
@@ -110,9 +110,11 @@ def test_fresh_create_layout(isolated_workspace, repo_skills, repo_plugins):
     config = (home / "config.yaml").read_text()
     assert _enabled_toolsets(config) == ["hermes-acp", "memory"]
     assert "    - dramaclaw" in config
-    assert "你是虾导" in (home / "SOUL.md").read_text()
+    assert "You are 虾导" in (home / "SOUL.md").read_text()
+    assert "default to english" in (home / "SOUL.md").read_text().lower()
     memory = (home / "memories" / "MEMORY.md").read_text()
-    assert "虾导在 DramaClaw 会话中面向用户自称“虾导”" in memory
+    assert "introduce yourself only as 虾导" in memory
+    assert "default to english" in memory.lower()
     assert "我是虾导，DramaClaw 的小说转视频创作助手。" not in memory
 
 
@@ -452,10 +454,10 @@ def test_legacy_identity_context_is_migrated(isolated_workspace, repo_skills, re
 
     soul = (home / "SOUL.md").read_text(encoding="utf-8")
     memory = (memories / "MEMORY.md").read_text(encoding="utf-8")
-    assert "你是虾导" in soul
+    assert "You are 虾导" in soul
     assert "You are Hermes Agent" not in soul
     assert "我是虾导，DramaClaw 的小说转视频创作助手。" not in memory
-    assert "DramaClaw 管理的虾导会话" in memory
+    assert "hermes-acp" in memory
     assert "DramaClaw 管理的 Hermes 会话" not in memory
 
 


### PR DESCRIPTION
## Summary
- Default new-user UI locale to English (`i18n` / app-store / release notifications); persisted `zh` users keep Chinese
- Pass UI `language` on chat WebSocket turns and inject locale-aware Hermes reply contracts (SOUL/MEMORY, plugin instructions, stop/error strings)
- Add EN/ZH local-LLM (Ollama / hybrid) guide and cross-links from docs/README

## Test plan
- [ ] Clear site data → UI opens in English; switch account menu language → UI follows
- [ ] Hermes chat with `language=en` replies in English; with `language=zh` replies in Chinese
- [ ] `uv run pytest tests/test_chat_reply_language.py tests/test_hermes_workspace.py`
- [ ] Frontend: `vitest` for release-notifications + app-store language defaults