### PR TITLE
fix: isolate EE video from CE settings

### DIFF
--- a/src/novelvideo/generators/video_generator.py
+++ b/src/novelvideo/generators/video_generator.py
@@ -1935,29 +1935,31 @@ class NewApiVideoGenerator(VideoGeneratorBase):
             self.base_url = ""
         else:
             from novelvideo.config import get_effective_newapi_gateway_config
+            from novelvideo.shared.runtime_env import is_ce_effective
 
             gateway = get_effective_newapi_gateway_config()
-            try:
-                from novelvideo.model_gateway_settings import (
-                    MODE_CUSTOM,
-                    MODE_HYBRID,
-                    get_ce_newapi_config_for_mode,
-                    get_effective_newapi_config,
-                    get_newapi_media_model_mappings,
-                )
+            if is_ce_effective():
+                try:
+                    from novelvideo.model_gateway_settings import (
+                        MODE_CUSTOM,
+                        MODE_HYBRID,
+                        get_ce_newapi_config_for_mode,
+                        get_effective_newapi_config,
+                        get_newapi_media_model_mappings,
+                    )
 
-                active_gateway = get_effective_newapi_config()
-                media_mapping = get_newapi_media_model_mappings().get(
-                    model or NEWAPI_VIDEO_MODEL,
-                    {},
-                )
-                if (
-                    active_gateway.mode == MODE_HYBRID
-                    and media_mapping.get("provider") == "comfyui"
-                ):
-                    gateway = get_ce_newapi_config_for_mode(MODE_CUSTOM)
-            except (RuntimeError, ImportError):
-                pass
+                    active_gateway = get_effective_newapi_config()
+                    media_mapping = get_newapi_media_model_mappings().get(
+                        model or NEWAPI_VIDEO_MODEL,
+                        {},
+                    )
+                    if (
+                        active_gateway.mode == MODE_HYBRID
+                        and media_mapping.get("provider") == "comfyui"
+                    ):
+                        gateway = get_ce_newapi_config_for_mode(MODE_CUSTOM)
+                except (RuntimeError, ImportError):
+                    pass
             self.api_key = api_key if api_key is not None else gateway.api_key
             self.base_url = (endpoint or gateway.base_url).rstrip("/")
         self.model = model or NEWAPI_VIDEO_MODEL
@@ -4325,26 +4327,28 @@ def newapi_video_backend_options(
     *, include_seedance2_variants: bool = False
 ) -> dict[str, str]:
     from novelvideo.config import NEWAPI_VIDEO_MODELS
+    from novelvideo.shared.runtime_env import is_ce_effective
 
     models = [
         model
         for model in NEWAPI_VIDEO_MODELS
         if model not in NEWAPI_DISABLED_VIDEO_MODELS
     ]
-    try:
-        from novelvideo.model_gateway_settings import get_newapi_media_model_mappings
+    if is_ce_effective():
+        try:
+            from novelvideo.model_gateway_settings import get_newapi_media_model_mappings
 
-        for model, mapping in get_newapi_media_model_mappings().items():
-            media_type = str(mapping.get("mediaType") or "video").strip().lower()
-            if (
-                mapping.get("provider") == "comfyui"
-                and mapping.get("enabled") is not False
-                and media_type == "video"
-                and model not in models
-            ):
-                models.append(model)
-    except (RuntimeError, ImportError):
-        pass
+            for model, mapping in get_newapi_media_model_mappings().items():
+                media_type = str(mapping.get("mediaType") or "video").strip().lower()
+                if (
+                    mapping.get("provider") == "comfyui"
+                    and mapping.get("enabled") is not False
+                    and media_type == "video"
+                    and model not in models
+                ):
+                    models.append(model)
+        except (RuntimeError, ImportError):
+            pass
     if include_seedance2_variants:
         for model in NEWAPI_MAINLINE_SEEDANCE2_MODELS:
             if model not in models:

