### PR TITLE
feat: add structured_v2 import without graph or embedding

### DIFF
--- a/license-inventory.csv
+++ b/license-inventory.csv
@@ -1644,6 +1644,8 @@ src/novelvideo/sqlite_pragmas.py,Elastic-2.0,2026 SuperTale contributors,REUSE.t
 src/novelvideo/sqlite_schema.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 src/novelvideo/sqlite_store.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 src/novelvideo/stage_asset_tasks.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
+src/novelvideo/story_analysis.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
+src/novelvideo/structured_ingest.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 src/novelvideo/storage/__init__.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 src/novelvideo/storage/media_relay.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 src/novelvideo/styles/presets/STYLE_DESIGN.md,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
@@ -2050,6 +2052,7 @@ tests/test_stage_asset_scene_360_credit.py,Elastic-2.0,2026 SuperTale contributo
 tests/test_stage_asset_scene_360_provider.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_stage_asset_step_contract.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_storyboard_prompt_visual_authority.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
+tests/test_structured_ingest.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_style_template_manifest.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_superpower_model_config.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_task_backend_celery_metadata.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation

--- a/license-inventory.csv
+++ b/license-inventory.csv
@@ -1551,6 +1551,7 @@ src/novelvideo/generators/wan2-2-I2V-LightX2V.json,Elastic-2.0,2026 SuperTale co
 src/novelvideo/graph_preview.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 src/novelvideo/image_request_usage.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 src/novelvideo/identity_prerequisites.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
+src/novelvideo/knowledge_pipeline.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 src/novelvideo/llm_instrumentation.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 src/novelvideo/manual_shots.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 src/novelvideo/media_model_request_schema.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
@@ -1952,6 +1953,7 @@ tests/test_indextts2_beat_audio_task.py,Elastic-2.0,2026 SuperTale contributors,
 tests/test_indextts2_fal.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_indextts2_fal_smoke.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_ingest_progress.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
+tests/test_knowledge_pipeline_dual_track.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_literal_script_writing_audio_type.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_llm_instrumentation_logging.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_m10_final_gate.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation

--- a/src/novelvideo/agents/episode_planner.py
+++ b/src/novelvideo/agents/episode_planner.py
@@ -181,6 +181,12 @@ def create_episode_planner_agent(tools: List[Callable]) -> Agent:
 # =============================================================================
 
 
+# Legacy-only AI episode planner.
+# No current frontend workflow selects this mode: the "plan episodes" button
+# posts an empty body (frontend/src/routes/_app/projects.$project/episodes.tsx),
+# so planning_mode falls back to the "chapters" default in api/schemas.py.
+# Reaching this code still requires an explicit planning_mode="ai" from an API
+# client. Structured-v2 projects must not enter this path.
 class EpisodePlannerAgent:
     """剧集规划 Agent - 使用图谱搜索进行多轮迭代式规划。
 

--- a/src/novelvideo/api/routes/episodes.py
+++ b/src/novelvideo/api/routes/episodes.py
@@ -27,6 +27,10 @@ from novelvideo.identity_prerequisites import (
     identity_prerequisite_response,
     require_identity_characters,
 )
+from novelvideo.knowledge_pipeline import (
+    KnowledgePipelineUnsupported,
+    is_structured_v2,
+)
 from novelvideo.ports import get_task_backend, get_usage_meter
 from novelvideo.project_config import load_project_config_file_from_state_dir
 from novelvideo.task_identity import project_task_state_key
@@ -271,6 +275,15 @@ async def plan_episodes(project: str, body: EpisodePlanRequest, user: dict = Dep
     if ctx is not None:
         if not has_imported_novel(resolved.project_dir):
             return novel_import_required_response()
+        # The AI planners read the Cognee graph, which structured_v2 projects do
+        # not have. Reject before enqueue so the user gets an answer instead of
+        # a task that is guaranteed to fail after reserving credit.
+        if is_structured_v2(state_dir) and body.planning_mode != "chapters":
+            return {
+                "ok": False,
+                "code": KnowledgePipelineUnsupported.error_code,
+                "error": "该项目只支持按章节/集号的确定性分集",
+            }
         queued = await get_task_backend().enqueue_project_task(
             ctx,
             product_surface="mainline",

--- a/src/novelvideo/api/routes/ingest.py
+++ b/src/novelvideo/api/routes/ingest.py
@@ -20,6 +20,7 @@ from novelvideo.api.chapter_preview import (
 from novelvideo.api.deps import make_cognee_store_for_context, resolve_project_scope
 from novelvideo.api.schemas import IngestStart
 from novelvideo.cognee.ladybug_access import ladybug_graph_access
+from novelvideo.knowledge_pipeline import is_structured_v2
 from novelvideo.graph_preview import (
     empty_graph_preview,
     load_graph_preview,
@@ -66,6 +67,13 @@ async def get_ingest_knowledge_graph(
     # returning a stale sidecar or opening its embedded graph database from an
     # API worker.
     if not (ctx.output_dir / "novel.txt").is_file():
+        return {"ok": True, "data": empty_graph_preview()}
+
+    # structured_v2 projects never build a graph. Return the empty preview
+    # rather than reaching the legacy materialization path below, which would
+    # open Ladybug and construct a Cognee-backed store for a project that has
+    # neither.
+    if is_structured_v2(ctx.state_dir):
         return {"ok": True, "data": empty_graph_preview()}
 
     snapshot = load_graph_preview(ctx.state_dir)

--- a/src/novelvideo/cognee/pipeline.py
+++ b/src/novelvideo/cognee/pipeline.py
@@ -508,6 +508,9 @@ async def extract_characters_from_graph(
 # ============================================================
 
 
+# Legacy-only: reached from build_episodes(), which runs only when
+# planning_mode="ai". No current frontend workflow selects that mode.
+# Structured-v2 projects must not enter this path.
 async def extract_episodes_with_characters(
     text: str,
     target_episodes: int = 10,

--- a/src/novelvideo/cognee/store.py
+++ b/src/novelvideo/cognee/store.py
@@ -35,6 +35,10 @@ from novelvideo.graph_preview import (
     delete_graph_preview,
     write_graph_preview,
 )
+from novelvideo.knowledge_pipeline import (
+    KnowledgePipelineUnsupported,
+    is_structured_v2,
+)
 from novelvideo.official_defaults import DEFAULT_COGNEE_LLM_MODEL
 from novelvideo.novel_source import require_imported_novel
 from novelvideo.project_config import ensure_cognee_embedding_binding_in_state_dir
@@ -286,7 +290,36 @@ class CogneeStore:
         """统一别名查找键，降低空格/大小写差异导致的失配。"""
         return " ".join((value or "").replace("\u3000", " ").strip().lower().split())
 
+    @property
+    def _cognee_enabled(self) -> bool:
+        """Whether this project may touch Cognee, embeddings or the graph.
+
+        Resolved lazily from the project's recorded track so that stores built
+        without ``initialize()`` (legacy tests, ad-hoc scripts) are gated too.
+        ``initialize()`` overwrites the cached value once it has decided.
+        """
+        cached = self.__dict__.get("_cognee_enabled_flag")
+        if cached is None:
+            cached = not is_structured_v2(self.__dict__.get("state_dir"))
+            self.__dict__["_cognee_enabled_flag"] = cached
+        return cached
+
+    def _require_cognee(self, operation: str) -> None:
+        """Fail loudly instead of silently falling back to the Cognee path.
+
+        A fallback here would bind a structured project to an embedding model,
+        which is the one outcome the second track exists to prevent.
+        """
+        if not self._cognee_enabled:
+            raise KnowledgePipelineUnsupported(
+                f"{operation} is unavailable for structured_v2 projects"
+            )
+
     def embedding_model_scope(self):
+        # Guarded as well as the public graph methods: entering the scope is how
+        # an embedding binding gets created, so a caller reaching past the public
+        # API must not be able to bind a structured project by accident.
+        self._require_cognee("embedding model scope")
         model = getattr(self, "cognee_embedding_model", None)
         dimensions = getattr(self, "cognee_embedding_dimensions", None)
         if not model or dimensions is None:
@@ -445,7 +478,25 @@ class CogneeStore:
         return await store._ensure_db()
 
     async def initialize(self):
-        """初始化 SQLite 数据库和 Cognee 配置。"""
+        """初始化 SQLite 数据库和 Cognee 配置。
+
+        structured_v2 项目降级为纯 SQLite 门面而不是抛异常：生产中有大量
+        runner 和 API 依赖（肖像、参考图、剧本、分镜、视频、Freezone 等）只把
+        本类当 SQLite 门面使用，完全不需要图谱。在这里硬失败会让这些路径在
+        新项目上全线 500。图谱能力本身由 ``_require_cognee`` 单独把守。
+        """
+        # 必须先判定 track，再决定是否绑定 embedding：
+        # ensure_cognee_embedding_binding_in_state_dir() 会为缺字段的项目回填
+        # 绑定并写回 project_config.json，一旦调用就再也退不回去了。
+        if is_structured_v2(self.state_dir):
+            self.__dict__["_cognee_enabled_flag"] = False
+            await self._ensure_db()
+            console.print(
+                f"[dim]存储层已初始化 (structured_v2, 无图谱, db: {self.db_path})[/dim]"
+            )
+            return
+
+        self.__dict__["_cognee_enabled_flag"] = True
         embedding_binding = ensure_cognee_embedding_binding_in_state_dir(self.state_dir)
         self.cognee_embedding_model = embedding_binding.internal_model
         self.cognee_embedding_dimensions = embedding_binding.dimensions
@@ -537,6 +588,7 @@ class CogneeStore:
         on_log: Optional[Callable[[str], None]] = None,
     ) -> dict:
         """快速导入，并独占当前项目的 Cognee/Ladybug 图谱。"""
+        self._require_cognee("Cognee graph ingest")
         async with ladybug_graph_access(self.state_dir, read_only=False):
             return await self._ingest_novel_fast_locked(
                 novel_path,
@@ -668,6 +720,7 @@ class CogneeStore:
         }
 
     async def materialize_graph_preview(self, max_nodes: int = 48) -> dict:
+        self._require_cognee("graph preview")
         async with ladybug_graph_access(self.state_dir, read_only=True):
             snapshot = await self.get_graph_snapshot(max_nodes=max_nodes)
             if not snapshot.get("nodes"):
@@ -684,6 +737,7 @@ class CogneeStore:
         oversized or vector-shaped values before returning them to the browser.
         """
 
