### PR TITLE
feat(tasks): float self-contained project jobs

### DIFF
--- a/src/novelvideo/api/routes/freezone.py
+++ b/src/novelvideo/api/routes/freezone.py
@@ -1289,7 +1289,16 @@ async def _task_projection_payload(
     projector = _installed_task_projector()
     if projector is None:
         return {}
-    store = await make_sqlite_store_for_context(ctx)
+    # A projected task with an explicitly empty requirement set still needs a
+    # projection envelope off the home node: it certifies that the enqueue
+    # path audited the task as independent of project state.  Do not open the
+    # beat SQLite store merely to produce that empty envelope; standalone
+    # canvas tasks intentionally have no database dependency.
+    from novelvideo.task_backend.projection import PROJECTION_REQUIREMENTS
+
+    store = None
+    if PROJECTION_REQUIREMENTS.get(task_type) != frozenset():
+        store = await make_sqlite_store_for_context(ctx)
     projection = await _build_task_projection(
         projector,
         store=store,
@@ -1804,6 +1813,13 @@ async def _start_or_enqueue_standalone_frame_from_context_job(
         **(task_display or {}),
     }
     if ctx is not None:
+        projection_payload = await _task_projection_payload(
+            ctx=ctx,
+            username=username,
+            project_name=project_name,
+            episode=0,
+            task_type=task_type,
+        )
         queued = await get_task_backend().enqueue_project_task(
             ctx,
             product_surface="freezone",
@@ -1820,6 +1836,7 @@ async def _start_or_enqueue_standalone_frame_from_context_job(
                 "canvas_id": canvas_id or "",
                 "node_id": node_id or "",
                 **display_payload,
+                **projection_payload,
             },
         )
         return _project_job_response(

--- a/src/novelvideo/task_backend/run_core.py
+++ b/src/novelvideo/task_backend/run_core.py
@@ -46,6 +46,7 @@ from novelvideo.task_backend.registry import (
     get_project_task_runner,
     project_task_requires_home_node,
 )
+from novelvideo.task_backend.projection import PROJECTION_REQUIREMENTS, read_projection
 from novelvideo.task_backend.subprocesses import project_task_subprocess_context
 from novelvideo.task_state import project_task_run_context
 
@@ -687,8 +688,15 @@ def run_project_task_core_sync(
     # The registry is populated lazily, so make sure it is loaded before asking
     # it — an empty registry would read as "unregistered", not as "free".
     _ensure_builtin_runners_registered()
-    if project_task_requires_home_node(task_type):
+    requires_home_node = project_task_requires_home_node(task_type)
+    if requires_home_node:
         require_project_home_node(ctx, operation="run project task")
+    elif not ctx.is_home_node and task_type in PROJECTION_REQUIREMENTS:
+        projection = read_projection(delivery.payload)
+        if projection is None or projection.task_type != task_type:
+            # Projection is optional for the inline/home-node rollback path,
+            # but a foreign worker must never fall back to project-local state.
+            require_project_home_node(ctx, operation="run unprojected project task")
     episode = int(delivery.episode or 0)
     beat_num = delivery.beat_num
     scope = delivery.scope

--- a/src/novelvideo/task_backend/runners/freezone.py
+++ b/src/novelvideo/task_backend/runners/freezone.py
@@ -1407,34 +1407,68 @@ def run_freezone_audio_eleven_music(
     )
 
 
-register_project_task_runner("freezone_gen", run_freezone_gen)
-register_project_task_runner("freezone_edit", run_freezone_edit)
+register_project_task_runner("freezone_gen", run_freezone_gen, requires_home_node=False)
+register_project_task_runner("freezone_edit", run_freezone_edit, requires_home_node=False)
 register_project_task_runner(
-    "mainline_sketch_from_context", run_mainline_sketch_from_context
+    "mainline_sketch_from_context",
+    run_mainline_sketch_from_context,
+    requires_home_node=False,
 )
 register_project_task_runner(
-    "mainline_frame_from_context", run_mainline_frame_from_context
+    "mainline_frame_from_context",
+    run_mainline_frame_from_context,
+    requires_home_node=False,
 )
 register_project_task_runner(
     "mainline_director_control_sketch",
     run_mainline_director_control_sketch,
+    requires_home_node=False,
 )
-register_project_task_runner("freezone_mask_edit", run_freezone_mask_edit)
-register_project_task_runner("freezone_extract", run_freezone_extract)
-register_project_task_runner("freezone_analyze", run_freezone_analyze)
-register_project_task_runner("freezone_video_story", run_freezone_video_story)
-register_project_task_runner("freezone_video_erase", run_freezone_video_erase)
-register_project_task_runner("freezone_video_upscale", run_freezone_video_upscale)
-register_project_task_runner("freezone_audio_separate", run_freezone_audio_separate)
-register_project_task_runner("freezone_video_compose", run_freezone_video_compose)
-register_project_task_runner("freezone_text_translate", run_freezone_text_translate)
-register_project_task_runner("freezone_text_generate", run_freezone_text_generate)
-register_project_task_runner("freezone_story_script", run_freezone_story_script)
+register_project_task_runner(
+    "freezone_mask_edit", run_freezone_mask_edit, requires_home_node=False
+)
+register_project_task_runner(
+    "freezone_extract", run_freezone_extract, requires_home_node=False
+)
+register_project_task_runner(
+    "freezone_analyze", run_freezone_analyze, requires_home_node=False
+)
+register_project_task_runner(
+    "freezone_video_story", run_freezone_video_story, requires_home_node=False
+)
+register_project_task_runner(
+    "freezone_video_erase", run_freezone_video_erase, requires_home_node=False
+)
+register_project_task_runner(
+    "freezone_video_upscale", run_freezone_video_upscale, requires_home_node=False
+)
+register_project_task_runner(
+    "freezone_audio_separate", run_freezone_audio_separate, requires_home_node=False
+)
+register_project_task_runner(
+    "freezone_video_compose", run_freezone_video_compose, requires_home_node=False
+)
+register_project_task_runner(
+    "freezone_text_translate", run_freezone_text_translate, requires_home_node=False
+)
+register_project_task_runner(
+    "freezone_text_generate", run_freezone_text_generate, requires_home_node=False
+)
+register_project_task_runner(
+    "freezone_story_script", run_freezone_story_script, requires_home_node=False
+)
 register_project_task_runner(
     "freezone_image_reverse_prompt",
     run_freezone_image_reverse_prompt,
+    requires_home_node=False,
 )
-register_project_task_runner("freezone_audio_speech", run_freezone_audio_speech)
 register_project_task_runner(
-    "freezone_audio_eleven_music", run_freezone_audio_eleven_music
+    "freezone_audio_speech",
+    run_freezone_audio_speech,
+    requires_home_node=False,
+)
+register_project_task_runner(
+    "freezone_audio_eleven_music",
+    run_freezone_audio_eleven_music,
+    requires_home_node=False,
 )

--- a/src/novelvideo/task_backend/runners/stage_asset.py
+++ b/src/novelvideo/task_backend/runners/stage_asset.py
@@ -510,4 +510,6 @@ def run_freezone_image_to_3gs(
     return result
 
 
-register_project_task_runner("freezone_image_to_3gs", run_freezone_image_to_3gs)
+register_project_task_runner(
+    "freezone_image_to_3gs", run_freezone_image_to_3gs, requires_home_node=False
+)

--- a/src/novelvideo/task_backend/runners/video.py
+++ b/src/novelvideo/task_backend/runners/video.py
@@ -920,4 +920,6 @@ def run_freezone_video_gen(
     )
 
 
-register_project_task_runner("freezone_video_gen", run_freezone_video_gen)
+register_project_task_runner(
+    "freezone_video_gen", run_freezone_video_gen, requires_home_node=False
+)

--- a/tests/test_freezone_image_backend.py
+++ b/tests/test_freezone_image_backend.py
@@ -5825,6 +5825,15 @@ async def test_skill_run_standalone_frame_from_context_queues_candidate_without_
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    from novelvideo.ports.registry import register_port
+    from novelvideo.task_backend.projection import build_projection
+
+    class InstalledProjector:
+        async def build(self, store, config, *, task_type):
+            assert store is None
+            return await build_projection(store, config, task_type=task_type)
+
+    register_port("task_projection", InstalledProjector())
     project_dir, _output_dir = _patch_freezone_project(monkeypatch, tmp_path)
     _write_canvas_with_node(
         tmp_path,
@@ -5898,6 +5907,11 @@ async def test_skill_run_standalone_frame_from_context_queues_candidate_without_
     assert captured["task_type"] == "mainline_frame_from_context"
     assert captured["episode"] == 0
     assert "beat_num" not in captured
+    assert captured["payload"]["projection"] == {
+        "projection_version": 1,
+        "task_type": "mainline_frame_from_context",
+        "fields": {},
+    }
     config = captured["payload"]["config"]
     assert config["standalone_beat_context"] is True
     assert config["selected_panel_indices"] == [0]

--- a/tests/test_task_runner_home_node_placement.py
+++ b/tests/test_task_runner_home_node_placement.py
@@ -1,16 +1,4 @@
-"""Runner placement declared once in the registry, checked once at run_core entry.
-
-B2 §6.4 step 9/10, narrowed by TCP-P54: this only builds the *mechanism*.
-Not a single ``requires_home_node`` is flipped to ``False`` here, and no
-existing guard is removed — the two task-state write guards (CE
-``task_state.py:396-398`` and EE ``task_state_store.py``) stay unconditional
-and cannot see ``task_type``, so flipping a flag would only move the failure
-from "rejected before starting" to "died halfway through, still holding the
-dedup lock".
-
-What the mechanism buys today: the check moves from the first progress write
-to the task entry, so a misrouted task fails earlier and louder.
-"""
+"""Runner placement declared once in the registry, checked once at run_core entry."""
 
 from __future__ import annotations
 
@@ -32,6 +20,32 @@ from novelvideo.task_backend.registry import (
     register_project_task_runner,
     registered_project_task_types,
 )
+from novelvideo.task_backend.projection import PROJECTION_REQUIREMENTS
+
+
+PLACEMENT_FREE_TASKS = {
+    "freezone_analyze",
+    "freezone_audio_eleven_music",
+    "freezone_audio_separate",
+    "freezone_audio_speech",
+    "freezone_edit",
+    "freezone_extract",
+    "freezone_gen",
+    "freezone_image_reverse_prompt",
+    "freezone_image_to_3gs",
+    "freezone_mask_edit",
+    "freezone_story_script",
+    "freezone_text_generate",
+    "freezone_text_translate",
+    "freezone_video_compose",
+    "freezone_video_erase",
+    "freezone_video_gen",
+    "freezone_video_story",
+    "freezone_video_upscale",
+    "mainline_director_control_sketch",
+    "mainline_frame_from_context",
+    "mainline_sketch_from_context",
+}
 
 
 @pytest.fixture
@@ -67,21 +81,18 @@ def test_registering_without_placement_keeps_the_task_home_node_bound(isolated_r
     assert "tcp_d2_probe" in registered_project_task_types()
 
 
-def test_every_builtin_runner_stays_home_node_bound_with_no_lane():
-    """The 48 existing registration sites are not touched, so nothing may drift.
-
-    This is the "22 个既有注册点行为逐字不变" assertion: both new parameters
-    default in a way that reproduces today's behaviour exactly.
-    """
+def test_only_audited_self_contained_builtin_runners_are_placement_free():
+    """Audited payload/shared-output runners may float; every other runner stays bound."""
     import novelvideo.task_backend.runners  # noqa: F401
 
     task_types = registered_project_task_types()
     assert len(task_types) >= 25
 
-    flipped = [t for t in task_types if project_task_requires_home_node(t) is not True]
+    flipped = {t for t in task_types if project_task_requires_home_node(t) is not True}
     laned = [t for t in task_types if project_task_lane(t) is not None]
 
-    assert flipped == []
+    assert flipped == PLACEMENT_FREE_TASKS
+    assert set(PROJECTION_REQUIREMENTS) <= PLACEMENT_FREE_TASKS
     assert laned == []
 
 
@@ -145,7 +156,9 @@ class _FakeTaskManager:
         self.failed.append(kwargs)
 
 
-def _verified_delivery(*, task_type: str) -> VerifiedTaskDelivery:
+def _verified_delivery(
+    *, task_type: str, payload: dict | None = None
+) -> VerifiedTaskDelivery:
     admission = AdmissionContext(
         requester_user_id="usr_1",
         billing_principal=BillingPrincipal(kind="local", id="usr_1"),
@@ -165,7 +178,7 @@ def _verified_delivery(*, task_type: str) -> VerifiedTaskDelivery:
         beat_num=None,
         scope=None,
         queue_kind="default",
-        payload={},
+        payload=payload or {},
     )
 
 
@@ -266,13 +279,7 @@ def test_home_node_bound_task_still_runs_on_its_home_node(
 def test_placement_free_task_is_not_stopped_by_the_entry_check(
     tmp_path, quiet_run_core, isolated_registry
 ):
-    """Only the entry layer is asserted here.
-
-    Deliberately *not* asserted: that such a task can run to completion. The
-    task-state write guards are untouched by this EU (TCP-P54), so a real
-    ``requires_home_node=False`` task would still die at its first progress
-    write. That is exactly why no flag is flipped in production code.
-    """
+    """The entry layer lets an explicitly placement-free runner execute remotely."""
     ran: list[dict] = []
 
     def tracking_runner(envelope, _ctx):
@@ -285,6 +292,69 @@ def test_placement_free_task_is_not_stopped_by_the_entry_check(
 
     result = quiet_run_core.run_project_task_core_sync(
         _verified_delivery(task_type="tcp_d2_free"),
+        _ctx(tmp_path, is_home_node=False),
+        _FakeTaskManager(),
+        run_task_id="task_1",
+    )
+
+    assert result == {"ok": True}
+    assert len(ran) == 1
+
+
+def test_projected_placement_free_task_requires_projection_off_home_node(
+    tmp_path, quiet_run_core, isolated_registry
+):
+    ran: list[dict] = []
+
+    def tracking_runner(envelope, _ctx):
+        ran.append(dict(envelope))
+        return {"ok": True}
+
+    register_project_task_runner(
+        "mainline_frame_from_context",
+        tracking_runner,
+        requires_home_node=False,
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        quiet_run_core.run_project_task_core_sync(
+            _verified_delivery(task_type="mainline_frame_from_context"),
+            _ctx(tmp_path, is_home_node=False),
+            _FakeTaskManager(),
+            run_task_id="task_1",
+        )
+
+    assert exc_info.value.status_code == 409
+    assert ran == []
+
+
+def test_projected_placement_free_task_runs_with_projection_off_home_node(
+    tmp_path, quiet_run_core, isolated_registry
+):
+    ran: list[dict] = []
+
+    def tracking_runner(envelope, _ctx):
+        ran.append(dict(envelope))
+        return {"ok": True}
+
+    register_project_task_runner(
+        "mainline_frame_from_context",
+        tracking_runner,
+        requires_home_node=False,
+    )
+    payload = {
+        "projection": {
+            "projection_version": 1,
+            "task_type": "mainline_frame_from_context",
+            "fields": {},
+        }
+    }
+
+    result = quiet_run_core.run_project_task_core_sync(
+        _verified_delivery(
+            task_type="mainline_frame_from_context",
+            payload=payload,
+        ),
         _ctx(tmp_path, is_home_node=False),
         _FakeTaskManager(),
         run_task_id="task_1",


### PR DESCRIPTION
## Summary

- allow 21 audited self-contained project task runners to execute away from the project home node
- keep `stage_asset` and `scene_pano_generation` home-node bound because they publish fixed asset paths and perform unlocked manifest read-modify-write updates
- require an available project projection before projection-dependent tasks may execute off the home node
- add regression coverage for the placement allowlist and off-home projection guard

## Verification

- `PYTHONPATH=src .venv/bin/python -m pytest tests/test_task_runner_home_node_placement.py tests/test_task_backend_registry.py tests/test_task_runner_state_dir.py tests/test_freezone_audio_node_placement.py tests/test_freezone_canvas_route_home_node_guard.py -q` (51 passed)
- `git diff --check`

## Impact

No migration or provider configuration change. The two manifest-mutating stage tasks remain on the home node pending a serialized publish/manifest update mechanism.