--- a/src/novelvideo/model_gateway_settings.py
+++ b/src/novelvideo/model_gateway_settings.py
@@ -529,6 +529,8 @@ def save_newapi_provider_channels(
 
 
 def get_newapi_media_model_mappings() -> dict[str, dict[str, Any]]:
+    if not _uses_ce_gateway_settings():
+        return {}
     settings = get_model_gateway_settings()
     return _decode_media_model_mappings(
         settings.get("custom_newapi_media_model_mappings")

--- a/tests/test_model_gateway_settings.py
+++ b/tests/test_model_gateway_settings.py
@@ -555,6 +555,45 @@ def test_legacy_pydantic_factory_uses_ee_deployment_gateway(monkeypatch, tmp_pat
     assert captured["base_url"] == "https://ee-gateway.example/v1"
 
 
+def test_ee_media_model_mappings_do_not_open_ce_settings(monkeypatch, tmp_path):
+    _isolate_settings_db(monkeypatch, tmp_path)
+    monkeypatch.setenv("ST_EDITION", "ee")
+    monkeypatch.setenv("ST_CONTROL_PLANE_DSN", "postgresql://control-plane")
+    monkeypatch.setattr(
+        model_gateway_settings,
+        "_connect",
+        lambda: pytest.fail("EE must not open CE settings.db"),
+    )
+
+    assert get_newapi_media_model_mappings() == {}
+    assert not (tmp_path / "state").exists()
+
+
+def test_ee_platform_video_paths_do_not_call_ce_media_model_accessor(
+    monkeypatch,
+    tmp_path,
+):
+    _isolate_settings_db(monkeypatch, tmp_path)
+    monkeypatch.setenv("ST_EDITION", "ee")
+    monkeypatch.setenv("ST_CONTROL_PLANE_DSN", "postgresql://control-plane")
+    monkeypatch.setenv("NEWAPI_API_KEY", "sk-ee-secret")
+    monkeypatch.setenv("NEWAPI_BASE_URL", "https://ee-gateway.example/v1")
+    monkeypatch.setattr(config, "NEWAPI_API_KEY", "sk-ee-secret")
+    monkeypatch.setattr(config, "NEWAPI_BASE_URL", "https://ee-gateway.example/v1")
+    monkeypatch.setattr(
+        model_gateway_settings,
+        "get_newapi_media_model_mappings",
+        lambda: pytest.fail("EE video paths must not call the CE accessor"),
+    )
+
+    generator = NewApiVideoGenerator(model="seedance-2.0")
+    options = newapi_video_backend_options()
+
+    assert generator.api_key == "sk-ee-secret"
+    assert generator.base_url == "https://ee-gateway.example/v1"
+    assert "newapi_seedance-2.0" in options
+
+
 def test_cognee_newapi_resolution_prefers_saved_gateway(monkeypatch, tmp_path):
     _isolate_settings_db(monkeypatch, tmp_path)
     monkeypatch.delenv("COGNEE_LLM_PROVIDER", raising=False)


### PR DESCRIPTION
## Summary
- prevent EE platform video construction from calling CE-local media model settings
- keep CE hybrid and ComfyUI routing behind the effective CE edition boundary
- add defensive accessor isolation and regression tests for read-only or unavailable CE state

## Test Plan
- [x] uv run pytest tests/test_model_gateway_settings.py tests/test_p0g4c_video_egress.py -q
- [x] uv run ruff check src/novelvideo/generators/video_generator.py src/novelvideo/model_gateway_settings.py tests/test_model_gateway_settings.py
- [x] gitleaks git --pre-commit --redact --staged --verbose
- [x] uv run python scripts/lint_banned_words.py
- [x] git diff --cached --check

## Impact
- No database migration
- No deployment configuration change
- EE platform video uses deployment New API configuration without reading STATE_DIR/local/settings.db
- CE local gateway and ComfyUI behavior remains unchanged