+        self._require_cognee("graph snapshot")
         max_nodes = max(20, min(int(max_nodes), 80))
         max_edges = min(max_nodes * 3, 160)
         raw_nodes, raw_edges = await self._get_dataset_graph_data(
@@ -929,6 +983,7 @@ class CogneeStore:
         图谱构建只负责发现缺失的基础角色。已有角色可能已经有用户编辑、
         身份图、声线和资产配置，不能被一次图谱重扫覆盖。
         """
+        self._require_cognee("graph character build")
         from .pipeline import extract_characters_from_graph
 
         def report(progress: float, task: str):
@@ -1561,6 +1616,7 @@ class CogneeStore:
 
     async def search(self, query: str, mode: str = "graph", top_k: int = 10) -> str:
         """语义检索。"""
+        self._require_cognee("graph search")
         async with ladybug_graph_access(self.state_dir, read_only=True):
             with preserve_st_env():
                 from cognee.modules.data.exceptions.exceptions import DatasetNotFoundError
@@ -1891,6 +1947,7 @@ class CogneeStore:
         这里只补缺失的基础场景；已有基础场景和派生 plate 都是资产事实，
         不能被一次图谱重扫清空或覆盖。
         """
+        self._require_cognee("graph scene build")
         from .pipeline import extract_scenes_from_graph
 
         def report(progress: float, task: str):
@@ -1949,6 +2006,7 @@ class CogneeStore:
         on_log: Optional[Callable[[str], None]] = None,
     ) -> List[NovelProp]:
         """从图谱构建道具（分阶段架构第二步）。"""
+        self._require_cognee("graph prop build")
         from .pipeline import extract_props_from_graph
 
         def report(progress: float, task: str):

--- a/src/novelvideo/cognee/tools.py
+++ b/src/novelvideo/cognee/tools.py
@@ -13,6 +13,13 @@ from typing import Callable, List
 from novelvideo.cognee import CogneeStore
 from novelvideo.utils.logging import tool_logger
 
+# Legacy-only AI episode planner.
+# No current frontend workflow selects this mode: the "plan episodes" button
+# posts an empty body (frontend/src/routes/_app/projects.$project/episodes.tsx),
+# so planning_mode falls back to the "chapters" default in api/schemas.py.
+# Reaching this code still requires an explicit planning_mode="ai" from an API
+# client. Structured-v2 projects must not enter this path.
+# These tools all run cognee.search() and therefore require an embedding index.
 def create_episode_planner_tools(store: CogneeStore) -> List[Callable]:
     """创建 EpisodePlanner 的 Cognee 工具集。
 

--- a/src/novelvideo/knowledge_pipeline.py
+++ b/src/novelvideo/knowledge_pipeline.py
@@ -1,0 +1,69 @@
+"""Project-bound knowledge pipeline selection (dual-track).
+
+Two tracks coexist permanently:
+
+``cognee_legacy``
+    Everything created before structured extraction existed.  These projects are
+    bound to a Cognee dataset and an embedding model, and their behaviour must
+    not change.
+
+``structured_v2``
+    Deterministic extraction straight from the imported source text into SQLite.
+    No embedding model, no vector index, no graph search.
+
+The track is a permanent property of a project, chosen at creation time and
+never migrated.  It is stored under ``knowledge_pipeline`` in
+``project_config.json``.
+
+Two rules make the dual track safe:
+
+1. The track is read from the *raw* configuration file, never from the effective
+   configuration.  ``_effective_project_config`` merges
+   ``_default_project_config()`` over the stored values, so a default entry would
+   silently reclassify every legacy project that predates the field.
+
+2. A missing field means ``cognee_legacy``.  Absence of the embedding keys is not
+   a usable signal either: ``ensure_cognee_embedding_binding_in_state_dir``
+   backfills them for legacy projects, so only the explicit
+   ``knowledge_pipeline`` field can be trusted.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+KNOWLEDGE_PIPELINE_KEY = "knowledge_pipeline"
+
+COGNEE_LEGACY = "cognee_legacy"
+STRUCTURED_V2 = "structured_v2"
+
+
+class KnowledgePipelineUnsupported(RuntimeError):
+    """Raised when a project asks for a capability its track does not provide.
+
+    Structured projects must fail loudly here rather than fall back to the
+    Cognee path: a silent fallback would re-bind the project to an embedding
+    model, which is exactly what the second track exists to avoid.
+    """
+
+    error_code = "KNOWLEDGE_PIPELINE_UNSUPPORTED"
+
+
+def knowledge_pipeline_from_state_dir(state_dir: str | Path | None) -> str:
+    """Return the track recorded for a project, defaulting to the legacy one."""
+    if not state_dir:
+        return COGNEE_LEGACY
+
+    from novelvideo.project_config import load_project_config_file_from_state_dir
+
+    raw = load_project_config_file_from_state_dir(state_dir)
+    value = str(raw.get(KNOWLEDGE_PIPELINE_KEY, "") or "").strip()
+    return STRUCTURED_V2 if value == STRUCTURED_V2 else COGNEE_LEGACY
+
+
+def is_structured_v2(state_dir: str | Path | None) -> bool:
+    return knowledge_pipeline_from_state_dir(state_dir) == STRUCTURED_V2
+
+
+def is_cognee_legacy(state_dir: str | Path | None) -> bool:
+    return not is_structured_v2(state_dir)

--- a/src/novelvideo/sqlite_store.py
+++ b/src/novelvideo/sqlite_store.py
@@ -295,13 +295,69 @@ CREATE TABLE IF NOT EXISTS seedance2_voice_audio_records (
 );
 CREATE INDEX IF NOT EXISTS idx_seedance2_voice_audio_speaker
     ON seedance2_voice_audio_records(episode_number, speaker);
