### PR TITLE
fix(canvas): gate remaining model task entries

### DIFF
--- a/frontend/src/__tests__/features/canvas/text-clone-audio-content.test.tsx
+++ b/frontend/src/__tests__/features/canvas/text-clone-audio-content.test.tsx
@@ -45,6 +45,10 @@ vi.mock("@/lib/queries/generation-credit-cost", () => ({
   useGenerationCreditCost: () => ({ data: null, error: null }),
 }));
 
+vi.mock("@/lib/model-task-access", () => ({
+  useModelTaskAccess: () => ({ blocked: false, denialReason: null, message: null }),
+}));
+
 vi.mock("@/features/canvas/application/useNodeGenerationTaskState", () => ({
   useNodeGenerationTaskState: () => ({ isGenerating: false }),
 }));

--- a/frontend/src/__tests__/features/canvas/text-to-video-live-content.test.tsx
+++ b/frontend/src/__tests__/features/canvas/text-to-video-live-content.test.tsx
@@ -53,6 +53,10 @@ vi.mock("@/lib/queries/generation-credit-cost", () => ({
   useGenerationCreditCost: () => ({ data: null, error: null }),
 }));
 
+vi.mock("@/lib/model-task-access", () => ({
+  useModelTaskAccess: () => ({ blocked: false, denialReason: null, message: null }),
+}));
+
 vi.mock("@/features/canvas/application/useNodeGenerationTaskState", () => ({
   useNodeGenerationTaskState: () => ({ isGenerating: false }),
 }));

