### PR TITLE
fix: isolate EE config from CE provisioner

### DIFF
--- a/docs/superpowers/plans/2026-08-21-ee-config-ce-provisioner-isolation.md
+++ b/docs/superpowers/plans/2026-08-21-ee-config-ce-provisioner-isolation.md
@@ -1,0 +1,240 @@
+# EE Config and CE Provisioner Isolation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Keep the shared EE model-gateway config endpoint functional without calling or opening any CE-local settings database.
+
+**Architecture:** Compose the endpoint response by effective edition: CE uses the existing provisioner builder, while EE returns a fixed disabled provisioner contract. Add a defensive guard to the low-level settings reader so accidental EE callers cannot reach SQLite.
+
+**Tech Stack:** Python 3.12, FastAPI, pytest, TestClient, monkeypatch
+
+---
+
+## File map
+
+- Modify `tests/test_model_gateway_settings.py`: add EE route isolation, low-level accessor isolation, and CE route control tests.
+- Modify `src/novelvideo/api/routes/model_gateway.py`: add edition-aware provisioner status composition.
+- Modify `src/novelvideo/model_gateway_settings.py`: prevent effective EE from calling `_read_all()`.
+
+### Task 1: Add failing EE regression tests
+
+**Files:**
+- Modify: `tests/test_model_gateway_settings.py`
+- Test: `tests/test_model_gateway_settings.py`
+
+- [ ] **Step 1: Add the route isolation test**
+
+```python
+def test_ee_model_gateway_config_skips_ce_provisioner_and_settings(
+    monkeypatch,
+    tmp_path,
+):
+    _isolate_settings_db(monkeypatch, tmp_path)
+    monkeypatch.setenv("ST_EDITION", "ee")
+    monkeypatch.setenv("ST_CONTROL_PLANE_DSN", "postgresql://control-plane")
+    monkeypatch.setenv("NEWAPI_BASE_URL", "https://ee-gateway.example/v1")
+    monkeypatch.setenv("NEWAPI_API_KEY", "sk-ee-secret")
+    monkeypatch.setattr(model_gateway.app_config, "NEWAPI_API_KEY", "sk-ee-secret")
+    monkeypatch.setattr(
+        model_gateway,
+        "build_provisioner_status",
+        lambda: pytest.fail("EE must not build CE provisioner status"),
+    )
+    monkeypatch.setattr(
+        model_gateway_settings,
+        "_connect",
+        lambda: pytest.fail("EE must not open CE settings.db"),
+    )
+    app = FastAPI()
+    app.include_router(model_gateway.router)
+
+    response = TestClient(app).get("/model-gateway/config")
+
+    assert response.status_code == 200
+    data = response.json()["data"]
+    assert data["effective"]["baseUrl"] == "https://ee-gateway.example/v1"
+    assert data["provisioner"] == {
+        "enabled": False,
+        "adminBaseUrl": "",
+        "dbConfigured": False,
+        "database": {
+            "configured": False,
+            "available": False,
+            "source": "unavailable",
+        },
+        "adminUsername": "",
+        "relayTokenName": "",
+        "providers": {},
+        "providerChannels": [],
+        "mediaModels": {},
+        "embeddingModel": {},
+        "relayBaseUrl": "",
+    }
+    assert not (tmp_path / "state").exists()
+```
+
+- [ ] **Step 2: Add the low-level defensive-boundary test**
+
+```python
+def test_ee_model_gateway_settings_reader_does_not_open_sqlite(monkeypatch, tmp_path):
+    _isolate_settings_db(monkeypatch, tmp_path)
+    monkeypatch.setenv("ST_EDITION", "ee")
+    monkeypatch.setenv("ST_CONTROL_PLANE_DSN", "postgresql://control-plane")
+    monkeypatch.setattr(
+        model_gateway_settings,
+        "_connect",
+        lambda: pytest.fail("EE must not open CE settings.db"),
+    )
+
+    assert model_gateway_settings.get_model_gateway_settings() == {
+        "model_gateway_mode": MODE_OFFICIAL
+    }
+    assert not (tmp_path / "state").exists()
+```
+
+- [ ] **Step 3: Run both tests and verify RED**
+
+Run: `uv run pytest tests/test_model_gateway_settings.py::test_ee_model_gateway_config_skips_ce_provisioner_and_settings tests/test_model_gateway_settings.py::test_ee_model_gateway_settings_reader_does_not_open_sqlite -q`
+
+Expected: the route test fails with `EE must not build CE provisioner status`; the reader test fails with `EE must not open CE settings.db`.
+
+### Task 2: Implement the edition boundaries
+
+**Files:**
+- Modify: `src/novelvideo/api/routes/model_gateway.py:476`
+- Modify: `src/novelvideo/model_gateway_settings.py:940`
+- Test: `tests/test_model_gateway_settings.py`
+
+- [ ] **Step 1: Add edition-aware provisioner status composition**
+
+```python
+def _provisioner_status() -> dict[str, Any]:
+    if is_ce_effective():
+        return build_provisioner_status()
+    return {
+        "enabled": False,
+        "adminBaseUrl": "",
+        "dbConfigured": False,
+        "database": {
+            "configured": False,
+            "available": False,
+            "source": "unavailable",
+        },
+        "adminUsername": "",
+        "relayTokenName": "",
+        "providers": {},
+        "providerChannels": [],
+        "mediaModels": {},
+        "embeddingModel": {},
+        "relayBaseUrl": "",
+    }
+```
+
+Change the route field to:
+
+```python
+            "provisioner": _provisioner_status(),
+```
+
+- [ ] **Step 2: Add the defensive settings-reader guard**
+
+```python
+def get_model_gateway_settings() -> dict[str, str]:
+    data = _read_all() if _uses_ce_gateway_settings() else {}
+    data.setdefault("model_gateway_mode", MODE_OFFICIAL)
+    return data
+```
+
+- [ ] **Step 3: Run the new EE tests and verify GREEN**
+
+Run: `uv run pytest tests/test_model_gateway_settings.py::test_ee_model_gateway_config_skips_ce_provisioner_and_settings tests/test_model_gateway_settings.py::test_ee_model_gateway_settings_reader_does_not_open_sqlite -q`
+
+Expected: `2 passed`.
+
+### Task 3: Preserve CE behavior
+
+**Files:**
+- Modify: `tests/test_model_gateway_settings.py`
+- Test: `tests/test_model_gateway_settings.py`
+
+- [ ] **Step 1: Add a CE control test**
+
+```python
+def test_ce_model_gateway_config_uses_provisioner_builder(monkeypatch, tmp_path):
+    _isolate_settings_db(monkeypatch, tmp_path)
+    expected = {
+        "enabled": True,
+        "adminBaseUrl": "http://new-api:3000",
+        "dbConfigured": True,
+        "database": {"configured": True},
+        "adminUsername": "root",
+        "relayTokenName": "ce-runtime",
+        "providers": {"openrouter": {}},
+        "providerChannels": [],
+        "mediaModels": {},
+        "embeddingModel": {},
+        "relayBaseUrl": "http://new-api:3000/v1",
+    }
+    monkeypatch.setattr(model_gateway, "build_provisioner_status", lambda: expected)
+    app = FastAPI()
+    app.include_router(model_gateway.router)
+
+    response = TestClient(app).get("/model-gateway/config")
+
+    assert response.status_code == 200
+    assert response.json()["data"]["provisioner"] == expected
+```
+
+- [ ] **Step 2: Run the CE control test**
+
+Run: `uv run pytest tests/test_model_gateway_settings.py::test_ce_model_gateway_config_uses_provisioner_builder -q`
+
+Expected: PASS.
+
+### Task 4: Verify and publish
+
+**Files:**
+- Verify: `src/novelvideo/api/routes/model_gateway.py`
+- Verify: `src/novelvideo/model_gateway_settings.py`
+- Verify: `tests/test_model_gateway_settings.py`
+
+- [ ] **Step 1: Run focused regression and lint**
+
+Run: `uv run pytest tests/test_model_gateway_settings.py -q`
+
+Expected: all tests pass.
+
+Run: `uv run ruff check src/novelvideo/api/routes/model_gateway.py src/novelvideo/model_gateway_settings.py tests/test_model_gateway_settings.py`
+
+Expected: `All checks passed!`
+
+- [ ] **Step 2: Run repository safety checks**
+
+Run: `git diff --check`
+
+Expected: exit 0.
+
+Run: `gitleaks git --pre-commit --redact --staged --verbose`
+
+Expected: `no leaks found`.
+
+Run: `uv run python scripts/lint_banned_words.py`
+
+Expected: `✓ 无禁用词。`
+
+- [ ] **Step 3: Commit with DCO sign-off**
+
+```bash
+git add -- src/novelvideo/api/routes/model_gateway.py src/novelvideo/model_gateway_settings.py tests/test_model_gateway_settings.py
+git commit -s -m "fix: isolate EE config from CE provisioner"
+```
+
+- [ ] **Step 4: Audit, push, and open a draft PR**
+
+Run: `git log origin/staging..HEAD --format='%h %an <%ae>%n%B%n---'`
+
+Expected: every commit has a matching `Signed-off-by` trailer.
+
+Run: `git push -u origin fix/ee-config-no-ce-provisioner`
+
+Create a draft PR with base `staging`, summarizing the EE route boundary, defensive settings-reader guard, and verification results.

