### PR TITLE
fix(assets): show Director World conversion costs

### DIFF
--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -1474,6 +1474,13 @@
         "masterToPly": "master→Director World",
         "reverseToPly": "reverse→Director World",
         "panoToPly": "360→Director World",
+        "singleFaceFeature": "Scene single-face to SOG",
+        "panoFeature": "Scene panorama to SOG",
+        "confirmTitle": "Confirm conversion",
+        "confirmDescription": "{{feature}} is estimated to use {{cost}} credits. Confirm to start the task.",
+        "confirmAction": "Confirm and start",
+        "costLoading": "Loading the current organization price",
+        "costUnavailable": "Price is temporarily unavailable. Try again later.",
         "openWorld": "Open Director World",
         "worldNotReady": "Director World not ready"
       },

--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -1477,7 +1477,7 @@
         "singleFaceFeature": "Scene single-face to SOG",
         "panoFeature": "Scene panorama to SOG",
         "confirmTitle": "Confirm conversion",
-        "confirmDescription": "{{feature}} is estimated to use {{cost}} credits. Confirm to start the task.",
+        "confirmDescription": "{{feature}} will start immediately after confirmation.",
         "confirmAction": "Confirm and start",
         "costLoading": "Loading the current organization price",
         "costUnavailable": "Price is temporarily unavailable. Try again later.",

--- a/frontend/public/locales/zh/translation.json
+++ b/frontend/public/locales/zh/translation.json
@@ -1474,6 +1474,13 @@
         "masterToPly": "正面→导演世界",
         "reverseToPly": "背面→导演世界",
         "panoToPly": "360→导演世界",
+        "singleFaceFeature": "场景单面转 SOG",
+        "panoFeature": "场景全景转 SOG",
+        "confirmTitle": "确认启动转换",
+        "confirmDescription": "{{feature}}，本次预计消耗 {{cost}} 积分。确认后将立即启动任务。",
+        "confirmAction": "确认并启动",
+        "costLoading": "正在获取当前组织价格",
+        "costUnavailable": "暂时无法获取价格，请稍后重试",
         "openWorld": "打开导演世界",
         "worldNotReady": "导演世界（片场未就绪）"
       },

--- a/frontend/public/locales/zh/translation.json
+++ b/frontend/public/locales/zh/translation.json
@@ -1477,7 +1477,7 @@
         "singleFaceFeature": "场景单面转 SOG",
         "panoFeature": "场景全景转 SOG",
         "confirmTitle": "确认启动转换",
-        "confirmDescription": "{{feature}}，本次预计消耗 {{cost}} 积分。确认后将立即启动任务。",
+        "confirmDescription": "{{feature}}，确认后将立即启动任务。",
         "confirmAction": "确认并启动",
         "costLoading": "正在获取当前组织价格",
         "costUnavailable": "暂时无法获取价格，请稍后重试",

