### PR TITLE
feat: add dual-track knowledge pipeline boundary

### DIFF
--- a/license-inventory.csv
+++ b/license-inventory.csv
@@ -1551,6 +1551,7 @@ src/novelvideo/generators/wan2-2-I2V-LightX2V.json,Elastic-2.0,2026 SuperTale co
 src/novelvideo/graph_preview.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 src/novelvideo/image_request_usage.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 src/novelvideo/identity_prerequisites.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
+src/novelvideo/knowledge_pipeline.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 src/novelvideo/llm_instrumentation.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 src/novelvideo/manual_shots.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 src/novelvideo/media_model_request_schema.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
@@ -1952,6 +1953,7 @@ tests/test_indextts2_beat_audio_task.py,Elastic-2.0,2026 SuperTale contributors,
 tests/test_indextts2_fal.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_indextts2_fal_smoke.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_ingest_progress.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
+tests/test_knowledge_pipeline_dual_track.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_literal_script_writing_audio_type.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_llm_instrumentation_logging.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_m10_final_gate.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation

--- a/src/novelvideo/agents/episode_planner.py
+++ b/src/novelvideo/agents/episode_planner.py
@@ -181,6 +181,12 @@ def create_episode_planner_agent(tools: List[Callable]) -> Agent:
 # =============================================================================
 
 