--- a/docs/superpowers/specs/2026-08-21-ee-config-ce-provisioner-isolation-design.md
+++ b/docs/superpowers/specs/2026-08-21-ee-config-ce-provisioner-isolation-design.md
@@ -1,0 +1,63 @@
+# EE Config and CE Provisioner Isolation Design
+
+## Context
+
+`GET /api/v1/model-gateway/config` is a shared settings endpoint. Both editions need its effective platform gateway and media-relay status, but its `provisioner` section describes CE-only local NewAPI state: database configuration, provider channels, local media-model mappings, and embedding-model settings.
+
+The endpoint currently calls `build_provisioner_status()` for every edition. In EE this reaches `get_model_gateway_settings()` and can open or create `STATE_DIR/local/settings.db`. That violates the edition boundary even when the filesystem is writable, and can return HTTP 500 when the EE state mount is read-only.
+
+## Required behavior
+
+- EE requests to `/model-gateway/config` must continue returning effective deployment gateway and media-relay status.
+- EE must not call the CE provisioner builder or any CE-local settings accessor while serving that endpoint.
+- The response must preserve the existing `provisioner` object contract so the shared settings frontend can render without an edition-specific API shape.
+- The EE `provisioner` object must report the CE subsystem as disabled and expose empty channels, media models, and embedding settings.
+- CE requests must retain the current provisioner status behavior and continue reading their local settings database.
+
+## Design
+
+Add an edition-aware status composition boundary in `api/routes/model_gateway.py`:
+
+- In effective CE, call `build_provisioner_status()` unchanged.
+- In EE, return a static platform-safe provisioner status with `enabled: false`, blank admin/token/relay fields, `dbConfigured: false`, `database.configured: false`, `database.available: false`, and empty provider/channel/media-model/embedding-model collections. Do not import or call CE settings readers to construct this object.
+
+Add a defensive read boundary in `get_model_gateway_settings()`:
+
+- In effective EE, return the normal default settings shape without calling `_read_all()`.
+- In effective CE, retain the existing `_read_all()` behavior.
+
+The route-level split is the primary fix. The low-level guard is defense against future accidental EE callers; it is not the intended EE execution path.
+
+## Data flow
+
+```text
+GET /model-gateway/config
+  ├─ EE
+  │   ├─ build deployment gateway status
+  │   ├─ return static disabled CE provisioner status
+  │   └─ build environment-backed media-relay status
+  └─ CE
+      ├─ build CE gateway status
+      ├─ build CE provisioner status from settings.db
+      └─ build CE media-relay status
+```
+
+## Error handling
+
+The EE path avoids CE SQLite by construction; it must not catch or hide filesystem failures. CE remains responsible for its local database, so genuine CE storage failures continue to surface normally.
+
+## Verification
+
+Use TDD with a regression test that configures effective EE, makes both `build_provisioner_status()` and `_connect()` fail if invoked, requests `/model-gateway/config`, and verifies:
+
+- HTTP 200;
+- environment-derived gateway and media-relay fields remain present;
+- `provisioner.enabled` is false;
+- CE database, provider channels, media models, and embedding model are empty/unconfigured;
+- no state directory is created.
+
+Keep a CE control test proving the same endpoint still calls the real provisioner builder and returns its result. Run the complete model-gateway settings tests and focused API regressions.
+
+## Scope
+
+No frontend change, database migration, deployment configuration change, or CE provisioner refactor is included. The change only separates shared EE status from CE-local provisioner state.

