### PR TITLE
perf(canvas): reduce repeated graph and media work

### DIFF
--- a/frontend/src/__tests__/features/freezone/asset-library-browser-item-actions.test.tsx
+++ b/frontend/src/__tests__/features/freezone/asset-library-browser-item-actions.test.tsx
@@ -62,6 +62,16 @@ const VOICE_ONLY = {
   audio_url: "/static/admin/58/freezone/_uploads/voice.mp3",
 };
 
+const VIDEO_ONLY = {
+  id: "item-3",
+  name: "分镜预览",
+  media: "video",
+  source: "upload",
+  category: "other",
+  folder: "other",
+  video_url: "/static/admin/58/freezone/_uploads/preview.mp4",
+};
+
 function renderBrowser(onSendToCanvas?: (entry: unknown) => void) {
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
   const wrapper = ({ children }: { children: ReactNode }) => (
@@ -112,6 +122,16 @@ describe("AssetLibraryBrowser item actions", () => {
     const folder = await screen.findByLabelText("文件夹 音效");
 
     expect(folder.querySelector("img")).toBeNull();
+  });
+
+  it("does not preload metadata for every video in an opened folder", async () => {
+    fetchFreezoneVideoCharacterLibrary.mockResolvedValue([VIDEO_ONLY]);
+    renderBrowser(() => {});
+    await openFolder("待分类资产");
+
+    const video = document.querySelector("video");
+    expect(video).toBeTruthy();
+    expect(video?.getAttribute("preload")).toBe("none");
   });
 
   it("offers the four actions on a locally uploaded asset", async () => {

--- a/frontend/src/features/canvas/nodes/ImageGenNode.tsx
+++ b/frontend/src/features/canvas/nodes/ImageGenNode.tsx
@@ -176,11 +176,11 @@ import {
   readStyleNodeSyncState,
   writeStyleNodeSyncState,
 } from '@/features/canvas/application/styleNodeSync';
-import { joinUpstreamText } from '@/features/canvas/application/graphContentResolver';
 import {
-  useUpstreamContents,
-  useUpstreamNodes,
-} from '@/features/canvas/application/useUpstreamGraph';
+  extractUpstreamContent,
+  joinUpstreamText,
+} from '@/features/canvas/application/graphContentResolver';
+import { useUpstreamNodes } from '@/features/canvas/application/useUpstreamGraph';
 import { useNodeGenerationTaskState } from '@/features/canvas/application/useNodeGenerationTaskState';
 import {
   PromptMentionEditor,
@@ -524,7 +524,14 @@ export const ImageGenNode = memo(({ id, data, selected, width, height }: ImageGe
     { isLoading: styleTemplatesLoading, hasError: styleTemplatesError !== null },
   );
 
-  const upstreamContents = useUpstreamContents(id);
+  // Subscribe to the upstream graph once. Calling useUpstreamContents here and
+  // useUpstreamNodes below created two independent Zustand selectors, so every
+  // canvas-store update walked the full nodes/edges arrays twice per image node.
+  const upstreamNodes = useUpstreamNodes(id);
+  const upstreamContents = useMemo(
+    () => upstreamNodes.map(extractUpstreamContent),
+    [upstreamNodes],
+  );
   // ImageGen 上游只消费「文本 + 图片」，视频/音频内容被丢弃 ——
   // 即便 upload 节点带了视频 URL，也不进 OpsPanel 也不进 reference_urls。
   const upstreamImageContents = useMemo(() => {
@@ -590,7 +597,6 @@ export const ImageGenNode = memo(({ id, data, selected, width, height }: ImageGe
     () => collectCandidateBindingsForNode(connectedEdges, id).map((binding) => binding.role),
     [connectedEdges, id],
   );
-  const upstreamNodes = useUpstreamNodes(id);
   // 节点被连线（存在入边）后：隐藏「试试」CTA，只在节点中间显示一个图标（对齐 libtv）。
   // 风格节点不算 —— 它是本节点自己的选择在画布上的投影，不是「用户接了个上游」，
   // 选个风格就把空节点的 CTA 收掉会很莫名。

--- a/frontend/src/features/freezone/AssetLibraryBrowser.tsx
+++ b/frontend/src/features/freezone/AssetLibraryBrowser.tsx
@@ -261,7 +261,7 @@ export function AssetLibraryBrowser({
                     className="h-full w-full object-cover"
                     muted
                     playsInline
-                    preload="metadata"
+                    preload="none"
                   />
                   {/* 视频没有 poster 时是一片黑，补个角标让它和图片区分开 */}
                   <span className="pointer-events-none absolute left-0.5 top-0.5 rounded bg-black/55 p-0.5 text-white/90">


### PR DESCRIPTION
## Summary
- reuse the existing upstream-node subscription in ImageGenNode instead of walking the canvas graph twice per store update
- stop asset-library video rows from preloading metadata when a folder opens
- cover the video preload behavior with a focused regression test

## Verification
- npm test -- --run src/__tests__/features/freezone/asset-library-browser-item-actions.test.tsx
- npm test -- --run src/__tests__/features/canvas/catalog-image-model-mode-wiring.test.ts src/__tests__/features/canvas/catalog-image-model-params.test.ts src/__tests__/features/canvas/image-gen-director-world-entry.test.ts src/__tests__/features/canvas/image-gen-error-notification.test.ts src/__tests__/features/canvas/image-gen-node-context-palette.test.tsx src/__tests__/features/canvas/image-gen-node-credit-contract.test.ts src/__tests__/features/canvas/image-gen-stale-error-banner.test.ts src/__tests__/features/canvas/natural-size-record-trust.test.ts src/__tests__/lib/model-task-access.test.tsx
- npm run build

## Impact
- no API, migration, configuration, provider, or compliance changes
- behavior is unchanged except that offscreen library videos no longer eagerly fetch metadata