### PR TITLE
feat(brainclaw): issue keyless trusted capabilities

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -338,9 +338,9 @@ BRAINCLAW_OUTCOME_URL=
 BRAINCLAW_OUTCOME_KEY_FILE=
 BRAINCLAW_OUTCOME_STATE_DIR=state/brainclaw
 
-# Optional BrainClaw Control Context signing. All four are required together;
-# leaving them empty means DramaClaw sends no envelope and BrainClaw records the
-# traffic as diagnostic evidence rather than a formal statistical family.
+# Optional legacy direct-HTTP Control Context signing. This is not the normal
+# Hermes -> Claymore evidence path below. All four are required together;
+# leaving them empty disables only this direct transport.
 # The keyring is the same owner-only JSON file the BrainClaw Gateway loads, so
 # the two ends cannot drift on encoding. The grouping key must be a *separate*
 # file with a longer lifetime: rotating it splits one episode into two families,
@@ -353,16 +353,15 @@ BRAINCLAW_CONTROL_CONTEXT_GROUPING_KEY_EPOCH=1
 # ---------------------------------------------------------------------------
 # BrainClaw evidence plane — the issuing end.
 #
-#   K1  capability        Signed here, verified by the Gateway.
-#   K3  grouping          Here only. It derives every opaque trajectory and
-#                         project id; a copy anywhere else would let that side
-#                         mint identities rather than pass them through.
-#   K2  control context   NOT here. Gateway signs, BrainClaw verifies.
+# Trusted mode needs no shared signing keys. DramaClaw creates one persistent,
+# local-only grouping key under STATE_DIR/brainclaw/grouping.key so raw project
+# and trajectory ids never leave this process. The two K1 variables below are
+# optional and used only when the selected Gateway channel is in verified mode.
 # ---------------------------------------------------------------------------
-BRAINCLAW_CAPABILITY_KEYRING_FILE=/run/secrets/brainclaw_capability_keyring
+BRAINCLAW_CAPABILITY_KEYRING_FILE=
 BRAINCLAW_CAPABILITY_SIGNING_KEY_ID=
-BRAINCLAW_CONTROL_CONTEXT_GROUPING_KEY_FILE=/run/secrets/brainclaw_grouping_key
-BRAINCLAW_CONTROL_CONTEXT_GROUPING_KEY_EPOCH=1
+# The grouping path/epoch above are shared with the direct transport. When the
+# path is empty, the capability issuer auto-generates it in persistent state.
 
 # The gateway origin. Under the per-turn latch this is also the only host a
 # worker may reach: a request to anything else is refused before it is sent,

--- a/docker-compose.brainclaw-evidence.yml
+++ b/docker-compose.brainclaw-evidence.yml
@@ -1,8 +1,10 @@
 # DramaClaw with the BrainClaw evidence plane wired.
 #
-# Trusted collection needs no shared signing keys. DramaClaw creates one local,
-# persistent grouping key under its state directory to keep raw project and
-# trajectory ids private; it never leaves this container.
+# Trusted collection needs no shared signing keys. It is accepted only when an
+# administrator explicitly selects trusted mode on the paired Claymore channel;
+# channels default to off and verified channels reject the unsigned t1 envelope.
+# DramaClaw creates one local, persistent grouping key under its state directory
+# to keep raw project and trajectory ids private; it never leaves this container.
 #
 # The image must carry the Hermes fork. The default install spec in the
 # Dockerfile pulls hermes-agent from PyPI, which keeps the same version string

--- a/docker-compose.brainclaw-evidence.yml
+++ b/docker-compose.brainclaw-evidence.yml
@@ -1,13 +1,8 @@
 # DramaClaw with the BrainClaw evidence plane wired.
 #
-# This side holds two of the three keys and must never hold the third:
-#   K1 capability      signed here, verified by the Gateway
-#   K3 grouping        here only. It derives every opaque trajectory and project
-#                      identifier, so a copy anywhere else would let that side
-#                      mint identities rather than pass them through — which is
-#                      the whole separation.
-#   K2 control context NOT here. The Gateway signs it, BrainClaw verifies it;
-#                      DramaClaw is not a party to that hop.
+# Trusted collection needs no shared signing keys. DramaClaw creates one local,
+# persistent grouping key under its state directory to keep raw project and
+# trajectory ids private; it never leaves this container.
 #
 # The image must carry the Hermes fork. The default install spec in the
 # Dockerfile pulls hermes-agent from PyPI, which keeps the same version string