--- a/frontend/src/__tests__/components/assets/scene-asset-card.test.tsx
+++ b/frontend/src/__tests__/components/assets/scene-asset-card.test.tsx
@@ -17,6 +17,9 @@ beforeAll(async () => {
     resources: {
       zh: {
         translation: {
+          common: {
+            cancel: "取消",
+          },
           assets: {
             common: {
               edit: "编辑",
@@ -54,6 +57,12 @@ beforeAll(async () => {
                 masterToPly: "master→导演世界",
                 reverseToPly: "reverse→导演世界",
                 panoToPly: "360→导演世界",
+                singleFaceFeature: "场景单面转 SOG",
+                panoFeature: "场景全景转 SOG",
+                confirmTitle: "确认启动转换",
+                confirmDescription:
+                  "{{feature}}，本次预计消耗 {{cost}} 积分。确认后将立即启动任务。",
+                confirmAction: "确认并启动",
                 openWorld: "打开导演世界",
                 worldNotReady: "导演世界（片场未就绪）",
               },
@@ -83,6 +92,8 @@ function renderCard(scene: SceneAsset, overrides = {}) {
     onUploadCustomPackage: vi.fn(),
     onDeleteCustomPackage: vi.fn(),
     onGenerateStagePly: vi.fn(),
+    singleFaceStageCost: "6",
+    panoStageCost: "8",
     ...overrides,
   };
   render(
@@ -190,10 +201,45 @@ describe("SceneAssetCard", () => {
     expect(handlers.onOpenStageViewer).toHaveBeenCalledOnce();
 
     fireEvent.click(screen.getByRole("button", { name: "master→导演世界" }));
+    expect(handlers.onGenerateStagePly).not.toHaveBeenCalled();
+    expect(screen.getByRole("alertdialog")).toHaveTextContent(
+      "场景单面转 SOG，本次预计消耗 6 积分",
+    );
+    fireEvent.click(screen.getByRole("button", { name: "确认并启动" }));
     expect(handlers.onGenerateStagePly).toHaveBeenCalledWith("master");
 
     fireEvent.click(screen.getByRole("button", { name: "360→导演世界" }));
+    expect(screen.getByRole("alertdialog")).toHaveTextContent(
+      "场景全景转 SOG，本次预计消耗 8 积分",
+    );
+    fireEvent.click(screen.getByRole("button", { name: "确认并启动" }));
     expect(handlers.onGenerateStagePly).toHaveBeenCalledWith("pano");
+  });
+
+  it("disables Director World conversion when the organization price is unavailable", () => {
+    renderCard(
+      {
+        name: "皇宫大殿",
+        scene_type: "interior",
+        environment_prompt: "",
+        description: "",
+        aliases: [],
+        notes: "",
+        master_url: "/static/master.png",
+        reverse_master_url: "/static/reverse.png",
+        pano_url: "/static/pano.png",
+      },
+      {
+        singleFaceStageCost: "需配置",
+        singleFaceStageDisabledReason: "计费规则未配置，请联系管理员设置积分规则",
+        panoStageCost: "需配置",
+        panoStageDisabledReason: "计费规则未配置，请联系管理员设置积分规则",
+      },
+    );
+
+    expect(screen.getByRole("button", { name: "master→导演世界" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "reverse→导演世界" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "360→导演世界" })).toBeDisabled();
   });
 
   it("falls back to text-to-360 when master is missing", () => {

--- a/frontend/src/__tests__/components/assets/scene-asset-card.test.tsx
+++ b/frontend/src/__tests__/components/assets/scene-asset-card.test.tsx
@@ -60,8 +60,7 @@ beforeAll(async () => {
                 singleFaceFeature: "场景单面转 SOG",
                 panoFeature: "场景全景转 SOG",
                 confirmTitle: "确认启动转换",
-                confirmDescription:
-                  "{{feature}}，本次预计消耗 {{cost}} 积分。确认后将立即启动任务。",
+                confirmDescription: "{{feature}}，确认后将立即启动任务。",
                 confirmAction: "确认并启动",
                 openWorld: "打开导演世界",
                 worldNotReady: "导演世界（片场未就绪）",
@@ -203,15 +202,17 @@ describe("SceneAssetCard", () => {
     fireEvent.click(screen.getByRole("button", { name: "master→导演世界" }));
     expect(handlers.onGenerateStagePly).not.toHaveBeenCalled();
     expect(screen.getByRole("alertdialog")).toHaveTextContent(
-      "场景单面转 SOG，本次预计消耗 6 积分",
+      "场景单面转 SOG，确认后将立即启动任务。",
     );
+    expect(screen.getByRole("alertdialog")).toHaveTextContent("6");
     fireEvent.click(screen.getByRole("button", { name: "确认并启动" }));
     expect(handlers.onGenerateStagePly).toHaveBeenCalledWith("master");
 
     fireEvent.click(screen.getByRole("button", { name: "360→导演世界" }));
     expect(screen.getByRole("alertdialog")).toHaveTextContent(
-      "场景全景转 SOG，本次预计消耗 8 积分",
+      "场景全景转 SOG，确认后将立即启动任务。",
     );
+    expect(screen.getByRole("alertdialog")).toHaveTextContent("8");
     fireEvent.click(screen.getByRole("button", { name: "确认并启动" }));
     expect(handlers.onGenerateStagePly).toHaveBeenCalledWith("pano");
   });

--- a/frontend/src/__tests__/components/episode/beat-workbench/m05-credit-cost.ce.test.tsx
+++ b/frontend/src/__tests__/components/episode/beat-workbench/m05-credit-cost.ce.test.tsx
@@ -3,7 +3,7 @@
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { I18nextProvider, initReactI18next } from "react-i18next";
 import i18next from "i18next";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
@@ -63,6 +63,11 @@ beforeAll(async () => {
                 masterToPly: "master→导演世界",
                 reverseToPly: "reverse→导演世界",
                 panoToPly: "360→导演世界",
+                singleFaceFeature: "场景单面转 SOG",
+                panoFeature: "场景全景转 SOG",
+                confirmTitle: "确认启动转换",
+                confirmDescription: "{{feature}}，确认后将立即启动任务。",
+                confirmAction: "确认并启动",
                 openWorld: "打开导演世界",
                 worldNotReady: "导演世界（片场未就绪）",
               },
@@ -130,6 +135,25 @@ describe("M05 CE generation credit cost gating", () => {
     expect(screen.queryByText("12 credits")).not.toBeInTheDocument();
     expect(screen.queryByText("6 credits")).not.toBeInTheDocument();
     expect(screen.queryByText("8 credits")).not.toBeInTheDocument();
+  });
+
+  it("keeps Director World confirmation copy free of credit prices in CE runtime", () => {
+    renderSceneAssetCard({
+      name: "皇宫大殿",
+      scene_type: "interior",
+      environment_prompt: "金色宫灯、朱红立柱、纵深空间",
+      description: "",
+      aliases: [],
+      notes: "",
+      master_url: "/static/u/p/assets/scenes/hall/master.png",
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "master→导演世界" }));
+
+    const dialog = screen.getByRole("alertdialog");
+    expect(dialog).toHaveTextContent("场景单面转 SOG，确认后将立即启动任务。");
+    expect(dialog).not.toHaveTextContent("6 credits");
+    expect(dialog).not.toHaveTextContent("积分");
   });
 
   it("routes every named M05 cost display through CreditCostInline", () => {

--- a/frontend/src/__tests__/components/episode/beat-workbench/m05-credit-cost.ce.test.tsx
+++ b/frontend/src/__tests__/components/episode/beat-workbench/m05-credit-cost.ce.test.tsx
@@ -87,6 +87,8 @@ function renderSceneAssetCard(scene: SceneAsset) {
         masterCost="12 credits"
         reverseCost="12 credits"
         panoCost="12 credits"
+        singleFaceStageCost="6 credits"
+        panoStageCost="8 credits"
         onEdit={vi.fn()}
         onDelete={vi.fn()}
         onUploadMaster={vi.fn()}
@@ -112,7 +114,7 @@ describe("M05 CE generation credit cost gating", () => {
     runtimeState.isCeRuntime = true;
   });
 
-  it("hides scene master, reverse, and pano costs in CE runtime", () => {
+  it("hides scene image and Director World conversion costs in CE runtime", () => {
     renderSceneAssetCard({
       name: "皇宫大殿",
       scene_type: "interior",
@@ -126,6 +128,8 @@ describe("M05 CE generation credit cost gating", () => {
     });
 
     expect(screen.queryByText("12 credits")).not.toBeInTheDocument();
+    expect(screen.queryByText("6 credits")).not.toBeInTheDocument();
+    expect(screen.queryByText("8 credits")).not.toBeInTheDocument();
   });
 
   it("routes every named M05 cost display through CreditCostInline", () => {
@@ -138,6 +142,12 @@ describe("M05 CE generation credit cost gating", () => {
     expect(source("src/components/assets/scene-asset-card.tsx")).toEqual(
       expect.stringMatching(/<CreditCostInline\s+display=\{panoCost\}/),
     );
+    expect(source("src/components/assets/scene-asset-card.tsx")).toEqual(
+      expect.stringMatching(/<CreditCostInline\s+display=\{singleFaceStageCost\}/),
+    );
+    expect(source("src/components/assets/scene-asset-card.tsx")).toEqual(
+      expect.stringMatching(/<CreditCostInline\s+display=\{panoStageCost\}/),
+    );
     expect(source("src/components/assets/scenes-panel.tsx")).toEqual(
       expect.stringContaining("masterCost={sceneReferenceCostDisplay}"),
     );
@@ -146,6 +156,20 @@ describe("M05 CE generation credit cost gating", () => {
     );
     expect(source("src/components/assets/scenes-panel.tsx")).toEqual(
       expect.stringContaining("panoCost={panoCostDisplay}"),
+    );
+    expect(source("src/components/assets/scenes-panel.tsx")).toEqual(
+      expect.stringContaining(
+        '"mainline.scene_single_face_to_sog"',
+      ),
+    );
+    expect(source("src/components/assets/scenes-panel.tsx")).toEqual(
+      expect.stringContaining('"mainline.scene_pano_to_sog"'),
+    );
+    expect(source("src/components/assets/scenes-panel.tsx")).toEqual(
+      expect.stringContaining("singleFaceStageDisabledReason="),
+    );
+    expect(source("src/components/assets/scenes-panel.tsx")).toEqual(
+      expect.stringContaining("panoStageDisabledReason="),
     );
     expect(source("src/components/assets/scenes-panel.tsx")).toEqual(
       expect.stringContaining('useGenerationCreditCost("feature", "mainline.build_scenes")'),

--- a/frontend/src/components/assets/scene-asset-card.tsx
+++ b/frontend/src/components/assets/scene-asset-card.tsx
@@ -17,6 +17,16 @@ import { useTranslation } from "react-i18next";
 
 import { Button } from "@/components/ui/button";
 import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import {
   Card,
   CardContent,
   CardHeader,
@@ -53,6 +63,12 @@ interface SceneAssetCardProps {
   reversePromotion?: CreditPromotionDisplay | null;
   panoCost?: string;
   panoPromotion?: CreditPromotionDisplay | null;
+  singleFaceStageCost?: string;
+  singleFaceStagePromotion?: CreditPromotionDisplay | null;
+  singleFaceStageDisabledReason?: string;
+  panoStageCost?: string;
+  panoStagePromotion?: CreditPromotionDisplay | null;
+  panoStageDisabledReason?: string;
   customUploading?: boolean;
   customDeleting?: boolean;
   onEdit: () => void;
@@ -177,6 +193,12 @@ export function SceneAssetCard({
   reversePromotion,
   panoCost,
   panoPromotion,
+  singleFaceStageCost,
+  singleFaceStagePromotion,
+  singleFaceStageDisabledReason,
+  panoStageCost,
+  panoStagePromotion,
+  panoStageDisabledReason,
   customUploading = false,
   customDeleting = false,
   onEdit,
@@ -199,6 +221,8 @@ export function SceneAssetCard({
   const { t } = useTranslation();
   const [previewSrc, setPreviewSrc] = useState<string | null>(null);
   const [previewLabel, setPreviewLabel] = useState("");
+  const [pendingStageSource, setPendingStageSource] =
+    useState<SceneStagePlySource | null>(null);
   const hasMaster = Boolean(resolveMediaUrl(scene.master_url));
   const hasReverse = Boolean(resolveMediaUrl(scene.reverse_master_url));
   const hasPano = Boolean(resolveMediaUrl(scene.pano_url));
@@ -216,6 +240,12 @@ export function SceneAssetCard({
     : t("assets.scenes.generatePanoFromText");
   const stage = scene.stage_3gs;
   const canOpenStageViewer = Boolean(onOpenStageViewer);
+  const pendingStageFeature =
+    pendingStageSource === "pano"
+      ? t("assets.scenes.stage.panoFeature")
+      : t("assets.scenes.stage.singleFaceFeature");
+  const pendingStageCost =
+    pendingStageSource === "pano" ? panoStageCost : singleFaceStageCost;
 
   const masterResolved = resolveMediaUrl(scene.master_url);
   const reverseResolved = resolveMediaUrl(scene.reverse_master_url);
@@ -514,8 +544,13 @@ export function SceneAssetCard({
                   type="button"
                   size="sm"
                   variant="ghost"
-                  onClick={() => onGenerateStagePly("master")}
-                  disabled={!hasMaster || stageBusy}
+                  onClick={() => setPendingStageSource("master")}
+                  disabled={
+                    !hasMaster ||
+                    stageBusy ||
+                    Boolean(singleFaceStageDisabledReason)
+                  }
+                  title={singleFaceStageDisabledReason}
                   className="h-8 gap-1.5 rounded-[8px] px-2.5 text-xs"
                 >
                   {masterPlyRunning ? (
@@ -524,13 +559,22 @@ export function SceneAssetCard({
                     <RefreshCw className="size-3.5" />
                   )}
                   {t("assets.scenes.stage.masterToPly")}
+                  <CreditCostInline
+                    display={singleFaceStageCost}
+                    promotion={singleFaceStagePromotion}
+                  />
                 </Button>
                 <Button
                   type="button"
                   size="sm"
                   variant="ghost"
-                  onClick={() => onGenerateStagePly("reverse")}
-                  disabled={!hasReverse || stageBusy}
+                  onClick={() => setPendingStageSource("reverse")}
+                  disabled={
+                    !hasReverse ||
+                    stageBusy ||
+                    Boolean(singleFaceStageDisabledReason)
+                  }
+                  title={singleFaceStageDisabledReason}
                   className="h-8 gap-1.5 rounded-[8px] px-2.5 text-xs"
                 >
                   {reversePlyRunning ? (
@@ -539,13 +583,23 @@ export function SceneAssetCard({
                     <RefreshCw className="size-3.5" />
                   )}
                   {t("assets.scenes.stage.reverseToPly")}
+                  <CreditCostInline
+                    display={singleFaceStageCost}
+                    promotion={singleFaceStagePromotion}
+                  />
                 </Button>
                 <Button
                   type="button"
                   size="sm"
                   variant="ghost"
-                  onClick={() => onGenerateStagePly("pano")}
-                  disabled={!hasPano || panoRunning || stageBusy}
+                  onClick={() => setPendingStageSource("pano")}
+                  disabled={
+                    !hasPano ||
+                    panoRunning ||
+                    stageBusy ||
+                    Boolean(panoStageDisabledReason)
+                  }
+                  title={panoStageDisabledReason}
                   className="h-8 gap-1.5 rounded-[8px] px-2.5 text-xs"
                 >
                   {panoPlyRunning ? (
@@ -554,6 +608,10 @@ export function SceneAssetCard({
                     <RefreshCw className="size-3.5" />
                   )}
                   {t("assets.scenes.stage.panoToPly")}
+                  <CreditCostInline
+                    display={panoStageCost}
+                    promotion={panoStagePromotion}
+                  />
                 </Button>
                 {canOpenStageViewer ? (
                   <Button
@@ -576,6 +634,45 @@ export function SceneAssetCard({
           )}
         </CardContent>
       </Card>
+      <AlertDialog
+        open={pendingStageSource !== null}
+        onOpenChange={(open) => !open && setPendingStageSource(null)}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>
+              {t("assets.scenes.stage.confirmTitle")}
+            </AlertDialogTitle>
+            <AlertDialogDescription>
+              {t("assets.scenes.stage.confirmDescription", {
+                feature: pendingStageFeature,
+                cost: pendingStageCost,
+              })}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>{t("common.cancel")}</AlertDialogCancel>
+            <AlertDialogAction
+              variant="outline"
+              onClick={() => {
+                const source = pendingStageSource;
+                setPendingStageSource(null);
+                if (source) onGenerateStagePly(source);
+              }}
+            >
+              {t("assets.scenes.stage.confirmAction")}
+              <CreditCostInline
+                display={pendingStageCost}
+                promotion={
+                  pendingStageSource === "pano"
+                    ? panoStagePromotion
+                    : singleFaceStagePromotion
+                }
+              />
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
       {previewSrc && (
         <div
           className="fixed inset-0 z-50 flex items-center justify-center bg-black/80 p-6"

--- a/frontend/src/components/assets/scene-asset-card.tsx
+++ b/frontend/src/components/assets/scene-asset-card.tsx
@@ -646,7 +646,6 @@ export function SceneAssetCard({
             <AlertDialogDescription>
               {t("assets.scenes.stage.confirmDescription", {
                 feature: pendingStageFeature,
-                cost: pendingStageCost,
               })}
             </AlertDialogDescription>
           </AlertDialogHeader>

--- a/frontend/src/components/assets/scenes-panel.tsx
+++ b/frontend/src/components/assets/scenes-panel.tsx
@@ -634,6 +634,16 @@ function SceneAssetCardController({
     "mainline.scene_pano_generation",
     { surface: "supertale" },
   );
+  const singleFaceStageCost = useGenerationCreditCost(
+    "feature",
+    "mainline.scene_single_face_to_sog",
+    { surface: "supertale" },
+  );
+  const panoStageCost = useGenerationCreditCost(
+    "feature",
+    "mainline.scene_pano_to_sog",
+    { surface: "supertale" },
+  );
   const sceneReferenceCostDisplay =
     sceneReferenceCost.data?.data.display ??
     (sceneReferenceCost.error instanceof BillingRuleNotConfiguredError
@@ -644,6 +654,34 @@ function SceneAssetCardController({
     (panoCost.error instanceof BillingRuleNotConfiguredError
       ? t("common.billingRuleNotConfiguredShort")
       : undefined);
+  const singleFaceStageRuleMissing =
+    singleFaceStageCost.error instanceof BillingRuleNotConfiguredError;
+  const panoStageRuleMissing =
+    panoStageCost.error instanceof BillingRuleNotConfiguredError;
+  const singleFaceStageCostDisplay =
+    singleFaceStageCost.data?.data.display ??
+    (singleFaceStageRuleMissing
+      ? t("common.billingRuleNotConfiguredShort")
+      : undefined);
+  const panoStageCostDisplay =
+    panoStageCost.data?.data.display ??
+    (panoStageRuleMissing
+      ? t("common.billingRuleNotConfiguredShort")
+      : undefined);
+  const singleFaceStageDisabledReason = singleFaceStageCost.data?.data.display
+    ? undefined
+    : singleFaceStageRuleMissing
+      ? t("common.billingRuleNotConfigured")
+      : singleFaceStageCost.isPending
+        ? t("assets.scenes.stage.costLoading")
+        : t("assets.scenes.stage.costUnavailable");
+  const panoStageDisabledReason = panoStageCost.data?.data.display
+    ? undefined
+    : panoStageRuleMissing
+      ? t("common.billingRuleNotConfigured")
+      : panoStageCost.isPending
+        ? t("assets.scenes.stage.costLoading")
+        : t("assets.scenes.stage.costUnavailable");
   const generateStagePly = useGenerateScene3gsPlyAsync(project, scene.name);
   const saveDirectorWorld = useSaveSceneDirectorWorld(project, scene.name);
   const clearDirectorWorld = useClearSceneDirectorWorld(project, scene.name);
@@ -966,6 +1004,12 @@ function SceneAssetCardController({
         reversePromotion={sceneReferenceCost.data?.data.promotion}
         panoCost={panoCostDisplay}
         panoPromotion={panoCost.data?.data.promotion}
+        singleFaceStageCost={singleFaceStageCostDisplay}
+        singleFaceStagePromotion={singleFaceStageCost.data?.data.promotion}
+        singleFaceStageDisabledReason={singleFaceStageDisabledReason}
+        panoStageCost={panoStageCostDisplay}
+        panoStagePromotion={panoStageCost.data?.data.promotion}
+        panoStageDisabledReason={panoStageDisabledReason}
         onEdit={onEdit}
         onDelete={onDelete}
         onUploadMaster={() => masterInputRef.current?.click()}


### PR DESCRIPTION
## Summary

- query organization-effective pricing for `mainline.scene_single_face_to_sog` and `mainline.scene_pano_to_sog`
- show the quoted credit cost on the front, back, and 360 Director World conversion actions
- require a confirmation dialog that names the feature and displays the current price before starting
- disable conversion while pricing is unavailable or unconfigured, with an administrator-facing explanation
- keep CE credit displays hidden through the shared `CreditCostInline` component

## Verification

- `vitest run src/__tests__/components/assets/scene-asset-card.test.tsx src/__tests__/components/episode/beat-workbench/m05-credit-cost.ce.test.tsx`
- `vitest run src/__tests__/components/assets/asset-panels-rename.test.tsx src/__tests__/lib/queries/scenes.test.tsx src/__tests__/components/episode/task-controller-provider.test.tsx`
- `tsc -b`
- `vite build`

## Impact

- frontend only
- no migration or backend billing changes
- targets `staging`