+# Legacy-only AI episode planner.
+# No current frontend workflow selects this mode: the "plan episodes" button
+# posts an empty body (frontend/src/routes/_app/projects.$project/episodes.tsx),
+# so planning_mode falls back to the "chapters" default in api/schemas.py.
+# Reaching this code still requires an explicit planning_mode="ai" from an API
+# client. Structured-v2 projects must not enter this path.
 class EpisodePlannerAgent:
     """剧集规划 Agent - 使用图谱搜索进行多轮迭代式规划。
 

--- a/src/novelvideo/api/routes/ingest.py
+++ b/src/novelvideo/api/routes/ingest.py
@@ -20,6 +20,7 @@ from novelvideo.api.chapter_preview import (
 from novelvideo.api.deps import make_cognee_store_for_context, resolve_project_scope
 from novelvideo.api.schemas import IngestStart
 from novelvideo.cognee.ladybug_access import ladybug_graph_access
+from novelvideo.knowledge_pipeline import is_structured_v2
 from novelvideo.graph_preview import (
     empty_graph_preview,
     load_graph_preview,
@@ -66,6 +67,13 @@ async def get_ingest_knowledge_graph(
     # returning a stale sidecar or opening its embedded graph database from an
     # API worker.
     if not (ctx.output_dir / "novel.txt").is_file():
+        return {"ok": True, "data": empty_graph_preview()}
+
+    # structured_v2 projects never build a graph. Return the empty preview
+    # rather than reaching the legacy materialization path below, which would
+    # open Ladybug and construct a Cognee-backed store for a project that has
+    # neither.
+    if is_structured_v2(ctx.state_dir):
         return {"ok": True, "data": empty_graph_preview()}
 
     snapshot = load_graph_preview(ctx.state_dir)

--- a/src/novelvideo/cognee/pipeline.py
+++ b/src/novelvideo/cognee/pipeline.py
@@ -508,6 +508,9 @@ async def extract_characters_from_graph(
 # ============================================================
 
 
+# Legacy-only: reached from build_episodes(), which runs only when
+# planning_mode="ai". No current frontend workflow selects that mode.
+# Structured-v2 projects must not enter this path.
 async def extract_episodes_with_characters(
     text: str,
     target_episodes: int = 10,

--- a/src/novelvideo/cognee/store.py
+++ b/src/novelvideo/cognee/store.py
@@ -35,6 +35,10 @@ from novelvideo.graph_preview import (
     delete_graph_preview,
     write_graph_preview,
 )
+from novelvideo.knowledge_pipeline import (
+    KnowledgePipelineUnsupported,
+    is_structured_v2,
+)
 from novelvideo.official_defaults import DEFAULT_COGNEE_LLM_MODEL
 from novelvideo.novel_source import require_imported_novel
 from novelvideo.project_config import ensure_cognee_embedding_binding_in_state_dir
@@ -286,7 +290,36 @@ class CogneeStore:
         """统一别名查找键，降低空格/大小写差异导致的失配。"""
         return " ".join((value or "").replace("\u3000", " ").strip().lower().split())
 
+    @property
+    def _cognee_enabled(self) -> bool:
+        """Whether this project may touch Cognee, embeddings or the graph.
+
+        Resolved lazily from the project's recorded track so that stores built
+        without ``initialize()`` (legacy tests, ad-hoc scripts) are gated too.
+        ``initialize()`` overwrites the cached value once it has decided.
+        """
+        cached = self.__dict__.get("_cognee_enabled_flag")
+        if cached is None:
+            cached = not is_structured_v2(self.__dict__.get("state_dir"))
+            self.__dict__["_cognee_enabled_flag"] = cached
+        return cached
+
+    def _require_cognee(self, operation: str) -> None:
+        """Fail loudly instead of silently falling back to the Cognee path.
+
+        A fallback here would bind a structured project to an embedding model,
+        which is the one outcome the second track exists to prevent.
+        """
+        if not self._cognee_enabled:
+            raise KnowledgePipelineUnsupported(
+                f"{operation} is unavailable for structured_v2 projects"
+            )
+
     def embedding_model_scope(self):
+        # Guarded as well as the public graph methods: entering the scope is how
+        # an embedding binding gets created, so a caller reaching past the public
+        # API must not be able to bind a structured project by accident.
+        self._require_cognee("embedding model scope")
         model = getattr(self, "cognee_embedding_model", None)
         dimensions = getattr(self, "cognee_embedding_dimensions", None)
         if not model or dimensions is None:
@@ -445,7 +478,25 @@ class CogneeStore:
         return await store._ensure_db()
 
     async def initialize(self):
-        """初始化 SQLite 数据库和 Cognee 配置。"""
+        """初始化 SQLite 数据库和 Cognee 配置。
+
+        structured_v2 项目降级为纯 SQLite 门面而不是抛异常：生产中有大量
+        runner 和 API 依赖（肖像、参考图、剧本、分镜、视频、Freezone 等）只把
+        本类当 SQLite 门面使用，完全不需要图谱。在这里硬失败会让这些路径在
+        新项目上全线 500。图谱能力本身由 ``_require_cognee`` 单独把守。
+        """
+        # 必须先判定 track，再决定是否绑定 embedding：
+        # ensure_cognee_embedding_binding_in_state_dir() 会为缺字段的项目回填
+        # 绑定并写回 project_config.json，一旦调用就再也退不回去了。
+        if is_structured_v2(self.state_dir):
+            self.__dict__["_cognee_enabled_flag"] = False
+            await self._ensure_db()
+            console.print(
+                f"[dim]存储层已初始化 (structured_v2, 无图谱, db: {self.db_path})[/dim]"
+            )
+            return
+
+        self.__dict__["_cognee_enabled_flag"] = True
         embedding_binding = ensure_cognee_embedding_binding_in_state_dir(self.state_dir)
         self.cognee_embedding_model = embedding_binding.internal_model
         self.cognee_embedding_dimensions = embedding_binding.dimensions
@@ -537,6 +588,7 @@ class CogneeStore:
         on_log: Optional[Callable[[str], None]] = None,
     ) -> dict:
         """快速导入，并独占当前项目的 Cognee/Ladybug 图谱。"""
+        self._require_cognee("Cognee graph ingest")
         async with ladybug_graph_access(self.state_dir, read_only=False):
             return await self._ingest_novel_fast_locked(
                 novel_path,
@@ -668,6 +720,7 @@ class CogneeStore:
         }
 
     async def materialize_graph_preview(self, max_nodes: int = 48) -> dict:
+        self._require_cognee("graph preview")
         async with ladybug_graph_access(self.state_dir, read_only=True):
             snapshot = await self.get_graph_snapshot(max_nodes=max_nodes)
             if not snapshot.get("nodes"):
@@ -684,6 +737,7 @@ class CogneeStore:
         oversized or vector-shaped values before returning them to the browser.
         """
 