+
+-- structured_v2 analysis bookkeeping.
+--
+-- A run is keyed by what it analysed (source_sha256) and how (schema_version),
+-- so re-importing identical text reuses completed chunks and only failed or
+-- stale ones are recomputed. Chunks store source offsets rather than a copy of
+-- the text: duplicating a whole novel per run would dwarf the rest of the
+-- project database.
+CREATE TABLE IF NOT EXISTS story_analysis_runs (
+    run_id            TEXT PRIMARY KEY,
+    pipeline_version  TEXT NOT NULL,
+    schema_version    INTEGER NOT NULL DEFAULT 1,
+    spine_template    TEXT NOT NULL DEFAULT '',
+    source_sha256     TEXT NOT NULL,
+    source_length     INTEGER NOT NULL DEFAULT 0,
+    status            TEXT NOT NULL DEFAULT 'pending',
+    error             TEXT NOT NULL DEFAULT '',
+    created_at        TEXT DEFAULT (datetime('now')),
+    completed_at      TEXT DEFAULT ''
+);
+CREATE INDEX IF NOT EXISTS idx_story_analysis_runs_source
+    ON story_analysis_runs(source_sha256, schema_version);
+
+CREATE TABLE IF NOT EXISTS story_analysis_chunks (
+    run_id            TEXT NOT NULL,
+    chunk_id          TEXT NOT NULL,
+    chunk_index       INTEGER NOT NULL DEFAULT 0,
+    section_type      TEXT NOT NULL DEFAULT '',
+    section_label     TEXT NOT NULL DEFAULT '',
+    source_start      INTEGER NOT NULL DEFAULT 0,
+    source_end        INTEGER NOT NULL DEFAULT 0,
+    source_hash       TEXT NOT NULL DEFAULT '',
+    status            TEXT NOT NULL DEFAULT 'pending',
+    attempts          INTEGER NOT NULL DEFAULT 0,
+    error             TEXT NOT NULL DEFAULT '',
+    result_json       TEXT NOT NULL DEFAULT '{}',
+    PRIMARY KEY (run_id, chunk_id)
+);
+CREATE INDEX IF NOT EXISTS idx_story_analysis_chunks_status
+    ON story_analysis_chunks(run_id, status);
+
+-- Every structured entity keeps at least one span of real source text, so a
+-- character or scene can always be traced back to what produced it.
+CREATE TABLE IF NOT EXISTS entity_evidence (
+    run_id            TEXT NOT NULL,
+    entity_type       TEXT NOT NULL,
+    entity_id         TEXT NOT NULL,
+    chunk_id          TEXT NOT NULL,
+    source_start      INTEGER NOT NULL,
+    source_end        INTEGER NOT NULL,
+    evidence_kind     TEXT NOT NULL DEFAULT '',
+    evidence_text     TEXT NOT NULL DEFAULT '',
+    PRIMARY KEY (run_id, entity_type, entity_id, chunk_id, source_start, source_end)
+);
+CREATE INDEX IF NOT EXISTS idx_entity_evidence_entity
+    ON entity_evidence(entity_type, entity_id);
 """
 
 _PROJECT_STORE_SCHEMA_COMPONENT = "project_store"
 # MIGRATION CONTRACT: increment this whenever SQLITE_SCHEMA_SQL or any
 # _ensure_*_columns migration above changes. Existing databases skip the
 # initializer after this version has been recorded.
-_PROJECT_STORE_SCHEMA_VERSION = 1
+_PROJECT_STORE_SCHEMA_VERSION = 2
 
 
 def _table_columns(db: sqlite3.Connection, table: str) -> set[str]:
@@ -2257,6 +2313,197 @@ class SQLiteStore:
         cursor = await db.execute("DELETE FROM scenes")
         await db.commit()
         return cursor.rowcount or 0
+
+    # ============================================================
+    # structured_v2 分析 run / chunk / 证据
+    # ============================================================
+
+    async def get_reusable_analysis_run(
+        self,
+        *,
+        source_sha256: str,
+        schema_version: int,
+        pipeline_version: str,
+    ) -> dict | None:
+        """Find a run that analysed identical text with identical code.
+
+        Reuse is keyed on all three: different source text or a changed
+        extraction contract must not inherit another run's chunk results.
+        """
+        db = await self._ensure_db()
+        async with db.execute(
+            """SELECT * FROM story_analysis_runs
+               WHERE source_sha256 = ? AND schema_version = ?
+                 AND pipeline_version = ?
+               ORDER BY created_at DESC LIMIT 1""",
+            (source_sha256, int(schema_version), pipeline_version),
+        ) as cursor:
+            row = await cursor.fetchone()
+        return dict(row) if row else None
+
+    async def start_analysis_run(
+        self,
+        *,
+        run_id: str,
+        pipeline_version: str,
+        schema_version: int,
+        spine_template: str,
+        source_sha256: str,
+        source_length: int,
+        chunks: list,
+    ) -> None:
+        """Record a run and its chunk plan in one transaction.
+
+        A half-written plan would let a resume believe chunks are missing rather
+        than pending, so the run row and every chunk land together.
+        """
+        db = await self._ensure_db()
+        try:
+            await db.execute("BEGIN")
+            await db.execute(
+                """INSERT OR REPLACE INTO story_analysis_runs
+                   (run_id, pipeline_version, schema_version, spine_template,
+                    source_sha256, source_length, status, error, completed_at)
+                   VALUES (?, ?, ?, ?, ?, ?, 'pending', '', '')""",
+                (
+                    run_id,
+                    pipeline_version,
+                    int(schema_version),
+                    spine_template,
+                    source_sha256,
+                    int(source_length),
+                ),
+            )
+            await db.execute(
+                "DELETE FROM story_analysis_chunks WHERE run_id = ?", (run_id,)
+            )
+            await db.executemany(
+                """INSERT INTO story_analysis_chunks
+                   (run_id, chunk_id, chunk_index, section_type, section_label,
+                    source_start, source_end, source_hash, status)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'pending')""",
+                [
+                    (
+                        run_id,
+                        chunk.chunk_id,
+                        int(chunk.chunk_index),
+                        chunk.section_type,
+                        chunk.section_label,
+                        int(chunk.source_start),
+                        int(chunk.source_end),
+                        chunk.source_hash,
+                    )
+                    for chunk in chunks
+                ],
+            )
+            await db.commit()
+        except Exception:
+            await db.rollback()
+            raise
+
+    async def list_analysis_chunks(
+        self, run_id: str, *, status: str | None = None
+    ) -> list[dict]:
+        db = await self._ensure_db()
+        sql = "SELECT * FROM story_analysis_chunks WHERE run_id = ?"
+        params: list = [run_id]
+        if status:
+            sql += " AND status = ?"
+            params.append(status)
+        sql += " ORDER BY chunk_index"
+        async with db.execute(sql, params) as cursor:
+            rows = await cursor.fetchall()
+        return [dict(row) for row in rows]
+
+    async def mark_analysis_chunk_done(
+        self, run_id: str, chunk_id: str, result_json: str
+    ) -> None:
+        db = await self._ensure_db()
+        await db.execute(
+            """UPDATE story_analysis_chunks
+               SET status = 'done', error = '', result_json = ?,
+                   attempts = attempts + 1
+               WHERE run_id = ? AND chunk_id = ?""",
+            (result_json, run_id, chunk_id),
+        )
+        await db.commit()
+
+    async def mark_analysis_chunk_failed(
+        self, run_id: str, chunk_id: str, error: str
+    ) -> None:
+        db = await self._ensure_db()
+        await db.execute(
+            """UPDATE story_analysis_chunks
+               SET status = 'failed', error = ?, attempts = attempts + 1
+               WHERE run_id = ? AND chunk_id = ?""",
+            (str(error)[:2000], run_id, chunk_id),
+        )
+        await db.commit()
+
+    async def finish_analysis_run(
+        self, run_id: str, *, status: str, error: str = ""
+    ) -> None:
+        db = await self._ensure_db()
+        await db.execute(
+            """UPDATE story_analysis_runs
+               SET status = ?, error = ?, completed_at = datetime('now')
+               WHERE run_id = ?""",
+            (status, str(error)[:2000], run_id),
+        )
+        await db.commit()
+
+    async def replace_entity_evidence(
+        self, run_id: str, entity_type: str, entity_id: str, evidence: list[dict]
+    ) -> None:
+        """Rewrite one entity's evidence for a run.
+
+        Replacing rather than appending keeps a re-run of the same chunk from
+        accumulating duplicate spans for the same entity.
+        """
+        db = await self._ensure_db()
+        try:
+            await db.execute("BEGIN")
+            await db.execute(
+                """DELETE FROM entity_evidence
+                   WHERE run_id = ? AND entity_type = ? AND entity_id = ?""",
+                (run_id, entity_type, entity_id),
+            )
+            await db.executemany(
+                """INSERT OR REPLACE INTO entity_evidence
+                   (run_id, entity_type, entity_id, chunk_id, source_start,
+                    source_end, evidence_kind, evidence_text)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+                [
+                    (
+                        run_id,
+                        entity_type,
+                        entity_id,
+                        str(item.get("chunk_id", "")),
+                        int(item.get("source_start", 0)),
+                        int(item.get("source_end", 0)),
+                        str(item.get("evidence_kind", "")),
+                        str(item.get("evidence_text", "")),
+                    )
+                    for item in evidence
+                ],
+            )
+            await db.commit()
+        except Exception:
+            await db.rollback()
+            raise
+
+    async def list_entity_evidence(
+        self, entity_type: str, entity_id: str
+    ) -> list[dict]:
+        db = await self._ensure_db()
+        async with db.execute(
+            """SELECT * FROM entity_evidence
+               WHERE entity_type = ? AND entity_id = ?
+               ORDER BY chunk_id, source_start""",
+            (entity_type, entity_id),
+        ) as cursor:
+            rows = await cursor.fetchall()
+        return [dict(row) for row in rows]
 
     async def delete_all_props(self) -> int:
         """删除所有道具。"""