@@ -26,15 +21,9 @@ services:
     ports:
       - "${DRAMACLAW_BIND_ADDRESS:-127.0.0.1}:${DRAMACLAW_PORT:-8000}:8000"
     volumes:
-      - ${DRAMACLAW_STATE_DIR:?set DRAMACLAW_STATE_DIR}/capability-keyring.json:/run/secrets/brainclaw_capability_keyring:ro
-      - ${DRAMACLAW_STATE_DIR}/grouping.key:/run/secrets/brainclaw_grouping_key:ro
       - ${DRAMACLAW_DATA_DIR:-./data}:/data
     environment:
-      # K1: the capability this side signs for each turn.
-      - BRAINCLAW_CAPABILITY_KEYRING_FILE=/run/secrets/brainclaw_capability_keyring
-      - BRAINCLAW_CAPABILITY_SIGNING_KEY_ID=${BRAINCLAW_CAPABILITY_SIGNING_KEY_ID:?set the key id the keyring names}
-      # K3: never leaves this container.
-      - BRAINCLAW_CONTROL_CONTEXT_GROUPING_KEY_FILE=/run/secrets/brainclaw_grouping_key
+      # Optional override. By default the key is generated once under /data/state.
       - BRAINCLAW_CONTROL_CONTEXT_GROUPING_KEY_EPOCH=${BRAINCLAW_CONTROL_CONTEXT_GROUPING_KEY_EPOCH:-1}
       # Where the workers send model traffic. Also the only host they may reach:
       # under the per-turn latch a request to anything else is refused before it

--- a/src/novelvideo/brainclaw_control_capability.py
+++ b/src/novelvideo/brainclaw_control_capability.py
@@ -22,6 +22,14 @@ Trusted mode uses no shared signing key. Verified mode retains the original
 two-signature protocol for deployments that need cryptographic caller
 authentication. In both modes the local grouping key never appears here:
 DramaClaw derives opaque ids and the envelope carries only those results.
+
+The trust decision is made by the paired Claymore channel, never by this
+header alone. Claymore channels default to ``off``; only an administrator may
+select ``trusted`` and accept ``t1``. A ``verified`` channel rejects ``t1`` and
+requires the signed ``v1`` envelope. BrainClaw independently refuses ``t1``
+when its verified-mode keyring is configured. The paired implementation and
+cross-language vectors are reviewed in:
+https://github.com/claymorelab/claymore-llm-gateway/pull/50
 """
 
 from __future__ import annotations
@@ -34,6 +42,7 @@ import os
 import re
 import secrets
 import stat
+import tempfile
 import threading
 import time
 from dataclasses import dataclass
@@ -210,24 +219,33 @@ def _default_grouping_key_path() -> Path:
 
 
 def _ensure_local_grouping_key(path: Path) -> Path:
-    """Create the one local-only identity key once, safe under worker races."""
+    """Atomically publish one complete local-only identity key.
+
+    The final path must not exist until all 32 bytes have been written and
+    synced. Creating the final inode first leaves a window where another
+    process observes an empty file and rejects the first turn.
+    """
     path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
-    try:
-        descriptor = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
-    except FileExistsError:
-        return path
+    descriptor, temporary_name = tempfile.mkstemp(
+        prefix=f".{path.name}.", suffix=".tmp", dir=path.parent
+    )
+    temporary_path = Path(temporary_name)
     try:
         with os.fdopen(descriptor, "wb") as target:
             target.write(secrets.token_bytes(32))
             target.flush()
             os.fsync(target.fileno())
-    except BaseException:
         try:
-            path.unlink()
-        except OSError:
+            # link() is the publication point: it never overwrites a winner,
+            # and the target inode is already complete before it becomes
+            # visible under the stable name.
+            os.link(temporary_path, path)
+        except FileExistsError:
             pass
-        raise
+    finally:
+        temporary_path.unlink(missing_ok=True)
     return path
+
 
 class ControlCapabilityIssuer:
     """Mints one capability per agent turn.
@@ -247,6 +265,8 @@ class ControlCapabilityIssuer:
         grouping_key_epoch: int,
         ttl_seconds: int = DEFAULT_TTL_SECONDS,
     ) -> None:
+        if (keyring_path is None) != (signing_key_id is None):
+            raise ValueError("capability keyring and signing key id must be configured together")
         self.signing_key_id = signing_key_id or TRUSTED_KEY_ID
         self.signing_key: bytes | None = None
         if keyring_path is not None:

