### PR TITLE
fix: generate history thumbnails on image completion

### DIFF
--- a/src/novelvideo/api/routes/files.py
+++ b/src/novelvideo/api/routes/files.py
@@ -10,7 +10,7 @@ logger = logging.getLogger("novelvideo.api.files")
 
 from novelvideo.api.auth import get_api_user
 from novelvideo.api.deps import ProjectResolution, resolve_project_scope
-from novelvideo.utils.thumbnails import fresh_thumbnail, prewarm
+from novelvideo.utils.thumbnails import fresh_thumbnail
 
 router = APIRouter()
 
@@ -76,19 +76,16 @@ def _maybe_thumbnail_response(
     write-back readiness probe cost more than the transfer, and a freshly
     written variant is not in OSS yet anyway.
 
-    A cold one is a different trade entirely, so it is never built here — the
-    miss is queued and this returns ``None``, leaving the caller to hand back
-    the same OSS redirect it would have without variants at all. See
-    ``fresh_thumbnail`` for why building on the request path is the wrong side
-    of that trade.
+    A cold one is a different trade entirely, so it is never built or queued
+    here. This returns ``None`` and leaves the caller to hand back the same OSS
+    redirect it would have without variants at all. Thumbnail creation belongs
+    to the generation-history write path; opening an old or cold canvas must
+    never start image decoding work in the API process.
     """
     if not variant:
         return None
     thumb = fresh_thumbnail(project_dir, requested, variant)
     if thumb is None:
-        # Only the variant that was actually asked for: whoever asked will ask
-        # again, and a node that never requests `thumb` should not pay for one.
-        prewarm(project_dir, requested, [variant])
         return None
     cache_control = _variant_cache_control(request)
     try:

--- a/src/novelvideo/freezone/history.py
+++ b/src/novelvideo/freezone/history.py
@@ -21,6 +21,7 @@ from novelvideo.freezone.paths import (
     freezone_root,
     resolve_static_url_to_path,
 )
+
 # Imported as a module, not by name: the prewarm call below must resolve through
 # it at call time. Import-safe without Pillow — the renderer loads PIL lazily.
 from novelvideo.utils import thumbnails
@@ -116,73 +117,56 @@ def append_generation_history(
     path = generation_history_path(project_dir, normalized["canvas_id"], node_id)
     path.parent.mkdir(parents=True, exist_ok=True)
     with path.open("a", encoding="utf-8") as f:
-        f.write(json.dumps(normalized, ensure_ascii=False, separators=(",", ":")) + "\n")
-    prewarm_record_variants(project_dir, normalized)
+        f.write(
+            json.dumps(normalized, ensure_ascii=False, separators=(",", ":")) + "\n"
+        )
+    prewarm_history_thumbnail(project_dir, normalized)
     return normalized
 
 
-# Enough to cover a multi-image result without letting a pathological payload
-# turn one append into a scan; the read path covers whatever is skipped.
-_PREWARM_MAX_URLS = 8
-_PREWARM_MAX_DEPTH = 4
+# Keep this allowlist aligned with the one generated image the history strip
+# displays. Video, audio, 3D and text records do not enter this path.
+_IMAGE_OUTPUT_KEYS = ("output_url", "image_url", "master_url", "url")
 
 
-def prewarm_record_variants(project_dir: Path, record: dict[str, Any]) -> int:
-    """Queue downscaled variants for whatever images this record points at.
+def prewarm_history_thumbnail(project_dir: Path, record: dict[str, Any]) -> int:
+    """Queue one 320px thumbnail for a newly written history record.
 
-    The history strip renders every record as a thumbnail, so the moment a
-    record is written we already know which images the next reader will
-    shrink. Doing it here means a freshly generated node has warm variants
-    before anyone clicks it; the read path (``st_thumb``) still covers old
-    records and anything skipped below.
-
-    Walks the whole ``result`` payload instead of an allowlist of keys so a
-    new result field is covered the day it is added — non-images are dropped
-    by suffix, and anything resolving outside the project is dropped by
-    ``resolve_static_url_to_path``. Best-effort: returns the number of jobs
-    queued and never raises into the caller's write path.
+    This is intentionally narrow: one record produces at most one background
+    job and only the ``thumb`` variant. Existing records are never scanned or
+    backfilled while being read, so opening a large history cannot fan out into
+    CPU-bound image decodes. Best-effort and never allowed to break the history
+    write.
     """
+
+    if (
+        record.get("status") not in {"completed", "succeeded"}
+        or record.get("media_type") != "image"
+    ):
+        return 0
 
     result = record.get("result")
     if not isinstance(result, dict):
         return 0
 
-    seen: set[str] = set()
-    queued = 0
-
-    def walk(value: Any, depth: int) -> None:
-        nonlocal queued
-        if depth > _PREWARM_MAX_DEPTH or len(seen) >= _PREWARM_MAX_URLS:
-            return
-        if isinstance(value, str):
+    try:
+        for key in _IMAGE_OUTPUT_KEYS:
+            value = result.get(key)
+            if not isinstance(value, str):
+                continue
             url = value.strip()
-            # Cheap suffix gate first: a result payload also carries model
-            # names, revised prompts and ids, and none of those should reach
-            # the path resolver.
-            if (
-                not url
-                or url in seen
-                or not thumbnails.is_thumbnailable(Path(urlsplit(url).path))
-            ):
-                return
-            seen.add(url)
+            if not url or not thumbnails.is_thumbnailable(Path(urlsplit(url).path)):
+                continue
             try:
                 source = resolve_static_url_to_path(url, project_dir)
-            except ValueError:
-                return
-            queued += thumbnails.prewarm(project_dir, source)
-        elif isinstance(value, dict):
-            for item in value.values():
-                walk(item, depth + 1)
-        elif isinstance(value, (list, tuple)):
-            for item in value:
-                walk(item, depth + 1)
-
-    try:
-        walk(result, 0)
+            except (OSError, ValueError):
+                continue
+            return thumbnails.prewarm(project_dir, source, ["thumb"])
     except Exception:
-        logger.debug("thumbnail prewarm skipped for %s", record.get("id"), exc_info=True)
-    return queued
+        logger.debug(
+            "thumbnail prewarm skipped for %s", record.get("id"), exc_info=True
+        )
+    return 0
 
 
 def _read_history_file(path: Path) -> list[dict[str, Any]]:
@@ -208,7 +192,9 @@ def read_generation_history(
     node_id: str,
     limit: int = _DEFAULT_LIMIT,
 ) -> list[dict[str, Any]]:
-    records = _read_history_file(generation_history_path(project_dir, canvas_id, node_id))
+    records = _read_history_file(
+        generation_history_path(project_dir, canvas_id, node_id)
+    )
     if limit <= 0:
         return records
     return records[-limit:]

--- a/src/novelvideo/utils/thumbnails.py
+++ b/src/novelvideo/utils/thumbnails.py
@@ -13,17 +13,18 @@ The cache is addressed purely by source path::
 
 so nothing about it leaks into a data schema. History records and canvas
 JSON keep storing the original URL; callers opt in per render by asking for
-a variant, and old data benefits without any backfill.
-Freshness is exact rather than heuristic: a generated variant is stamped
-with its source's mtime, so ``thumb.mtime == source.mtime`` means current
-and a regenerated source invalidates automatically without leaving stale
-files behind.
+a variant. Only newly appended history records proactively create one.
+Freshness uses write ordering: a generated variant is stamped with its source's
+mtime when the filesystem preserves ``os.utime``; object-store FUSE mounts may
+instead give it the later upload time. In both cases ``thumb.mtime >=
+source.mtime`` means current, while rewriting the source moves its mtime past
+the existing thumbnail and invalidates it.
 
 Building and serving are deliberately separate. ``fresh_thumbnail`` is what a
-request calls and it never builds; ``ensure_thumbnail`` builds and only ever
-runs in the background. A variant a request wants but does not have is queued
-and the original goes out instead, so a cold project costs exactly what it did
-before variants existed and warms itself up as it is used.
+request calls and it never builds or queues work; ``ensure_thumbnail`` builds
+and only ever runs in the background after a new history record is written (or
+from the explicit offline backfill tool). A missing variant falls back to the
+original without making an old project warm itself on read.
 
 Every failure path returns ``None`` so the caller falls back to the
 original. A slow node beats a broken one.
@@ -93,9 +94,8 @@ _MAX_SOURCE_PIXELS = 40_000_000
 _WEBP_QUALITY = 80
 _WEBP_METHOD = 4
 
-# Bound concurrent decodes so a burst of cold thumbnails (a history strip is
-# nine at once) cannot monopolise the machine. This is a process-wide ceiling
-# across every caller — HTTP, prewarm workers, offline backfill.
+# Bound concurrent decodes. This is a process-wide ceiling shared by the
+# serving process's single prewarm worker and the explicit offline backfill.
 DEFAULT_RENDER_CONCURRENCY = 4
 _render_slots = threading.Semaphore(DEFAULT_RENDER_CONCURRENCY)
 
@@ -207,10 +207,9 @@ def fresh_thumbnail(
     source over the ossfs mount just to hand back a smaller copy of it. That is
     a worse first visit than the one variants were introduced to fix.
 
-    So a miss falls back to the redirect and queues the build for next time: a
-    cold project behaves exactly as it did before variants existed, and warms
-    itself up as it is used. Variants can only ever be an improvement, which is
-    also what makes the offline backfill purely optional.
+    So a miss only falls back to the redirect. New history records prewarm their
+    single display thumbnail at write time; old data remains untouched unless
+    an operator deliberately runs the offline backfill tool.
 
     Cheap enough to call on the event loop — two stats, fewer than the path
     resolution the caller already did to get here.
@@ -230,7 +229,12 @@ def fresh_thumbnail(
 
 def _is_current(dest: Path, source_mtime_ns: int) -> bool:
     try:
-        return dest.stat().st_mtime_ns == source_mtime_ns
+        # ossfs/geesefs may silently discard the source timestamp requested by
+        # os.utime and keep the variant's later upload time instead. A variant
+        # is written only after its source exists, so either equality (local
+        # disk) or a later destination timestamp (FUSE) is current. Rewriting
+        # the source moves it past the existing variant and makes this false.
+        return dest.stat().st_mtime_ns >= source_mtime_ns
     except OSError:
         return False
 
@@ -293,9 +297,9 @@ def _render(
     tmp = dest.with_name(f"{dest.name}.{os.getpid()}.{threading.get_ident()}.tmp")
     try:
         out.save(tmp, "WEBP", quality=_WEBP_QUALITY, method=_WEBP_METHOD)
-        # Stamp the source's mtime onto the variant; that equality *is* the
-        # freshness check, and it closes the race where the source is
-        # rewritten while we render.
+        # Preserve exact source freshness where supported. Object-store FUSE
+        # mounts may ignore this and retain their later upload timestamp;
+        # _is_current deliberately accepts either representation.
         os.utime(tmp, ns=(source_mtime_ns, source_mtime_ns))
         os.replace(tmp, dest)
     except Exception:
@@ -306,30 +310,24 @@ def _render(
 
 # --- background prewarm ---------------------------------------------------
 #
-# Two feeders. A generation runner knows a file's final bytes the moment it
-# writes them, and that is the cheapest moment to build its variants: the source
-# is still in the page cache and nobody is waiting on the result. The read path
-# feeds it too, because ``fresh_thumbnail`` deliberately refuses to build on a
-# miss -- the request is served from OSS and the build happens here instead.
+# A generation runner knows a file's final bytes when it writes the history
+# record, and that is the cheapest moment to build its thumbnail: the source is
+# still in the page cache and nobody is waiting on the result. Reads never feed
+# this queue.
 #
 # Nothing may ever pay for this, least of all a request handler, hence a bounded
 # queue that drops rather than blocks when saturated. A drop only means the next
 # visit is cold again.
 
-# These are the only renderers in a serving process now that the read path never
-# builds, and they share the process-wide decode budget regardless, so matching
-# it exactly is what keeps that budget reachable.
-_PREWARM_WORKERS = DEFAULT_RENDER_CONCURRENCY
+# One serving-process worker keeps thumbnail work from competing with normal
+# generation. Offline backfill controls its own concurrency separately.
+_PREWARM_WORKERS = 1
 _PREWARM_QUEUE_SIZE = 512
 
 _PrewarmJob = tuple[Path, Path, str]
 
-# The read path queues on every miss, so one paint of a cold canvas offers the
-# same job once per visible node -- and again on the next paint, since nothing
-# is current yet. Without this, a single canvas load would pack the queue with
-# copies of a handful of jobs and drop the genuinely distinct ones. Keyed on the
-# strings rather than resolved paths so queueing stays syscall-free; a dedup
-# missed that way only costs one redundant job.
+# Duplicate writes/retries can still offer the same job while it is in flight.
+# Keyed on strings rather than resolved paths so queueing stays syscall-free.
 _PrewarmKey = tuple[str, str, str]
 _prewarm_inflight: set[_PrewarmKey] = set()
 _prewarm_inflight_lock = threading.Lock()

--- a/tests/test_media_thumbnails.py
+++ b/tests/test_media_thumbnails.py
@@ -29,12 +29,10 @@ def _drain_prewarm() -> None:
 
 
 def _warm(project_dir: Path, source: Path, variant: str) -> None:
-    """Build a variant the way the read path does: queue it, then wait.
+    """Build a variant through the same background queue production uses.
 
     The request path never builds one itself, so every test below that is about
-    *serving* a variant has to warm it first. Going through prewarm rather than
-    calling ensure_thumbnail keeps the test honest about how a variant comes to
-    exist in production.
+    *serving* a variant has to warm it first.
     """
 
     assert thumbnails.prewarm(project_dir, source, [variant]) == 1
@@ -92,7 +90,10 @@ def test_builds_webp_within_the_variant_budget(tmp_path):
     dest = thumbnails.ensure_thumbnail(tmp_path, source, "thumb")
 
     assert dest is not None
-    assert dest == tmp_path / "_thumbs" / "thumb" / "freezone" / "_outputs" / "big.png.webp"
+    assert (
+        dest
+        == tmp_path / "_thumbs" / "thumb" / "freezone" / "_outputs" / "big.png.webp"
+    )
     with Image.open(dest) as im:
         assert im.format == "WEBP"
         assert max(im.size) <= thumbnails.VARIANTS["thumb"]
@@ -107,6 +108,19 @@ def test_variant_is_stamped_with_the_source_mtime(tmp_path):
 
     assert dest is not None
     assert dest.stat().st_mtime_ns == source.stat().st_mtime_ns
+
+
+def test_variant_stays_current_when_fuse_replaces_the_requested_mtime(tmp_path):
+    source = _write_png(tmp_path / "a.png")
+    dest = thumbnails.ensure_thumbnail(tmp_path, source, "thumb")
+    assert dest is not None
+
+    # ossfs/geesefs may report success for os.utime but keep the later object
+    # upload time after rename/copy instead of the timestamp requested above.
+    later = source.stat().st_mtime_ns + 10**9
+    os.utime(dest, ns=(later, later))
+
+    assert thumbnails.fresh_thumbnail(tmp_path, source, "thumb") == dest
 
 
 def test_second_call_reuses_the_cached_variant(tmp_path, monkeypatch):
@@ -301,7 +315,9 @@ def test_undecodable_source_falls_back_instead_of_raising(tmp_path):
 def test_failed_render_leaves_no_temp_file_behind(tmp_path, monkeypatch):
     source = _write_png(tmp_path / "a.png")
     monkeypatch.setattr(
-        thumbnails.os, "replace", lambda *_a, **_k: (_ for _ in ()).throw(OSError("nope"))
+        thumbnails.os,
+        "replace",
+        lambda *_a, **_k: (_ for _ in ()).throw(OSError("nope")),
     )
 
     assert thumbnails.ensure_thumbnail(tmp_path, source, "thumb") is None
@@ -390,6 +406,34 @@ def test_media_route_serves_the_variant_when_asked(monkeypatch, tmp_path):
     assert thumb.headers["content-type"] == "image/webp"
     assert len(thumb.content) < len(full.content)
     assert len(full.content) == source.stat().st_size
+
+
+def test_media_route_serves_a_variant_when_fuse_discards_its_stamp(
+    monkeypatch, tmp_path
+):
+    """Exercise the production ossfs/geesefs timestamp behavior end to end."""
+
+    real_replace = os.replace
+
+    def replace_and_use_upload_time(src, dest):
+        real_replace(src, dest)
+        if thumbnails.THUMB_ROOT in Path(dest).parts:
+            os.utime(dest, ns=(_MTIME_AFTER, _MTIME_AFTER))
+
+    monkeypatch.setattr(thumbnails.os, "replace", replace_and_use_upload_time)
+
+    source = _write_png(tmp_path / "freezone" / "_outputs" / "big.png", (2000, 1200))
+    _warm(tmp_path, source, "thumb")
+    client = _client(monkeypatch, tmp_path)
+
+    response = client.get(
+        "/projects/demo/media/freezone/_outputs/big.png",
+        params={"st_thumb": "thumb"},
+    )
+
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "image/webp"
+    assert len(response.content) < source.stat().st_size
 
 
 def test_media_route_ignores_an_unknown_variant(monkeypatch, tmp_path):
@@ -494,53 +538,44 @@ def test_a_regenerated_source_is_revalidated_to_the_new_variant(monkeypatch, tmp
     # revalidated into a 304 — it gets the new bytes.
     assert second.headers["etag"] != first.headers["etag"]
     stale = client.get(
-        url, params={"st_thumb": "thumb"}, headers={"If-None-Match": first.headers["etag"]}
+        url,
+        params={"st_thumb": "thumb"},
+        headers={"If-None-Match": first.headers["etag"]},
     )
     assert stale.status_code == 200
     assert stale.content == second.content
 
 
-def test_a_cold_variant_request_serves_the_original_and_warms_up_behind_it(
+def test_a_cold_variant_request_serves_the_original_without_queuing_work(
     monkeypatch, tmp_path
 ):
-    """The request path must never decode an original.
+    """Reading old history must never schedule CPU-bound thumbnail work.
 
     Serving a request *without* a variant is a 302 to presigned OSS: the
     original never travels through this process. Building on demand trades that
     away for reading and decoding it locally, so the first visit to a cold
     project would pull every full-resolution source over the ossfs mount just to
-    hand back a smaller copy — a worse first visit than the one variants exist
-    to fix. The miss is queued instead, and the response is byte-for-byte what
-    it would have been before variants existed.
+    hand back a smaller copy. The response stays byte-for-byte what it would
+    have been before variants existed and no future render is scheduled.
     """
 
     source = _write_png(tmp_path / "freezone" / "_outputs" / "big.png", (2000, 1200))
     client = _client(monkeypatch, tmp_path)
     url = "/projects/demo/media/freezone/_outputs/big.png"
 
-    rendered_on: list[str] = []
-    original_render = thumbnails._render
-
-    def record(*args, **kwargs):
-        rendered_on.append(threading.current_thread().name)
-        return original_render(*args, **kwargs)
-
-    monkeypatch.setattr(thumbnails, "_render", record)
+    prewarm_calls: list[Path] = []
+    monkeypatch.setattr(
+        thumbnails,
+        "prewarm",
+        lambda _project_dir, requested, *_args: prewarm_calls.append(requested),
+    )
 
     cold = client.get(url, params={"st_thumb": "thumb"})
 
     assert cold.status_code == 200
     assert cold.content == source.read_bytes()
-
-    _drain_prewarm()
-    warm = client.get(url, params={"st_thumb": "thumb"})
-
-    assert warm.headers["content-type"] == "image/webp"
-    assert len(warm.content) < len(cold.content)
-    # Asserted by thread rather than by "nothing rendered during the request":
-    # a worker can pick the job up while the response is still being written, so
-    # the timing is racy but the thread it runs on never is.
-    assert rendered_on and all(n.startswith("thumb-prewarm") for n in rendered_on)
+    assert prewarm_calls == []
+    assert not (tmp_path / thumbnails.THUMB_ROOT).exists()
 
 
 def test_an_identical_prewarm_job_is_not_queued_twice(tmp_path, monkeypatch):
@@ -653,14 +688,22 @@ def test_prewarm_never_raises_into_its_caller(tmp_path, monkeypatch):
 
 
 def _record(result):
-    return {"id": "freezone_gen:abc", "media_type": "image", "result": result}
+    return {
+        "id": "freezone_gen:abc",
+        "status": "completed",
+        "media_type": "image",
+        "result": result,
+    }
 
 
 def _prewarm_spy(monkeypatch):
-    calls: list[Path] = []
-    monkeypatch.setattr(
-        thumbnails, "prewarm", lambda project_dir, source, *a, **k: (calls.append(source), 1)[1]
-    )
+    calls: list[tuple[Path, tuple[str, ...]]] = []
+
+    def record(_project_dir, source, variants=None):
+        calls.append((source, tuple(variants or ())))
+        return 1
+
+    monkeypatch.setattr(thumbnails, "prewarm", record)
     return calls
 
 
@@ -670,7 +713,7 @@ def test_history_record_prewarms_its_output_image(tmp_path, monkeypatch):
     source = _write_png(tmp_path / "freezone" / "_outputs" / "gen" / "job.png")
     calls = _prewarm_spy(monkeypatch)
 
-    queued = history.prewarm_record_variants(
+    queued = history.prewarm_history_thumbnail(
         tmp_path,
         _record(
             {
@@ -680,30 +723,29 @@ def test_history_record_prewarms_its_output_image(tmp_path, monkeypatch):
         ),
     )
 
-    assert queued == 1  # same URL twice is one job
-    assert calls == [source]
+    assert queued == 1
+    assert calls == [(source, ("thumb",))]
 
 
-def test_history_record_prewarms_images_nested_in_lists(tmp_path, monkeypatch):
+def test_history_record_only_prewarms_the_displayed_output(tmp_path, monkeypatch):
     from novelvideo.freezone import history
 
     for index in range(3):
         _write_png(tmp_path / "freezone" / "_outputs" / f"{index}.png")
     calls = _prewarm_spy(monkeypatch)
 
-    history.prewarm_record_variants(
+    history.prewarm_history_thumbnail(
         tmp_path,
         _record(
             {
-                "images": [
-                    {"url": f"/static/projects/p/freezone/_outputs/{i}.png"}
-                    for i in range(3)
-                ]
+                "output_url": "/static/projects/p/freezone/_outputs/0.png",
+                "image_url": "/static/projects/p/freezone/_outputs/1.png",
+                "images": [{"url": "/static/projects/p/freezone/_outputs/2.png"}],
             }
         ),
     )
 
-    assert sorted(path.name for path in calls) == ["0.png", "1.png", "2.png"]
+    assert calls == [(tmp_path / "freezone" / "_outputs" / "0.png", ("thumb",))]
 
 
 def test_history_record_ignores_non_image_payload_strings(tmp_path, monkeypatch):
@@ -711,7 +753,7 @@ def test_history_record_ignores_non_image_payload_strings(tmp_path, monkeypatch)
 
     calls = _prewarm_spy(monkeypatch)
 
-    history.prewarm_record_variants(
+    history.prewarm_history_thumbnail(
         tmp_path,
         _record(
             {
@@ -726,18 +768,34 @@ def test_history_record_ignores_non_image_payload_strings(tmp_path, monkeypatch)
     assert calls == []
 
 
+def test_unfinished_history_record_never_queues_a_thumbnail(tmp_path, monkeypatch):
+    from novelvideo.freezone import history
+
+    calls = _prewarm_spy(monkeypatch)
+
+    queued = history.prewarm_history_thumbnail(
+        tmp_path,
+        {
+            **_record({"output_url": "/static/projects/p/freezone/_outputs/a.png"}),
+            "status": "failed",
+        },
+    )
+
+    assert queued == 0
+    assert calls == []
+
+
 def test_history_record_ignores_urls_escaping_the_project(tmp_path, monkeypatch):
     from novelvideo.freezone import history
 
     calls = _prewarm_spy(monkeypatch)
 
-    history.prewarm_record_variants(
+    history.prewarm_history_thumbnail(
         tmp_path,
         _record(
             {
-                "a": "https://evil.example.com/x.png",
-                "b": "/static/projects/p/../../../../etc/passwd.png",
-                "c": "//evil.example.com/y.png",
+                "output_url": "https://evil.example.com/x.png",
+                "image_url": "/static/projects/p/../../../../etc/passwd.png",
             }
         ),
     )
@@ -745,24 +803,53 @@ def test_history_record_ignores_urls_escaping_the_project(tmp_path, monkeypatch)
     assert calls == []
 
 
-def test_history_record_caps_how_many_images_it_queues(tmp_path, monkeypatch):
+def test_history_record_skips_an_invalid_candidate_url(tmp_path, monkeypatch):
+    from novelvideo.freezone import history
+
+    source = _write_png(tmp_path / "freezone" / "_outputs" / "valid.png")
+    calls = _prewarm_spy(monkeypatch)
+
+    queued = history.prewarm_history_thumbnail(
+        tmp_path,
+        _record(
+            {
+                "output_url": "https://provider.example/result.png",
+                "image_url": "/static/projects/p/freezone/_outputs/valid.png",
+            }
+        ),
+    )
+
+    assert queued == 1
+    assert calls == [(source, ("thumb",))]
+
+
+def test_non_image_history_never_prewarms_a_thumbnail(tmp_path, monkeypatch):
     from novelvideo.freezone import history
 
     calls = _prewarm_spy(monkeypatch)
 
-    history.prewarm_record_variants(
+    queued = history.prewarm_history_thumbnail(
         tmp_path,
-        _record({f"u{i}": f"/static/projects/p/img_{i}.png" for i in range(40)}),
+        {
+            **_record(
+                {
+                    "output_url": "/static/projects/p/freezone/_outputs/movie.mp4",
+                    "preview_image_url": "/static/projects/p/freezone/_outputs/poster.png",
+                }
+            ),
+            "media_type": "video",
+        },
     )
 
-    assert len(calls) <= history._PREWARM_MAX_URLS
+    assert queued == 0
+    assert calls == []
 
 
 @pytest.mark.parametrize("result", [None, "", [], "not-a-dict", 7])
 def test_history_record_without_a_result_dict_queues_nothing(tmp_path, result):
     from novelvideo.freezone import history
 
-    assert history.prewarm_record_variants(tmp_path, _record(result)) == 0
+    assert history.prewarm_history_thumbnail(tmp_path, _record(result)) == 0
 
 
 def test_appending_a_history_record_prewarms_its_media(tmp_path, monkeypatch):
@@ -775,10 +862,12 @@ def test_appending_a_history_record_prewarms_its_media(tmp_path, monkeypatch):
         project_dir=tmp_path,
         canvas_id="repro",
         node_id="node-1",
-        record=_record({"output_url": "/static/projects/p/freezone/_outputs/gen/job.png"}),
+        record=_record(
+            {"output_url": "/static/projects/p/freezone/_outputs/gen/job.png"}
+        ),
     )
 
-    assert calls == [source]
+    assert calls == [(source, ("thumb",))]
 
 
 def test_a_broken_prewarm_never_breaks_the_history_write(tmp_path, monkeypatch):
@@ -795,7 +884,9 @@ def test_a_broken_prewarm_never_breaks_the_history_write(tmp_path, monkeypatch):
         project_dir=tmp_path,
         canvas_id="repro",
         node_id="node-1",
-        record=_record({"output_url": "/static/projects/p/freezone/_outputs/gen/job.png"}),
+        record=_record(
+            {"output_url": "/static/projects/p/freezone/_outputs/gen/job.png"}
+        ),
     )
 
     assert written is not None


### PR DESCRIPTION
## Summary

- generate one 320px WebP thumbnail when a completed image is appended to node history
- stop queueing thumbnail generation on media read misses
- leave existing history untouched and fall back to the original when no thumbnail exists
- limit serving-process thumbnail generation to one background worker
- accept later thumbnail mtimes from ossfs/geesefs mounts that discard os.utime stamps

## Verification

- uv run ruff check src/novelvideo/api/routes/files.py src/novelvideo/freezone/history.py src/novelvideo/utils/thumbnails.py tests/test_media_thumbnails.py
- uv run ruff format --check src/novelvideo/api/routes/files.py src/novelvideo/freezone/history.py src/novelvideo/utils/thumbnails.py tests/test_media_thumbnails.py
- uv run pytest tests/test_media_thumbnails.py tests/test_freezone_generation_history_prompt.py tests/test_freezone_canvas_generation_history.py tests/test_project_static_media.py -q (95 passed)

## Impact

- no frontend or API contract change; existing st_thumb=thumb URLs are reused
- no migration, configuration, provider, or compliance impact
- uploads and thumb2x/card variants remain outside the automatic write-time path