+        self._require_cognee("graph snapshot")
         max_nodes = max(20, min(int(max_nodes), 80))
         max_edges = min(max_nodes * 3, 160)
         raw_nodes, raw_edges = await self._get_dataset_graph_data(
@@ -929,6 +983,7 @@ class CogneeStore:
         图谱构建只负责发现缺失的基础角色。已有角色可能已经有用户编辑、
         身份图、声线和资产配置，不能被一次图谱重扫覆盖。
         """
+        self._require_cognee("graph character build")
         from .pipeline import extract_characters_from_graph
 
         def report(progress: float, task: str):
@@ -1561,6 +1616,7 @@ class CogneeStore:
 
     async def search(self, query: str, mode: str = "graph", top_k: int = 10) -> str:
         """语义检索。"""
+        self._require_cognee("graph search")
         async with ladybug_graph_access(self.state_dir, read_only=True):
             with preserve_st_env():
                 from cognee.modules.data.exceptions.exceptions import DatasetNotFoundError
@@ -1891,6 +1947,7 @@ class CogneeStore:
         这里只补缺失的基础场景；已有基础场景和派生 plate 都是资产事实，
         不能被一次图谱重扫清空或覆盖。
         """
+        self._require_cognee("graph scene build")
         from .pipeline import extract_scenes_from_graph
 
         def report(progress: float, task: str):
@@ -1949,6 +2006,7 @@ class CogneeStore:
         on_log: Optional[Callable[[str], None]] = None,
     ) -> List[NovelProp]:
         """从图谱构建道具（分阶段架构第二步）。"""
+        self._require_cognee("graph prop build")
         from .pipeline import extract_props_from_graph
 
         def report(progress: float, task: str):

--- a/src/novelvideo/cognee/tools.py
+++ b/src/novelvideo/cognee/tools.py
@@ -13,6 +13,13 @@ from typing import Callable, List
 from novelvideo.cognee import CogneeStore
 from novelvideo.utils.logging import tool_logger
 
+# Legacy-only AI episode planner.
+# No current frontend workflow selects this mode: the "plan episodes" button
+# posts an empty body (frontend/src/routes/_app/projects.$project/episodes.tsx),
+# so planning_mode falls back to the "chapters" default in api/schemas.py.
+# Reaching this code still requires an explicit planning_mode="ai" from an API
+# client. Structured-v2 projects must not enter this path.
+# These tools all run cognee.search() and therefore require an embedding index.
 def create_episode_planner_tools(store: CogneeStore) -> List[Callable]:
     """创建 EpisodePlanner 的 Cognee 工具集。
 

--- a/src/novelvideo/knowledge_pipeline.py
+++ b/src/novelvideo/knowledge_pipeline.py
@@ -1,0 +1,69 @@
+"""Project-bound knowledge pipeline selection (dual-track).
+
+Two tracks coexist permanently:
+
+``cognee_legacy``
+    Everything created before structured extraction existed.  These projects are
+    bound to a Cognee dataset and an embedding model, and their behaviour must
+    not change.
+
+``structured_v2``
+    Deterministic extraction straight from the imported source text into SQLite.
+    No embedding model, no vector index, no graph search.
+
+The track is a permanent property of a project, chosen at creation time and
+never migrated.  It is stored under ``knowledge_pipeline`` in
+``project_config.json``.
+
+Two rules make the dual track safe:
+
+1. The track is read from the *raw* configuration file, never from the effective
+   configuration.  ``_effective_project_config`` merges
+   ``_default_project_config()`` over the stored values, so a default entry would
+   silently reclassify every legacy project that predates the field.
+
+2. A missing field means ``cognee_legacy``.  Absence of the embedding keys is not
+   a usable signal either: ``ensure_cognee_embedding_binding_in_state_dir``
+   backfills them for legacy projects, so only the explicit
+   ``knowledge_pipeline`` field can be trusted.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+KNOWLEDGE_PIPELINE_KEY = "knowledge_pipeline"
+
+COGNEE_LEGACY = "cognee_legacy"
+STRUCTURED_V2 = "structured_v2"
+
+
+class KnowledgePipelineUnsupported(RuntimeError):
+    """Raised when a project asks for a capability its track does not provide.
+
+    Structured projects must fail loudly here rather than fall back to the
+    Cognee path: a silent fallback would re-bind the project to an embedding
+    model, which is exactly what the second track exists to avoid.
+    """
+
+    error_code = "KNOWLEDGE_PIPELINE_UNSUPPORTED"
+
+
+def knowledge_pipeline_from_state_dir(state_dir: str | Path | None) -> str:
+    """Return the track recorded for a project, defaulting to the legacy one."""
+    if not state_dir:
+        return COGNEE_LEGACY
+
+    from novelvideo.project_config import load_project_config_file_from_state_dir
+
+    raw = load_project_config_file_from_state_dir(state_dir)
+    value = str(raw.get(KNOWLEDGE_PIPELINE_KEY, "") or "").strip()
+    return STRUCTURED_V2 if value == STRUCTURED_V2 else COGNEE_LEGACY
+
+
+def is_structured_v2(state_dir: str | Path | None) -> bool:
+    return knowledge_pipeline_from_state_dir(state_dir) == STRUCTURED_V2
+
+
+def is_cognee_legacy(state_dir: str | Path | None) -> bool:
+    return not is_structured_v2(state_dir)

