### PR TITLE
fix(media): 降采样副本改内容寻址，修 ossfs 上新鲜度判定恒假

### DIFF
--- a/scripts/backfill_thumbnails.py
+++ b/scripts/backfill_thumbnails.py
@@ -9,9 +9,10 @@ of an untouched project is all originals, which is exactly the slow paint
 variants exist to remove. Worth running ahead of time for a project you know is
 about to be opened; unnecessary for one already in use.
 
-Safe to re-run: a variant whose mtime already matches its source is left
-alone, so a second pass over an unchanged project does nothing but stat
-files. Interrupting is safe too — variants are written atomically.
+Safe to re-run: a variant that already exists for the source's current
+revision is left alone, so a second pass over an unchanged project does
+nothing but stat files. Interrupting is safe too — variants are written
+atomically.
 
     scripts/backfill_thumbnails.py output/alice/my-project
     scripts/backfill_thumbnails.py --root output --jobs 8
@@ -105,12 +106,11 @@ def backfill_project(
             if dest is None:
                 totals.skipped += 1
                 continue
-            try:
-                if dest.stat().st_mtime_ns == source.stat().st_mtime_ns:
-                    totals.current += 1
-                    continue
-            except OSError:
-                pass
+            # Existence is the whole freshness check — the source's revision is
+            # part of `dest` (see novelvideo.utils.thumbnails).
+            if dest.is_file():
+                totals.current += 1
+                continue
             work.append((source, variant))
 
     if dry_run:

--- a/src/novelvideo/api/routes/files.py
+++ b/src/novelvideo/api/routes/files.py
@@ -32,8 +32,10 @@ def _variant_cache_control(request: Request | None) -> str:
 
     So: versioned URL -> cache hard, the URL changes when the bytes do.
     Bare URL -> revalidate, and let ``FileResponse``'s ETag/Last-Modified turn
-    that into a cheap 304. Variants are stamped with their source's mtime, so
-    the validator moves exactly when the source does.
+    that into a cheap 304. A regenerated source is served out of a different
+    variant file (the revision is part of its path, see
+    ``novelvideo.utils.thumbnails``), so the validator moves exactly when the
+    source does.
     """
 
     params = request.query_params if request is not None else {}

--- a/src/novelvideo/utils/thumbnails.py
+++ b/src/novelvideo/utils/thumbnails.py
@@ -7,17 +7,32 @@ free, nine such images cost ~2.1s of main-thread decode + raster in the
 browser and drop seven frames. Serving a pre-shrunk variant removes that
 work entirely (measured: 105.4MB -> 0.23MB, 2156ms of long tasks -> 0).
 
-The cache is addressed purely by source path::
+The cache is addressed by the source's path *and revision*::
 
-    <project_dir>/_thumbs/<variant>/<path relative to project_dir>.webp
+    <project_dir>/_thumbs/<variant>/<path relative to project_dir>/<stamp>.webp
 
 so nothing about it leaks into a data schema. History records and canvas
 JSON keep storing the original URL; callers opt in per render by asking for
 a variant, and old data benefits without any backfill.
-Freshness is exact rather than heuristic: a generated variant is stamped
-with its source's mtime, so ``thumb.mtime == source.mtime`` means current
-and a regenerated source invalidates automatically without leaving stale
-files behind.
+
+``<stamp>`` is the source's mtime-in-seconds and size, which makes freshness a
+question of *which file exists* rather than of comparing metadata between two
+files. The first shipped version compared them — the variant was stamped with
+its source's mtime through ``os.utime`` and "current" meant ``thumb.mtime ==
+source.mtime`` — and that is precisely what did not survive production: the
+project tree is an ossfs mount, where the stamp is lost across ``os.replace``
+(the rename is a server-side copy, and the object comes back carrying the write
+time). Every lookup missed, so every request re-rendered the variant it had
+just discarded and then served the original anyway — strictly more work than
+before variants existed, for no effect a user could see.
+
+Putting the revision in the path removes the assumption instead of tightening
+it: whatever mtime the filesystem decides to hand the variant, nothing reads
+it. Seconds rather than nanoseconds for the same reason — sub-second mtime is
+not something every mount reports, let alone reports stably, and a stamp that
+wobbles between two stats of an unchanged file would land us right back on the
+re-render treadmill. Size rides along so a rewrite inside the same second still
+invalidates.
 
 Building and serving are deliberately separate. ``fresh_thumbnail`` is what a
 request calls and it never builds; ``ensure_thumbnail`` builds and only ever
@@ -134,8 +149,32 @@ def normalize_variant(value: str | None) -> Optional[str]:
     return name if name in VARIANTS else None
 
 
-def thumbnail_path(project_dir: Path, source: Path, variant: str) -> Optional[Path]:
-    """Map a source file to its cache location, or ``None`` if out of scope."""
+def _source_stamp(stat_result: os.stat_result) -> str:
+    """The revision half of a variant's address. See the module docstring."""
+
+    return f"{int(stat_result.st_mtime)}-{stat_result.st_size}"
+
+
+def thumbnail_path(
+    project_dir: Path,
+    source: Path,
+    variant: str,
+    *,
+    stat_result: "os.stat_result | None" = None,
+) -> Optional[Path]:
+    """Map a source file to its cache location, or ``None`` if out of scope.
+
+    The source's own relative path becomes a *directory* holding one file per
+    revision. A flat ``<name>.<stamp>.webp`` would have worked for lookups just
+    as well, but not for the housekeeping: superseding a variant would then
+    have to filter a sibling list shared with every other image in the same
+    folder — and ``freezone/_outputs/freezone_gen/`` holds thousands. One
+    directory per source keeps that sweep to a handful of entries.
+
+    Returns ``None`` rather than raising when the source cannot be stat'ed, so
+    a file that vanished mid-request falls back to the original like every
+    other decline here.
+    """
 
     try:
         rel = source.resolve().relative_to(project_dir.resolve())
@@ -144,9 +183,13 @@ def thumbnail_path(project_dir: Path, source: Path, variant: str) -> Optional[Pa
     # Never thumbnail a thumbnail — that would nest caches on every request.
     if rel.parts and rel.parts[0] == THUMB_ROOT:
         return None
-    # Suffix is appended rather than replaced so `a.png` and `a.jpg` cannot
-    # collide on a shared `a.webp`.
-    return project_dir / THUMB_ROOT / variant / rel.with_name(rel.name + ".webp")
+    # The source's file name stays a whole path segment, suffix included, so
+    # `a.png` and `a.jpg` cannot collide on a shared `a/`.
+    try:
+        stamp = _source_stamp(stat_result if stat_result is not None else source.stat())
+    except OSError:
+        return None
+    return project_dir / THUMB_ROOT / variant / rel / f"{stamp}.webp"
 
 
 def is_thumbnailable(source: Path) -> bool:
@@ -172,23 +215,25 @@ def ensure_thumbnail(
     try:
         if not is_thumbnailable(source):
             return None
-        dest = thumbnail_path(project_dir, source, name)
-        if dest is None:
-            return None
         stat = source.stat()
         if stat.st_size > _MAX_SOURCE_BYTES:
             return None
-        source_mtime_ns = stat.st_mtime_ns
+        # One stat, reused for the ceiling above and the stamp below: the
+        # revision has to be the one we just checked, not one re-read a syscall
+        # later.
+        dest = thumbnail_path(project_dir, source, name, stat_result=stat)
+        if dest is None:
+            return None
 
-        if _is_current(dest, source_mtime_ns):
+        if _is_current(dest):
             return dest
         with _stripe_for(dest):
             # Re-check under the lock: whoever we queued behind may have just
             # written exactly the file we were about to render.
-            if _is_current(dest, source_mtime_ns):
+            if _is_current(dest):
                 return dest
             with _render_slots:
-                return _render(source, dest, max_edge, source_mtime_ns)
+                return _render(source, dest, max_edge)
     except Exception:
         logger.debug("thumbnail skipped for %s (%s)", source, variant, exc_info=True)
         return None
@@ -223,21 +268,27 @@ def fresh_thumbnail(
         dest = thumbnail_path(project_dir, source, name)
         if dest is None:
             return None
-        return dest if _is_current(dest, source.stat().st_mtime_ns) else None
+        return dest if _is_current(dest) else None
     except OSError:
         return None
 
 
-def _is_current(dest: Path, source_mtime_ns: int) -> bool:
+def _is_current(dest: Path) -> bool:
+    """Whether a variant for this exact source revision is already on disk.
+
+    Existence *is* the answer: the revision is part of the path, so a file that
+    is there was built from the bytes we are being asked about. The variant's
+    own metadata is never consulted — the module docstring records what
+    happened the last time it was.
+    """
+
     try:
-        return dest.stat().st_mtime_ns == source_mtime_ns
+        return dest.is_file()
     except OSError:
         return False
 
 
-def _render(
-    source: Path, dest: Path, max_edge: int, source_mtime_ns: int
-) -> Optional[Path]:
+def _render(source: Path, dest: Path, max_edge: int) -> Optional[Path]:
     from PIL import Image, ImageOps
 
     with Image.open(source) as opened:
@@ -293,15 +344,43 @@ def _render(
     tmp = dest.with_name(f"{dest.name}.{os.getpid()}.{threading.get_ident()}.tmp")
     try:
         out.save(tmp, "WEBP", quality=_WEBP_QUALITY, method=_WEBP_METHOD)
-        # Stamp the source's mtime onto the variant; that equality *is* the
-        # freshness check, and it closes the race where the source is
-        # rewritten while we render.
-        os.utime(tmp, ns=(source_mtime_ns, source_mtime_ns))
         os.replace(tmp, dest)
     except Exception:
         tmp.unlink(missing_ok=True)
         raise
+    _discard_superseded(dest)
     return dest
+
+
+def _discard_superseded(dest: Path) -> None:
+    """Drop the revisions this variant replaces.
+
+    A new revision writes a new file name instead of overwriting the old one,
+    so without this the directory would keep one copy per revision of the
+    source forever. Everything beside ``dest`` is by construction an older
+    variant of the same source at the same tier, which is what makes this a
+    single small listing rather than a filtered scan.
+
+    Best effort in both directions. A failure only costs disk — the variant the
+    caller asked for is already in place. And a render that finishes out of
+    order can delete a *newer* sibling, which costs one rebuild the next time
+    that revision is asked for; the alternative is holding a lock across the
+    decode, which is the thing the striped locks exist to avoid.
+    """
+
+    try:
+        with os.scandir(dest.parent) as entries:
+            for entry in entries:
+                # A `.tmp` belongs to a render still in flight — quite possibly
+                # the one that is about to supersede this one.
+                if entry.name == dest.name or entry.name.endswith(".tmp"):
+                    continue
+                try:
+                    os.unlink(entry.path)
+                except OSError:
+                    pass
+    except OSError:
+        logger.debug("could not sweep superseded variants in %s", dest.parent)
 
 
 # --- background prewarm ---------------------------------------------------

--- a/src/novelvideo/utils/thumbnails.py
+++ b/src/novelvideo/utils/thumbnails.py
@@ -28,11 +28,25 @@ before variants existed, for no effect a user could see.
 
 Putting the revision in the path removes the assumption instead of tightening
 it: whatever mtime the filesystem decides to hand the variant, nothing reads
-it. Seconds rather than nanoseconds for the same reason — sub-second mtime is
-not something every mount reports, let alone reports stably, and a stamp that
-wobbles between two stats of an unchanged file would land us right back on the
-re-render treadmill. Size rides along so a rewrite inside the same second still
-invalidates.
+it.
+
+Seconds rather than nanoseconds, and that costs something worth naming. A
+source rewritten in place, inside the same second, to a byte-identical size
+keeps its stamp, so the previous variant is served until the source changes
+again. The finer clock would close that, and is exactly what must not be
+trusted here: ossfs derives an object's mtime from OSS metadata, which is
+second-granularity, but may serve the local write time — nanoseconds and all —
+until its attribute cache expires. A stamp that wobbles between two stats of an
+unchanged file puts every request back on the re-render treadmill, silently,
+which is the failure this module exists to undo. Serving one stale thumbnail is
+the smaller loss, so the coarser clock wins. Size rides along and catches the
+same-second rewrites that do change length, which is most of them.
+
+Nothing in the tree is written that way today — generated images and uploads
+both carry a job id or a timestamp in their names, so a rewrite lands on a new
+path. Should something start overwriting sources in place, close this by
+deleting the source's variant directory at the write site rather than by
+reaching for a finer clock.
 
 Building and serving are deliberately separate. ``fresh_thumbnail`` is what a
 request calls and it never builds; ``ensure_thumbnail`` builds and only ever
@@ -50,6 +64,7 @@ import logging
 import os
 import queue
 import threading
+import time
 from collections.abc import Iterable
 from pathlib import Path
 from typing import Optional
@@ -352,22 +367,60 @@ def _render(source: Path, dest: Path, max_edge: int) -> Optional[Path]:
     return dest
 
 
+# How long a superseded variant is left alone before it may be swept. A route
+# hands back a path and Starlette opens it later, from its own `__call__` —
+# unlink in that gap and the response dies with FileNotFoundError instead of
+# serving. Nothing legitimate sits in that gap for a minute.
+_SUPERSEDED_GRACE_SECONDS = 60.0
+
+
+def _stamp_parts(name: str) -> Optional[tuple[int, int]]:
+    """``(seconds, size)`` out of a variant file name, or ``None`` if unparsable.
+
+    Split from the right: the size is the last field, and everything before it
+    is the mtime — which is signed, so it may carry a ``-`` of its own.
+    """
+
+    if not name.endswith(".webp"):
+        return None
+    seconds, _, size = name[: -len(".webp")].rpartition("-")
+    try:
+        return int(seconds), int(size)
+    except ValueError:
+        return None
+
+
 def _discard_superseded(dest: Path) -> None:
-    """Drop the revisions this variant replaces.
+    """Drop the revisions this variant demonstrably replaces.
 
     A new revision writes a new file name instead of overwriting the old one,
     so without this the directory would keep one copy per revision of the
-    source forever. Everything beside ``dest`` is by construction an older
-    variant of the same source at the same tier, which is what makes this a
-    single small listing rather than a filtered scan.
+    source forever.
 
-    Best effort in both directions. A failure only costs disk — the variant the
-    caller asked for is already in place. And a render that finishes out of
-    order can delete a *newer* sibling, which costs one rebuild the next time
-    that revision is asked for; the alternative is holding a lock across the
-    decode, which is the thing the striped locks exist to avoid.
+    Two things this deliberately will not do, both of which cost a live request
+    rather than disk:
+
+    *Delete forwards.* Renders of two revisions can be in flight at once — they
+    have different destinations and therefore usually different stripe locks —
+    and the older one can finish last. It must not take the newer variant with
+    it, so a sibling is swept only when its own stamp is strictly older than
+    ours. Equal seconds with a different size is not an ordering, so those are
+    left alone too; the cost of keeping one extra file is a rounding error
+    against getting this wrong.
+
+    *Delete something that may already be on its way out.* ``fresh_thumbnail``
+    hands the route a path, and ``FileResponse`` does not open it until well
+    after the handler returned. A file young enough to be inside that window is
+    skipped and swept by a later render instead.
+
+    Best effort throughout: every failure here costs disk, and the variant the
+    caller asked for is already in place.
     """
 
+    ours = _stamp_parts(dest.name)
+    if ours is None:
+        return
+    now = time.time()
     try:
         with os.scandir(dest.parent) as entries:
             for entry in entries:
@@ -375,7 +428,12 @@ def _discard_superseded(dest: Path) -> None:
                 # the one that is about to supersede this one.
                 if entry.name == dest.name or entry.name.endswith(".tmp"):
                     continue
+                theirs = _stamp_parts(entry.name)
+                if theirs is None or theirs[0] >= ours[0]:
+                    continue
                 try:
+                    if now - entry.stat().st_mtime < _SUPERSEDED_GRACE_SECONDS:
+                        continue
                     os.unlink(entry.path)
                 except OSError:
                     pass

--- a/tests/test_media_thumbnails.py
+++ b/tests/test_media_thumbnails.py
@@ -92,7 +92,16 @@ def test_builds_webp_within_the_variant_budget(tmp_path):
     dest = thumbnails.ensure_thumbnail(tmp_path, source, "thumb")
 
     assert dest is not None
-    assert dest == tmp_path / "_thumbs" / "thumb" / "freezone" / "_outputs" / "big.png.webp"
+    stat = source.stat()
+    assert dest == (
+        tmp_path
+        / "_thumbs"
+        / "thumb"
+        / "freezone"
+        / "_outputs"
+        / "big.png"
+        / f"{int(stat.st_mtime)}-{stat.st_size}.webp"
+    )
     with Image.open(dest) as im:
         assert im.format == "WEBP"
         assert max(im.size) <= thumbnails.VARIANTS["thumb"]
@@ -100,13 +109,25 @@ def test_builds_webp_within_the_variant_budget(tmp_path):
     assert dest.stat().st_size < source.stat().st_size
 
 
-def test_variant_is_stamped_with_the_source_mtime(tmp_path):
+def test_a_variant_is_found_whatever_mtime_the_filesystem_gave_it(tmp_path):
+    """The production failure, as a test.
+
+    The project tree is an ossfs mount, and a file lands there carrying the
+    time it was written no matter what the writer asked for. The first version
+    of this cache stamped the source's mtime onto the variant and called it
+    current when the two matched, so on that mount every lookup missed, every
+    request re-rendered the variant it had just discarded, and every response
+    was still the original. Nothing may read a variant's own timestamps.
+    """
+
     source = _write_png(tmp_path / "a.png")
+    built = thumbnails.ensure_thumbnail(tmp_path, source, "thumb")
+    assert built is not None
 
-    dest = thumbnails.ensure_thumbnail(tmp_path, source, "thumb")
+    os.utime(built, ns=(_MTIME_AFTER, _MTIME_AFTER))
 
-    assert dest is not None
-    assert dest.stat().st_mtime_ns == source.stat().st_mtime_ns
+    assert thumbnails.fresh_thumbnail(tmp_path, source, "thumb") == built
+    assert thumbnails.ensure_thumbnail(tmp_path, source, "thumb") == built
 
 
 def test_second_call_reuses_the_cached_variant(tmp_path, monkeypatch):
@@ -133,7 +154,26 @@ def test_regenerated_source_invalidates_the_variant(tmp_path):
     second = thumbnails.ensure_thumbnail(tmp_path, source, "thumb")
     assert second is not None
     assert second.read_bytes() != first_bytes
-    assert second.stat().st_mtime_ns == source.stat().st_mtime_ns
+    # A revision is a distinct file rather than an overwrite, so the one it
+    # supersedes has to be swept or the cache grows a copy per regeneration.
+    assert second != first
+    assert not first.exists()
+
+
+def test_superseded_revisions_do_not_accumulate(tmp_path):
+    source = _write_png(tmp_path / "a.png", (1600, 900))
+    variant_dir = thumbnails.thumbnail_path(tmp_path, source, "thumb").parent
+
+    for index, shade in enumerate((20, 90, 160, 230)):
+        _write_png(source, (1600, 900), color=(shade, shade, shade))
+        # A solid PNG of the same size can encode to the same byte count, so
+        # move the clock rather than relying on the size half of the stamp.
+        moved = _MTIME_AFTER + index * 10**9
+        os.utime(source, ns=(moved, moved))
+        assert thumbnails.ensure_thumbnail(tmp_path, source, "thumb") is not None
+
+    current = thumbnails.thumbnail_path(tmp_path, source, "thumb")
+    assert [entry.name for entry in variant_dir.iterdir()] == [current.name]
 
 
 def test_variant_follows_the_orientation_the_browser_shows(tmp_path):
@@ -498,6 +538,40 @@ def test_a_regenerated_source_is_revalidated_to_the_new_variant(monkeypatch, tmp
     )
     assert stale.status_code == 200
     assert stale.content == second.content
+
+
+def test_variants_survive_a_mount_that_rewrites_the_stamp(monkeypatch, tmp_path):
+    """ossfs, simulated end to end.
+
+    There the rename behind a variant write is a server-side copy, and the
+    object comes back carrying the copy's time rather than the one that was
+    stamped on it. This is the shape of the bug that made the first version of
+    this feature a no-op online, so it is checked through the route rather than
+    against the cache helpers alone.
+    """
+
+    real_replace = os.replace
+
+    def replace_and_lose_the_stamp(src, dst):
+        real_replace(src, dst)
+        # Only the cache, so patching `os.replace` process-wide cannot disturb
+        # anything else this test happens to run through.
+        if thumbnails.THUMB_ROOT in Path(dst).parts:
+            os.utime(dst, ns=(_MTIME_AFTER, _MTIME_AFTER))
+
+    monkeypatch.setattr(thumbnails.os, "replace", replace_and_lose_the_stamp)
+
+    source = _write_png(tmp_path / "freezone" / "_outputs" / "big.png", (2000, 1200))
+    _warm(tmp_path, source, "thumb")
+    client = _client(monkeypatch, tmp_path)
+
+    response = client.get(
+        "/projects/demo/media/freezone/_outputs/big.png", params={"st_thumb": "thumb"}
+    )
+
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "image/webp"
+    assert len(response.content) < source.stat().st_size
 
 
 def test_a_cold_variant_request_serves_the_original_and_warms_up_behind_it(

--- a/tests/test_media_thumbnails.py
+++ b/tests/test_media_thumbnails.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 import threading
+import time
 from pathlib import Path
 
 import pytest
@@ -141,6 +142,14 @@ def test_second_call_reuses_the_cached_variant(tmp_path, monkeypatch):
     assert thumbnails.ensure_thumbnail(tmp_path, source, "thumb") is not None
 
 
+def _age_out(variant_dir: Path) -> None:
+    """Push every variant in `variant_dir` past the sweep's grace period."""
+
+    stale = time.time() - thumbnails._SUPERSEDED_GRACE_SECONDS - 60
+    for entry in variant_dir.iterdir():
+        os.utime(entry, (stale, stale))
+
+
 def test_regenerated_source_invalidates_the_variant(tmp_path):
     source = _write_png(tmp_path / "a.png", (1600, 900), color=(10, 10, 200))
     first = thumbnails.ensure_thumbnail(tmp_path, source, "thumb")
@@ -150,6 +159,9 @@ def test_regenerated_source_invalidates_the_variant(tmp_path):
     # Same path, different content and a newer mtime — what a regenerate does.
     _write_png(tmp_path / "a.png", (1600, 900), color=(240, 240, 10))
     os.utime(source, ns=(source.stat().st_mtime_ns + 10**9,) * 2)
+    # Past the window that protects a variant a response may still be opening,
+    # so what this asserts below is the sweep and not the grace period.
+    _age_out(first.parent)
 
     second = thumbnails.ensure_thumbnail(tmp_path, source, "thumb")
     assert second is not None
@@ -170,10 +182,63 @@ def test_superseded_revisions_do_not_accumulate(tmp_path):
         # move the clock rather than relying on the size half of the stamp.
         moved = _MTIME_AFTER + index * 10**9
         os.utime(source, ns=(moved, moved))
+        # Every revision so far is old enough to sweep; without this they are
+        # all inside the window that protects an in-flight response.
+        if variant_dir.exists():
+            _age_out(variant_dir)
         assert thumbnails.ensure_thumbnail(tmp_path, source, "thumb") is not None
 
     current = thumbnails.thumbnail_path(tmp_path, source, "thumb")
     assert [entry.name for entry in variant_dir.iterdir()] == [current.name]
+
+
+def test_a_late_render_does_not_delete_the_revision_that_replaced_it(tmp_path):
+    """Two revisions can render at once, and the older one can finish last.
+
+    They have different destinations and so usually different stripe locks, so
+    nothing serialises them. If the straggler swept the directory flat it would
+    delete the variant that superseded it -- and not merely cost a rebuild: the
+    route hands `FileResponse` a path it opens later, so unlinking underneath a
+    live response fails the request.
+    """
+
+    source = _write_png(tmp_path / "b.png", (1600, 900))
+    os.utime(source, ns=(_MTIME_AFTER, _MTIME_AFTER))
+    stale_dest = thumbnails.thumbnail_path(tmp_path, source, "thumb")
+
+    _write_png(source, (1600, 900), color=(200, 50, 50))
+    moved = _MTIME_AFTER + 10**9
+    os.utime(source, ns=(moved, moved))
+    current = thumbnails.ensure_thumbnail(tmp_path, source, "thumb")
+    assert current is not None and current != stale_dest
+
+    # The older render lands now, after the newer one is already on disk. Age
+    # the directory first so the grace period is not what saves it.
+    _age_out(current.parent)
+    thumbnails._render(source, stale_dest, thumbnails.VARIANTS["thumb"])
+
+    assert current.exists(), "a late render deleted the revision that replaced it"
+
+
+def test_a_just_written_variant_survives_the_sweep(tmp_path):
+    """The sweep must not race the gap between handing out a path and opening it.
+
+    `fresh_thumbnail` returns a path and Starlette opens it from its own
+    `__call__`, long after the handler returned. A variant young enough to be
+    inside that gap is left for a later render to collect.
+    """
+
+    source = _write_png(tmp_path / "c.png", (1600, 900))
+    os.utime(source, ns=(_MTIME_AFTER, _MTIME_AFTER))
+    serving = thumbnails.ensure_thumbnail(tmp_path, source, "thumb")
+    assert serving is not None
+
+    _write_png(source, (1600, 900), color=(200, 50, 50))
+    moved = _MTIME_AFTER + 10**9
+    os.utime(source, ns=(moved, moved))
+    assert thumbnails.ensure_thumbnail(tmp_path, source, "thumb") is not None
+
+    assert serving.exists(), "swept a variant a response could still be opening"
 
 
 def test_variant_follows_the_orientation_the_browser_shows(tmp_path):


### PR DESCRIPTION
## 问题

#329 上线后没有任何效果 —— 画布大图节点该有的降采样副本，线上一次都没被用上。

副本的新鲜度判定是「副本 mtime == 源图 mtime」，靠 `os.utime` 把源图的 mtime 打到副本上。线上 `OUTPUT_DIR` 是 **ossfs 挂载**，这个前提不成立：rename 走服务端 copy，对象回来带的是写入时刻，`utime` 也不生效。于是 `_is_current()` 永远 False —— **每次请求重渲一遍副本、丢掉、再把原图发出去**，比没上这个功能还多花一次服务端解码。

线上实测（2026-08-21）：

| 探测 | 结果 |
|---|---|
| 源图 `Last-Modified` ×3 | `03:44:02` / `03:44:02` / `03:44:02`（稳定） |
| 同图 `?st_thumb=thumb` ×3 | `image/png` **7,757,679 B** ×3（整张原图） |
| 副本文件 `Last-Modified` | 每次请求都往后跳 |

边缘缓存已排除（这些大对象全程 `MISS`/`BYPASS`）。

讽刺的是 `files.py:142` 就写着 `OUTPUT_DIR is an ossfs mount`，离 #329 改动四行远 —— 信息一直在，只是没连上。

## 改法

把源的版本编进副本路径，新鲜度退化成「这个文件在不在」：

```
旧  <project>/_thumbs/<variant>/<rel>.webp          + os.utime 打源 mtime
新  <project>/_thumbs/<variant>/<rel>/<stamp>.webp     stamp = int(mtime)-size
```

`_is_current()` 从 `dest.stat().st_mtime_ns == source_mtime_ns` 变成 `dest.is_file()`。**副本自己的元数据从此没人读**，挂载怎么改写都不影响 —— 是把假设拿掉，不是把假设收紧。

几处不显然的地方：

- **秒级而非纳秒级，这有代价。** ossfs 的 mtime 源自 OSS 元数据（秒级），但在属性缓存过期前可能返回带纳秒的本地写入时刻；一个会在两次 stat 之间抖的 stamp 会让每个请求静默地回到重渲跑步机 —— 正是 #329 上线三周没人发现的那个故障。代价是：**原地重写、同一秒、字节数恰好相同的源会继续吃旧副本**（size 只挡得住大小也变了的那些）。发一张过期缩略图是比整个功能静默失效小得多的损失。当前代码里够不到这个窗口 —— 生成图和上传文件的名字都带 job id 或时间戳，重写会落到新路径。真要支持原地覆盖，正确的关法是在写入处删掉该源的副本目录，而不是去动时钟。
- **一源一目录**，而不是扁平的 `<name>.<stamp>.webp`。差别只在清理：扁平方案要在跟同目录所有图共享的兄弟列表里过滤，而 `freezone/_outputs/freezone_gen/` 下有几千个文件。
- **`_discard_superseded` 是新欠的债。** 旧方案原地覆盖、天然不留垃圾；内容寻址换来每个版本一个文件，得自己扫。清理只向后删、不向前删：兄弟的 stamp 秒数严格小于本次才扫（秒数相同、大小不同不构成顺序，留着）。另加 60 秒宽限 —— `fresh_thumbnail` 把路径交给路由，而 `FileResponse` 直到自己的 `__call__` 才打开它，在这个空档里 unlink 会让请求以 `FileNotFoundError` 收场，不是慢一点。
- **`ensure_thumbnail` 只 stat 一次**，体积上限和 stamp 共用同一个结果：stamp 必须是刚校验过的那个版本，不能是一次 syscall 之后重读的。

## 测试

原来的断言在 `tmp_path` 上跑，本地文件系统完整保留纳秒，那条断言恒真 —— 测的是「我刚写进去的值等于我刚写进去的值」，CI 绿也拦不住。

补两条回归，**在旧实现上都挂**：

- `test_a_variant_is_found_whatever_mtime_the_filesystem_gave_it` —— 副本被任意改写 mtime 后仍然命中
- `test_variants_survive_a_mount_that_rewrites_the_stamp` —— monkeypatch 掉 `os.replace` 模拟挂载重写时间戳，走真实 HTTP 路由断言拿到的是 webp 而非原图

外加 `test_superseded_revisions_do_not_accumulate` 盯住新方案的磁盘增长。

本地：`tests/test_media_thumbnails.py` 69 passed；连同 `test_project_static_media` / `test_spa_static_serving` / `test_media_relay` / `test_api_beats_media_urls` 共 101 passed；`ruff check .` 全过；`tsc -b` + `pnpm build` 过（本 PR 无前端改动）。

## 部署后怎么验

把同一条探测原样再跑一次：

```js
fetch('/static/projects/<p>/freezone/_uploads/20260818_025747_185525_3.png?st_thumb=thumb',
      {credentials:'include', cache:'no-store'})
```

回 `image/webp` ~15KB = 成了；还回 `image/png` 7.7MB = 没成。没有解释空间。

## 已知边界

- **不重新部署 API pod 就是零效果**，本 PR 只动后端 Python。
- **每张图第一次请求仍然是原图** —— 冷 miss 的设计就是「服务原图 + 排队预热」。想让首次点击也快，需要贴着挂载跑一遍 `scripts/backfill_thumbnails.py`。
- **线上旧方案留下的扁平文件 `_thumbs/<variant>/<rel>.webp` 是死数据**，可直接删；新路径要的是同名*目录*，与旧文件不冲突，不删也不会坏。
- 本 PR 不扩前端变体覆盖率 —— 仍有约 100 处 `resolveImageDisplayUrl` 不带 `st_thumb`。那会牵到下载 / 全屏预览 / canvas 导出等不能降清晰度的路径，单独判。
- **未在真 ossfs 上跑过这一版**：`_discard_superseded` 的扫目录和多出来的那层目录，在该文件系统上是新行为（嵌套目录创建本身已有现成证据 —— 线上那些 `_thumbs/thumb/freezone/_outputs/...` 就是 `mkdir(parents=True)` 建出来的）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013mSG9HXhpS5G6MuyQsS1bN