--- a/license-inventory.csv
+++ b/license-inventory.csv
@@ -86,6 +86,8 @@ docs/en/guides/troubleshooting.md,Elastic-2.0,2026 SuperTale contributors,REUSE.
 docs/en/license.md,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 docs/en/reference/environment-variables.md,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 docs/releasing.md,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
+docs/superpowers/plans/2026-08-21-ee-config-ce-provisioner-isolation.md,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
+docs/superpowers/specs/2026-08-21-ee-config-ce-provisioner-isolation-design.md,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 docs/test-governance/ee-split-migrated-tests.tsv,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 docs/zh/README.md,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 docs/zh/concepts/architecture.md,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation

--- a/src/novelvideo/api/routes/model_gateway.py
+++ b/src/novelvideo/api/routes/model_gateway.py
@@ -473,6 +473,28 @@ def _media_relay_status() -> dict[str, Any]:
     )
 
 
+def _provisioner_status() -> dict[str, Any]:
+    if is_ce_effective():
+        return build_provisioner_status()
+    return {
+        "enabled": False,
+        "adminBaseUrl": "",
+        "dbConfigured": False,
+        "database": {
+            "configured": False,
+            "available": False,
+            "source": "unavailable",
+        },
+        "adminUsername": "",
+        "relayTokenName": "",
+        "providers": {},
+        "providerChannels": [],
+        "mediaModels": {},
+        "embeddingModel": {},
+        "relayBaseUrl": "",
+    }
+
+
 @router.get("/config")
 async def get_model_gateway_config() -> dict[str, Any]:
     return {
@@ -482,7 +504,7 @@ async def get_model_gateway_config() -> dict[str, Any]:
                 official_base_url=app_config.OFFICIAL_NEWAPI_BASE_URL,
                 official_api_key=app_config.NEWAPI_API_KEY,
             ),