--- a/src/novelvideo/story_analysis.py
+++ b/src/novelvideo/story_analysis.py
@@ -1,0 +1,196 @@
+"""Deterministic source-text chunking for the structured_v2 pipeline.
+
+Structured extraction never hands a whole novel or screenplay to one model
+call.  It splits the imported text along boundaries the format already provides
+— scene headings for screenplays, chapter markers for prose — and analyses each
+piece independently so that work is bounded, parallelisable and resumable.
+
+Every chunk carries the character offsets it came from.  That is what lets a
+later extraction prove an entity is real: the evidence it reports has to appear
+inside the span it claims, in the imported text, or the candidate is dropped.
+
+Offsets are recovered without changing the shared parsers.  ``parse_scene_blocks``
+runs on stripped, blank-filtered lines and cannot report positions in the
+original text, and it is used by asset compilation, screenplay normalization and
+import quality checks — so instead of altering it, scene headers are located by
+scanning forward from the previous block's end.  Blocks come back in source
+order, so a forward-only scan cannot match an earlier occurrence.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass, field
+from typing import Literal
+
+SectionType = Literal["scene", "chapter", "window"]
+
+# Prose without any chapter marker still has to be analysed. Windows are large
+# enough to carry context across a conversation but small enough to stay well
+# inside a model's useful attention span.
+_WINDOW_CHARS = 6000
+_WINDOW_OVERLAP = 200
+
+
+@dataclass(frozen=True)
+class SourceChunk:
+    """One analysable span of the imported text."""
+
+    chunk_id: str
+    chunk_index: int
+    section_type: SectionType
+    section_label: str
+    source_start: int
+    source_end: int
+    text: str
+    characters: list[str] = field(default_factory=list)
+
+    @property
+    def source_hash(self) -> str:
+        return hashlib.sha256(self.text.encode("utf-8")).hexdigest()
+
+
+def source_sha256(text: str) -> str:
+    return hashlib.sha256((text or "").encode("utf-8")).hexdigest()
+
+
+def chunk_source_text(text: str, spine_template: str | None) -> list[SourceChunk]:
+    """Split imported text along the boundaries its format already provides.
+
+    Screenplays are cut at scene headings, prose at chapter markers.  Either may
+    fall through to fixed windows when the expected markers are absent, so that
+    a malformed import still produces analysable chunks instead of nothing.
+    """
+    if not (text or "").strip():
+        return []
+
+    if str(spine_template or "").strip() == "drama":
+        chunks = _chunk_by_scene(text)
+    else:
+        chunks = _chunk_by_chapter(text)
+
+    return chunks or _chunk_by_window(text)
+
+
+def _chunk_by_scene(text: str) -> list[SourceChunk]:
+    from novelvideo.utils.screenplay_scene_parser import parse_scene_blocks
+
+    blocks = parse_scene_blocks(text)
+    if not blocks:
+        return []
+
+    starts: list[int] = []
+    cursor = 0
+    for block in blocks:
+        anchor = (block.header_line or "").strip()
+        if not anchor:
+            anchor = next((line for line in block.lines if line.strip()), "").strip()
+
+        found = text.find(anchor, cursor) if anchor else -1
+        if found < 0:
+            # An anchor that cannot be located (the parser rewrote it, or the
+            # same heading was consumed earlier) must not silently swallow the
+            # preceding block: start where the previous one ended instead.
+            found = cursor
+        starts.append(found)
+        cursor = found + max(len(anchor), 1)
+
+    chunks: list[SourceChunk] = []
+    for index, block in enumerate(blocks):
+        start = starts[index]
+        end = starts[index + 1] if index + 1 < len(starts) else len(text)
+        if end <= start:
+            continue
+        label = block.header_line.strip() or block.location.strip() or f"场 {index + 1}"
+        chunks.append(
+            SourceChunk(
+                chunk_id=f"scene-{index:04d}",
+                chunk_index=index,
+                section_type="scene",
+                section_label=label,
+                source_start=start,
+                source_end=end,
+                text=text[start:end],
+                characters=list(block.characters),
+            )
+        )
+    return chunks
+
+
+def _chunk_by_chapter(text: str) -> list[SourceChunk]:
+    from novelvideo.cognee.chapter_detector import ChapterDetector
+
+    # A marker-less novel comes back as one synthesized chapter covering the
+    # whole text. Accepting it would defeat the point of chunking, and its
+    # content is rewritten by the detector's fallback preparation, so the
+    # offsets would not match the source either. Let the window path take over.
+    chapters = [
+        chapter
+        for chapter in ChapterDetector().detect(text)
+        if not getattr(chapter, "is_fallback", False)
+    ]
+    if not chapters:
+        return []
+
+    # ChapterDetector splits on "\n" without dropping blank lines, so line
+    # indices map back to character offsets exactly.
+    lines = text.split("\n")
+    line_offsets: list[int] = []
+    running = 0
+    for line in lines:
+        line_offsets.append(running)
+        running += len(line) + 1
+    line_offsets.append(len(text))
+
+    def offset_of(line_index: int) -> int:
+        clamped = max(0, min(int(line_index), len(line_offsets) - 1))
+        return line_offsets[clamped]
+
+    chunks: list[SourceChunk] = []
+    for index, chapter in enumerate(chapters):
+        start = offset_of(chapter.start_line)
+        end = min(offset_of(chapter.end_line), len(text))
+        if end <= start:
+            continue
+        chunks.append(
+            SourceChunk(
+                chunk_id=f"chapter-{index:04d}",
+                chunk_index=index,
+                section_type="chapter",
+                section_label=f"第{chapter.number}章",
+                source_start=start,
+                source_end=end,
+                text=text[start:end],
+            )
+        )
+    return chunks
+
+
+def _chunk_by_window(text: str) -> list[SourceChunk]:
+    """Fall back to overlapping fixed windows when no markers were found.
+
+    The overlap keeps an entity introduced right at a boundary from being cut in
+    half and missed by both neighbours.
+    """
+    chunks: list[SourceChunk] = []
+    start = 0
+    index = 0
+    length = len(text)
+    while start < length:
+        end = min(start + _WINDOW_CHARS, length)
+        chunks.append(
+            SourceChunk(
+                chunk_id=f"window-{index:04d}",
+                chunk_index=index,
+                section_type="window",
+                section_label=f"片段 {index + 1}",
+                source_start=start,
+                source_end=end,
+                text=text[start:end],
+            )
+        )
+        if end >= length:
+            break
+        start = end - _WINDOW_OVERLAP
+        index += 1
+    return chunks

--- a/src/novelvideo/structured_ingest.py
+++ b/src/novelvideo/structured_ingest.py
@@ -1,0 +1,124 @@
+"""Import for structured_v2 projects: no graph, no embedding, no vector index.
+
+The legacy import spends most of its wall clock inside ``cognee.add`` /
+``cognify`` / ``memify``, and every one of those calls goes through the shared
+embedding model.  Structured projects need none of it: extraction reads the
+source text directly, so import reduces to validating the upload, persisting it,
+and recording a deterministic chunk plan for later analysis.
+
+The validation order matches the legacy path deliberately, including the rule
+that ``novel.txt`` is written last.  That file is the public "import succeeded"
+marker: several routes treat its presence as proof the project is importable,
+so it must not appear while the import can still fail.
+"""
+
+from __future__ import annotations
+
+import uuid
+from pathlib import Path
+from typing import Any, Callable, Optional
+
+from novelvideo.story_analysis import chunk_source_text, source_sha256
+from novelvideo.utils.document_parsers import load_novel_text
+
+# Bump when the chunking contract changes in a way that invalidates stored
+# chunk results. Runs are reused only when text, schema and pipeline all match.
+STRUCTURED_PIPELINE_VERSION = "structured_v2.1"
+STRUCTURED_SCHEMA_VERSION = 1
+
+_PROGRESS = {
+    "read": 0.05,
+    "validated": 0.25,
+    "chunked": 0.60,
+    "planned": 0.85,
+    "save": 0.95,
+    "complete": 1.0,
+}
+
+
+async def ingest_source_text_structured(
+    store: Any,
+    novel_path: str,
+    *,
+    spine_template: str | None = None,
+    on_progress: Optional[Callable[[float, str], None]] = None,
+    on_log: Optional[Callable[[str], None]] = None,
+) -> dict:
+    """Validate, chunk and persist an import without building any graph.
+
+    ``store`` is a SQLiteStore (or anything exposing the same content and
+    analysis-run methods).
+    """
+
+    def report(progress: float, task: str) -> None:
+        if on_progress:
+            on_progress(progress, task)
+
+    def log(message: str) -> None:
+        if on_log:
+            on_log(message)
+
+    if not Path(novel_path).exists():
+        raise FileNotFoundError(f"文件不存在: {novel_path}")
+
+    report(_PROGRESS["read"], "读取并校验原文...")
+    log(f"读取文件: {novel_path}")
+    content = load_novel_text(novel_path)
+    if not content.strip():
+        raise ValueError("小说内容为空，无法导入")
+    log(f"文件读取完成: {len(content)} 字符")
+
+    template = str(spine_template or "").strip()
+    if template == "drama":
+        from novelvideo.utils.screenplay_quality import assess_screenplay_scene_headers
+
+        if assess_screenplay_scene_headers(content).status == "missing":
+            raise ValueError("精品剧必须包含场景头，请补充后重新导入")
+    report(_PROGRESS["validated"], "原文校验完成")
+
+    report(_PROGRESS["chunked"], "切分原文...")
+    chunks = chunk_source_text(content, template)
+    if not chunks:
+        raise ValueError("原文切分结果为空，无法分析")
+    section_type = chunks[0].section_type
+    log(f"确定性切分完成: {len(chunks)} 个片段（{section_type}）")
+
+    report(_PROGRESS["planned"], "记录分析计划...")
+    digest = source_sha256(content)
+    reused = await store.get_reusable_analysis_run(
+        source_sha256=digest,
+        schema_version=STRUCTURED_SCHEMA_VERSION,
+        pipeline_version=STRUCTURED_PIPELINE_VERSION,
+    )
+    if reused:
+        # Identical text analysed by identical code: keep the existing run so a
+        # re-import resumes its completed chunks instead of discarding them.
+        run_id = str(reused["run_id"])
+        log(f"复用已有分析计划: {run_id}")
+    else:
+        run_id = uuid.uuid4().hex
+        await store.start_analysis_run(
+            run_id=run_id,
+            pipeline_version=STRUCTURED_PIPELINE_VERSION,
+            schema_version=STRUCTURED_SCHEMA_VERSION,
+            spine_template=template,
+            source_sha256=digest,
+            source_length=len(content),
+            chunks=chunks,
+        )
+        log(f"分析计划已记录: {run_id}")
+
+    # novel.txt is the public success marker and therefore lands last.
+    report(_PROGRESS["save"], "保存导入结果...")
+    store.save_novel_content(content)
+    log("原文已保存")
+
+    report(_PROGRESS["complete"], "导入完成")
+    return {
+        "char_count": len(content),
+        "status": "source_ready",
+        "pipeline": "structured_v2",
+        "run_id": run_id,
+        "chunks": len(chunks),
+        "section_type": section_type,
+    }

--- a/src/novelvideo/task_backend/runners/graph_build.py
+++ b/src/novelvideo/task_backend/runners/graph_build.py
@@ -7,6 +7,10 @@ from typing import Any
 
 from novelvideo.model_gateway_runtime import model_gateway_scope_for_runner
 from novelvideo.novel_source import require_imported_novel
+from novelvideo.knowledge_pipeline import (
+    KnowledgePipelineUnsupported,
+    is_structured_v2,
+)
 from novelvideo.project_context import ProjectContext
 from novelvideo.task_backend.cancel import await_envelope_with_cancel_watch
 from novelvideo.task_backend.registry import register_project_task_runner
@@ -132,6 +136,13 @@ async def _run_build_episodes(
     planning_mode = str(config.get("planning_mode", "ai"))
     generate_metadata = bool(config.get("generate_metadata", False))
     require_imported_novel(ctx.output_dir)
+    # Defence in depth: the route rejects AI modes for structured projects
+    # before enqueue, but a task queued before the project's track was known
+    # must not reach a planner that needs the graph.
+    if is_structured_v2(ctx.state_dir) and planning_mode != "chapters":
+        raise KnowledgePipelineUnsupported(
+            "structured_v2 only supports deterministic chapter/episode mapping"
+        )
     store = await _load_store(ctx)
     try:
 

--- a/src/novelvideo/task_backend/runners/ingest.py
+++ b/src/novelvideo/task_backend/runners/ingest.py
@@ -28,18 +28,32 @@ def run_ingest_fast(
 async def _run_ingest_fast(
     envelope: dict[str, Any], ctx: ProjectContext
 ) -> dict[str, Any]:
-    from novelvideo.cognee import CogneeStore
+    from novelvideo.knowledge_pipeline import is_structured_v2
 
     payload = envelope.get("payload") or {}
     novel_path = str(payload["novel_path"])
     config = dict(payload.get("config") or {})
     manager = get_task_manager()
 
-    store = CogneeStore(
-        ctx.owner_project_label,
-        output_dir=str(ctx.output_dir),
-        state_dir=str(ctx.state_dir),
-    )
+    # structured_v2 imports never build a graph, so they open the project with
+    # SQLiteStore directly rather than through the Cognee facade.
+    structured = is_structured_v2(ctx.state_dir)
+    if structured:
+        from novelvideo.sqlite_store import SQLiteStore
+
+        store = SQLiteStore(
+            ctx.owner_project_label,
+            output_dir=str(ctx.output_dir),
+            state_dir=str(ctx.state_dir),
+        )
+    else:
+        from novelvideo.cognee import CogneeStore
+
+        store = CogneeStore(
+            ctx.owner_project_label,
+            output_dir=str(ctx.output_dir),
+            state_dir=str(ctx.state_dir),
+        )
     await store.initialize()
 
     def update(progress: float | None, task: str) -> None:
@@ -59,6 +73,18 @@ async def _run_ingest_fast(
         )
 
     try:
+        if structured:
+            from novelvideo.structured_ingest import ingest_source_text_structured
+
+            return await ingest_source_text_structured(
+                store,
+                novel_path,
+                spine_template=str(config.get("spine_template") or "").strip()
+                or None,
+                on_progress=update,
+                on_log=lambda message: update(None, message),
+            )
+
         result = await store.ingest_novel_fast(
             novel_path,
             rebuild=bool(config.get("rebuild", False)),

--- a/tests/test_cognee_pipeline_concurrency.py
+++ b/tests/test_cognee_pipeline_concurrency.py
@@ -401,7 +401,9 @@ async def test_episode_runner_persists_agent_plan_only_to_sqlite(monkeypatch):
         FakePlanner,
     )
 
-    ctx = SimpleNamespace(output_dir="/tmp/output")
+    # A real ProjectContext always carries state_dir; the runner reads it to
+    # resolve the project's knowledge pipeline.
+    ctx = SimpleNamespace(output_dir="/tmp/output", state_dir="/tmp/state")
     result = await graph_build._run_build_episodes(
         {"payload": {"config": {"target_episodes": 1}}},
         ctx,

--- a/tests/test_knowledge_pipeline_dual_track.py
+++ b/tests/test_knowledge_pipeline_dual_track.py
@@ -1,0 +1,232 @@
+"""Dual-track knowledge pipeline boundary.
+
+The contract this file defends:
+
+* legacy projects behave exactly as before, including projects that predate the
+  ``knowledge_pipeline`` field entirely;
+* structured_v2 projects can still use the store as a plain SQLite facade,
+  because most runners and API routes depend on it that way;
+* structured_v2 projects can never reach Cognee, an embedding binding, or the
+  graph — the attempt must raise rather than silently fall back.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from novelvideo.knowledge_pipeline import (
+    COGNEE_LEGACY,
+    KNOWLEDGE_PIPELINE_KEY,
+    KnowledgePipelineUnsupported,
+    STRUCTURED_V2,
+    is_structured_v2,
+    knowledge_pipeline_from_state_dir,
+)
+
+
+def _write_config(state_dir: Path, config: dict) -> None:
+    state_dir.mkdir(parents=True, exist_ok=True)
+    (state_dir / "project_config.json").write_text(
+        json.dumps(config, ensure_ascii=False), encoding="utf-8"
+    )
+
+
+# ── track resolution ─────────────────────────────────────────────────────────
+
+
+def test_missing_config_file_is_legacy(tmp_path):
+    assert knowledge_pipeline_from_state_dir(tmp_path) == COGNEE_LEGACY
+
+
+def test_project_without_the_field_is_legacy(tmp_path):
+    """Projects created before the field existed must not be reclassified."""
+    _write_config(tmp_path, {"user": "someone", "spine_template": "drama"})
+    assert knowledge_pipeline_from_state_dir(tmp_path) == COGNEE_LEGACY
+
+
+def test_embedding_bound_project_is_legacy(tmp_path):
+    _write_config(
+        tmp_path,
+        {
+            "user": "someone",
+            "cognee_embedding_model": "DC-cognee-embedding-v2",
+            "cognee_embedding_dimension": 1024,
+        },
+    )
+    assert knowledge_pipeline_from_state_dir(tmp_path) == COGNEE_LEGACY
+
+
+def test_explicit_structured_field_is_structured(tmp_path):
+    _write_config(tmp_path, {KNOWLEDGE_PIPELINE_KEY: STRUCTURED_V2})
+    assert is_structured_v2(tmp_path)
+
+
+def test_unknown_pipeline_value_falls_back_to_legacy(tmp_path):
+    """An unrecognised value must never be treated as structured."""
+    _write_config(tmp_path, {KNOWLEDGE_PIPELINE_KEY: "something-else"})
+    assert knowledge_pipeline_from_state_dir(tmp_path) == COGNEE_LEGACY
+
+
+def test_absent_embedding_keys_do_not_imply_structured(tmp_path):
+    """Missing embedding keys are not a usable signal.
+
+    ``ensure_cognee_embedding_binding_in_state_dir`` backfills them for legacy
+    projects, so only the explicit field can be trusted.
+    """
+    _write_config(tmp_path, {"user": "someone"})
+    assert not is_structured_v2(tmp_path)
+
+
+def test_default_project_config_does_not_carry_the_field():
+    """The field must never reach a project through the effective-config merge.
+
+    ``_effective_project_config`` merges the defaults over stored values, so a
+    default entry would silently reclassify every legacy project.
+    """
+    from novelvideo.project_config import _default_project_config
+
+    assert KNOWLEDGE_PIPELINE_KEY not in _default_project_config()
+
+
+def test_effective_config_merge_cannot_make_a_legacy_project_structured(tmp_path):
+    from novelvideo.project_config import load_project_config_from_state_dir
+
+    _write_config(tmp_path, {"user": "someone", "spine_template": "drama"})
+    effective = load_project_config_from_state_dir(tmp_path)
+    assert effective.get(KNOWLEDGE_PIPELINE_KEY, COGNEE_LEGACY) == COGNEE_LEGACY
+
+
+# ── store behaviour ──────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def structured_store(tmp_path):
+    from novelvideo.cognee.store import CogneeStore
+
+    state_dir = tmp_path / "user" / "structured"
+    _write_config(state_dir, {KNOWLEDGE_PIPELINE_KEY: STRUCTURED_V2})
+    return CogneeStore(
+        "user/structured",
+        output_dir=str(state_dir),
+        state_dir=str(state_dir),
+    )
+
+
+@pytest.fixture
+def legacy_store(tmp_path):
+    from novelvideo.cognee.store import CogneeStore
+
+    state_dir = tmp_path / "user" / "legacy"
+    _write_config(state_dir, {"user": "user"})
+    return CogneeStore(
+        "user/legacy",
+        output_dir=str(state_dir),
+        state_dir=str(state_dir),
+    )
+
+
+async def test_structured_initialize_never_binds_an_embedding_model(
+    structured_store, monkeypatch
+):
+    """The sentinel: initialize() must not reach any Cognee/embedding entry."""
+    import novelvideo.cognee.store as store_module
+
+    def _boom(*args, **kwargs):
+        raise AssertionError("structured_v2 must not touch Cognee or embeddings")
+
+    monkeypatch.setattr(
+        store_module, "ensure_cognee_embedding_binding_in_state_dir", _boom
+    )
+    monkeypatch.setattr(store_module, "init_cognee", _boom)
+    monkeypatch.setattr(store_module, "setup", _boom)
+
+    try:
+        await structured_store.initialize()
+    finally:
+        await structured_store.close()
+
+
+async def test_structured_initialize_writes_no_embedding_fields(structured_store):
+    from novelvideo.embedding_models import (
+        PROJECT_EMBEDDING_DIMENSION_KEY,
+        PROJECT_EMBEDDING_MODEL_KEY,
+    )
+
+    config_path = Path(structured_store.state_dir) / "project_config.json"
+    try:
+        await structured_store.initialize()
+    finally:
+        await structured_store.close()
+
+    config = json.loads(config_path.read_text(encoding="utf-8"))
+    assert PROJECT_EMBEDDING_MODEL_KEY not in config
+    assert PROJECT_EMBEDDING_DIMENSION_KEY not in config
+    assert config[KNOWLEDGE_PIPELINE_KEY] == STRUCTURED_V2
+
+
+async def test_structured_store_still_works_as_a_sqlite_facade(structured_store):
+    """Runners that only need SQLite must keep working after the default flips.
+
+    Portrait, prop/scene reference, script, sketch, video, verification and the
+    Freezone routes all construct a CogneeStore purely for SQLite access.
+    """
+    from novelvideo.cognee.pipeline import NovelCharacter
+
+    try:
+        await structured_store.initialize()
+        await structured_store.load_graph_state()
+
+        await structured_store.add_character(NovelCharacter(name="林默"))
+        assert structured_store.get_character("林默") is not None
+        assert structured_store.character_count == 1
+
+        structured_store.save_novel_content("正文")
+        assert structured_store.load_novel_content() == "正文"
+    finally:
+        await structured_store.close()
+
+
+@pytest.mark.parametrize(
+    "operation",
+    [
+        "search",
+        "ingest_novel_fast",
+        "build_characters_from_graph",
+        "build_scenes_from_graph",
+        "build_props_from_graph",
+        "get_graph_snapshot",
+        "materialize_graph_preview",
+    ],
+)
+async def test_structured_graph_capabilities_raise(structured_store, operation):
+    try:
+        await structured_store.initialize()
+        with pytest.raises(KnowledgePipelineUnsupported):
+            await getattr(structured_store, operation)("query")
+    finally:
+        await structured_store.close()
+
+
+async def test_structured_embedding_scope_raises(structured_store):
+    """Guarded too: entering the scope is how a binding gets created."""
+    try:
+        await structured_store.initialize()
+        with pytest.raises(KnowledgePipelineUnsupported):
+            structured_store.embedding_model_scope()
+    finally:
+        await structured_store.close()
+
+
+def test_uninitialized_structured_store_is_still_gated(structured_store):
+    """Stores built without initialize() must resolve the track lazily."""
+    with pytest.raises(KnowledgePipelineUnsupported):
+        structured_store.embedding_model_scope()
+
+
+def test_legacy_store_keeps_graph_capabilities(legacy_store):
+    """The gate must be invisible to legacy projects."""
+    assert legacy_store._cognee_enabled
+    legacy_store._require_cognee("graph search")