--- a/frontend/src/__tests__/lib/model-task-access.test.tsx
+++ b/frontend/src/__tests__/lib/model-task-access.test.tsx
@@ -191,7 +191,7 @@ describe("model task access wiring", () => {
   const read = (path: string) => readFileSync(join(root, path), "utf8");
 
   // Gating one node is not a fix: a blocked member simply switches to another
-  // node and hits the same denial. All six entries share the gate.
+  // node and hits the same denial. Every model-backed entry shares the gate.
   it.each([
     "src/features/canvas/nodes/ImageGenNode.tsx",
     "src/features/canvas/nodes/ImageEditNode.tsx",
@@ -199,6 +199,8 @@ describe("model task access wiring", () => {
     "src/features/canvas/nodes/StoryboardGenNode.tsx",
     "src/features/canvas/nodes/ScriptNode.tsx",
     "src/features/canvas/nodes/useAudioGeneration.ts",
+    "src/features/canvas/nodes/TextAnnotationNode.tsx",
+    "src/features/canvas/nodes/ThreeDWorldNode.tsx",
   ])("%s consumes the shared gate", (path) => {
     expect(read(path)).toContain("useModelTaskAccess");
   });

--- a/frontend/src/features/canvas/nodes/AudioOperationsPanel.tsx
+++ b/frontend/src/features/canvas/nodes/AudioOperationsPanel.tsx
@@ -189,7 +189,7 @@ export function AudioOperationsPanel({ nodeId, data }: AudioOperationsPanelProps
   );
 
   const handleTranslate = useCallback(async () => {
-    if (isGenerating || isTranslating) return;
+    if (modelTaskAccess.blocked || isGenerating || isTranslating) return;
     const trimmed = text.trim();
     if (trimmed.length === 0) return;
     const project = readUrl().project;
@@ -219,7 +219,7 @@ export function AudioOperationsPanel({ nodeId, data }: AudioOperationsPanelProps
     } finally {
       setIsTranslating(false);
     }
-  }, [isGenerating, handleTextChange, isTranslating, t, text]);
+  }, [handleTextChange, isGenerating, isTranslating, modelTaskAccess.blocked, t, text]);
 
   // 文本框为空但引用了非空文本时也允许提交（effectivePrompt 会回退到上游引用）。
   const submitDisabled =
@@ -331,9 +331,14 @@ export function AudioOperationsPanel({ nodeId, data }: AudioOperationsPanelProps
 
       <div className="flex shrink-0 items-center justify-end gap-2 px-3 pb-3 pt-1">
         <IconButton
-          title="翻译（中英文互译）"
+          title={modelTaskAccess.message ?? '翻译（中英文互译）'}
           onClick={handleTranslate}
-          disabled={isGenerating || isTranslating || text.trim().length === 0}
+          disabled={
+            modelTaskAccess.blocked
+            || isGenerating
+            || isTranslating
+            || text.trim().length === 0
+          }
           active={isTranslating}
         >
           {isTranslating ? (

--- a/frontend/src/features/canvas/nodes/TextAnnotationNode.tsx
+++ b/frontend/src/features/canvas/nodes/TextAnnotationNode.tsx
@@ -68,6 +68,7 @@ import {
 import { CreditCostInline } from '@/components/credit-cost-inline';
 import type { CreditPromotionDisplay } from '@/components/credits/credit-visual';
 import { useGenerationCreditCost } from '@/lib/queries/generation-credit-cost';
+import { useModelTaskAccess } from '@/lib/model-task-access';
 import {
   BillingRuleNotConfiguredError,
   backendErrorToastMessage,
@@ -159,6 +160,7 @@ export const TextAnnotationNode = memo(({
   height,
 }: TextAnnotationNodeProps) => {
   const { t } = useTranslation();
+  const modelTaskAccess = useModelTaskAccess();
   const reactFlow = useReactFlow();
   const setSelectedNode = useCanvasStore((state) => state.setSelectedNode);
   const isBoxSelecting = useIsBoxSelecting();
@@ -366,6 +368,7 @@ export const TextAnnotationNode = memo(({
   }, [enterEditMode, id, spawnAudioNode, spawnUploadNode, spawnVideoNode, updateNodeData]);
 
   const runImageToPrompt = useCallback(async () => {
+    if (modelTaskAccess.blocked) return;
     const projectId = readUrl().project;
     if (!projectId) {
       console.error('[text-node] no project in URL');
@@ -409,11 +412,11 @@ export const TextAnnotationNode = memo(({
       console.error('[text-node] reverse-prompt failed', error);
       updateNodeData(id, { isGenerating: false, generationStartedAt: null });
     }
-  }, [id, reversePromptInstruction, updateNodeData]);
+  }, [id, modelTaskAccess.blocked, reversePromptInstruction, updateNodeData]);
 
   const runTextGenerate = useCallback(async (promptOverride?: string) => {
     const prompt = (promptOverride ?? instruction).trim();
-    if (!prompt || textGenerateBillingRuleMissing) return;
+    if (modelTaskAccess.blocked || !prompt || textGenerateBillingRuleMissing) return;
     const projectId = readUrl().project;
     if (!projectId) {
       console.error('[text-node] text generation: no project in URL');
@@ -444,10 +447,10 @@ export const TextAnnotationNode = memo(({
       toast.error(backendErrorToastMessage(error, t));
       updateNodeData(id, { isGenerating: false, generationStartedAt: null });
     }
-  }, [id, instruction, t, textGenerateBillingRuleMissing, updateNodeData]);
+  }, [id, instruction, modelTaskAccess.blocked, t, textGenerateBillingRuleMissing, updateNodeData]);
 
   const runInstructionTranslate = useCallback(async () => {
-    if (isGenerating || isTranslating) return;
+    if (modelTaskAccess.blocked || isGenerating || isTranslating) return;
     const trimmed = instruction.trim();
     if (trimmed.length === 0) return;
     const projectId = readUrl().project;
@@ -471,10 +474,10 @@ export const TextAnnotationNode = memo(({
     } finally {
       setIsTranslating(false);
     }
-  }, [id, instruction, isGenerating, isTranslating, updateNodeData]);
+  }, [id, instruction, isGenerating, isTranslating, modelTaskAccess.blocked, updateNodeData]);
 
   const runContentTranslate = useCallback(async () => {
-    if (isGenerating || isTranslating) return;
+    if (modelTaskAccess.blocked || isGenerating || isTranslating) return;
     const trimmed = content.trim();
     if (trimmed.length === 0) return;
     const projectId = readUrl().project;
@@ -498,7 +501,7 @@ export const TextAnnotationNode = memo(({
     } finally {
       setIsTranslating(false);
     }
-  }, [content, id, isGenerating, isTranslating, updateNodeData]);
+  }, [content, id, isGenerating, isTranslating, modelTaskAccess.blocked, updateNodeData]);
 
   const textPlaceholder = t('node.textNode.placeholder');
   const hasUserContent = content.trim().length > 0 && content.trim() !== textPlaceholder.trim();
@@ -533,6 +536,7 @@ export const TextAnnotationNode = memo(({
   ]);
 
   const submitDisabled = isGenerating
+    || modelTaskAccess.blocked
     || (mode === 'writing' && (textGenerateBillingRuleMissing || instruction.trim().length === 0))
     || (
       mode === 'textToVideo'
@@ -599,7 +603,10 @@ export const TextAnnotationNode = memo(({
           promotion={textGenerateCost.data?.data.promotion}
           submitDisabled={submitDisabled}
           translateDisabled={
-            isGenerating || isTranslating || instruction.trim().length === 0
+            modelTaskAccess.blocked
+            || isGenerating
+            || isTranslating
+            || instruction.trim().length === 0
           }
           onGenerate={handleSubmit}
           onTranslate={runInstructionTranslate}
@@ -614,7 +621,10 @@ export const TextAnnotationNode = memo(({
           isTranslating={isTranslating}
           width={resolvedWidth}
           translateDisabled={
-            isGenerating || isTranslating || content.trim().length === 0
+            modelTaskAccess.blocked
+            || isGenerating
+            || isTranslating
+            || content.trim().length === 0
           }
           onTranslate={runContentTranslate}
         />
@@ -770,7 +780,10 @@ export const TextAnnotationNode = memo(({
                           void runInstructionTranslate();
                         }}
                         disabled={
-                          isGenerating || isTranslating || instruction.trim().length === 0
+                          modelTaskAccess.blocked
+                          || isGenerating
+                          || isTranslating
+                          || instruction.trim().length === 0
                         }
                         className={`${NODE_INLINE_ICON_BUTTON_CLASS} ${
                           isTranslating ? NODE_INLINE_ICON_BUTTON_ACTIVE_CLASS : ''

--- a/frontend/src/features/canvas/nodes/ThreeDWorldNode.tsx
+++ b/frontend/src/features/canvas/nodes/ThreeDWorldNode.tsx
@@ -104,6 +104,7 @@ import { useDetachUpstream } from '@/features/canvas/hooks/useDetachUpstream';
 import { readUrl } from '@/lib/url-params';
 import { BillingRuleNotConfiguredError } from '@/lib/api-errors';
 import { useGenerationCreditCost } from '@/lib/queries/generation-credit-cost';
+import { useModelTaskAccess } from '@/lib/model-task-access';
 import {
   CreditCostPill,
   type CreditPromotionDisplay,
@@ -615,6 +616,8 @@ interface OpsPanelProps {
   isGenerating: boolean;
   hasUpstream: boolean;
   billingRuleMissing: boolean;
+  modelTaskBlocked: boolean;
+  modelTaskMessage: string | null;
   creditCostDisplay: string | null;
   creditPromotion?: CreditPromotionDisplay | null;
   errorMessage?: string | null;
@@ -637,6 +640,8 @@ function OpsPanel({
   isGenerating,
   hasUpstream,
   billingRuleMissing,
+  modelTaskBlocked,
+  modelTaskMessage,
   creditCostDisplay,
   creditPromotion,
   errorMessage,
@@ -731,19 +736,21 @@ function OpsPanel({
         <CreditCostPill
           display={creditCostDisplay}
           promotion={creditPromotion}
-          disabled={isGenerating || !hasUpstream || billingRuleMissing}
+          disabled={isGenerating || !hasUpstream || billingRuleMissing || modelTaskBlocked}
           className={NODE_CREDIT_PILL_FLAT_CLASS}
         />
         <button
           type="button"
-          disabled={isGenerating || !hasUpstream || billingRuleMissing}
+          disabled={isGenerating || !hasUpstream || billingRuleMissing || modelTaskBlocked}
           onClick={(event) => {
             event.stopPropagation();
             onSubmit();
           }}
           onPointerDown={(event) => event.stopPropagation()}
           title={
-            billingRuleMissing
+            modelTaskBlocked
+              ? modelTaskMessage ?? t('modelTaskAccess.blocked.generic')
+              : billingRuleMissing
               ? t('common.billingRuleNotConfiguredShort')
               : hasUpstream
                 ? t('nodeToolbar.generateDirectorWorld')
@@ -751,7 +758,7 @@ function OpsPanel({
           }
           aria-label={t('nodeToolbar.generateDirectorWorld')}
           className={`${NODE_GENERATE_BUTTON_BASE_CLASS} ${
-            isGenerating || !hasUpstream || billingRuleMissing
+            isGenerating || !hasUpstream || billingRuleMissing || modelTaskBlocked
               ? NODE_GENERATE_BUTTON_DISABLED_CLASS
               : NODE_GENERATE_BUTTON_ENABLED_CLASS
           }`}
@@ -809,6 +816,7 @@ function HistoryPanel({
 
 export const ThreeDWorldNode = memo(({ id, data, selected, width, height }: ThreeDWorldNodeProps) => {
   const { t } = useTranslation();
+  const modelTaskAccess = useModelTaskAccess();
   const worldCreditCost = useGenerationCreditCost(
     'feature',
     'freezone.image_to_3gs',
@@ -1018,6 +1026,7 @@ export const ThreeDWorldNode = memo(({ id, data, selected, width, height }: Thre
       : inferredImageSourceKind;
 
   const handleSubmit = useCallback(async () => {
+    if (modelTaskAccess.blocked) return;
     const projectId = readUrl().project;
     const sourceNode = sourceNodeForGeneration;
     if (!projectId) {
@@ -1118,6 +1127,7 @@ export const ThreeDWorldNode = memo(({ id, data, selected, width, height }: Thre
     data.sources,
     id,
     isGenerating,
+    modelTaskAccess.blocked,
     refreshHistory,
     selectedImageSourceKind,
     sourceNodeForGeneration,
@@ -1460,6 +1470,8 @@ export const ThreeDWorldNode = memo(({ id, data, selected, width, height }: Thre
             isGenerating={isGenerating}
             hasUpstream={hasUpstream}
             billingRuleMissing={worldBillingRuleMissing}
+            modelTaskBlocked={modelTaskAccess.blocked}
+            modelTaskMessage={modelTaskAccess.message}
             creditCostDisplay={worldCreditCostDisplay}
             creditPromotion={worldCreditCost.data?.data.promotion}
             errorMessage={data.errorMessage}


### PR DESCRIPTION
## Summary
- gate text generation, reverse prompt, and translation actions on organization model-task admission
- gate audio translation and image-to-3DGS submission
- add wiring coverage and keep existing text-node tests isolated from organization queries

## Verification
- frontend full test suite: 362 files, 2617 tests passed
- TypeScript noEmit check passed
- production frontend build passed

## Release impact
Fixes staging-only organization admission behavior before promotion to main. No migration or provider configuration change.