--- a/src/novelvideo/brainclaw_control_capability.py
+++ b/src/novelvideo/brainclaw_control_capability.py
@@ -1,7 +1,7 @@
 """Issue the short-lived capability Hermes carries to the DramaClaw Gateway.
 
-This is a *different* credential from the BrainClaw Control Context, on a
-different trust leg, with a different key:
+This is a *different* envelope from the BrainClaw Control Context, on a
+different hop:
 
     DramaClaw --capability--> Gateway --control context--> BrainClaw
 
@@ -18,9 +18,10 @@ replay it until it expires. Everything below follows from that:
 * it is never logged, never persisted, and stripped at the Gateway before the
   request continues to a provider.
 
-The grouping key never appears here. DramaClaw derives the opaque ids with it
-and this envelope only carries the results, so a Gateway that verifies
-capabilities still cannot derive or reverse a group id.
+Trusted mode uses no shared signing key. Verified mode retains the original
+two-signature protocol for deployments that need cryptographic caller
+authentication. In both modes the local grouping key never appears here:
+DramaClaw derives opaque ids and the envelope carries only those results.
 """
 
 from __future__ import annotations
@@ -43,6 +44,8 @@ from novelvideo.brainclaw_control_context import group_id
 
 HEADER = "X-DramaClaw-Control-Capability"
 ENVELOPE_VERSION = "v1"
+TRUSTED_ENVELOPE_VERSION = "t1"
+TRUSTED_KEY_ID = "trusted-local"
 PAYLOAD_SCHEMA = "dramaclaw.control-capability/v1"
 ISSUER = "dramaclaw"
 AUDIENCE = "dramaclaw-gateway"