--- a/tests/test_sqlite_schema_initialization.py
+++ b/tests/test_sqlite_schema_initialization.py
@@ -10,7 +10,10 @@ from pathlib import Path
 
 import pytest
 
-from novelvideo.sqlite_store import SQLiteStore
+from novelvideo.sqlite_store import (
+    _PROJECT_STORE_SCHEMA_VERSION,
+    SQLiteStore,
+)
 from novelvideo.task_state import TaskStateManager
 
 
@@ -309,7 +312,9 @@ def test_task_and_project_schema_initialize_safely_across_processes(tmp_path):
             ).fetchall()
         )
         assert components["task_state"] == 1
-        assert components["project_store"] == 1
+        # Track the constant rather than a literal, so a schema bump does
+        # not silently make this assertion stale.
+        assert components["project_store"] == _PROJECT_STORE_SCHEMA_VERSION
         tables = {
             row[0]
             for row in conn.execute(

--- a/tests/test_structured_ingest.py
+++ b/tests/test_structured_ingest.py
@@ -1,0 +1,513 @@
+"""structured_v2 import: deterministic chunking, no graph, resumable runs."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from novelvideo.knowledge_pipeline import KNOWLEDGE_PIPELINE_KEY, STRUCTURED_V2
+from novelvideo.story_analysis import chunk_source_text, source_sha256
+
+DRAMA_TEXT = """第一集
+
+1-1 林家客厅 日 内
+人物：林默、林母
+林默推开门。
+林母抬头看他。
+
+1-2 巷口 夜 外
+人物：林默
+林默独自走过巷口。
+
+1-3 林家客厅 夜 内
+人物：林默
+林默坐在沙发上发呆。
+"""
+
+NARRATED_TEXT = """第一章 归来
+
+林默回到阔别十年的故乡。
+街道还是老样子。
+
+第二章 旧友
+
+他在巷口遇见了旧友。
+
+第三章 真相
+
+旧友告诉他一个秘密。
+"""
+
+
+def _write_config(state_dir: Path, config: dict) -> None:
+    state_dir.mkdir(parents=True, exist_ok=True)
+    (state_dir / "project_config.json").write_text(
+        json.dumps(config, ensure_ascii=False), encoding="utf-8"
+    )
+
+
+# ── chunking ────────────────────────────────────────────────────────────────
+
+
+def _assert_offsets_are_exact(chunks, text):
+    """Every chunk must quote the source exactly at the offsets it reports.
+
+    This is what later extraction relies on to prove an entity is real, so a
+    drifting offset has to fail here rather than silently validate invented
+    evidence.
+    """
+    for chunk in chunks:
+        assert chunk.source_start < chunk.source_end
+        assert text[chunk.source_start : chunk.source_end] == chunk.text
+
+
+def test_drama_chunks_split_on_scene_headings():
+    chunks = chunk_source_text(DRAMA_TEXT, "drama")
+    assert len(chunks) >= 3
+    assert all(chunk.section_type == "scene" for chunk in chunks)
+    _assert_offsets_are_exact(chunks, DRAMA_TEXT)
+
+
+def test_drama_chunks_are_ordered_and_non_overlapping():
+    chunks = chunk_source_text(DRAMA_TEXT, "drama")
+    for earlier, later in zip(chunks, chunks[1:]):
+        assert earlier.source_end <= later.source_start
+
+
+def test_drama_chunk_keeps_its_scene_body():
+    chunks = chunk_source_text(DRAMA_TEXT, "drama")
+    joined = [chunk.text for chunk in chunks]
+    assert any("林母抬头看他" in text for text in joined)
+    assert any("林默独自走过巷口" in text for text in joined)
+
+
+def test_narrated_chunks_split_on_chapters():
+    chunks = chunk_source_text(NARRATED_TEXT, "narrated")
+    assert len(chunks) == 3
+    assert all(chunk.section_type == "chapter" for chunk in chunks)
+    _assert_offsets_are_exact(chunks, NARRATED_TEXT)
+
+
+def test_narrated_chapter_offsets_land_on_chapter_starts():
+    chunks = chunk_source_text(NARRATED_TEXT, "narrated")
+    assert chunks[0].text.startswith("第一章")
+    assert chunks[1].text.startswith("第二章")
+    assert "旧友告诉他一个秘密" in chunks[2].text
+
+
+def test_prose_without_chapter_markers_falls_back_to_windows():
+    """A malformed import must still produce analysable chunks."""
+    text = "没有任何章节标记的长文。" * 2000
+    chunks = chunk_source_text(text, "narrated")
+    assert chunks
+    assert all(chunk.section_type == "window" for chunk in chunks)
+    for chunk in chunks:
+        assert text[chunk.source_start : chunk.source_end] == chunk.text
+
+
+def test_window_fallback_overlaps_so_boundaries_are_not_lost():
+    text = "甲" * 20000
+    chunks = chunk_source_text(text, "narrated")
+    assert len(chunks) > 1
+    for earlier, later in zip(chunks, chunks[1:]):
+        assert later.source_start < earlier.source_end
+
+
+def test_empty_text_produces_no_chunks():
+    assert chunk_source_text("   \n  ", "drama") == []
+
+
+def test_chunk_hash_tracks_content():
+    chunks = chunk_source_text(NARRATED_TEXT, "narrated")
+    assert chunks[0].source_hash != chunks[1].source_hash
+    assert len(chunks[0].source_hash) == 64
+
+
+# ── import ──────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+async def structured_project(tmp_path):
+    from novelvideo.sqlite_store import SQLiteStore
+
+    state_dir = tmp_path / "user" / "structured"
+    _write_config(state_dir, {KNOWLEDGE_PIPELINE_KEY: STRUCTURED_V2})
+    store = SQLiteStore(
+        "user/structured",
+        output_dir=str(state_dir),
+        state_dir=str(state_dir),
+    )
+    await store.initialize()
+    try:
+        yield store, state_dir
+    finally:
+        await store.close()
+
+
+async def test_structured_import_records_run_and_chunks(structured_project, tmp_path):
+    from novelvideo.structured_ingest import (
+        STRUCTURED_PIPELINE_VERSION,
+        STRUCTURED_SCHEMA_VERSION,
+        ingest_source_text_structured,
+    )
+
+    store, state_dir = structured_project
+    novel = tmp_path / "novel.txt"
+    novel.write_text(NARRATED_TEXT, encoding="utf-8")
+
+    result = await ingest_source_text_structured(
+        store, str(novel), spine_template="narrated"
+    )
+
+    assert result["pipeline"] == "structured_v2"
+    assert result["status"] == "source_ready"
+    assert result["chunks"] == 3
+    assert result["section_type"] == "chapter"
+
+    run = await store.get_reusable_analysis_run(
+        source_sha256=source_sha256(NARRATED_TEXT),
+        schema_version=STRUCTURED_SCHEMA_VERSION,
+        pipeline_version=STRUCTURED_PIPELINE_VERSION,
+    )
+    assert run is not None and run["run_id"] == result["run_id"]
+
+    chunks = await store.list_analysis_chunks(result["run_id"])
+    assert len(chunks) == 3
+    assert [chunk["status"] for chunk in chunks] == ["pending"] * 3
+    assert [chunk["chunk_index"] for chunk in chunks] == [0, 1, 2]
+
+
+async def test_structured_import_never_touches_cognee(
+    structured_project, tmp_path, monkeypatch
+):
+    """The sentinel: import is where the legacy path spends its embedding time."""
+    import cognee
+
+    from novelvideo.structured_ingest import ingest_source_text_structured
+
+    def _boom(*args, **kwargs):
+        raise AssertionError("structured_v2 import must not touch Cognee")
+
+    for name in ("add", "cognify", "memify", "search"):
+        monkeypatch.setattr(cognee, name, _boom, raising=False)
+
+    store, _ = structured_project
+    novel = tmp_path / "novel.txt"
+    novel.write_text(NARRATED_TEXT, encoding="utf-8")
+
+    await ingest_source_text_structured(store, str(novel), spine_template="narrated")
+
+
+async def test_structured_import_writes_no_embedding_fields(
+    structured_project, tmp_path
+):
+    from novelvideo.embedding_models import (
+        PROJECT_EMBEDDING_DIMENSION_KEY,
+        PROJECT_EMBEDDING_MODEL_KEY,
+    )
+    from novelvideo.structured_ingest import ingest_source_text_structured
+
+    store, state_dir = structured_project
+    novel = tmp_path / "novel.txt"
+    novel.write_text(NARRATED_TEXT, encoding="utf-8")
+
+    await ingest_source_text_structured(store, str(novel), spine_template="narrated")
+
+    config = json.loads((state_dir / "project_config.json").read_text(encoding="utf-8"))
+    assert PROJECT_EMBEDDING_MODEL_KEY not in config
+    assert PROJECT_EMBEDDING_DIMENSION_KEY not in config
+
+
+async def test_reimporting_identical_text_reuses_the_run(structured_project, tmp_path):
+    """Resume must not discard completed chunk work for unchanged text."""
+    from novelvideo.structured_ingest import ingest_source_text_structured
+
+    store, _ = structured_project
+    novel = tmp_path / "novel.txt"
+    novel.write_text(NARRATED_TEXT, encoding="utf-8")
+
+    first = await ingest_source_text_structured(
+        store, str(novel), spine_template="narrated"
+    )
+    chunks = await store.list_analysis_chunks(first["run_id"])
+    await store.mark_analysis_chunk_done(
+        first["run_id"], chunks[0]["chunk_id"], json.dumps({"characters": ["林默"]})
+    )
+
+    second = await ingest_source_text_structured(
+        store, str(novel), spine_template="narrated"
+    )
+    assert second["run_id"] == first["run_id"]
+
+    after = await store.list_analysis_chunks(first["run_id"])
+    done = [chunk for chunk in after if chunk["status"] == "done"]
+    assert len(done) == 1
+    assert json.loads(done[0]["result_json"]) == {"characters": ["林默"]}
+
+
+async def test_changing_the_text_starts_a_new_run(structured_project, tmp_path):
+    from novelvideo.structured_ingest import ingest_source_text_structured
+
+    store, _ = structured_project
+    novel = tmp_path / "novel.txt"
+
+    novel.write_text(NARRATED_TEXT, encoding="utf-8")
+    first = await ingest_source_text_structured(
+        store, str(novel), spine_template="narrated"
+    )
+
+    novel.write_text(NARRATED_TEXT + "\n第四章 结局\n\n他终于释怀。\n", encoding="utf-8")
+    second = await ingest_source_text_structured(
+        store, str(novel), spine_template="narrated"
+    )
+
+    assert second["run_id"] != first["run_id"]
+    assert second["chunks"] == 4
+
+
+async def test_novel_txt_is_not_written_when_import_fails(structured_project, tmp_path):
+    """novel.txt is the public success marker and must not survive a failure."""
+    from novelvideo.structured_ingest import ingest_source_text_structured
+
+    store, state_dir = structured_project
+    novel = tmp_path / "script.txt"
+    novel.write_text("这是一段没有任何场景头的正文。\n", encoding="utf-8")
+
+    with pytest.raises(ValueError):
+        await ingest_source_text_structured(store, str(novel), spine_template="drama")
+
+    assert not (Path(store.project_dir) / "novel.txt").exists()
+
+
+async def test_empty_upload_is_rejected(structured_project, tmp_path):
+    from novelvideo.structured_ingest import ingest_source_text_structured
+
+    store, _ = structured_project
+    novel = tmp_path / "empty.txt"
+    novel.write_text("   \n\n", encoding="utf-8")
+
+    with pytest.raises(ValueError):
+        await ingest_source_text_structured(
+            store, str(novel), spine_template="narrated"
+        )
+
+
+async def test_drama_import_chunks_by_scene(structured_project, tmp_path):
+    from novelvideo.structured_ingest import ingest_source_text_structured
+
+    store, _ = structured_project
+    novel = tmp_path / "script.txt"
+    novel.write_text(DRAMA_TEXT, encoding="utf-8")
+
+    result = await ingest_source_text_structured(
+        store, str(novel), spine_template="drama"
+    )
+    assert result["section_type"] == "scene"
+    assert result["chunks"] >= 3
+
+
+# ── evidence ────────────────────────────────────────────────────────────────
+
+
+async def test_entity_evidence_round_trips(structured_project, tmp_path):
+    from novelvideo.structured_ingest import ingest_source_text_structured
+
+    store, _ = structured_project
+    novel = tmp_path / "novel.txt"
+    novel.write_text(NARRATED_TEXT, encoding="utf-8")
+    result = await ingest_source_text_structured(
+        store, str(novel), spine_template="narrated"
+    )
+
+    await store.replace_entity_evidence(
+        result["run_id"],
+        "character",
+        "林默",
+        [
+            {
+                "chunk_id": "chapter-0000",
+                "source_start": 0,
+                "source_end": 10,
+                "evidence_kind": "mention",
+                "evidence_text": "林默回到阔别十年的故乡",
+            }
+        ],
+    )
+    rows = await store.list_entity_evidence("character", "林默")
+    assert len(rows) == 1
+    assert rows[0]["evidence_text"] == "林默回到阔别十年的故乡"
+
+
+async def test_replacing_evidence_does_not_accumulate_duplicates(
+    structured_project, tmp_path
+):
+    """Re-running a chunk must not pile up repeated spans for one entity."""
+    from novelvideo.structured_ingest import ingest_source_text_structured
+
+    store, _ = structured_project
+    novel = tmp_path / "novel.txt"
+    novel.write_text(NARRATED_TEXT, encoding="utf-8")
+    result = await ingest_source_text_structured(
+        store, str(novel), spine_template="narrated"
+    )
+
+    evidence = [
+        {
+            "chunk_id": "chapter-0000",
+            "source_start": 0,
+            "source_end": 10,
+            "evidence_kind": "mention",
+            "evidence_text": "林默",
+        }
+    ]
+    await store.replace_entity_evidence(result["run_id"], "character", "林默", evidence)
+    await store.replace_entity_evidence(result["run_id"], "character", "林默", evidence)
+
+    assert len(await store.list_entity_evidence("character", "林默")) == 1
+
+
+# ── AI planning rejection ───────────────────────────────────────────────────
+
+
+async def test_structured_project_rejects_ai_planning_before_enqueue(
+    tmp_path, monkeypatch
+):
+    """Reject before enqueue so the user gets an answer, not a doomed task.
+
+    The AI planners read the Cognee graph, which structured projects do not
+    have, and enqueueing would reserve credit for work that cannot succeed.
+    """
+    from types import SimpleNamespace
+
+    from novelvideo.api.routes import episodes
+    from novelvideo.api.schemas import EpisodePlanRequest
+    from novelvideo.knowledge_pipeline import KnowledgePipelineUnsupported
+
+    state_dir = tmp_path / "user" / "structured"
+    _write_config(state_dir, {KNOWLEDGE_PIPELINE_KEY: STRUCTURED_V2})
+    project_dir = tmp_path / "out"
+    project_dir.mkdir()
+    (project_dir / "novel.txt").write_text(NARRATED_TEXT, encoding="utf-8")
+
+    async def resolve_project_scope(project, user, required_role="viewer"):
+        return SimpleNamespace(
+            ctx=SimpleNamespace(project_id="proj_1"),
+            output_dir=str(project_dir),
+            state_dir=str(state_dir),
+            project_dir=str(project_dir),
+        )
+
+    async def reject_enqueue(*_args, **_kwargs):
+        raise AssertionError("structured_v2 must not enqueue an AI planning task")
+
+    monkeypatch.setattr(episodes, "resolve_project_scope", resolve_project_scope)
+    monkeypatch.setattr(
+        episodes,
+        "get_task_backend",
+        lambda: SimpleNamespace(enqueue_project_task=reject_enqueue),
+    )
+
+    response = await episodes.plan_episodes(
+        project="proj_1",
+        body=EpisodePlanRequest(target_episodes=10, planning_mode="ai"),
+        user={"username": "admin"},
+    )
+
+    assert response["ok"] is False
+    assert response["code"] == KnowledgePipelineUnsupported.error_code
+
+
+async def test_structured_project_allows_deterministic_chapter_planning(
+    tmp_path, monkeypatch
+):
+    """The mode the frontend actually uses must keep working."""
+    from types import SimpleNamespace
+
+    from novelvideo.api.routes import episodes
+    from novelvideo.api.schemas import EpisodePlanRequest
+
+    state_dir = tmp_path / "user" / "structured"
+    _write_config(state_dir, {KNOWLEDGE_PIPELINE_KEY: STRUCTURED_V2})
+    project_dir = tmp_path / "out"
+    project_dir.mkdir()
+    (project_dir / "novel.txt").write_text(NARRATED_TEXT, encoding="utf-8")
+
+    enqueued = {}
+
+    async def resolve_project_scope(project, user, required_role="viewer"):
+        return SimpleNamespace(
+            ctx=SimpleNamespace(project_id="proj_1"),
+            output_dir=str(project_dir),
+            state_dir=str(state_dir),
+            project_dir=str(project_dir),
+        )
+
+    async def accept_enqueue(*_args, **kwargs):
+        enqueued.update(kwargs)
+        return SimpleNamespace(
+            task_state=SimpleNamespace(task_id="task_1"),
+            backend="celery",
+            queue="default",
+        )
+
+    monkeypatch.setattr(episodes, "resolve_project_scope", resolve_project_scope)
+    monkeypatch.setattr(
+        episodes,
+        "get_task_backend",
+        lambda: SimpleNamespace(enqueue_project_task=accept_enqueue),
+    )
+
+    response = await episodes.plan_episodes(
+        project="proj_1",
+        body=EpisodePlanRequest(target_episodes=10, planning_mode="chapters"),
+        user={"username": "admin"},
+    )
+
+    assert response["ok"] is True
+    assert enqueued["payload"]["config"]["planning_mode"] == "chapters"
+
+
+async def test_legacy_project_still_accepts_ai_planning(tmp_path, monkeypatch):
+    """The gate must be invisible to legacy projects."""
+    from types import SimpleNamespace
+
+    from novelvideo.api.routes import episodes
+    from novelvideo.api.schemas import EpisodePlanRequest
+
+    state_dir = tmp_path / "user" / "legacy"
+    _write_config(state_dir, {"user": "user"})
+    project_dir = tmp_path / "out"
+    project_dir.mkdir()
+    (project_dir / "novel.txt").write_text(NARRATED_TEXT, encoding="utf-8")
+
+    async def resolve_project_scope(project, user, required_role="viewer"):
+        return SimpleNamespace(
+            ctx=SimpleNamespace(project_id="proj_1"),
+            output_dir=str(project_dir),
+            state_dir=str(state_dir),
+            project_dir=str(project_dir),
+        )
+
+    async def accept_enqueue(*_args, **_kwargs):
+        return SimpleNamespace(
+            task_state=SimpleNamespace(task_id="task_1"),
+            backend="celery",
+            queue="default",
+        )
+
+    monkeypatch.setattr(episodes, "resolve_project_scope", resolve_project_scope)
+    monkeypatch.setattr(
+        episodes,
+        "get_task_backend",
+        lambda: SimpleNamespace(enqueue_project_task=accept_enqueue),
+    )
+
+    response = await episodes.plan_episodes(
+        project="proj_1",
+        body=EpisodePlanRequest(target_episodes=10, planning_mode="ai"),
+        user={"username": "admin"},
+    )
+
+    assert response["ok"] is True


### PR DESCRIPTION
## Summary

Structured-v2 import: validate, chunk, persist. No `cognee.add` / `cognify` / `memify`, no embedding, no vector index.

Stacked on #352 — review that first. This is PR 2 of 4.

## Why import is where this pays off

Legacy import spends most of its wall clock inside the three Cognee calls, and every one of them goes through the shared embedding model, which serializes work across projects. Structured extraction reads the source text directly, so import reduces to validating the upload, persisting it, and recording a deterministic chunk plan.

`novel.txt` is still written last — it is the public "import succeeded" marker, so it must not appear while the import can still fail.

## Chunking

Chunks follow the boundaries each format already provides: scene headings for screenplays, chapter markers for prose. Analysis is therefore bounded and parallelisable instead of one call over a whole novel.

Every chunk carries the character offsets it came from. That is what later extraction uses to prove an entity is real — reported evidence has to appear inside the span it claims, or the candidate is dropped.

**Offsets are recovered without touching the shared parsers.** `parse_scene_blocks` runs on stripped, blank-filtered lines and cannot report positions in the original text, and asset compilation, screenplay normalization and import quality checks all depend on it. Scene headers are instead located by scanning forward from the previous block's end; blocks come back in source order, so a forward-only scan cannot match an earlier occurrence.

`ChapterDetector` synthesizes a single `is_fallback` chapter covering the whole text when no markers exist. Accepting it would defeat the point of chunking, and its content is rewritten by the detector's fallback preparation so the offsets would not match the source. Marker-less prose falls through to overlapping fixed windows instead; the overlap keeps an entity introduced at a boundary from being missed by both neighbours.

## Analysis bookkeeping (schema version 1 → 2)

Three tables: `story_analysis_runs`, `story_analysis_chunks`, `entity_evidence`.

- Runs are keyed on source text, schema version and pipeline version **together**, so re-importing identical text with identical code resumes completed chunks while any change starts fresh.
- Chunks store offsets rather than a copy of the text — duplicating a whole novel per run would dwarf the rest of the project database.
- The run row and its chunk plan land in one transaction: a half-written plan would let a resume believe chunks are missing rather than pending.
- `replace_entity_evidence` replaces rather than appends, so re-running a chunk cannot accumulate duplicate spans.

## AI planning rejection

The episode plan route rejects AI planning modes for structured projects **before enqueue**, so the user gets an answer instead of a task guaranteed to fail after reserving credit. The runner repeats the check for tasks queued before the project's track was known. Deterministic `chapters` planning — the only mode the frontend actually sends — is untouched.

## Test fixtures updated rather than worked around

- `test_sqlite_schema_initialization` asserted `project_store == 1` as a literal; it now tracks `_PROJECT_STORE_SCHEMA_VERSION`, so a future bump cannot silently make it stale.
- `test_cognee_pipeline_concurrency`'s fake context lacked `state_dir`, which every real `ProjectContext` carries. Adding it to the fixture was correct; a `getattr` fallback in the runner would have hidden a genuinely missing attribute.

## Verification

- `uv run pytest -q` — 3616 passed, 16 skipped, 1 failed
- The single failure is `test_api_project_summary_paths::test_project_summary_counts_from_registered_state_dir`, which **fails identically on the `staging` baseline** (verified by running the full suite on `origin/staging`) and passes in isolation — pre-existing test-ordering pollution, unrelated to this change.
- `tests/test_structured_ingest.py` — 22 new tests: exact-offset assertions for both chunkers, ordering/non-overlap, window fallback and its overlap, run reuse for identical text, a new run when text changes, `novel.txt` absent after a failed import, empty-upload rejection, evidence round-trip and de-duplication, and a sentinel that fails if import touches `cognee.add/cognify/memify/search`.
- `uv run ruff check src/ tests/` — clean

## Impact

Schema bumps 1 → 2; the three tables are `CREATE TABLE IF NOT EXISTS` additions with no changes to existing tables, so legacy databases pick them up on next open and behave identically. No project is `structured_v2` yet, so no import path changes for anything on disk today.