-            "provisioner": build_provisioner_status(),
+            "provisioner": _provisioner_status(),
             "mediaRelay": _media_relay_status(),
         },
     }

--- a/src/novelvideo/model_gateway_settings.py
+++ b/src/novelvideo/model_gateway_settings.py
@@ -938,7 +938,7 @@ def save_media_relay_config(
 
 
 def get_model_gateway_settings() -> dict[str, str]:
-    data = _read_all()
+    data = _read_all() if _uses_ce_gateway_settings() else {}
     data.setdefault("model_gateway_mode", MODE_OFFICIAL)
     return data
 

--- a/tests/test_model_gateway_settings.py
+++ b/tests/test_model_gateway_settings.py
@@ -594,6 +594,22 @@ def test_ee_platform_video_paths_do_not_call_ce_media_model_accessor(
     assert "newapi_seedance-2.0" in options
 
 
+def test_ee_model_gateway_settings_reader_does_not_open_sqlite(monkeypatch, tmp_path):
+    _isolate_settings_db(monkeypatch, tmp_path)
+    monkeypatch.setenv("ST_EDITION", "ee")
+    monkeypatch.setenv("ST_CONTROL_PLANE_DSN", "postgresql://control-plane")
+    monkeypatch.setattr(
+        model_gateway_settings,
+        "_connect",
+        lambda: pytest.fail("EE must not open CE settings.db"),
+    )
+
+    assert model_gateway_settings.get_model_gateway_settings() == {
+        "model_gateway_mode": MODE_OFFICIAL
+    }
+    assert not (tmp_path / "state").exists()
+
+
 def test_cognee_newapi_resolution_prefers_saved_gateway(monkeypatch, tmp_path):
     _isolate_settings_db(monkeypatch, tmp_path)
     monkeypatch.delenv("COGNEE_LLM_PROVIDER", raising=False)
@@ -1581,6 +1597,79 @@ def test_model_gateway_config_route_masks_effective_key(monkeypatch, tmp_path):
     assert data["mode"] == MODE_OFFICIAL
     assert data["effective"]["apiKeyPreview"] == "sk-o...cret"
     assert "sk-official-secret" not in response.text
+
+
+def test_ee_model_gateway_config_skips_ce_provisioner_and_settings(
+    monkeypatch,
+    tmp_path,
+):
+    _isolate_settings_db(monkeypatch, tmp_path)
+    monkeypatch.setenv("ST_EDITION", "ee")
+    monkeypatch.setenv("ST_CONTROL_PLANE_DSN", "postgresql://control-plane")
+    monkeypatch.setenv("NEWAPI_BASE_URL", "https://ee-gateway.example/v1")
+    monkeypatch.setenv("NEWAPI_API_KEY", "sk-ee-secret")
+    monkeypatch.setattr(model_gateway.app_config, "NEWAPI_API_KEY", "sk-ee-secret")
+    monkeypatch.setattr(
+        model_gateway,
+        "build_provisioner_status",
+        lambda: pytest.fail("EE must not build CE provisioner status"),
+    )
+    monkeypatch.setattr(
+        model_gateway_settings,
+        "_connect",
+        lambda: pytest.fail("EE must not open CE settings.db"),
+    )
+    app = FastAPI()
+    app.include_router(model_gateway.router)
+
+    response = TestClient(app).get("/model-gateway/config")
+
+    assert response.status_code == 200
+    data = response.json()["data"]
+    assert data["effective"]["baseUrl"] == "https://ee-gateway.example/v1"
+    assert data["provisioner"] == {
+        "enabled": False,
+        "adminBaseUrl": "",
+        "dbConfigured": False,
+        "database": {
+            "configured": False,
+            "available": False,
+            "source": "unavailable",
+        },
+        "adminUsername": "",
+        "relayTokenName": "",
+        "providers": {},
+        "providerChannels": [],
+        "mediaModels": {},
+        "embeddingModel": {},
+        "relayBaseUrl": "",
+    }
+    assert not (tmp_path / "state").exists()
+
+
+def test_ce_model_gateway_config_uses_provisioner_builder(monkeypatch, tmp_path):
+    _isolate_settings_db(monkeypatch, tmp_path)
+    expected = {
+        "enabled": True,
+        "adminBaseUrl": "http://new-api:3000",
+        "dbConfigured": True,
+        "database": {"configured": True},
+        "adminUsername": "root",
+        "relayTokenName": "ce-runtime",
+        "providers": {"openrouter": {}},
+        "providerChannels": [],
+        "mediaModels": {},
+        "embeddingModel": {},
+        "relayBaseUrl": "http://new-api:3000/v1",
+    }
+    monkeypatch.setattr(model_gateway, "build_provisioner_status", lambda: expected)
+    app = FastAPI()
+    app.include_router(model_gateway.router)
+
+    response = TestClient(app).get("/model-gateway/config")
+
+    assert response.status_code == 200
+    assert response.json()["data"]["provisioner"] == expected
 
 
 def test_model_gateway_config_excludes_closed_source_provider_presets(


### PR DESCRIPTION
## Summary
- keep the shared model-gateway config endpoint available in EE while skipping the CE provisioner builder entirely
- return a stable disabled provisioner contract for EE and preserve the existing CE path
- add a defensive settings-reader boundary plus TDD regression coverage proving EE never opens settings.db

## Test Plan
- [x] TDD RED: both EE isolation tests failed at the expected CE calls before implementation
- [x] uv run pytest tests/test_model_gateway_settings.py -q
- [x] uv run ruff check src/novelvideo/api/routes/model_gateway.py src/novelvideo/model_gateway_settings.py tests/test_model_gateway_settings.py
- [x] gitleaks git --pre-commit --redact --staged --verbose
- [x] uv run python scripts/lint_banned_words.py
- [x] git diff --check origin/staging...HEAD

## Impact
- No frontend change
- No database migration
- No deployment configuration change
- EE keeps platform gateway and media-relay status without reading CE-local settings
- CE provisioner behavior remains unchanged