@@ -136,6 +139,22 @@ def sign_control_capability(capability: ControlCapability, *, signing_key: bytes
     return header
 
 
+def encode_trusted_capability(capability: ControlCapability) -> str:
+    """Encode identity for a Gateway explicitly configured to trust callers.
+
+    This carries no signature and makes no authentication claim. Structural,
+    privacy and TTL checks still run at Claymore; the mode is appropriate when
+    the deployment controls which callers can reach that gateway.
+    """
+    payload_b64 = _b64u(
+        json.dumps(capability.payload(), sort_keys=True, separators=(",", ":")).encode()
+    )
+    header = f"{TRUSTED_ENVELOPE_VERSION}.{payload_b64}"
+    if len(header.encode()) > MAX_HEADER_BYTES:
+        raise ValueError("trusted control capability header exceeds the size limit")
+    return header
+
+
 def _sign(signing_key: bytes, version: str, key_id: str, payload_b64: str) -> str:
     # The signature covers the payload's exact base64 string, never a
     # re-serialised JSON object, so canonicalisation can never diverge between
@@ -183,33 +202,64 @@ def _binary_key_bytes(raw: bytes) -> bytes:
     """
     return raw
 
+
+def _default_grouping_key_path() -> Path:
+    from novelvideo.config import STATE_DIR
+
+    return Path(STATE_DIR) / "brainclaw" / "grouping.key"
+
+
+def _ensure_local_grouping_key(path: Path) -> Path:
+    """Create the one local-only identity key once, safe under worker races."""
+    path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+    try:
+        descriptor = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    except FileExistsError:
+        return path
+    try:
+        with os.fdopen(descriptor, "wb") as target:
+            target.write(secrets.token_bytes(32))
+            target.flush()
+            os.fsync(target.fileno())
+    except BaseException:
+        try:
+            path.unlink()
+        except OSError:
+            pass
+        raise
+    return path
+
 class ControlCapabilityIssuer:
     """Mints one capability per agent turn.
 
-    This is the only place that holds both keys, and the only place that ever
-    sees a raw trajectory or project id. The grouping key derives the opaque ids
-    here; the capability signing key attests them to the Gateway. Nothing
-    downstream — not Hermes, not the Gateway — can derive or reverse a group id.
+    This is the only place that sees raw trajectory/project ids. The local
+    grouping key derives opaque ids here. A signing key is optional and is used
+    only by verified mode; trusted mode sends the same strictly validated
+    claims without claiming cryptographic authentication.
     """
 
     def __init__(
         self,
         *,
-        keyring_path: Path,
-        signing_key_id: str,
+        keyring_path: Path | None,
+        signing_key_id: str | None,
         grouping_key_path: Path,
         grouping_key_epoch: int,
         ttl_seconds: int = DEFAULT_TTL_SECONDS,
     ) -> None:
-        from novelvideo.brainclaw_control_context_transport import _load_keyring_secret
+        self.signing_key_id = signing_key_id or TRUSTED_KEY_ID
+        self.signing_key: bytes | None = None
+        if keyring_path is not None:
+            if not signing_key_id:
+                raise ValueError("a capability keyring requires a signing key id")
+            from novelvideo.brainclaw_control_context_transport import _load_keyring_secret
 
-        self.signing_key_id = signing_key_id
-        self.signing_key = _load_keyring_secret(keyring_path, signing_key_id)
+            self.signing_key = _load_keyring_secret(keyring_path, signing_key_id)
         self.grouping_key = _binary_key_bytes(_read_owner_only(grouping_key_path))
         if len(self.grouping_key) < 32:
             raise ValueError("grouping key is too short")
-        if self.grouping_key == self.signing_key:
-            # One secret for both would tie an trajectory's identity lifetime to
+        if self.signing_key is not None and self.grouping_key == self.signing_key:
+            # One secret for both would tie a trajectory's identity lifetime to
             # signing-key rotation, which is the split the epoch exists to show.
             raise ValueError("grouping key must not equal the capability signing key")
         if grouping_key_epoch < 0:
@@ -250,30 +300,33 @@ class ControlCapabilityIssuer:
             turn_kind=turn_kind,
             replay_scope_limit=replay_scope_limit,
         )
+        if self.signing_key is None:
+            return encode_trusted_capability(capability)
         return sign_control_capability(capability, signing_key=self.signing_key)
 
 
 def control_capability_issuer() -> "ControlCapabilityIssuer | None":
-    """Build the issuer once, or return None when issuing is not configured.
+    """Build the issuer once.
 
-    An unconfigured deployment issues nothing, Hermes carries nothing, and the
-    Gateway mints no Control Context. That is a first-class state: the traffic
-    is served normally and recorded as diagnostic rather than formal evidence.
+    With no shared signing-key configuration this defaults to trusted mode and
+    creates one persistent local grouping key. Supplying both signing settings
+    opts into the original verified protocol; half-configuration is rejected.
     """
     global _issuer, _issuer_loaded
     with _issuer_lock:
         if _issuer_loaded:
             return _issuer
-        _issuer_loaded = True
         keyring = os.environ.get("BRAINCLAW_CAPABILITY_KEYRING_FILE", "").strip()
         key_id = os.environ.get("BRAINCLAW_CAPABILITY_SIGNING_KEY_ID", "").strip()
         grouping = os.environ.get("BRAINCLAW_CONTROL_CONTEXT_GROUPING_KEY_FILE", "").strip()
-        if not (keyring and key_id and grouping):
-            return None
-        _issuer = ControlCapabilityIssuer(
-            keyring_path=Path(keyring),
-            signing_key_id=key_id,
-            grouping_key_path=Path(grouping),
+        if bool(keyring) != bool(key_id):
+            raise ValueError("capability keyring and signing key id must be configured together")
+        grouping_path = Path(grouping) if grouping else _default_grouping_key_path()
+        _ensure_local_grouping_key(grouping_path)
+        issuer = ControlCapabilityIssuer(
+            keyring_path=Path(keyring) if keyring else None,
+            signing_key_id=key_id or None,
+            grouping_key_path=grouping_path,
             grouping_key_epoch=int(
                 os.environ.get("BRAINCLAW_CONTROL_CONTEXT_GROUPING_KEY_EPOCH", "1") or "1"
             ),
@@ -282,6 +335,8 @@ def control_capability_issuer() -> "ControlCapabilityIssuer | None":
                 or DEFAULT_TTL_SECONDS
             ),
         )
+        _issuer = issuer
+        _issuer_loaded = True
         return _issuer
 
 

--- a/tests/test_brainclaw_capability_issuer.py
+++ b/tests/test_brainclaw_capability_issuer.py
@@ -38,7 +38,8 @@ def issuer(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> cap.ControlCapabi
 
 
 def _claims(header: str) -> dict:
-    payload = header.split(".")[2]
+    parts = header.split(".")
+    payload = parts[1] if parts[0] == cap.TRUSTED_ENVELOPE_VERSION else parts[2]
     return json.loads(base64.urlsafe_b64decode(payload + "=" * (-len(payload) % 4)))
 
 
@@ -100,12 +101,104 @@ def test_one_secret_may_not_serve_both_roles(tmp_path: Path) -> None:
         )
 
 
-def test_an_unconfigured_deployment_issues_nothing(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_an_unconfigured_deployment_issues_trusted_identity_without_shared_keys(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     for name in ("BRAINCLAW_CAPABILITY_KEYRING_FILE", "BRAINCLAW_CAPABILITY_SIGNING_KEY_ID",
                  "BRAINCLAW_CONTROL_CONTEXT_GROUPING_KEY_FILE"):
         monkeypatch.delenv(name, raising=False)
     cap.reset_control_capability_issuer()
-    assert cap.control_capability_issuer() is None
+
+    grouping = tmp_path / "state" / "brainclaw" / "grouping.key"
+    monkeypatch.setattr(cap, "_default_grouping_key_path", lambda: grouping)
+    built = cap.control_capability_issuer()
+    assert built is not None
+    header = built.issue(trajectory_id="tr-1", project_id="proj-1", turn_id="turn-1")
+    assert header.startswith("t1.")
+    assert len(header.split(".")) == 2
+    assert grouping.stat().st_mode & 0o777 == 0o600
+    assert len(grouping.read_bytes()) == 32
+    claims = _claims(header)
+    assert claims["key_id"] == cap.TRUSTED_KEY_ID
+    assert "tr-1" not in header and "proj-1" not in header
+    cap.reset_control_capability_issuer()
+
+
+def test_trusted_capability_matches_the_claymore_contract_exactly() -> None:
+    capability = cap.ControlCapability(
+        key_id=cap.TRUSTED_KEY_ID,
+        turn_id="turn-vector",
+        trajectory_group_id="hmac-sha256:9f2b7c1e4a6d8035",
+        project_group_id="hmac-sha256:03e5a1d9b7c20468",
+        grouping_key_epoch=1,
+        issued_at=2_000_000_000,
+        expires_at=2_000_000_300,
+        nonce="AAAAAAAAAAAAAAAAAAAAAA",
+    )
+    assert cap.encode_trusted_capability(capability) == (
+        "t1.eyJhdWRpZW5jZSI6ImRyYW1hY2xhdy1nYXRld2F5IiwiZXhwaXJlc19hdCI6"
+        "MjAwMDAwMDMwMCwiZ3JvdXBpbmdfa2V5X2Vwb2NoIjoxLCJpc3N1ZWRfYXQiOjIw"
+        "MDAwMDAwMDAsImlzc3VlciI6ImRyYW1hY2xhdyIsImtleV9pZCI6InRydXN0ZWQt"
+        "bG9jYWwiLCJub25jZSI6IkFBQUFBQUFBQUFBQUFBQUFBQUFBQUEiLCJwcm9qZWN0"
+        "X2dyb3VwX2lkIjoiaG1hYy1zaGEyNTY6MDNlNWExZDliN2MyMDQ2OCIsInJlcGxh"
+        "eV9zY29wZV9saW1pdCI6Im1vZGVsX291dHB1dF9vbmx5Iiwic2NoZW1hX3ZlcnNp"
+        "b24iOiJkcmFtYWNsYXcuY29udHJvbC1jYXBhYmlsaXR5L3YxIiwidHJhamVjdG9y"
+        "eV9ncm91cF9pZCI6ImhtYWMtc2hhMjU2OjlmMmI3YzFlNGE2ZDgwMzUiLCJ0dXJu"
+        "X2lkIjoidHVybi12ZWN0b3IiLCJ0dXJuX2tpbmQiOiJmb3JlZ3JvdW5kX3VzZXIifQ"
+    )
+
+
+def test_local_grouping_key_is_reused_across_process_restarts(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    for name in ("BRAINCLAW_CAPABILITY_KEYRING_FILE", "BRAINCLAW_CAPABILITY_SIGNING_KEY_ID",
+                 "BRAINCLAW_CONTROL_CONTEXT_GROUPING_KEY_FILE"):
+        monkeypatch.delenv(name, raising=False)
+    grouping = tmp_path / "state" / "brainclaw" / "grouping.key"
+    monkeypatch.setattr(cap, "_default_grouping_key_path", lambda: grouping)
+    cap.reset_control_capability_issuer()
+    first = cap.control_capability_issuer()
+    assert first is not None
+    first_id = _claims(first.issue(
+        trajectory_id="tr-1", project_id="proj-1", turn_id="turn-1"
+    ))["trajectory_group_id"]
+    original_key = grouping.read_bytes()
+
+    cap.reset_control_capability_issuer()
+    second = cap.control_capability_issuer()
+    assert second is not None
+    second_id = _claims(second.issue(
+        trajectory_id="tr-1", project_id="proj-1", turn_id="turn-2"
+    ))["trajectory_group_id"]
+    assert grouping.read_bytes() == original_key
+    assert second_id == first_id
+    cap.reset_control_capability_issuer()
+
+
+def test_a_transient_initialisation_failure_is_not_cached(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    for name in ("BRAINCLAW_CAPABILITY_KEYRING_FILE", "BRAINCLAW_CAPABILITY_SIGNING_KEY_ID",
+                 "BRAINCLAW_CONTROL_CONTEXT_GROUPING_KEY_FILE"):
+        monkeypatch.delenv(name, raising=False)
+    grouping = tmp_path / "brainclaw" / "grouping.key"
+    monkeypatch.setattr(cap, "_default_grouping_key_path", lambda: grouping)
+    original = cap._ensure_local_grouping_key
+    attempts = 0
+
+    def fail_once(path: Path) -> Path:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise OSError("transient filesystem failure")
+        return original(path)
+
+    monkeypatch.setattr(cap, "_ensure_local_grouping_key", fail_once)
+    cap.reset_control_capability_issuer()
+    with pytest.raises(OSError, match="transient filesystem failure"):
+        cap.control_capability_issuer()
+    assert cap.control_capability_issuer() is not None
+    assert attempts == 2
     cap.reset_control_capability_issuer()
 
 

--- a/tests/test_brainclaw_capability_issuer.py
+++ b/tests/test_brainclaw_capability_issuer.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import base64
 import json
+import threading
 from pathlib import Path
 
 import pytest
@@ -122,6 +123,69 @@ def test_an_unconfigured_deployment_issues_trusted_identity_without_shared_keys(
     assert claims["key_id"] == cap.TRUSTED_KEY_ID
     assert "tr-1" not in header and "proj-1" not in header
     cap.reset_control_capability_issuer()
+
+
+def test_grouping_key_is_not_visible_until_all_bytes_are_written(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    grouping = tmp_path / "brainclaw" / "grouping.key"
+    first_started = threading.Event()
+    release_first = threading.Event()
+    call_lock = threading.Lock()
+    calls = 0
+    errors: list[BaseException] = []
+
+    def controlled_key(length: int) -> bytes:
+        nonlocal calls
+        with call_lock:
+            calls += 1
+            call = calls
+        if call == 1:
+            first_started.set()
+            if not release_first.wait(timeout=5):
+                raise TimeoutError("test did not release the first writer")
+        return bytes([call]) * length
+
+    monkeypatch.setattr(cap.secrets, "token_bytes", controlled_key)
+
+    def first_writer() -> None:
+        try:
+            cap._ensure_local_grouping_key(grouping)
+        except BaseException as exc:  # surfaced in the test thread below
+            errors.append(exc)
+
+    thread = threading.Thread(target=first_writer)
+    thread.start()
+    assert first_started.wait(timeout=5)
+    try:
+        # The first writer has generated no bytes yet. A competing process must
+        # still publish a complete key rather than observe an empty final file.
+        cap._ensure_local_grouping_key(grouping)
+        assert grouping.read_bytes() == bytes([2]) * 32
+    finally:
+        release_first.set()
+        thread.join(timeout=5)
+
+    assert not thread.is_alive()
+    assert errors == []
+    assert grouping.read_bytes() == bytes([2]) * 32
+    assert list(grouping.parent.glob(f".{grouping.name}.*.tmp")) == []
+
+
+def test_trusted_constructor_rejects_a_custom_key_id_without_a_keyring(
+    tmp_path: Path,
+) -> None:
+    grouping = tmp_path / "grouping.key"
+    grouping.write_bytes(GROUPING_KEY)
+    grouping.chmod(0o600)
+
+    with pytest.raises(ValueError, match="configured together"):
+        cap.ControlCapabilityIssuer(
+            keyring_path=None,
+            signing_key_id="looks-verified-but-is-not",
+            grouping_key_path=grouping,
+            grouping_key_epoch=1,
+        )
 
 
 def test_trusted_capability_matches_the_claymore_contract_exactly() -> None:


### PR DESCRIPTION
## Summary
- issue a keyless t1 BrainClaw capability when no signing keyring is configured
- derive opaque trajectory/project identities from one persistent owner-only local grouping key
- retain the optional signed capability path for verified deployments
- update deployment examples and exact contract tests

## Tests
- uv run pytest tests/test_brainclaw_capability_issuer.py -q