--- a/tests/test_knowledge_pipeline_dual_track.py
+++ b/tests/test_knowledge_pipeline_dual_track.py
@@ -1,0 +1,232 @@
+"""Dual-track knowledge pipeline boundary.
+
+The contract this file defends:
+
+* legacy projects behave exactly as before, including projects that predate the
+  ``knowledge_pipeline`` field entirely;
+* structured_v2 projects can still use the store as a plain SQLite facade,
+  because most runners and API routes depend on it that way;
+* structured_v2 projects can never reach Cognee, an embedding binding, or the
+  graph — the attempt must raise rather than silently fall back.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from novelvideo.knowledge_pipeline import (
+    COGNEE_LEGACY,
+    KNOWLEDGE_PIPELINE_KEY,
+    KnowledgePipelineUnsupported,
+    STRUCTURED_V2,
+    is_structured_v2,
+    knowledge_pipeline_from_state_dir,
+)
+
+
+def _write_config(state_dir: Path, config: dict) -> None:
+    state_dir.mkdir(parents=True, exist_ok=True)
+    (state_dir / "project_config.json").write_text(
+        json.dumps(config, ensure_ascii=False), encoding="utf-8"
+    )
+
+
+# ── track resolution ─────────────────────────────────────────────────────────
+
+
+def test_missing_config_file_is_legacy(tmp_path):
+    assert knowledge_pipeline_from_state_dir(tmp_path) == COGNEE_LEGACY
+
+
+def test_project_without_the_field_is_legacy(tmp_path):
+    """Projects created before the field existed must not be reclassified."""
+    _write_config(tmp_path, {"user": "someone", "spine_template": "drama"})
+    assert knowledge_pipeline_from_state_dir(tmp_path) == COGNEE_LEGACY
+
+
+def test_embedding_bound_project_is_legacy(tmp_path):
+    _write_config(
+        tmp_path,
+        {
+            "user": "someone",
+            "cognee_embedding_model": "DC-cognee-embedding-v2",
+            "cognee_embedding_dimension": 1024,
+        },
+    )
+    assert knowledge_pipeline_from_state_dir(tmp_path) == COGNEE_LEGACY
+
+
+def test_explicit_structured_field_is_structured(tmp_path):
+    _write_config(tmp_path, {KNOWLEDGE_PIPELINE_KEY: STRUCTURED_V2})
+    assert is_structured_v2(tmp_path)
+
+
+def test_unknown_pipeline_value_falls_back_to_legacy(tmp_path):
+    """An unrecognised value must never be treated as structured."""
+    _write_config(tmp_path, {KNOWLEDGE_PIPELINE_KEY: "something-else"})
+    assert knowledge_pipeline_from_state_dir(tmp_path) == COGNEE_LEGACY
+
+
+def test_absent_embedding_keys_do_not_imply_structured(tmp_path):
+    """Missing embedding keys are not a usable signal.
+
+    ``ensure_cognee_embedding_binding_in_state_dir`` backfills them for legacy
+    projects, so only the explicit field can be trusted.
+    """
+    _write_config(tmp_path, {"user": "someone"})
+    assert not is_structured_v2(tmp_path)
+
+
+def test_default_project_config_does_not_carry_the_field():
+    """The field must never reach a project through the effective-config merge.
+
+    ``_effective_project_config`` merges the defaults over stored values, so a
+    default entry would silently reclassify every legacy project.
+    """
+    from novelvideo.project_config import _default_project_config
+
+    assert KNOWLEDGE_PIPELINE_KEY not in _default_project_config()
+
+
+def test_effective_config_merge_cannot_make_a_legacy_project_structured(tmp_path):
+    from novelvideo.project_config import load_project_config_from_state_dir
+
+    _write_config(tmp_path, {"user": "someone", "spine_template": "drama"})
+    effective = load_project_config_from_state_dir(tmp_path)
+    assert effective.get(KNOWLEDGE_PIPELINE_KEY, COGNEE_LEGACY) == COGNEE_LEGACY
+
+
+# ── store behaviour ──────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def structured_store(tmp_path):
+    from novelvideo.cognee.store import CogneeStore
+
+    state_dir = tmp_path / "user" / "structured"
+    _write_config(state_dir, {KNOWLEDGE_PIPELINE_KEY: STRUCTURED_V2})
+    return CogneeStore(
+        "user/structured",
+        output_dir=str(state_dir),
+        state_dir=str(state_dir),
+    )
+
+
+@pytest.fixture
+def legacy_store(tmp_path):
+    from novelvideo.cognee.store import CogneeStore
+
+    state_dir = tmp_path / "user" / "legacy"
+    _write_config(state_dir, {"user": "user"})
+    return CogneeStore(
+        "user/legacy",
+        output_dir=str(state_dir),
+        state_dir=str(state_dir),
+    )
+
+
+async def test_structured_initialize_never_binds_an_embedding_model(
+    structured_store, monkeypatch
+):
+    """The sentinel: initialize() must not reach any Cognee/embedding entry."""
+    import novelvideo.cognee.store as store_module
+
+    def _boom(*args, **kwargs):
+        raise AssertionError("structured_v2 must not touch Cognee or embeddings")
+
+    monkeypatch.setattr(
+        store_module, "ensure_cognee_embedding_binding_in_state_dir", _boom
+    )
+    monkeypatch.setattr(store_module, "init_cognee", _boom)
+    monkeypatch.setattr(store_module, "setup", _boom)
+
+    try:
+        await structured_store.initialize()
+    finally:
+        await structured_store.close()
+
+
+async def test_structured_initialize_writes_no_embedding_fields(structured_store):
+    from novelvideo.embedding_models import (
+        PROJECT_EMBEDDING_DIMENSION_KEY,
+        PROJECT_EMBEDDING_MODEL_KEY,
+    )
+
+    config_path = Path(structured_store.state_dir) / "project_config.json"
+    try:
+        await structured_store.initialize()
+    finally:
+        await structured_store.close()
+
+    config = json.loads(config_path.read_text(encoding="utf-8"))
+    assert PROJECT_EMBEDDING_MODEL_KEY not in config
+    assert PROJECT_EMBEDDING_DIMENSION_KEY not in config
+    assert config[KNOWLEDGE_PIPELINE_KEY] == STRUCTURED_V2
+
+
+async def test_structured_store_still_works_as_a_sqlite_facade(structured_store):
+    """Runners that only need SQLite must keep working after the default flips.
+
+    Portrait, prop/scene reference, script, sketch, video, verification and the
+    Freezone routes all construct a CogneeStore purely for SQLite access.
+    """
+    from novelvideo.cognee.pipeline import NovelCharacter
+
+    try:
+        await structured_store.initialize()
+        await structured_store.load_graph_state()
+
+        await structured_store.add_character(NovelCharacter(name="林默"))
+        assert structured_store.get_character("林默") is not None
+        assert structured_store.character_count == 1
+
+        structured_store.save_novel_content("正文")
+        assert structured_store.load_novel_content() == "正文"
+    finally:
+        await structured_store.close()
+
+
+@pytest.mark.parametrize(
+    "operation",
+    [
+        "search",
+        "ingest_novel_fast",
+        "build_characters_from_graph",
+        "build_scenes_from_graph",
+        "build_props_from_graph",
+        "get_graph_snapshot",
+        "materialize_graph_preview",
+    ],
+)
+async def test_structured_graph_capabilities_raise(structured_store, operation):
+    try:
+        await structured_store.initialize()
+        with pytest.raises(KnowledgePipelineUnsupported):
+            await getattr(structured_store, operation)("query")
+    finally:
+        await structured_store.close()
+
+
+async def test_structured_embedding_scope_raises(structured_store):
+    """Guarded too: entering the scope is how a binding gets created."""
+    try:
+        await structured_store.initialize()
+        with pytest.raises(KnowledgePipelineUnsupported):
+            structured_store.embedding_model_scope()
+    finally:
+        await structured_store.close()
+
+
+def test_uninitialized_structured_store_is_still_gated(structured_store):
+    """Stores built without initialize() must resolve the track lazily."""
+    with pytest.raises(KnowledgePipelineUnsupported):
+        structured_store.embedding_model_scope()
+
+
+def test_legacy_store_keeps_graph_capabilities(legacy_store):
+    """The gate must be invisible to legacy projects."""
+    assert legacy_store._cognee_enabled
+    legacy_store._require_cognee("graph search")


### PR DESCRIPTION
## Summary

Introduce the `structured_v2` track alongside `cognee_legacy`, so new projects can eventually skip Cognee, embeddings and graph search entirely. **This PR only establishes the boundary — no project default changes yet.** Legacy behaviour is unchanged.

This is PR 1 of 4. Follow-ups: structured ingest (2), structured character/scene builders (3), per-episode planners + default switch (4).

## Track resolution

- New `novelvideo/knowledge_pipeline.py`: `knowledge_pipeline_from_state_dir()` reads the **raw** project config, never the effective one. `_effective_project_config` merges `_default_project_config` over stored values, so a default entry would silently reclassify every legacy project that predates the field.
- A missing field means `cognee_legacy`. Absence of the embedding keys is not a usable signal either, because `ensure_cognee_embedding_binding_in_state_dir` backfills them for legacy projects — only the explicit field can be trusted.

## Why `initialize()` degrades instead of raising

Eight runners (portrait, prop/scene reference, script, sketch, video, verification, director world) plus four route modules via `api/deps` construct a `CogneeStore` **purely for SQLite access** and never touch the graph — `get_character_from_graph` is a SQLite read despite the name. Raising in `initialize()` would take all of them down once the default flips, so structured projects get a plain SQLite facade.

The track is resolved *before* the embedding binding, which would otherwise backfill and persist a binding that can no longer be undone.

## Capability gate

Graph capabilities are gated individually via `_require_cognee`: `search`, `ingest_novel_fast`, the three `build_*_from_graph` paths, `get_graph_snapshot`, `materialize_graph_preview`, and `embedding_model_scope`. The scope is included because entering it is how a binding gets created, so a caller reaching past the public API cannot bind a structured project by accident.

Structured projects fail loudly rather than falling back — a fallback would re-bind the very thing this track exists to avoid.

The ingest graph route short-circuits to an empty preview for structured projects instead of reaching the legacy materialization path, which would open Ladybug for a project that has no graph.

## Legacy-only annotations

`EpisodePlannerAgent`, its cognee search tools, and `extract_episodes_with_characters` are annotated legacy-only. No current frontend workflow selects that mode: the plan-episodes button posts an empty body, so `planning_mode` falls back to the `"chapters"` default in `api/schemas.py`. Reaching it still requires an explicit `planning_mode="ai"` from an API client, so the note says legacy-only rather than unreachable.

## Verification

- `uv run pytest -q` — 2492 passed, 16 skipped, 0 failed
- `tests/test_knowledge_pipeline_dual_track.py` — 21 new tests covering: legacy classification for projects with no field / with embedding keys / with an unknown value; the default-config merge cannot reclassify a legacy project; structured `initialize()` reaches no Cognee or embedding entry point (sentinel monkeypatches) and writes no embedding fields; structured stores still work as a SQLite facade; all seven graph capabilities plus `embedding_model_scope` raise; an uninitialized structured store is still gated; legacy stores keep every capability.
- `uv run ruff check` on changed files — clean

## Impact

No schema migration. No behaviour change for any existing project: every project on disk today resolves to `cognee_legacy`, and no code path creates a `structured_v2` project yet.
