### PR TITLE
feat: build characters and scenes from source text for structured_v1

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -109,6 +109,9 @@ COGNEE_EMBEDDING_DIM=1024
 # 每次小说导入 pipeline 的上游在途请求上限。多个同时导入的 pipeline 会分别计算。
 # LLM 的实体/关系抽取与摘要共享同一个并发额度。
 COGNEE_LLM_CONCURRENCY=2
+
+# structured_v2 逐片段抽取的并发槽位（角色抽取、场次规范化、场景描述生成）。
+STRUCTURED_LLM_CONCURRENCY=2
 # Embedding 并发限制当前仅适用于经 newAPI/custom LiteLLM 发出的请求；其他 provider 会记录绕过日志。
 COGNEE_EMBEDDING_BATCH_CONCURRENCY=4
 

--- a/.env.example
+++ b/.env.example
@@ -144,6 +144,9 @@ LITERAL_BEAT_META_MODEL=DC-literal-beat-meta-LLM
 # 场景库 / 从图谱构建 / 场景解析、规范化与 environment_prompt 生成。
 SCENE_BUILD_MODEL=DC-scene-builder-LLM
 
+# 角色库 / 从原文构建 / structured_v2 逐片段角色抽取与证据引用。
+CHARACTER_BUILD_MODEL=DC-character-builder-LLM
+
 # 剧集详情 / 规划场景。
 EPISODE_SCENE_PLANNER_MODEL=DC-episode-scene-planner-LLM
 

--- a/.env.example
+++ b/.env.example
@@ -110,7 +110,7 @@ COGNEE_EMBEDDING_DIM=1024
 # LLM 的实体/关系抽取与摘要共享同一个并发额度。
 COGNEE_LLM_CONCURRENCY=2
 
-# structured_v2 逐片段抽取的并发槽位（角色抽取、场次规范化、场景描述生成）。
+# structured_v1 逐片段抽取的并发槽位（角色抽取、场次规范化、场景描述生成）。
 STRUCTURED_LLM_CONCURRENCY=2
 # Embedding 并发限制当前仅适用于经 newAPI/custom LiteLLM 发出的请求；其他 provider 会记录绕过日志。
 COGNEE_EMBEDDING_BATCH_CONCURRENCY=4
@@ -147,7 +147,7 @@ LITERAL_BEAT_META_MODEL=DC-literal-beat-meta-LLM
 # 场景库 / 从图谱构建 / 场景解析、规范化与 environment_prompt 生成。
 SCENE_BUILD_MODEL=DC-scene-builder-LLM
 
-# 角色库 / 从原文构建 / structured_v2 逐片段角色抽取与证据引用。
+# 角色库 / 从原文构建 / structured_v1 逐片段角色抽取与证据引用。
 CHARACTER_BUILD_MODEL=DC-character-builder-LLM
 
 # 剧集详情 / 规划场景。

--- a/license-inventory.csv
+++ b/license-inventory.csv
@@ -1644,6 +1644,8 @@ src/novelvideo/sqlite_pragmas.py,Elastic-2.0,2026 SuperTale contributors,REUSE.t
 src/novelvideo/sqlite_schema.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 src/novelvideo/sqlite_store.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 src/novelvideo/stage_asset_tasks.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
+src/novelvideo/story_analysis.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
+src/novelvideo/structured_ingest.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 src/novelvideo/storage/__init__.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 src/novelvideo/storage/media_relay.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 src/novelvideo/styles/presets/STYLE_DESIGN.md,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
@@ -2050,6 +2052,7 @@ tests/test_stage_asset_scene_360_credit.py,Elastic-2.0,2026 SuperTale contributo
 tests/test_stage_asset_scene_360_provider.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_stage_asset_step_contract.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_storyboard_prompt_visual_authority.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
+tests/test_structured_ingest.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_style_template_manifest.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_superpower_model_config.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_task_backend_celery_metadata.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation

--- a/license-inventory.csv
+++ b/license-inventory.csv
@@ -1645,6 +1645,8 @@ src/novelvideo/sqlite_schema.py,Elastic-2.0,2026 SuperTale contributors,REUSE.to
 src/novelvideo/sqlite_store.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 src/novelvideo/stage_asset_tasks.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 src/novelvideo/story_analysis.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
+src/novelvideo/structured_builders.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
+src/novelvideo/structured_extraction.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 src/novelvideo/structured_ingest.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 src/novelvideo/storage/__init__.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 src/novelvideo/storage/media_relay.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
@@ -1703,6 +1705,7 @@ src/novelvideo/utils/asset_names.py,Elastic-2.0,2026 SuperTale contributors,REUS
 src/novelvideo/utils/asset_resolver.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 src/novelvideo/utils/async_ops.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 src/novelvideo/utils/background_anchor.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
+src/novelvideo/utils/bounded_concurrency.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 src/novelvideo/utils/debug_context.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 src/novelvideo/utils/derived_scenes.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 src/novelvideo/utils/document_parsers.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
@@ -2052,6 +2055,7 @@ tests/test_stage_asset_scene_360_credit.py,Elastic-2.0,2026 SuperTale contributo
 tests/test_stage_asset_scene_360_provider.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_stage_asset_step_contract.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_storyboard_prompt_visual_authority.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
+tests/test_structured_builders.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_structured_ingest.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_style_template_manifest.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_superpower_model_config.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation

--- a/license-inventory.csv
+++ b/license-inventory.csv
@@ -1551,6 +1551,7 @@ src/novelvideo/generators/wan2-2-I2V-LightX2V.json,Elastic-2.0,2026 SuperTale co
 src/novelvideo/graph_preview.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 src/novelvideo/image_request_usage.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 src/novelvideo/identity_prerequisites.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
+src/novelvideo/knowledge_pipeline.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 src/novelvideo/llm_instrumentation.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 src/novelvideo/manual_shots.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 src/novelvideo/media_model_request_schema.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
@@ -1952,6 +1953,7 @@ tests/test_indextts2_beat_audio_task.py,Elastic-2.0,2026 SuperTale contributors,
 tests/test_indextts2_fal.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_indextts2_fal_smoke.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_ingest_progress.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
+tests/test_knowledge_pipeline_dual_track.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_literal_script_writing_audio_type.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_llm_instrumentation_logging.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_m10_final_gate.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation

--- a/src/novelvideo/agents/episode_planner.py
+++ b/src/novelvideo/agents/episode_planner.py
@@ -181,6 +181,12 @@ def create_episode_planner_agent(tools: List[Callable]) -> Agent:
 # =============================================================================
 
 
+# Legacy-only AI episode planner.
+# No current frontend workflow selects this mode: the "plan episodes" button
+# posts an empty body (frontend/src/routes/_app/projects.$project/episodes.tsx),
+# so planning_mode falls back to the "chapters" default in api/schemas.py.
+# Reaching this code still requires an explicit planning_mode="ai" from an API
+# client. Structured-v2 projects must not enter this path.
 class EpisodePlannerAgent:
     """剧集规划 Agent - 使用图谱搜索进行多轮迭代式规划。
 

--- a/src/novelvideo/api/routes/episodes.py
+++ b/src/novelvideo/api/routes/episodes.py
@@ -29,7 +29,7 @@ from novelvideo.identity_prerequisites import (
 )
 from novelvideo.knowledge_pipeline import (
     KnowledgePipelineUnsupported,
-    is_structured_v2,
+    is_structured_pipeline,
 )
 from novelvideo.ports import get_task_backend, get_usage_meter
 from novelvideo.project_config import load_project_config_file_from_state_dir
@@ -275,10 +275,10 @@ async def plan_episodes(project: str, body: EpisodePlanRequest, user: dict = Dep
     if ctx is not None:
         if not has_imported_novel(resolved.project_dir):
             return novel_import_required_response()
-        # The AI planners read the Cognee graph, which structured_v2 projects do
+        # The AI planners read the Cognee graph, which structured_v1 projects do
         # not have. Reject before enqueue so the user gets an answer instead of
         # a task that is guaranteed to fail after reserving credit.
-        if is_structured_v2(state_dir) and body.planning_mode != "chapters":
+        if is_structured_pipeline(state_dir) and body.planning_mode != "chapters":
             return {
                 "ok": False,
                 "code": KnowledgePipelineUnsupported.error_code,

--- a/src/novelvideo/api/routes/episodes.py
+++ b/src/novelvideo/api/routes/episodes.py
@@ -27,6 +27,10 @@ from novelvideo.identity_prerequisites import (
     identity_prerequisite_response,
     require_identity_characters,
 )
+from novelvideo.knowledge_pipeline import (
+    KnowledgePipelineUnsupported,
+    is_structured_v2,
+)
 from novelvideo.ports import get_task_backend, get_usage_meter
 from novelvideo.project_config import load_project_config_file_from_state_dir
 from novelvideo.task_identity import project_task_state_key
@@ -271,6 +275,15 @@ async def plan_episodes(project: str, body: EpisodePlanRequest, user: dict = Dep
     if ctx is not None:
         if not has_imported_novel(resolved.project_dir):
             return novel_import_required_response()
+        # The AI planners read the Cognee graph, which structured_v2 projects do
+        # not have. Reject before enqueue so the user gets an answer instead of
+        # a task that is guaranteed to fail after reserving credit.
+        if is_structured_v2(state_dir) and body.planning_mode != "chapters":
+            return {
+                "ok": False,
+                "code": KnowledgePipelineUnsupported.error_code,
+                "error": "该项目只支持按章节/集号的确定性分集",
+            }
         queued = await get_task_backend().enqueue_project_task(
             ctx,
             product_surface="mainline",

--- a/src/novelvideo/api/routes/ingest.py
+++ b/src/novelvideo/api/routes/ingest.py
@@ -20,7 +20,7 @@ from novelvideo.api.chapter_preview import (
 from novelvideo.api.deps import make_cognee_store_for_context, resolve_project_scope
 from novelvideo.api.schemas import IngestStart
 from novelvideo.cognee.ladybug_access import ladybug_graph_access
-from novelvideo.knowledge_pipeline import is_structured_v2
+from novelvideo.knowledge_pipeline import is_structured_pipeline
 from novelvideo.graph_preview import (
     empty_graph_preview,
     load_graph_preview,
@@ -69,11 +69,11 @@ async def get_ingest_knowledge_graph(
     if not (ctx.output_dir / "novel.txt").is_file():
         return {"ok": True, "data": empty_graph_preview()}
 
-    # structured_v2 projects never build a graph. Return the empty preview
+    # structured_v1 projects never build a graph. Return the empty preview
     # rather than reaching the legacy materialization path below, which would
     # open Ladybug and construct a Cognee-backed store for a project that has
     # neither.
-    if is_structured_v2(ctx.state_dir):
+    if is_structured_pipeline(ctx.state_dir):
         return {"ok": True, "data": empty_graph_preview()}
 
     snapshot = load_graph_preview(ctx.state_dir)

--- a/src/novelvideo/api/routes/ingest.py
+++ b/src/novelvideo/api/routes/ingest.py
@@ -20,6 +20,7 @@ from novelvideo.api.chapter_preview import (
 from novelvideo.api.deps import make_cognee_store_for_context, resolve_project_scope
 from novelvideo.api.schemas import IngestStart
 from novelvideo.cognee.ladybug_access import ladybug_graph_access
+from novelvideo.knowledge_pipeline import is_structured_v2
 from novelvideo.graph_preview import (
     empty_graph_preview,
     load_graph_preview,
@@ -66,6 +67,13 @@ async def get_ingest_knowledge_graph(
     # returning a stale sidecar or opening its embedded graph database from an
     # API worker.
     if not (ctx.output_dir / "novel.txt").is_file():
+        return {"ok": True, "data": empty_graph_preview()}
+
+    # structured_v2 projects never build a graph. Return the empty preview
+    # rather than reaching the legacy materialization path below, which would
+    # open Ladybug and construct a Cognee-backed store for a project that has
+    # neither.
+    if is_structured_v2(ctx.state_dir):
         return {"ok": True, "data": empty_graph_preview()}
 
     snapshot = load_graph_preview(ctx.state_dir)

--- a/src/novelvideo/cognee/pipeline.py
+++ b/src/novelvideo/cognee/pipeline.py
@@ -15,6 +15,7 @@ from pydantic import BaseModel, Field, field_validator, model_validator
 
 from novelvideo.shared.env_guard import preserve_st_env
 from novelvideo.config import get_newapi_structured_output_litellm_kwargs
+from novelvideo.utils.bounded_concurrency import map_bounded
 from novelvideo.models import (
     CharacterIdentity,
     NovelCharacter,
@@ -1389,10 +1390,13 @@ async def extract_scenes_from_script(
             "Scene Build Enricher",
         )
 
-    for idx, cand in enumerate(normalized_scene_candidates):
-        progress = 0.5 + 0.4 * (idx / max(total, 1))
-        report(progress, f"生成场景描述 ({idx+1}/{total}): {cand['name']}")
+    # Each candidate's enrichment is an independent round trip. A feature-length
+    # screenplay carries well over a hundred scenes, so running them one at a
+    # time makes the build minutes of pure latency.
+    completed = 0
 
+    async def enrich(cand: dict):
+        nonlocal completed
         scene_type = cand["scene_type"] or (
             "interior" if cand["interior"] else "exterior"
         )
@@ -1413,8 +1417,20 @@ async def extract_scenes_from_script(
             scene.notes,
             _format_observed_times_note(cand.get("time_counts")),
         )
-        scenes.append(scene)
+        completed += 1
+        report(
+            0.5 + 0.4 * (completed / max(total, 1)),
+            f"生成场景描述 ({completed}/{total}): {cand['name']}",
+        )
         log(f"  ✓ {cand['name']}: environment_prompt={len(scene.environment_prompt)}字")
+        return scene
+
+    enriched = await map_bounded(
+        normalized_scene_candidates,
+        enrich,
+        on_error=lambda cand, exc: log(f"  ⚠️ {cand['name']} 环境描述失败，已跳过: {exc}"),
+    )
+    scenes.extend(scene for scene in enriched if scene is not None)
 
     log(f"场景提取完成: {len(scenes)} 个")
     report(1.0, "完成")

--- a/src/novelvideo/cognee/pipeline.py
+++ b/src/novelvideo/cognee/pipeline.py
@@ -508,6 +508,9 @@ async def extract_characters_from_graph(
 # ============================================================
 
 
+# Legacy-only: reached from build_episodes(), which runs only when
+# planning_mode="ai". No current frontend workflow selects that mode.
+# Structured-v2 projects must not enter this path.
 async def extract_episodes_with_characters(
     text: str,
     target_episodes: int = 10,

--- a/src/novelvideo/cognee/pipeline.py
+++ b/src/novelvideo/cognee/pipeline.py
@@ -15,7 +15,10 @@ from pydantic import BaseModel, Field, field_validator, model_validator
 
 from novelvideo.shared.env_guard import preserve_st_env
 from novelvideo.config import get_newapi_structured_output_litellm_kwargs
-from novelvideo.utils.bounded_concurrency import map_bounded
+from novelvideo.utils.bounded_concurrency import (
+    default_llm_concurrency,
+    map_bounded,
+)
 from novelvideo.models import (
     CharacterIdentity,
     NovelCharacter,
@@ -1428,6 +1431,7 @@ async def extract_scenes_from_script(
     enriched = await map_bounded(
         normalized_scene_candidates,
         enrich,
+        limit=default_llm_concurrency(),
         on_error=lambda cand, exc: log(f"  ⚠️ {cand['name']} 环境描述失败，已跳过: {exc}"),
     )
     scenes.extend(scene for scene in enriched if scene is not None)

--- a/src/novelvideo/cognee/pipeline.py
+++ b/src/novelvideo/cognee/pipeline.py
@@ -892,6 +892,118 @@ async def enrich_scene_environment_from_context(
     )
 
 
+# Several scenes fit in one enrichment call. Each description runs 150-200
+# characters, so a batch stays well inside a useful response length.
+_ENRICHMENT_BATCH_SIZE = 5
+
+
+async def enrich_scene_environments_batched(
+    candidates: list[dict[str, Any]],
+    *,
+    synopsis: str = "",
+    enrichment_agent: Any | None = None,
+    on_scene: Optional[Any] = None,
+) -> list[NovelScene]:
+    """Generate environment prompts for several scenes per request.
+
+    The enrichment agent already returns a list, but was being asked for one
+    scene at a time. A screenplay yields dozens of base scenes, and each call
+    costs the same few seconds of round trip regardless of how many it carries.
+
+    A batch that fails or comes back short falls through to per-scene calls for
+    exactly the scenes it missed, so batching can only cost time, never scenes.
+    """
+    if not candidates:
+        return []
+
+    agent = enrichment_agent or _create_scene_build_agent(
+        SCENE_ENRICHMENT_SYSTEM_PROMPT,
+        SceneEnrichmentList,
+        "Scene Build Enricher",
+    )
+    synopsis_section = f"\n\n【故事梗概与人物设定】\n{synopsis}" if synopsis else ""
+
+    def describe(candidate: dict[str, Any]) -> str:
+        context = "\n".join(
+            str(line) for line in (candidate.get("context_lines") or [])[:24]
+        )
+        interior = bool(candidate.get("interior", True))
+        return (
+            f"### 场景：{candidate['name']}\n"
+            f"室内外：{'内' if interior else '外'}\n"
+            f"出场人物：{', '.join(candidate.get('characters') or []) or '无'}\n"
+            f"原文段落：\n{context}"
+        )
+
+    async def run_batch(batch: list[dict[str, Any]]) -> list[NovelScene]:
+        prompt = (
+            "请为下面每一个场景分别生成 environment_prompt，"
+            "name 必须与给出的场景名完全一致，不要合并或遗漏：\n\n"
+            + "\n\n".join(describe(candidate) for candidate in batch)
+            + synopsis_section
+        )
+        produced: dict[str, NovelScene] = {}
+        try:
+            result = (await agent.run(prompt)).output
+            by_name = {
+                str(item.name or "").strip(): item for item in (result.scenes or [])
+            }
+            for candidate in batch:
+                item = by_name.get(candidate["name"])
+                if item is None:
+                    continue
+                scene_type = item.scene_type or candidate.get("scene_type") or (
+                    "interior" if candidate.get("interior", True) else "exterior"
+                )
+                produced[candidate["name"]] = NovelScene(
+                    name=candidate["name"],
+                    aliases=_clean_aliases(
+                        candidate["name"], candidate.get("aliases") or []
+                    ),
+                    scene_type=scene_type,
+                    environment_prompt=_ensure_directional_environment_prompt(
+                        prompt=item.environment_prompt,
+                        scene_name=candidate["name"],
+                        scene_type=scene_type,
+                        time_of_day="",
+                        context_lines=list(candidate.get("context_lines") or []),
+                    ),
+                    description=item.description,
+                )
+        except Exception as exc:  # noqa: BLE001 - falls back per scene below
+            import logging
+
+            logging.warning("批量场景描述生成失败，逐个重试: %s", exc)
+
+        scenes: list[NovelScene] = []
+        for candidate in batch:
+            scene = produced.get(candidate["name"])
+            if scene is None:
+                scene = await enrich_scene_environment_from_context(
+                    scene_name=candidate["name"],
+                    aliases=candidate.get("aliases") or [],
+                    scene_type=candidate.get("scene_type") or "",
+                    time_of_day=candidate.get("time_of_day") or "",
+                    interior=bool(candidate.get("interior", True)),
+                    episodes=candidate.get("episodes") or [],
+                    characters=candidate.get("characters") or [],
+                    context_lines=candidate.get("context_lines") or [],
+                    synopsis=synopsis,
+                    enrichment_agent=agent,
+                )
+            if on_scene:
+                on_scene(candidate, scene)
+            scenes.append(scene)
+        return scenes
+
+    batches = [
+        candidates[start : start + _ENRICHMENT_BATCH_SIZE]
+        for start in range(0, len(candidates), _ENRICHMENT_BATCH_SIZE)
+    ]
+    results = await map_bounded(batches, run_batch, limit=default_llm_concurrency())
+    return [scene for batch in results if batch for scene in batch]
+
+
 _DEFAULT_ENRICH_SCENE_ENVIRONMENT_FROM_CONTEXT = enrich_scene_environment_from_context
 
 
@@ -1398,23 +1510,8 @@ async def extract_scenes_from_script(
     # time makes the build minutes of pure latency.
     completed = 0
 
-    async def enrich(cand: dict):
+    def note_progress(cand: dict, scene) -> None:
         nonlocal completed
-        scene_type = cand["scene_type"] or (
-            "interior" if cand["interior"] else "exterior"
-        )
-        scene = await enrich_scene_environment_from_context(
-            scene_name=cand["name"],
-            aliases=cand["aliases"],
-            scene_type=scene_type,
-            time_of_day=cand["time_of_day"],
-            interior=cand["interior"],
-            episodes=cand["episodes"],
-            characters=cand["characters"],
-            context_lines=cand["context_lines"],
-            synopsis=synopsis,
-            enrichment_agent=enrichment_agent,
-        )
         scene.time_of_day = ""
         scene.notes = _append_scene_note(
             scene.notes,
@@ -1426,15 +1523,15 @@ async def extract_scenes_from_script(
             f"生成场景描述 ({completed}/{total}): {cand['name']}",
         )
         log(f"  ✓ {cand['name']}: environment_prompt={len(scene.environment_prompt)}字")
-        return scene
 
-    enriched = await map_bounded(
-        normalized_scene_candidates,
-        enrich,
-        limit=default_llm_concurrency(),
-        on_error=lambda cand, exc: log(f"  ⚠️ {cand['name']} 环境描述失败，已跳过: {exc}"),
+    scenes.extend(
+        await enrich_scene_environments_batched(
+            normalized_scene_candidates,
+            synopsis=synopsis,
+            enrichment_agent=enrichment_agent,
+            on_scene=note_progress,
+        )
     )
-    scenes.extend(scene for scene in enriched if scene is not None)
 
     log(f"场景提取完成: {len(scenes)} 个")
     report(1.0, "完成")

--- a/src/novelvideo/cognee/screenplay_normalizer.py
+++ b/src/novelvideo/cognee/screenplay_normalizer.py
@@ -6,6 +6,7 @@ from typing import Literal
 from pydantic import BaseModel, Field, field_validator, model_validator
 
 from novelvideo.time_of_day import LlmTimeOfDay, normalize_time_of_day
+from novelvideo.utils.bounded_concurrency import map_bounded
 from novelvideo.utils.screenplay_scene_parser import TIME_TOKEN_RE, parse_scene_blocks
 
 SceneType = Literal["interior", "exterior", "nature"]
@@ -279,10 +280,12 @@ async def normalize_screenplay_scenes(
         return []
 
     runner = agent or _create_screenplay_normalizer_agent()
-    normalized_blocks: list[NormalizedSceneBlock] = []
-    for block in parse_scene_blocks(source):
-        if not block.header_line:
-            continue
+    blocks = [block for block in parse_scene_blocks(source) if block.header_line]
+
+    # Headers are normalized independently, so they run in parallel with a
+    # bounded number in flight. Order is preserved because downstream scene
+    # merging resolves ties by first appearance.
+    async def normalize(block) -> NormalizedSceneBlock | None:
         normalized = await normalize_screenplay_scene_header(
             block.header_line,
             location_hint=block.location,
@@ -294,14 +297,14 @@ async def normalize_screenplay_scenes(
             agent=runner,
         )
         if not normalized:
-            continue
-        normalized_blocks.append(
-            NormalizedSceneBlock(
-                **normalized.model_dump(),
-                raw_header=block.header_line,
-                characters=list(block.characters),
-                evidence_lines=[block.header_line],
-                content_lines=list(block.lines),
-            )
+            return None
+        return NormalizedSceneBlock(
+            **normalized.model_dump(),
+            raw_header=block.header_line,
+            characters=list(block.characters),
+            evidence_lines=[block.header_line],
+            content_lines=list(block.lines),
         )
-    return normalized_blocks
+
+    results = await map_bounded(blocks, normalize)
+    return [block for block in results if block is not None]

--- a/src/novelvideo/cognee/screenplay_normalizer.py
+++ b/src/novelvideo/cognee/screenplay_normalizer.py
@@ -6,7 +6,10 @@ from typing import Literal
 from pydantic import BaseModel, Field, field_validator, model_validator
 
 from novelvideo.time_of_day import LlmTimeOfDay, normalize_time_of_day
-from novelvideo.utils.bounded_concurrency import map_bounded
+from novelvideo.utils.bounded_concurrency import (
+    default_llm_concurrency,
+    map_bounded,
+)
 from novelvideo.utils.screenplay_scene_parser import TIME_TOKEN_RE, parse_scene_blocks
 
 SceneType = Literal["interior", "exterior", "nature"]
@@ -306,5 +309,7 @@ async def normalize_screenplay_scenes(
             content_lines=list(block.lines),
         )
 
-    results = await map_bounded(blocks, normalize)
+    results = await map_bounded(
+        blocks, normalize, limit=default_llm_concurrency()
+    )
     return [block for block in results if block is not None]

--- a/src/novelvideo/cognee/screenplay_normalizer.py
+++ b/src/novelvideo/cognee/screenplay_normalizer.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import re
-from typing import Literal
+from typing import Any, Literal
 
 from pydantic import BaseModel, Field, field_validator, model_validator
 
@@ -14,6 +14,9 @@ from novelvideo.utils.screenplay_scene_parser import TIME_TOKEN_RE, parse_scene_
 
 SceneType = Literal["interior", "exterior", "nature"]
 InteriorExterior = Literal["内", "外", "无"]
+
+# Scene headings are ~14 characters each, so many fit comfortably in one call.
+_NORMALIZER_BATCH_SIZE = 20
 
 ATTACHED_SINGLE_CHAR_TIME_TOKENS = {"日", "夜", "晨", "午", "晚"}
 LOCATION_SUFFIXES_FOR_ATTACHED_TIME = {
@@ -169,6 +172,77 @@ class NormalizedSceneBlock(NormalizedSceneHeader):
         return self
 
 
+class BatchSceneHeaderItem(BaseModel):
+    """One scene inside a batched normalization response."""
+
+    index: int = Field(description="对应输入列表中的序号")
+    episode_number: int = Field(default=0)
+    scene_no: str = Field(default="")
+    location: str = Field(default="")
+    time_of_day: str = Field(default="无")
+    interior_exterior: str = Field(default="无")
+    aliases: list[str] = Field(default_factory=list)
+    scene_type: str = Field(default="interior")
+
+
+class NormalizedSceneHeaderBatch(BaseModel):
+    scenes: list[BatchSceneHeaderItem] = Field(default_factory=list)
+
+
+def _create_batch_normalizer_agent():
+    from pydantic_ai import Agent
+
+    from novelvideo.config import (
+        get_newapi_structured_output_model_settings,
+        get_newapi_text_pydantic_model,
+    )
+
+    return Agent(
+        get_newapi_text_pydantic_model(
+            "SCREENPLAY_NORMALIZER_MODEL",
+            "gemini-3.5-flash",
+            capability="cognee.llm",
+        ),
+        system_prompt=(
+            SCREENPLAY_NORMALIZER_SYSTEM_PROMPT
+            + "\n\n本次一次给出多个场景头。请对每一个分别规范化，"
+            "并用 index 标明它对应输入中的哪一条。不要遗漏任何一条。"
+        ),
+        model_settings=get_newapi_structured_output_model_settings(),
+        output_type=NormalizedSceneHeaderBatch,
+        output_retries=2,
+        name="剧本标准化分析师（批量）",
+    )
+
+
+def normalize_scene_header_locally(block) -> NormalizedSceneHeader | None:
+    """Build a normalized header from the parser alone, when it suffices.
+
+    A standard heading already states location, time and interior/exterior, so
+    asking a model to restate them is a round trip that buys nothing. Only
+    headings the parser could not fully resolve go to the model.
+    """
+    location = (block.location or "").strip()
+    interior_exterior = (block.interior_exterior or "").strip()
+    time_of_day = (block.time_of_day or "").strip()
+    if not location or interior_exterior not in {"内", "外"}:
+        return None
+    # A time the parser had to guess is exactly the ambiguity worth a model call.
+    if getattr(block, "time_inferred", False) or not time_of_day:
+        return None
+    return NormalizedSceneHeader.model_validate(
+        {
+            "episode_number": int(block.episode or 0),
+            "scene_no": str(block.scene_no or "").strip(),
+            "location": location,
+            "time_of_day": time_of_day,
+            "interior_exterior": interior_exterior,
+            "aliases": [],
+            "scene_type": "interior" if interior_exterior == "内" else "exterior",
+        }
+    )
+
+
 def _create_screenplay_normalizer_agent():
     from pydantic_ai import Agent
 
@@ -282,34 +356,85 @@ async def normalize_screenplay_scenes(
     if not source:
         return []
 
-    runner = agent or _create_screenplay_normalizer_agent()
     blocks = [block for block in parse_scene_blocks(source) if block.header_line]
+    if not blocks:
+        return []
 
-    # Headers are normalized independently, so they run in parallel with a
-    # bounded number in flight. Order is preserved because downstream scene
-    # merging resolves ties by first appearance.
-    async def normalize(block) -> NormalizedSceneBlock | None:
-        normalized = await normalize_screenplay_scene_header(
-            block.header_line,
-            location_hint=block.location,
-            time_of_day_hint=block.time_of_day,
-            interior_exterior_hint=block.interior_exterior,
-            episode_number_hint=block.episode,
-            scene_no_hint=block.scene_no,
-            context_lines=block.lines,
-            agent=runner,
-        )
-        if not normalized:
-            return None
+    def attach(block, header: NormalizedSceneHeader) -> NormalizedSceneBlock:
         return NormalizedSceneBlock(
-            **normalized.model_dump(),
+            **header.model_dump(),
             raw_header=block.header_line,
             characters=list(block.characters),
             evidence_lines=[block.header_line],
             content_lines=list(block.lines),
         )
 
-    results = await map_bounded(
-        blocks, normalize, limit=default_llm_concurrency()
-    )
-    return [block for block in results if block is not None]
+    # A standard heading already states everything the model would be asked to
+    # restate, and a scene heading is about fourteen characters long — one round
+    # trip each is almost all latency. Resolve what the parser can, and send only
+    # the rest, in batches.
+    resolved: dict[int, NormalizedSceneBlock] = {}
+    unresolved: list[tuple[int, Any]] = []
+    for index, block in enumerate(blocks):
+        local = normalize_scene_header_locally(block)
+        if local is not None:
+            resolved[index] = attach(block, local)
+        else:
+            unresolved.append((index, block))
+
+    if unresolved:
+        runner = agent or _create_batch_normalizer_agent()
+        batches = [
+            unresolved[start : start + _NORMALIZER_BATCH_SIZE]
+            for start in range(0, len(unresolved), _NORMALIZER_BATCH_SIZE)
+        ]
+
+        async def run_batch(batch: list[tuple[int, Any]]):
+            lines = []
+            for position, (_, block) in enumerate(batch):
+                context = " / ".join(
+                    str(line or "").strip() for line in (block.lines or [])[:6]
+                )
+                lines.append(
+                    f"[{position}] 场景头：{block.header_line}\n"
+                    f"     程序解析：集={int(block.episode or 0)} "
+                    f"场次={block.scene_no or '无'} 地点={block.location or '无'} "
+                    f"时间={block.time_of_day or '无'} "
+                    f"内外={block.interior_exterior or '无'}\n"
+                    f"     正文片段：{context or '（无）'}"
+                )
+            result = await runner.run(
+                "请规范化以下每一个场景头，index 用方括号里的序号：\n"
+                + "\n".join(lines)
+            )
+            produced: list[tuple[int, NormalizedSceneBlock]] = []
+            for item in result.output.scenes:
+                if not 0 <= item.index < len(batch):
+                    continue
+                original_index, block = batch[item.index]
+                values = item.model_dump()
+                values.pop("index", None)
+                values["episode_number"] = int(
+                    item.episode_number or block.episode or 0
+                )
+                values["scene_no"] = str(item.scene_no or block.scene_no or "").strip()
+                values["location"] = str(item.location or block.location or "").strip()
+                values["time_of_day"] = str(
+                    item.time_of_day or block.time_of_day or "无"
+                ).strip()
+                values["interior_exterior"] = str(
+                    item.interior_exterior or block.interior_exterior or "无"
+                ).strip()
+                if not values["location"]:
+                    continue
+                header = NormalizedSceneHeader.model_validate(values)
+                produced.append((original_index, attach(block, header)))
+            return produced
+
+        for outcome in await map_bounded(
+            batches, run_batch, limit=default_llm_concurrency()
+        ):
+            for original_index, normalized in outcome or []:
+                resolved[original_index] = normalized
+
+    return [resolved[index] for index in sorted(resolved)]

--- a/src/novelvideo/cognee/store.py
+++ b/src/novelvideo/cognee/store.py
@@ -37,7 +37,7 @@ from novelvideo.graph_preview import (
 )
 from novelvideo.knowledge_pipeline import (
     KnowledgePipelineUnsupported,
-    is_structured_v2,
+    is_structured_pipeline,
 )
 from novelvideo.official_defaults import DEFAULT_COGNEE_LLM_MODEL
 from novelvideo.novel_source import require_imported_novel
@@ -300,7 +300,7 @@ class CogneeStore:
         """
         cached = self.__dict__.get("_cognee_enabled_flag")
         if cached is None:
-            cached = not is_structured_v2(self.__dict__.get("state_dir"))
+            cached = not is_structured_pipeline(self.__dict__.get("state_dir"))
             self.__dict__["_cognee_enabled_flag"] = cached
         return cached
 
@@ -312,7 +312,7 @@ class CogneeStore:
         """
         if not self._cognee_enabled:
             raise KnowledgePipelineUnsupported(
-                f"{operation} is unavailable for structured_v2 projects"
+                f"{operation} is unavailable for structured_v1 projects"
             )
 
     def embedding_model_scope(self):
@@ -480,7 +480,7 @@ class CogneeStore:
     async def initialize(self):
         """初始化 SQLite 数据库和 Cognee 配置。
 
-        structured_v2 项目降级为纯 SQLite 门面而不是抛异常：生产中有大量
+        structured_v1 项目降级为纯 SQLite 门面而不是抛异常：生产中有大量
         runner 和 API 依赖（肖像、参考图、剧本、分镜、视频、Freezone 等）只把
         本类当 SQLite 门面使用，完全不需要图谱。在这里硬失败会让这些路径在
         新项目上全线 500。图谱能力本身由 ``_require_cognee`` 单独把守。
@@ -488,11 +488,11 @@ class CogneeStore:
         # 必须先判定 track，再决定是否绑定 embedding：
         # ensure_cognee_embedding_binding_in_state_dir() 会为缺字段的项目回填
         # 绑定并写回 project_config.json，一旦调用就再也退不回去了。
-        if is_structured_v2(self.state_dir):
+        if is_structured_pipeline(self.state_dir):
             self.__dict__["_cognee_enabled_flag"] = False
             await self._ensure_db()
             console.print(
-                f"[dim]存储层已初始化 (structured_v2, 无图谱, db: {self.db_path})[/dim]"
+                f"[dim]存储层已初始化 (structured_v1, 无图谱, db: {self.db_path})[/dim]"
             )
             return
 

--- a/src/novelvideo/cognee/store.py
+++ b/src/novelvideo/cognee/store.py
@@ -35,6 +35,10 @@ from novelvideo.graph_preview import (
     delete_graph_preview,
     write_graph_preview,
 )
+from novelvideo.knowledge_pipeline import (
+    KnowledgePipelineUnsupported,
+    is_structured_v2,
+)
 from novelvideo.official_defaults import DEFAULT_COGNEE_LLM_MODEL
 from novelvideo.novel_source import require_imported_novel
 from novelvideo.project_config import ensure_cognee_embedding_binding_in_state_dir
@@ -286,7 +290,36 @@ class CogneeStore:
         """统一别名查找键，降低空格/大小写差异导致的失配。"""
         return " ".join((value or "").replace("\u3000", " ").strip().lower().split())
 
+    @property
+    def _cognee_enabled(self) -> bool:
+        """Whether this project may touch Cognee, embeddings or the graph.
+
+        Resolved lazily from the project's recorded track so that stores built
+        without ``initialize()`` (legacy tests, ad-hoc scripts) are gated too.
+        ``initialize()`` overwrites the cached value once it has decided.
+        """
+        cached = self.__dict__.get("_cognee_enabled_flag")
+        if cached is None:
+            cached = not is_structured_v2(self.__dict__.get("state_dir"))
+            self.__dict__["_cognee_enabled_flag"] = cached
+        return cached
+
+    def _require_cognee(self, operation: str) -> None:
+        """Fail loudly instead of silently falling back to the Cognee path.
+
+        A fallback here would bind a structured project to an embedding model,
+        which is the one outcome the second track exists to prevent.
+        """
+        if not self._cognee_enabled:
+            raise KnowledgePipelineUnsupported(
+                f"{operation} is unavailable for structured_v2 projects"
+            )
+
     def embedding_model_scope(self):
+        # Guarded as well as the public graph methods: entering the scope is how
+        # an embedding binding gets created, so a caller reaching past the public
+        # API must not be able to bind a structured project by accident.
+        self._require_cognee("embedding model scope")
         model = getattr(self, "cognee_embedding_model", None)
         dimensions = getattr(self, "cognee_embedding_dimensions", None)
         if not model or dimensions is None:
@@ -445,7 +478,25 @@ class CogneeStore:
         return await store._ensure_db()
 
     async def initialize(self):
-        """初始化 SQLite 数据库和 Cognee 配置。"""
+        """初始化 SQLite 数据库和 Cognee 配置。
+
+        structured_v2 项目降级为纯 SQLite 门面而不是抛异常：生产中有大量
+        runner 和 API 依赖（肖像、参考图、剧本、分镜、视频、Freezone 等）只把
+        本类当 SQLite 门面使用，完全不需要图谱。在这里硬失败会让这些路径在
+        新项目上全线 500。图谱能力本身由 ``_require_cognee`` 单独把守。
+        """
+        # 必须先判定 track，再决定是否绑定 embedding：
+        # ensure_cognee_embedding_binding_in_state_dir() 会为缺字段的项目回填
+        # 绑定并写回 project_config.json，一旦调用就再也退不回去了。
+        if is_structured_v2(self.state_dir):
+            self.__dict__["_cognee_enabled_flag"] = False
+            await self._ensure_db()
+            console.print(
+                f"[dim]存储层已初始化 (structured_v2, 无图谱, db: {self.db_path})[/dim]"
+            )
+            return
+
+        self.__dict__["_cognee_enabled_flag"] = True
         embedding_binding = ensure_cognee_embedding_binding_in_state_dir(self.state_dir)
         self.cognee_embedding_model = embedding_binding.internal_model
         self.cognee_embedding_dimensions = embedding_binding.dimensions
@@ -537,6 +588,7 @@ class CogneeStore:
         on_log: Optional[Callable[[str], None]] = None,
     ) -> dict:
         """快速导入，并独占当前项目的 Cognee/Ladybug 图谱。"""
+        self._require_cognee("Cognee graph ingest")
         async with ladybug_graph_access(self.state_dir, read_only=False):
             return await self._ingest_novel_fast_locked(
                 novel_path,
@@ -668,6 +720,7 @@ class CogneeStore:
         }
 
     async def materialize_graph_preview(self, max_nodes: int = 48) -> dict:
+        self._require_cognee("graph preview")
         async with ladybug_graph_access(self.state_dir, read_only=True):
             snapshot = await self.get_graph_snapshot(max_nodes=max_nodes)
             if not snapshot.get("nodes"):
@@ -684,6 +737,7 @@ class CogneeStore:
         oversized or vector-shaped values before returning them to the browser.
         """
 
+        self._require_cognee("graph snapshot")
         max_nodes = max(20, min(int(max_nodes), 80))
         max_edges = min(max_nodes * 3, 160)
         raw_nodes, raw_edges = await self._get_dataset_graph_data(
@@ -929,6 +983,7 @@ class CogneeStore:
         图谱构建只负责发现缺失的基础角色。已有角色可能已经有用户编辑、
         身份图、声线和资产配置，不能被一次图谱重扫覆盖。
         """
+        self._require_cognee("graph character build")
         from .pipeline import extract_characters_from_graph
 
         def report(progress: float, task: str):
@@ -1561,6 +1616,7 @@ class CogneeStore:
 
     async def search(self, query: str, mode: str = "graph", top_k: int = 10) -> str:
         """语义检索。"""
+        self._require_cognee("graph search")
         async with ladybug_graph_access(self.state_dir, read_only=True):
             with preserve_st_env():
                 from cognee.modules.data.exceptions.exceptions import DatasetNotFoundError
@@ -1891,6 +1947,7 @@ class CogneeStore:
         这里只补缺失的基础场景；已有基础场景和派生 plate 都是资产事实，
         不能被一次图谱重扫清空或覆盖。
         """
+        self._require_cognee("graph scene build")
         from .pipeline import extract_scenes_from_graph
 
         def report(progress: float, task: str):
@@ -1949,6 +2006,7 @@ class CogneeStore:
         on_log: Optional[Callable[[str], None]] = None,
     ) -> List[NovelProp]:
         """从图谱构建道具（分阶段架构第二步）。"""
+        self._require_cognee("graph prop build")
         from .pipeline import extract_props_from_graph
 
         def report(progress: float, task: str):

--- a/src/novelvideo/cognee/tools.py
+++ b/src/novelvideo/cognee/tools.py
@@ -13,6 +13,13 @@ from typing import Callable, List
 from novelvideo.cognee import CogneeStore
 from novelvideo.utils.logging import tool_logger
 
+# Legacy-only AI episode planner.
+# No current frontend workflow selects this mode: the "plan episodes" button
+# posts an empty body (frontend/src/routes/_app/projects.$project/episodes.tsx),
+# so planning_mode falls back to the "chapters" default in api/schemas.py.
+# Reaching this code still requires an explicit planning_mode="ai" from an API
+# client. Structured-v2 projects must not enter this path.
+# These tools all run cognee.search() and therefore require an embedding index.
 def create_episode_planner_tools(store: CogneeStore) -> List[Callable]:
     """创建 EpisodePlanner 的 Cognee 工具集。
 

--- a/src/novelvideo/knowledge_pipeline.py
+++ b/src/novelvideo/knowledge_pipeline.py
@@ -1,0 +1,69 @@
+"""Project-bound knowledge pipeline selection (dual-track).
+
+Two tracks coexist permanently:
+
+``cognee_legacy``
+    Everything created before structured extraction existed.  These projects are
+    bound to a Cognee dataset and an embedding model, and their behaviour must
+    not change.
+
+``structured_v2``
+    Deterministic extraction straight from the imported source text into SQLite.
+    No embedding model, no vector index, no graph search.
+
+The track is a permanent property of a project, chosen at creation time and
+never migrated.  It is stored under ``knowledge_pipeline`` in
+``project_config.json``.
+
+Two rules make the dual track safe:
+
+1. The track is read from the *raw* configuration file, never from the effective
+   configuration.  ``_effective_project_config`` merges
+   ``_default_project_config()`` over the stored values, so a default entry would
+   silently reclassify every legacy project that predates the field.
+
+2. A missing field means ``cognee_legacy``.  Absence of the embedding keys is not
+   a usable signal either: ``ensure_cognee_embedding_binding_in_state_dir``
+   backfills them for legacy projects, so only the explicit
+   ``knowledge_pipeline`` field can be trusted.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+KNOWLEDGE_PIPELINE_KEY = "knowledge_pipeline"
+
+COGNEE_LEGACY = "cognee_legacy"
+STRUCTURED_V2 = "structured_v2"
+
+
+class KnowledgePipelineUnsupported(RuntimeError):
+    """Raised when a project asks for a capability its track does not provide.
+
+    Structured projects must fail loudly here rather than fall back to the
+    Cognee path: a silent fallback would re-bind the project to an embedding
+    model, which is exactly what the second track exists to avoid.
+    """
+
+    error_code = "KNOWLEDGE_PIPELINE_UNSUPPORTED"
+
+
+def knowledge_pipeline_from_state_dir(state_dir: str | Path | None) -> str:
+    """Return the track recorded for a project, defaulting to the legacy one."""
+    if not state_dir:
+        return COGNEE_LEGACY
+
+    from novelvideo.project_config import load_project_config_file_from_state_dir
+
+    raw = load_project_config_file_from_state_dir(state_dir)
+    value = str(raw.get(KNOWLEDGE_PIPELINE_KEY, "") or "").strip()
+    return STRUCTURED_V2 if value == STRUCTURED_V2 else COGNEE_LEGACY
+
+
+def is_structured_v2(state_dir: str | Path | None) -> bool:
+    return knowledge_pipeline_from_state_dir(state_dir) == STRUCTURED_V2
+
+
+def is_cognee_legacy(state_dir: str | Path | None) -> bool:
+    return not is_structured_v2(state_dir)

--- a/src/novelvideo/knowledge_pipeline.py
+++ b/src/novelvideo/knowledge_pipeline.py
@@ -7,7 +7,7 @@ Two tracks coexist permanently:
     bound to a Cognee dataset and an embedding model, and their behaviour must
     not change.
 
-``structured_v2``
+``structured_v1``
     Deterministic extraction straight from the imported source text into SQLite.
     No embedding model, no vector index, no graph search.
 
@@ -35,7 +35,7 @@ from pathlib import Path
 KNOWLEDGE_PIPELINE_KEY = "knowledge_pipeline"
 
 COGNEE_LEGACY = "cognee_legacy"
-STRUCTURED_V2 = "structured_v2"
+KNOWLEDGE_PIPELINE_STRUCTURED = "structured_v1"
 
 
 class KnowledgePipelineUnsupported(RuntimeError):
@@ -58,12 +58,12 @@ def knowledge_pipeline_from_state_dir(state_dir: str | Path | None) -> str:
 
     raw = load_project_config_file_from_state_dir(state_dir)
     value = str(raw.get(KNOWLEDGE_PIPELINE_KEY, "") or "").strip()
-    return STRUCTURED_V2 if value == STRUCTURED_V2 else COGNEE_LEGACY
+    return KNOWLEDGE_PIPELINE_STRUCTURED if value == KNOWLEDGE_PIPELINE_STRUCTURED else COGNEE_LEGACY
 
 
-def is_structured_v2(state_dir: str | Path | None) -> bool:
-    return knowledge_pipeline_from_state_dir(state_dir) == STRUCTURED_V2
+def is_structured_pipeline(state_dir: str | Path | None) -> bool:
+    return knowledge_pipeline_from_state_dir(state_dir) == KNOWLEDGE_PIPELINE_STRUCTURED
 
 
 def is_cognee_legacy(state_dir: str | Path | None) -> bool:
-    return not is_structured_v2(state_dir)
+    return not is_structured_pipeline(state_dir)

--- a/src/novelvideo/official_defaults.py
+++ b/src/novelvideo/official_defaults.py
@@ -26,6 +26,7 @@ DEFAULT_TEXT_MODEL_BY_ENV = {
     "IDENTITY_PLANNER_APPEARANCE_MODEL": "DC-identity-appearance-writer-LLM",
     "LITERAL_BEAT_META_MODEL": "DC-literal-beat-meta-LLM",
     "SCENE_BUILD_MODEL": "DC-scene-builder-LLM",
+    "CHARACTER_BUILD_MODEL": "DC-character-builder-LLM",
     "EPISODE_SCENE_PLANNER_MODEL": "DC-episode-scene-planner-LLM",
     "EPISODE_PROP_PLANNER_MODEL": "DC-episode-prop-planner-LLM",
     "FREEZONE_TRANSLATION_MODEL": DEFAULT_FREEZONE_TRANSLATION_MODEL,

--- a/src/novelvideo/sqlite_store.py
+++ b/src/novelvideo/sqlite_store.py
@@ -2386,19 +2386,22 @@ class SQLiteStore:
         source_sha256: str,
         schema_version: int,
         pipeline_version: str,
+        spine_template: str = "",
     ) -> dict | None:
-        """Find a run that analysed identical text with identical code.
+        """Find a run that analysed identical text the same way.
 
-        Reuse is keyed on all three: different source text or a changed
-        extraction contract must not inherit another run's chunk results.
+        Reuse is keyed on all four. Different source text or a changed
+        extraction contract must not inherit another run's chunk results, and
+        neither must a different spine template: the same novel chunked as a
+        screenplay and as narrated prose produces entirely different chunks.
         """
         db = await self._ensure_db()
         async with db.execute(
             """SELECT * FROM story_analysis_runs
                WHERE source_sha256 = ? AND schema_version = ?
-                 AND pipeline_version = ?
+                 AND pipeline_version = ? AND spine_template = ?
                ORDER BY created_at DESC LIMIT 1""",
-            (source_sha256, int(schema_version), pipeline_version),
+            (source_sha256, int(schema_version), pipeline_version, spine_template),
         ) as cursor:
             row = await cursor.fetchone()
         return dict(row) if row else None

--- a/src/novelvideo/sqlite_store.py
+++ b/src/novelvideo/sqlite_store.py
@@ -799,6 +799,68 @@ class SQLiteStore:
         for alias in character.aliases:
             self._alias_index[alias] = character.name
 
+    async def add_characters_atomic(
+        self, characters: list, *, skip_existing: bool = True
+    ) -> list[str]:
+        """Publish many characters in one transaction.
+
+        add_character() commits per row, so a failure partway through a build
+        leaves half a cast behind. Structured builds publish their whole result
+        at once instead: either every character lands or none does.
+
+        Existing characters are skipped by default. A character on disk may
+        already carry user edits, a portrait, identities and voice bindings, and
+        a rebuild must not overwrite any of that.
+        """
+        if not characters:
+            return []
+
+        db = await self._ensure_db()
+        existing = set(self._characters) if skip_existing else set()
+        pending = [
+            character
+            for character in characters
+            if not (skip_existing and character.name in existing)
+        ]
+        if not pending:
+            return []
+
+        try:
+            await db.execute("BEGIN")
+            for character in pending:
+                await db.execute(
+                    """INSERT INTO characters
+                       (name, aliases_json, role, is_main, gender, age_group,
+                        body_type, fish_voice_id, description, face_prompt,
+                        appearance_details, identities_json)
+                       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                       ON CONFLICT(name) DO NOTHING""",
+                    (
+                        character.name,
+                        json.dumps(character.aliases, ensure_ascii=False),
+                        character.role,
+                        1 if character.is_main else 0,
+                        character.gender,
+                        character.age_group,
+                        character.body_type,
+                        character.fish_voice_id,
+                        character.description,
+                        character.face_prompt,
+                        character.appearance_details,
+                        character.identities_json,
+                    ),
+                )
+            await db.commit()
+        except Exception:
+            await db.rollback()
+            raise
+
+        for character in pending:
+            self._characters[character.name] = character
+            for alias in character.aliases:
+                self._alias_index[alias] = character.name
+        return [character.name for character in pending]
+
     async def update_character(self, name: str, **updates) -> None:
         char = self.get_character(name)
         if not char:

--- a/src/novelvideo/sqlite_store.py
+++ b/src/novelvideo/sqlite_store.py
@@ -352,13 +352,25 @@ CREATE TABLE IF NOT EXISTS entity_evidence (
 );
 CREATE INDEX IF NOT EXISTS idx_entity_evidence_entity
     ON entity_evidence(entity_type, entity_id);
+
+-- The final result of a run, after merging and adjudication. Chunk results are
+-- not sufficient on their own: adjudication is a further model call whose
+-- outcome can differ between runs, so without this an unchanged source could
+-- produce a different cast every rebuild.
+CREATE TABLE IF NOT EXISTS story_analysis_artifacts (
+    run_id            TEXT NOT NULL,
+    artifact_type     TEXT NOT NULL,
+    result_json       TEXT NOT NULL DEFAULT '{}',
+    created_at        TEXT DEFAULT (datetime('now')),
+    PRIMARY KEY (run_id, artifact_type)
+);
 """
 
 _PROJECT_STORE_SCHEMA_COMPONENT = "project_store"
 # MIGRATION CONTRACT: increment this whenever SQLITE_SCHEMA_SQL or any
 # _ensure_*_columns migration above changes. Existing databases skip the
 # initializer after this version has been recorded.
-_PROJECT_STORE_SCHEMA_VERSION = 2
+_PROJECT_STORE_SCHEMA_VERSION = 3
 
 
 def _table_columns(db: sqlite3.Connection, table: str) -> set[str]:
@@ -2515,6 +2527,39 @@ class SQLiteStore:
                SET status = ?, error = ?, completed_at = datetime('now')
                WHERE run_id = ?""",
             (status, str(error)[:2000], run_id),
+        )
+        await db.commit()
+
+    async def get_analysis_artifact(self, run_id: str, artifact_type: str) -> str:
+        """Return a stored final result for a run, or an empty string."""
+        db = await self._ensure_db()
+        async with db.execute(
+            """SELECT result_json FROM story_analysis_artifacts
+               WHERE run_id = ? AND artifact_type = ?""",
+            (run_id, artifact_type),
+        ) as cursor:
+            row = await cursor.fetchone()
+        return str(row["result_json"]) if row else ""
+
+    async def save_analysis_artifact(
+        self, run_id: str, artifact_type: str, result_json: str
+    ) -> None:
+        """Store a run's final result so a rebuild need not recompute it.
+
+        Chunk results alone are not enough to skip all work: merging is cheap
+        but adjudication is another model call, and re-running it can decide
+        differently, so an unchanged source could yield a different cast on
+        every rebuild.
+        """
+        db = await self._ensure_db()
+        await db.execute(
+            """INSERT INTO story_analysis_artifacts
+               (run_id, artifact_type, result_json, created_at)
+               VALUES (?, ?, ?, datetime('now'))
+               ON CONFLICT(run_id, artifact_type) DO UPDATE SET
+                 result_json = excluded.result_json,
+                 created_at = excluded.created_at""",
+            (run_id, artifact_type, result_json),
         )
         await db.commit()
 

--- a/src/novelvideo/sqlite_store.py
+++ b/src/novelvideo/sqlite_store.py
@@ -296,7 +296,7 @@ CREATE TABLE IF NOT EXISTS seedance2_voice_audio_records (
 CREATE INDEX IF NOT EXISTS idx_seedance2_voice_audio_speaker
     ON seedance2_voice_audio_records(episode_number, speaker);
 
--- structured_v2 analysis bookkeeping.
+-- structured_v1 analysis bookkeeping.
 --
 -- A run is keyed by what it analysed (source_sha256) and how (schema_version),
 -- so re-importing identical text reuses completed chunks and only failed or
@@ -336,8 +336,9 @@ CREATE TABLE IF NOT EXISTS story_analysis_chunks (
 CREATE INDEX IF NOT EXISTS idx_story_analysis_chunks_status
     ON story_analysis_chunks(run_id, status);
 
--- Every structured entity keeps at least one span of real source text, so a
--- character or scene can always be traced back to what produced it.
+-- Structured entities keep spans of real source text so they can be traced back
+-- to what produced them. Only characters record evidence today; entity_type
+-- exists so scenes and props can join later without a schema change.
 CREATE TABLE IF NOT EXISTS entity_evidence (
     run_id            TEXT NOT NULL,
     entity_type       TEXT NOT NULL,
@@ -2377,7 +2378,7 @@ class SQLiteStore:
         return cursor.rowcount or 0
 
     # ============================================================
-    # structured_v2 分析 run / chunk / 证据
+    # structured_v1 分析 run / chunk / 证据
     # ============================================================
 
     async def get_reusable_analysis_run(

--- a/src/novelvideo/sqlite_store.py
+++ b/src/novelvideo/sqlite_store.py
@@ -295,13 +295,69 @@ CREATE TABLE IF NOT EXISTS seedance2_voice_audio_records (
 );
 CREATE INDEX IF NOT EXISTS idx_seedance2_voice_audio_speaker
     ON seedance2_voice_audio_records(episode_number, speaker);
+
+-- structured_v2 analysis bookkeeping.
+--
+-- A run is keyed by what it analysed (source_sha256) and how (schema_version),
+-- so re-importing identical text reuses completed chunks and only failed or
+-- stale ones are recomputed. Chunks store source offsets rather than a copy of
+-- the text: duplicating a whole novel per run would dwarf the rest of the
+-- project database.
+CREATE TABLE IF NOT EXISTS story_analysis_runs (
+    run_id            TEXT PRIMARY KEY,
+    pipeline_version  TEXT NOT NULL,
+    schema_version    INTEGER NOT NULL DEFAULT 1,
+    spine_template    TEXT NOT NULL DEFAULT '',
+    source_sha256     TEXT NOT NULL,
+    source_length     INTEGER NOT NULL DEFAULT 0,
+    status            TEXT NOT NULL DEFAULT 'pending',
+    error             TEXT NOT NULL DEFAULT '',
+    created_at        TEXT DEFAULT (datetime('now')),
+    completed_at      TEXT DEFAULT ''
+);
+CREATE INDEX IF NOT EXISTS idx_story_analysis_runs_source
+    ON story_analysis_runs(source_sha256, schema_version);
+
+CREATE TABLE IF NOT EXISTS story_analysis_chunks (
+    run_id            TEXT NOT NULL,
+    chunk_id          TEXT NOT NULL,
+    chunk_index       INTEGER NOT NULL DEFAULT 0,
+    section_type      TEXT NOT NULL DEFAULT '',
+    section_label     TEXT NOT NULL DEFAULT '',
+    source_start      INTEGER NOT NULL DEFAULT 0,
+    source_end        INTEGER NOT NULL DEFAULT 0,
+    source_hash       TEXT NOT NULL DEFAULT '',
+    status            TEXT NOT NULL DEFAULT 'pending',
+    attempts          INTEGER NOT NULL DEFAULT 0,
+    error             TEXT NOT NULL DEFAULT '',
+    result_json       TEXT NOT NULL DEFAULT '{}',
+    PRIMARY KEY (run_id, chunk_id)
+);
+CREATE INDEX IF NOT EXISTS idx_story_analysis_chunks_status
+    ON story_analysis_chunks(run_id, status);
+
+-- Every structured entity keeps at least one span of real source text, so a
+-- character or scene can always be traced back to what produced it.
+CREATE TABLE IF NOT EXISTS entity_evidence (
+    run_id            TEXT NOT NULL,
+    entity_type       TEXT NOT NULL,
+    entity_id         TEXT NOT NULL,
+    chunk_id          TEXT NOT NULL,
+    source_start      INTEGER NOT NULL,
+    source_end        INTEGER NOT NULL,
+    evidence_kind     TEXT NOT NULL DEFAULT '',
+    evidence_text     TEXT NOT NULL DEFAULT '',
+    PRIMARY KEY (run_id, entity_type, entity_id, chunk_id, source_start, source_end)
+);
+CREATE INDEX IF NOT EXISTS idx_entity_evidence_entity
+    ON entity_evidence(entity_type, entity_id);
 """
 
 _PROJECT_STORE_SCHEMA_COMPONENT = "project_store"
 # MIGRATION CONTRACT: increment this whenever SQLITE_SCHEMA_SQL or any
 # _ensure_*_columns migration above changes. Existing databases skip the
 # initializer after this version has been recorded.
-_PROJECT_STORE_SCHEMA_VERSION = 1
+_PROJECT_STORE_SCHEMA_VERSION = 2
 
 
 def _table_columns(db: sqlite3.Connection, table: str) -> set[str]:
@@ -2257,6 +2313,197 @@ class SQLiteStore:
         cursor = await db.execute("DELETE FROM scenes")
         await db.commit()
         return cursor.rowcount or 0
+
+    # ============================================================
+    # structured_v2 分析 run / chunk / 证据
+    # ============================================================
+
+    async def get_reusable_analysis_run(
+        self,
+        *,
+        source_sha256: str,
+        schema_version: int,
+        pipeline_version: str,
+    ) -> dict | None:
+        """Find a run that analysed identical text with identical code.
+
+        Reuse is keyed on all three: different source text or a changed
+        extraction contract must not inherit another run's chunk results.
+        """
+        db = await self._ensure_db()
+        async with db.execute(
+            """SELECT * FROM story_analysis_runs
+               WHERE source_sha256 = ? AND schema_version = ?
+                 AND pipeline_version = ?
+               ORDER BY created_at DESC LIMIT 1""",
+            (source_sha256, int(schema_version), pipeline_version),
+        ) as cursor:
+            row = await cursor.fetchone()
+        return dict(row) if row else None
+
+    async def start_analysis_run(
+        self,
+        *,
+        run_id: str,
+        pipeline_version: str,
+        schema_version: int,
+        spine_template: str,
+        source_sha256: str,
+        source_length: int,
+        chunks: list,
+    ) -> None:
+        """Record a run and its chunk plan in one transaction.
+
+        A half-written plan would let a resume believe chunks are missing rather
+        than pending, so the run row and every chunk land together.
+        """
+        db = await self._ensure_db()
+        try:
+            await db.execute("BEGIN")
+            await db.execute(
+                """INSERT OR REPLACE INTO story_analysis_runs
+                   (run_id, pipeline_version, schema_version, spine_template,
+                    source_sha256, source_length, status, error, completed_at)
+                   VALUES (?, ?, ?, ?, ?, ?, 'pending', '', '')""",
+                (
+                    run_id,
+                    pipeline_version,
+                    int(schema_version),
+                    spine_template,
+                    source_sha256,
+                    int(source_length),
+                ),
+            )
+            await db.execute(
+                "DELETE FROM story_analysis_chunks WHERE run_id = ?", (run_id,)
+            )
+            await db.executemany(
+                """INSERT INTO story_analysis_chunks
+                   (run_id, chunk_id, chunk_index, section_type, section_label,
+                    source_start, source_end, source_hash, status)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'pending')""",
+                [
+                    (
+                        run_id,
+                        chunk.chunk_id,
+                        int(chunk.chunk_index),
+                        chunk.section_type,
+                        chunk.section_label,
+                        int(chunk.source_start),
+                        int(chunk.source_end),
+                        chunk.source_hash,
+                    )
+                    for chunk in chunks
+                ],
+            )
+            await db.commit()
+        except Exception:
+            await db.rollback()
+            raise
+
+    async def list_analysis_chunks(
+        self, run_id: str, *, status: str | None = None
+    ) -> list[dict]:
+        db = await self._ensure_db()
+        sql = "SELECT * FROM story_analysis_chunks WHERE run_id = ?"
+        params: list = [run_id]
+        if status:
+            sql += " AND status = ?"
+            params.append(status)
+        sql += " ORDER BY chunk_index"
+        async with db.execute(sql, params) as cursor:
+            rows = await cursor.fetchall()
+        return [dict(row) for row in rows]
+
+    async def mark_analysis_chunk_done(
+        self, run_id: str, chunk_id: str, result_json: str
+    ) -> None:
+        db = await self._ensure_db()
+        await db.execute(
+            """UPDATE story_analysis_chunks
+               SET status = 'done', error = '', result_json = ?,
+                   attempts = attempts + 1
+               WHERE run_id = ? AND chunk_id = ?""",
+            (result_json, run_id, chunk_id),
+        )
+        await db.commit()
+
+    async def mark_analysis_chunk_failed(
+        self, run_id: str, chunk_id: str, error: str
+    ) -> None:
+        db = await self._ensure_db()
+        await db.execute(
+            """UPDATE story_analysis_chunks
+               SET status = 'failed', error = ?, attempts = attempts + 1
+               WHERE run_id = ? AND chunk_id = ?""",
+            (str(error)[:2000], run_id, chunk_id),
+        )
+        await db.commit()
+
+    async def finish_analysis_run(
+        self, run_id: str, *, status: str, error: str = ""
+    ) -> None:
+        db = await self._ensure_db()
+        await db.execute(
+            """UPDATE story_analysis_runs
+               SET status = ?, error = ?, completed_at = datetime('now')
+               WHERE run_id = ?""",
+            (status, str(error)[:2000], run_id),
+        )
+        await db.commit()
+
+    async def replace_entity_evidence(
+        self, run_id: str, entity_type: str, entity_id: str, evidence: list[dict]
+    ) -> None:
+        """Rewrite one entity's evidence for a run.
+
+        Replacing rather than appending keeps a re-run of the same chunk from
+        accumulating duplicate spans for the same entity.
+        """
+        db = await self._ensure_db()
+        try:
+            await db.execute("BEGIN")
+            await db.execute(
+                """DELETE FROM entity_evidence
+                   WHERE run_id = ? AND entity_type = ? AND entity_id = ?""",
+                (run_id, entity_type, entity_id),
+            )
+            await db.executemany(
+                """INSERT OR REPLACE INTO entity_evidence
+                   (run_id, entity_type, entity_id, chunk_id, source_start,
+                    source_end, evidence_kind, evidence_text)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+                [
+                    (
+                        run_id,
+                        entity_type,
+                        entity_id,
+                        str(item.get("chunk_id", "")),
+                        int(item.get("source_start", 0)),
+                        int(item.get("source_end", 0)),
+                        str(item.get("evidence_kind", "")),
+                        str(item.get("evidence_text", "")),
+                    )
+                    for item in evidence
+                ],
+            )
+            await db.commit()
+        except Exception:
+            await db.rollback()
+            raise
+
+    async def list_entity_evidence(
+        self, entity_type: str, entity_id: str
+    ) -> list[dict]:
+        db = await self._ensure_db()
+        async with db.execute(
+            """SELECT * FROM entity_evidence
+               WHERE entity_type = ? AND entity_id = ?
+               ORDER BY chunk_id, source_start""",
+            (entity_type, entity_id),
+        ) as cursor:
+            rows = await cursor.fetchall()
+        return [dict(row) for row in rows]
 
     async def delete_all_props(self) -> int:
         """删除所有道具。"""

--- a/src/novelvideo/story_analysis.py
+++ b/src/novelvideo/story_analysis.py
@@ -1,0 +1,196 @@
+"""Deterministic source-text chunking for the structured_v2 pipeline.
+
+Structured extraction never hands a whole novel or screenplay to one model
+call.  It splits the imported text along boundaries the format already provides
+— scene headings for screenplays, chapter markers for prose — and analyses each
+piece independently so that work is bounded, parallelisable and resumable.
+
+Every chunk carries the character offsets it came from.  That is what lets a
+later extraction prove an entity is real: the evidence it reports has to appear
+inside the span it claims, in the imported text, or the candidate is dropped.
+
+Offsets are recovered without changing the shared parsers.  ``parse_scene_blocks``
+runs on stripped, blank-filtered lines and cannot report positions in the
+original text, and it is used by asset compilation, screenplay normalization and
+import quality checks — so instead of altering it, scene headers are located by
+scanning forward from the previous block's end.  Blocks come back in source
+order, so a forward-only scan cannot match an earlier occurrence.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass, field
+from typing import Literal
+
+SectionType = Literal["scene", "chapter", "window"]
+
+# Prose without any chapter marker still has to be analysed. Windows are large
+# enough to carry context across a conversation but small enough to stay well
+# inside a model's useful attention span.
+_WINDOW_CHARS = 6000
+_WINDOW_OVERLAP = 200
+
+
+@dataclass(frozen=True)
+class SourceChunk:
+    """One analysable span of the imported text."""
+
+    chunk_id: str
+    chunk_index: int
+    section_type: SectionType
+    section_label: str
+    source_start: int
+    source_end: int
+    text: str
+    characters: list[str] = field(default_factory=list)
+
+    @property
+    def source_hash(self) -> str:
+        return hashlib.sha256(self.text.encode("utf-8")).hexdigest()
+
+
+def source_sha256(text: str) -> str:
+    return hashlib.sha256((text or "").encode("utf-8")).hexdigest()
+
+
+def chunk_source_text(text: str, spine_template: str | None) -> list[SourceChunk]:
+    """Split imported text along the boundaries its format already provides.
+
+    Screenplays are cut at scene headings, prose at chapter markers.  Either may
+    fall through to fixed windows when the expected markers are absent, so that
+    a malformed import still produces analysable chunks instead of nothing.
+    """
+    if not (text or "").strip():
+        return []
+
+    if str(spine_template or "").strip() == "drama":
+        chunks = _chunk_by_scene(text)
+    else:
+        chunks = _chunk_by_chapter(text)
+
+    return chunks or _chunk_by_window(text)
+
+
+def _chunk_by_scene(text: str) -> list[SourceChunk]:
+    from novelvideo.utils.screenplay_scene_parser import parse_scene_blocks
+
+    blocks = parse_scene_blocks(text)
+    if not blocks:
+        return []
+
+    starts: list[int] = []
+    cursor = 0
+    for block in blocks:
+        anchor = (block.header_line or "").strip()
+        if not anchor:
+            anchor = next((line for line in block.lines if line.strip()), "").strip()
+
+        found = text.find(anchor, cursor) if anchor else -1
+        if found < 0:
+            # An anchor that cannot be located (the parser rewrote it, or the
+            # same heading was consumed earlier) must not silently swallow the
+            # preceding block: start where the previous one ended instead.
+            found = cursor
+        starts.append(found)
+        cursor = found + max(len(anchor), 1)
+
+    chunks: list[SourceChunk] = []
+    for index, block in enumerate(blocks):
+        start = starts[index]
+        end = starts[index + 1] if index + 1 < len(starts) else len(text)
+        if end <= start:
+            continue
+        label = block.header_line.strip() or block.location.strip() or f"场 {index + 1}"
+        chunks.append(
+            SourceChunk(
+                chunk_id=f"scene-{index:04d}",
+                chunk_index=index,
+                section_type="scene",
+                section_label=label,
+                source_start=start,
+                source_end=end,
+                text=text[start:end],
+                characters=list(block.characters),
+            )
+        )
+    return chunks
+
+
+def _chunk_by_chapter(text: str) -> list[SourceChunk]:
+    from novelvideo.cognee.chapter_detector import ChapterDetector
+
+    # A marker-less novel comes back as one synthesized chapter covering the
+    # whole text. Accepting it would defeat the point of chunking, and its
+    # content is rewritten by the detector's fallback preparation, so the
+    # offsets would not match the source either. Let the window path take over.
+    chapters = [
+        chapter
+        for chapter in ChapterDetector().detect(text)
+        if not getattr(chapter, "is_fallback", False)
+    ]
+    if not chapters:
+        return []
+
+    # ChapterDetector splits on "\n" without dropping blank lines, so line
+    # indices map back to character offsets exactly.
+    lines = text.split("\n")
+    line_offsets: list[int] = []
+    running = 0
+    for line in lines:
+        line_offsets.append(running)
+        running += len(line) + 1
+    line_offsets.append(len(text))
+
+    def offset_of(line_index: int) -> int:
+        clamped = max(0, min(int(line_index), len(line_offsets) - 1))
+        return line_offsets[clamped]
+
+    chunks: list[SourceChunk] = []
+    for index, chapter in enumerate(chapters):
+        start = offset_of(chapter.start_line)
+        end = min(offset_of(chapter.end_line), len(text))
+        if end <= start:
+            continue
+        chunks.append(
+            SourceChunk(
+                chunk_id=f"chapter-{index:04d}",
+                chunk_index=index,
+                section_type="chapter",
+                section_label=f"第{chapter.number}章",
+                source_start=start,
+                source_end=end,
+                text=text[start:end],
+            )
+        )
+    return chunks
+
+
+def _chunk_by_window(text: str) -> list[SourceChunk]:
+    """Fall back to overlapping fixed windows when no markers were found.
+
+    The overlap keeps an entity introduced right at a boundary from being cut in
+    half and missed by both neighbours.
+    """
+    chunks: list[SourceChunk] = []
+    start = 0
+    index = 0
+    length = len(text)
+    while start < length:
+        end = min(start + _WINDOW_CHARS, length)
+        chunks.append(
+            SourceChunk(
+                chunk_id=f"window-{index:04d}",
+                chunk_index=index,
+                section_type="window",
+                section_label=f"片段 {index + 1}",
+                source_start=start,
+                source_end=end,
+                text=text[start:end],
+            )
+        )
+        if end >= length:
+            break
+        start = end - _WINDOW_OVERLAP
+        index += 1
+    return chunks

--- a/src/novelvideo/story_analysis.py
+++ b/src/novelvideo/story_analysis.py
@@ -1,4 +1,4 @@
-"""Deterministic source-text chunking for the structured_v2 pipeline.
+"""Deterministic source-text chunking for the structured_v1 pipeline.
 
 Structured extraction never hands a whole novel or screenplay to one model
 call.  It splits the imported text along boundaries the format already provides

--- a/src/novelvideo/story_analysis.py
+++ b/src/novelvideo/story_analysis.py
@@ -273,6 +273,23 @@ def _chunk_by_chapter(text: str) -> list[SourceChunk]:
         return line_offsets[clamped]
 
     chunks: list[SourceChunk] = []
+    # Same reason as the screenplay path: a synopsis or cast list sitting before
+    # the first chapter marker is the densest description the source has, and it
+    # would otherwise fall outside every chunk.
+    first_start = offset_of(chapters[0].start_line)
+    if first_start > 0:
+        chunks.append(
+            SourceChunk(
+                chunk_id="chapter-preamble",
+                chunk_index=0,
+                section_type="chapter",
+                section_label="卷首",
+                source_start=0,
+                source_end=first_start,
+                text=text[:first_start],
+            )
+        )
+
     for index, chapter in enumerate(chapters):
         start = offset_of(chapter.start_line)
         end = min(offset_of(chapter.end_line), len(text))

--- a/src/novelvideo/story_analysis.py
+++ b/src/novelvideo/story_analysis.py
@@ -20,7 +20,7 @@ order, so a forward-only scan cannot match an earlier occurrence.
 from __future__ import annotations
 
 import hashlib
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from typing import Literal
 
 SectionType = Literal["scene", "chapter", "window"]
@@ -69,7 +69,53 @@ def chunk_source_text(text: str, spine_template: str | None) -> list[SourceChunk
     else:
         chunks = _chunk_by_chapter(text)
 
-    return chunks or _chunk_by_window(text)
+    if not chunks:
+        return _chunk_by_window(text)
+
+    # A scene or chapter boundary is the right place to cut, but it says nothing
+    # about size: a single chapter can run tens of thousands of characters. Split
+    # oversized sections further so every chunk stays within a useful context,
+    # and renumber so chunk_index still matches position.
+    bounded: list[SourceChunk] = []
+    for chunk in chunks:
+        bounded.extend(_split_oversized(chunk))
+    return [
+        replace(chunk, chunk_index=index) for index, chunk in enumerate(bounded)
+    ]
+
+
+def _split_oversized(chunk: SourceChunk) -> list[SourceChunk]:
+    """Break one section into overlapping parts if it exceeds the window size.
+
+    Parts keep the parent's label and derive their ids from it, so evidence
+    recorded against a part still points at a recognisable section.
+    """
+    if len(chunk.text) <= _WINDOW_CHARS:
+        return [chunk]
+
+    parts: list[SourceChunk] = []
+    offset = 0
+    part_index = 0
+    length = len(chunk.text)
+    while offset < length:
+        end = min(offset + _WINDOW_CHARS, length)
+        parts.append(
+            SourceChunk(
+                chunk_id=f"{chunk.chunk_id}-p{part_index:03d}",
+                chunk_index=chunk.chunk_index,
+                section_type=chunk.section_type,
+                section_label=f"{chunk.section_label}({part_index + 1})",
+                source_start=chunk.source_start + offset,
+                source_end=chunk.source_start + end,
+                text=chunk.text[offset:end],
+                characters=list(chunk.characters),
+            )
+        )
+        if end >= length:
+            break
+        offset = end - _WINDOW_OVERLAP
+        part_index += 1
+    return parts
 
 
 def _chunk_by_scene(text: str) -> list[SourceChunk]:

--- a/src/novelvideo/story_analysis.py
+++ b/src/novelvideo/story_analysis.py
@@ -31,6 +31,11 @@ SectionType = Literal["scene", "chapter", "window"]
 _WINDOW_CHARS = 6000
 _WINDOW_OVERLAP = 200
 
+# Short neighbouring sections are packed up to this size. A call costs the
+# same few seconds whether it carries 300 characters or 3000, so packing is
+# what keeps a screenplay of many small scenes from being all latency.
+_TARGET_CHUNK_CHARS = 3000
+
 
 @dataclass(frozen=True)
 class SourceChunk:
@@ -73,15 +78,74 @@ def chunk_source_text(text: str, spine_template: str | None) -> list[SourceChunk
         return _chunk_by_window(text)
 
     # A scene or chapter boundary is the right place to cut, but it says nothing
-    # about size: a single chapter can run tens of thousands of characters. Split
-    # oversized sections further so every chunk stays within a useful context,
-    # and renumber so chunk_index still matches position.
+    # about size: a single chapter can run tens of thousands of characters, while
+    # a screenplay scene is often a few hundred. Split what is too big, then pack
+    # what is too small, and renumber so chunk_index still matches position.
     bounded: list[SourceChunk] = []
     for chunk in chunks:
         bounded.extend(_split_oversized(chunk))
+    packed = _pack_small(bounded)
     return [
-        replace(chunk, chunk_index=index) for index, chunk in enumerate(bounded)
+        replace(chunk, chunk_index=index) for index, chunk in enumerate(packed)
     ]
+
+
+def _pack_small(chunks: list[SourceChunk]) -> list[SourceChunk]:
+    """Group consecutive short sections into one analysable chunk.
+
+    A model call costs several seconds of round trip no matter how little text
+    it carries, so a screenplay of many short scenes spends nearly all its time
+    waiting rather than reading. Sections are contiguous by construction, so
+    joining neighbours keeps offsets exact and evidence still resolves against
+    the source.
+
+    Only neighbours of the same kind are joined, and packing stops at the target
+    size, so a chunk never grows past what one call can usefully consider.
+    """
+    packed: list[SourceChunk] = []
+    group: list[SourceChunk] = []
+
+    def flush() -> None:
+        if not group:
+            return
+        if len(group) == 1:
+            packed.append(group[0])
+        else:
+            first, last = group[0], group[-1]
+            label = first.section_label
+            if len(group) > 1:
+                label = f"{first.section_label} 等 {len(group)} 段"
+            characters: list[str] = []
+            for member in group:
+                for name in member.characters:
+                    if name not in characters:
+                        characters.append(name)
+            packed.append(
+                SourceChunk(
+                    chunk_id=f"{first.chunk_id}+{len(group)}",
+                    chunk_index=first.chunk_index,
+                    section_type=first.section_type,
+                    section_label=label,
+                    source_start=first.source_start,
+                    source_end=last.source_end,
+                    # Rebuilt from the members rather than re-sliced, so this
+                    # stays correct even if neighbours are ever non-contiguous.
+                    text="".join(member.text for member in group),
+                    characters=characters,
+                )
+            )
+        group.clear()
+
+    for chunk in chunks:
+        if group:
+            same_kind = chunk.section_type == group[0].section_type
+            contiguous = chunk.source_start == group[-1].source_end
+            width = (chunk.source_end - group[0].source_start)
+            if not (same_kind and contiguous) or width > _TARGET_CHUNK_CHARS:
+                flush()
+        group.append(chunk)
+    flush()
+    return packed
 
 
 def _split_oversized(chunk: SourceChunk) -> list[SourceChunk]:
@@ -142,6 +206,22 @@ def _chunk_by_scene(text: str) -> list[SourceChunk]:
         cursor = found + max(len(anchor), 1)
 
     chunks: list[SourceChunk] = []
+    # Whatever precedes the first scene heading — a synopsis, a cast list, the
+    # character bios — is often the densest description in the whole script, so
+    # it must not fall outside every chunk.
+    if starts and starts[0] > 0:
+        chunks.append(
+            SourceChunk(
+                chunk_id="scene-preamble",
+                chunk_index=0,
+                section_type="scene",
+                section_label="片头",
+                source_start=0,
+                source_end=starts[0],
+                text=text[: starts[0]],
+            )
+        )
+
     for index, block in enumerate(blocks):
         start = starts[index]
         end = starts[index + 1] if index + 1 < len(starts) else len(text)

--- a/src/novelvideo/structured_builders.py
+++ b/src/novelvideo/structured_builders.py
@@ -187,6 +187,7 @@ async def build_scenes_structured(
     discovered per episode from that episode's own text instead.
     """
     from novelvideo.cognee.pipeline import extract_scenes_from_script
+    from novelvideo.structured_extraction import adjudicate_scenes
 
     def report(progress: float, task: str) -> None:
         if on_progress:
@@ -219,6 +220,11 @@ async def build_scenes_structured(
         log("⚠️ 未从场次头提取到场景，保留现有场景数据")
         report(1.0, "提取无结果")
         return {"scenes": 0, "added_scenes": 0, "mode": "script"}
+
+    report(0.8, "归一同一地点的不同写法...")
+    scenes = await adjudicate_scenes(
+        scenes, occurrences=_scene_heading_counts(novel_text), on_log=log
+    )
 
     report(0.85, "保存新增场景...")
     added = 0
@@ -259,6 +265,22 @@ async def build_props_structured(
         "mode": "episode_on_demand",
         "message": PROP_BUILD_DEFERRED_MESSAGE,
     }
+
+
+def _scene_heading_counts(novel_text: str) -> dict[str, int]:
+    """How many scenes each heading location covers.
+
+    The adjudicator prefers the spelling the script actually uses most, which
+    is a better canonical name than whichever variant happened to sort first.
+    """
+    from novelvideo.utils.screenplay_scene_parser import parse_scene_blocks
+
+    counts: dict[str, int] = {}
+    for block in parse_scene_blocks(novel_text):
+        location = (block.location or "").strip()
+        if location:
+            counts[location] = counts.get(location, 0) + 1
+    return counts
 
 
 async def _current_run(store: Any, novel_text: str, spine_template: str) -> dict | None:

--- a/src/novelvideo/structured_builders.py
+++ b/src/novelvideo/structured_builders.py
@@ -1,0 +1,206 @@
+"""Project-level asset builds for structured_v2 projects.
+
+Each build reads the imported source text and publishes to SQLite.  None of them
+touch Cognee, an embedding model or the graph.
+
+The three builds differ in how much they can usefully do up front:
+
+* **Characters** are worth discovering across the whole work, for both formats.
+* **Scenes** are worth discovering up front only for screenplays, where scene
+  headings already name every location.  Narrated projects have no comparable
+  marker, so their scenes accumulate per episode instead.
+* **Props** are never worth a full-text sweep.  What matters is which objects
+  carry story weight in a given episode, which is a per-episode judgement.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Optional
+
+from novelvideo.novel_source import require_imported_novel
+from novelvideo.project_config import load_project_config_file_from_state_dir
+from novelvideo.story_analysis import chunk_source_text
+
+PROP_BUILD_DEFERRED_MESSAGE = "道具将在分集规划时按需生成"
+SCENE_BUILD_DEFERRED_MESSAGE = "解说剧场景将在分集规划时按需生成"
+
+
+def spine_template_for(store: Any) -> str:
+    config = load_project_config_file_from_state_dir(store.state_dir)
+    return str(config.get("spine_template") or "drama").strip()
+
+
+async def build_characters_structured(
+    store: Any,
+    *,
+    on_progress: Optional[Callable[[float, str], None]] = None,
+    on_log: Optional[Callable[[str], None]] = None,
+) -> list[str]:
+    """Discover characters from the source text and publish them atomically.
+
+    Only missing characters are added.  An existing character may already carry
+    user edits, a portrait, identities and voice bindings, so a rebuild must
+    never overwrite one.
+    """
+    from novelvideo.cognee.pipeline import NovelCharacter
+    from novelvideo.structured_extraction import extract_characters_from_chunks
+
+    def report(progress: float, task: str) -> None:
+        if on_progress:
+            on_progress(progress, task)
+
+    def log(message: str) -> None:
+        if on_log:
+            on_log(message)
+
+    novel_text = require_imported_novel(store.project_dir)
+    template = spine_template_for(store)
+
+    report(0.1, "切分原文...")
+    chunks = chunk_source_text(novel_text, template)
+    if not chunks:
+        log("⚠️ 原文切分结果为空")
+        report(1.0, "无可分析内容")
+        return []
+    log(f"确定性切分: {len(chunks)} 个片段（{chunks[0].section_type}）")
+
+    report(0.2, "逐片段抽取角色...")
+    merged = await extract_characters_from_chunks(
+        chunks,
+        on_log=log,
+    )
+    if not merged:
+        log("⚠️ 未抽取到有原文证据的角色，保留现有角色数据")
+        report(1.0, "提取无结果")
+        return []
+    log(f"归一后得到 {len(merged)} 个角色候选")
+
+    report(0.8, "发布角色...")
+    candidates = [
+        NovelCharacter(
+            name=item.name,
+            aliases=sorted(item.aliases),
+            gender=item.gender,
+            description=item.description,
+        )
+        for item in merged
+    ]
+    added = await store.add_characters_atomic(candidates, skip_existing=True)
+    log(f"已新增 {len(added)} 个角色，跳过已有 {len(candidates) - len(added)} 个")
+
+    report(0.95, "记录角色证据...")
+    run = await _current_run(store, novel_text)
+    if run:
+        by_name = {item.name: item for item in merged}
+        for name in added:
+            item = by_name.get(name)
+            if item:
+                await store.replace_entity_evidence(
+                    run["run_id"], "character", name, item.evidence
+                )
+
+    report(1.0, "角色提取完成")
+    return added
+
+
+async def build_scenes_structured(
+    store: Any,
+    *,
+    on_progress: Optional[Callable[[float, str], None]] = None,
+    on_log: Optional[Callable[[str], None]] = None,
+) -> dict:
+    """Build base scenes from screenplay headings; defer for narrated projects.
+
+    A screenplay names every location in its scene headings, so a full-text pass
+    produces a genuinely reusable catalogue.  Narrated source has no equivalent
+    marker: a full-text sweep would guess at locations, so those scenes are
+    discovered per episode from that episode's own text instead.
+    """
+    from novelvideo.cognee.pipeline import extract_scenes_from_script
+
+    def report(progress: float, task: str) -> None:
+        if on_progress:
+            on_progress(progress, task)
+
+    def log(message: str) -> None:
+        if on_log:
+            on_log(message)
+
+    novel_text = require_imported_novel(store.project_dir)
+    template = spine_template_for(store)
+
+    if template != "drama":
+        log(SCENE_BUILD_DEFERRED_MESSAGE)
+        report(1.0, "无需提前构建场景")
+        return {
+            "scenes": 0,
+            "added_scenes": 0,
+            "mode": "episode_on_demand",
+            "message": SCENE_BUILD_DEFERRED_MESSAGE,
+        }
+
+    report(0.1, "从场次头提取基础场景...")
+    scenes = await extract_scenes_from_script(
+        novel_text,
+        on_progress=lambda progress, task: report(0.1 + progress * 0.7, task),
+        on_log=on_log,
+    )
+    if not scenes:
+        log("⚠️ 未从场次头提取到场景，保留现有场景数据")
+        report(1.0, "提取无结果")
+        return {"scenes": 0, "added_scenes": 0, "mode": "script"}
+
+    report(0.85, "保存新增场景...")
+    added = 0
+    skipped = 0
+    for scene in scenes:
+        # Existing base scenes and their derived plates are asset facts; a
+        # rebuild adds what is missing and leaves the rest alone.
+        if await store.get_scene(scene.name):
+            skipped += 1
+            continue
+        await store.add_scene(scene)
+        added += 1
+    log(f"已新增 {added} 个场景，跳过已有 {skipped} 个")
+
+    report(1.0, "场景提取完成")
+    return {"scenes": len(scenes), "added_scenes": added, "mode": "script"}
+
+
+async def build_props_structured(
+    store: Any,
+    *,
+    on_progress: Optional[Callable[[float, str], None]] = None,
+    on_log: Optional[Callable[[str], None]] = None,
+) -> dict:
+    """Report that props are discovered per episode, not swept up front.
+
+    A full-text prop sweep cannot tell a story-bearing object from background
+    furniture, because that distinction depends on what an episode does with it.
+    This returns an explicit deferral rather than a silent no-op, so callers do
+    not read "0 props" as "the analysis found nothing".
+    """
+    if on_log:
+        on_log(PROP_BUILD_DEFERRED_MESSAGE)
+    if on_progress:
+        on_progress(1.0, "道具按分集生成")
+    return {
+        "props": 0,
+        "mode": "episode_on_demand",
+        "message": PROP_BUILD_DEFERRED_MESSAGE,
+    }
+
+
+async def _current_run(store: Any, novel_text: str) -> dict | None:
+    """Find the analysis run recorded for the text now on disk."""
+    from novelvideo.story_analysis import source_sha256
+    from novelvideo.structured_ingest import (
+        STRUCTURED_PIPELINE_VERSION,
+        STRUCTURED_SCHEMA_VERSION,
+    )
+
+    return await store.get_reusable_analysis_run(
+        source_sha256=source_sha256(novel_text),
+        schema_version=STRUCTURED_SCHEMA_VERSION,
+        pipeline_version=STRUCTURED_PIPELINE_VERSION,
+    )

--- a/src/novelvideo/structured_builders.py
+++ b/src/novelvideo/structured_builders.py
@@ -19,7 +19,7 @@ from typing import Any, Callable, Optional
 
 from novelvideo.novel_source import require_imported_novel
 from novelvideo.project_config import load_project_config_file_from_state_dir
-from novelvideo.story_analysis import chunk_source_text
+from novelvideo.story_analysis import SourceChunk, chunk_source_text
 
 PROP_BUILD_DEFERRED_MESSAGE = "道具将在分集规划时按需生成"
 SCENE_BUILD_DEFERRED_MESSAGE = "解说剧场景将在分集规划时按需生成"
@@ -43,7 +43,10 @@ async def build_characters_structured(
     never overwrite one.
     """
     from novelvideo.cognee.pipeline import NovelCharacter
-    from novelvideo.structured_extraction import extract_characters_from_chunks
+    from novelvideo.structured_extraction import (
+        ChunkCharacterOutput,
+        extract_characters_from_chunks,
+    )
 
     def report(progress: float, task: str) -> None:
         if on_progress:
@@ -64,11 +67,63 @@ async def build_characters_structured(
         return []
     log(f"确定性切分: {len(chunks)} 个片段（{chunks[0].section_type}）")
 
+    run = await _current_run(store, novel_text, template)
+    run_id = run["run_id"] if run else ""
+
+    # Resume: a retried task or a second click on "build characters" must not
+    # pay for every chunk again. Chunks already recorded as done are replayed
+    # from their stored result instead of being sent to the model.
+    cached: list[tuple[SourceChunk, ChunkCharacterOutput]] = []
+    pending = chunks
+    if run_id:
+        done = {
+            row["chunk_id"]: row
+            for row in await store.list_analysis_chunks(run_id, status="done")
+        }
+        by_id = {chunk.chunk_id: chunk for chunk in chunks}
+        for chunk_id, row in done.items():
+            chunk = by_id.get(chunk_id)
+            # A stored result only applies if the span it was produced from is
+            # byte-identical; otherwise the text moved and it must be redone.
+            if chunk is None or row["source_hash"] != chunk.source_hash:
+                continue
+            try:
+                cached.append(
+                    (chunk, ChunkCharacterOutput.model_validate_json(row["result_json"]))
+                )
+            except Exception:
+                continue
+        replayed = {chunk.chunk_id for chunk, _ in cached}
+        pending = [chunk for chunk in chunks if chunk.chunk_id not in replayed]
+        if cached:
+            log(f"复用 {len(cached)} 个已完成片段，仅重算 {len(pending)} 个")
+
+    async def persist_done(chunk: SourceChunk, output: ChunkCharacterOutput) -> None:
+        if run_id:
+            await store.mark_analysis_chunk_done(
+                run_id, chunk.chunk_id, output.model_dump_json()
+            )
+
+    async def persist_failed(chunk: SourceChunk, exc: BaseException) -> None:
+        if run_id:
+            await store.mark_analysis_chunk_failed(run_id, chunk.chunk_id, str(exc))
+
     report(0.2, "逐片段抽取角色...")
-    merged = await extract_characters_from_chunks(
-        chunks,
+    merged, failures = await extract_characters_from_chunks(
+        pending,
         on_log=log,
+        cached_outcomes=cached,
+        on_chunk_done=persist_done,
+        on_chunk_failed=persist_failed,
     )
+    if run_id:
+        # A run with failed chunks is "partial", not "completed": the next build
+        # must know there is work left rather than treating this as finished.
+        await store.finish_analysis_run(
+            run_id,
+            status="partial" if failures else "completed",
+            error=f"{len(failures)} chunks failed" if failures else "",
+        )
     if not merged:
         log("⚠️ 未抽取到有原文证据的角色，保留现有角色数据")
         report(1.0, "提取无结果")
@@ -89,14 +144,13 @@ async def build_characters_structured(
     log(f"已新增 {len(added)} 个角色，跳过已有 {len(candidates) - len(added)} 个")
 
     report(0.95, "记录角色证据...")
-    run = await _current_run(store, novel_text)
-    if run:
+    if run_id:
         by_name = {item.name: item for item in merged}
         for name in added:
             item = by_name.get(name)
             if item:
                 await store.replace_entity_evidence(
-                    run["run_id"], "character", name, item.evidence
+                    run_id, "character", name, item.evidence
                 )
 
     report(1.0, "角色提取完成")
@@ -191,8 +245,13 @@ async def build_props_structured(
     }
 
 
-async def _current_run(store: Any, novel_text: str) -> dict | None:
-    """Find the analysis run recorded for the text now on disk."""
+async def _current_run(store: Any, novel_text: str, spine_template: str) -> dict | None:
+    """Find the analysis run recorded for the text now on disk.
+
+    The spine template is part of the key: the same novel chunked as a
+    screenplay and as narrated prose produces different chunk plans, so one
+    must never inherit the other's results.
+    """
     from novelvideo.story_analysis import source_sha256
     from novelvideo.structured_ingest import (
         STRUCTURED_PIPELINE_VERSION,
@@ -203,4 +262,5 @@ async def _current_run(store: Any, novel_text: str) -> dict | None:
         source_sha256=source_sha256(novel_text),
         schema_version=STRUCTURED_SCHEMA_VERSION,
         pipeline_version=STRUCTURED_PIPELINE_VERSION,
+        spine_template=spine_template,
     )

--- a/src/novelvideo/structured_builders.py
+++ b/src/novelvideo/structured_builders.py
@@ -113,6 +113,7 @@ async def build_characters_structured(
         pending,
         on_log=log,
         cached_outcomes=cached,
+        source_text=novel_text,
         on_chunk_done=persist_done,
         on_chunk_failed=persist_failed,
     )

--- a/src/novelvideo/structured_builders.py
+++ b/src/novelvideo/structured_builders.py
@@ -19,6 +19,8 @@ from typing import Any, Callable, Optional
 
 from novelvideo.novel_source import require_imported_novel
 from novelvideo.project_config import load_project_config_file_from_state_dir
+import json
+
 from novelvideo.story_analysis import SourceChunk, chunk_source_text
 
 PROP_BUILD_DEFERRED_MESSAGE = "道具将在分集规划时按需生成"
@@ -42,9 +44,9 @@ async def build_characters_structured(
     user edits, a portrait, identities and voice bindings, so a rebuild must
     never overwrite one.
     """
-    from novelvideo.cognee.pipeline import NovelCharacter
     from novelvideo.structured_extraction import (
         ChunkCharacterOutput,
+        MergedCharacter,
         extract_characters_from_chunks,
     )
 
@@ -98,6 +100,33 @@ async def build_characters_structured(
         if cached:
             log(f"复用 {len(cached)} 个已完成片段，仅重算 {len(pending)} 个")
 
+    # A completed run replays its final cast rather than re-adjudicating. Chunk
+    # caching alone still costs one adjudication call per rebuild, and a second
+    # adjudication can decide differently — leaving an alias to reappear as its
+    # own character, which add_characters_atomic would then insert as a new row.
+    if run_id and not pending:
+        stored = await store.get_analysis_artifact(run_id, "characters")
+        if stored:
+            try:
+                payload = json.loads(stored)
+            except ValueError:
+                payload = None
+            if payload:
+                log(f"复用上次裁决结果：{len(payload)} 个角色，未调用模型")
+                merged = [
+                    MergedCharacter(
+                        name=item["name"],
+                        aliases=set(item.get("aliases") or []),
+                        gender=item.get("gender", ""),
+                        description=item.get("description", ""),
+                        evidence=list(item.get("evidence") or []),
+                    )
+                    for item in payload
+                ]
+                return await _publish_characters(
+                    store, merged, run_id, report, log
+                )
+
     async def persist_done(chunk: SourceChunk, output: ChunkCharacterOutput) -> None:
         if run_id:
             await store.mark_analysis_chunk_done(
@@ -114,6 +143,9 @@ async def build_characters_structured(
         on_log=log,
         cached_outcomes=cached,
         source_text=novel_text,
+        # Cast lists come from every chunk, including ones replayed from cache,
+        # so a resumed build protects the same characters a fresh one does.
+        roster={name for chunk in chunks for name in chunk.characters},
         on_chunk_done=persist_done,
         on_chunk_failed=persist_failed,
     )
@@ -136,6 +168,41 @@ async def build_characters_structured(
         report(1.0, "提取无结果")
         return []
     log(f"归一后得到 {len(merged)} 个角色候选")
+
+    if run_id:
+        await store.save_analysis_artifact(
+            run_id,
+            "characters",
+            json.dumps(
+                [
+                    {
+                        "name": item.name,
+                        "aliases": sorted(item.aliases),
+                        "gender": item.gender,
+                        "description": item.description,
+                        "evidence": item.evidence,
+                    }
+                    for item in merged
+                ],
+                ensure_ascii=False,
+            ),
+        )
+
+    return await _publish_characters(
+        store, merged, run_id, report, log, outcome
+    )
+
+
+async def _publish_characters(
+    store: Any,
+    merged: list,
+    run_id: str,
+    report: Callable[[float, str], None],
+    log: Callable[[str], None],
+    outcome: tuple[str, str] = ("completed", ""),
+) -> list[str]:
+    """Publish a settled cast, whether freshly built or replayed from cache."""
+    from novelvideo.cognee.pipeline import NovelCharacter
 
     report(0.8, "发布角色...")
     candidates = [
@@ -167,7 +234,10 @@ async def build_characters_structured(
     # Only now is the run genuinely finished. Marking it complete before
     # publishing would leave a run that claims success while its characters or
     # evidence never landed.
-    await finish(outcome)
+    if run_id:
+        await store.finish_analysis_run(
+            run_id, status=outcome[0], error=outcome[1]
+        )
 
     report(1.0, "角色提取完成")
     return added

--- a/src/novelvideo/structured_builders.py
+++ b/src/novelvideo/structured_builders.py
@@ -1,4 +1,4 @@
-"""Project-level asset builds for structured_v2 projects.
+"""Project-level asset builds for structured_v1 projects.
 
 Each build reads the imported source text and publishes to SQLite.  None of them
 touch Cognee, an embedding model or the graph.
@@ -116,15 +116,21 @@ async def build_characters_structured(
         on_chunk_done=persist_done,
         on_chunk_failed=persist_failed,
     )
-    if run_id:
-        # A run with failed chunks is "partial", not "completed": the next build
-        # must know there is work left rather than treating this as finished.
-        await store.finish_analysis_run(
-            run_id,
-            status="partial" if failures else "completed",
-            error=f"{len(failures)} chunks failed" if failures else "",
-        )
+    async def finish(status_error: tuple[str, str]) -> None:
+        if run_id:
+            await store.finish_analysis_run(
+                run_id, status=status_error[0], error=status_error[1]
+            )
+
+    outcome = (
+        ("partial", f"{len(failures)} chunks failed") if failures else ("completed", "")
+    )
+
     if not merged:
+        # Nothing to publish, but the run still has to be closed out, or the
+        # next build sees a run stuck at "pending" and cannot tell whether work
+        # is outstanding.
+        await finish(outcome)
         log("⚠️ 未抽取到有原文证据的角色，保留现有角色数据")
         report(1.0, "提取无结果")
         return []
@@ -145,13 +151,22 @@ async def build_characters_structured(
 
     report(0.95, "记录角色证据...")
     if run_id:
-        by_name = {item.name: item for item in merged}
-        for name in added:
-            item = by_name.get(name)
-            if item:
-                await store.replace_entity_evidence(
-                    run_id, "character", name, item.evidence
-                )
+        # Evidence is written for every merged character, not just the newly
+        # added ones. Publishing characters and writing their evidence are two
+        # steps: if the first succeeded and the second did not, a retry finds
+        # the characters already present, so keying on "added" would leave them
+        # permanently without provenance. Writing for all of them is idempotent
+        # — replace_entity_evidence rewrites rather than appends — and never
+        # touches the character rows a user may have edited.
+        for item in merged:
+            await store.replace_entity_evidence(
+                run_id, "character", item.name, item.evidence
+            )
+
+    # Only now is the run genuinely finished. Marking it complete before
+    # publishing would leave a run that claims success while its characters or
+    # evidence never landed.
+    await finish(outcome)
 
     report(1.0, "角色提取完成")
     return added

--- a/src/novelvideo/structured_extraction.py
+++ b/src/novelvideo/structured_extraction.py
@@ -1,0 +1,328 @@
+"""Character extraction straight from source text, without a knowledge graph.
+
+The legacy path asks Cognee for graph context and lets a model name whoever it
+finds there.  Structured extraction inverts that: the model only reports what a
+specific span of text supports, and every candidate it returns must quote the
+span it came from.  Quotes that cannot be found in the source are dropped, so a
+hallucinated name has no route into the character table.
+
+Merging is deliberately conservative.  A character's name is simultaneously a
+SQLite primary key, a REST identifier and an asset directory name, so a wrong
+merge is expensive to undo and a wrong split is cheap.  Rules therefore only
+merge what the text states outright, and anything genuinely ambiguous is left
+as separate candidates rather than guessed at.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import Any, Callable, Optional
+
+from pydantic import BaseModel, Field
+
+from novelvideo.story_analysis import SourceChunk
+from novelvideo.utils.bounded_concurrency import map_bounded
+
+# Titles and kinship terms refer to whoever is on stage at the time. The same
+# word in two chapters is routinely two different people, so they never merge
+# across chunks on their own and never become aliases automatically.
+GENERIC_ADDRESS_TERMS = {
+    "母亲", "父亲", "爸爸", "妈妈", "娘", "爹", "儿子", "女儿",
+    "哥哥", "姐姐", "弟弟", "妹妹", "爷爷", "奶奶", "外公", "外婆",
+    "医生", "护士", "老师", "司机", "老板", "警察", "士兵", "侍卫",
+    "陛下", "殿下", "大人", "公子", "小姐", "夫人", "先生", "少爷",
+    "掌柜", "伙计", "路人", "村民", "宫女", "太监", "将军", "丫鬟",
+    "男人", "女人", "老人", "孩子", "少年", "少女", "他", "她",
+}
+
+# Explicit alias statements. Only these license an alias link; a model asserting
+# two names are the same without the text saying so is not enough.
+_ALIAS_PATTERNS = [
+    re.compile(r"(?P<a>[一-鿿]{2,6})\s*(?:又名|本名|原名|真名|化名|人称|人称是|即)\s*(?P<b>[一-鿿]{2,6})"),
+    re.compile(r"(?P<a>[一-鿿]{2,6})\s*(?:又|也)\s*(?:叫|称|唤)(?:作|做)?\s*(?P<b>[一-鿿]{2,6})"),
+    re.compile(r"(?P<a>[一-鿿]{2,6})\s*(?:小名|乳名|别号|外号|绰号)\s*(?:叫|是|为)?\s*(?P<b>[一-鿿]{2,6})"),
+]
+
+
+class CharacterEvidence(BaseModel):
+    quote: str = Field(description="原文中的一句完整引用，必须逐字来自输入文本")
+    kind: str = Field(default="mention", description="mention / dialogue / description")
+
+
+class CharacterCandidate(BaseModel):
+    name: str = Field(description="角色在本片段中的称呼，保持原文写法")
+    aliases: list[str] = Field(default_factory=list, description="仅限本片段原文明确写出的别名")
+    gender: str = Field(default="", description="male / female / 空字符串表示未知")
+    description: str = Field(default="", description="本片段支持的简短描述")
+    evidence: list[CharacterEvidence] = Field(default_factory=list)
+
+
+class ChunkCharacterOutput(BaseModel):
+    characters: list[CharacterCandidate] = Field(default_factory=list)
+
+
+CHARACTER_EXTRACTION_SYSTEM_PROMPT = """你是剧本/小说的角色抽取器。输入是作品中的一个片段。
+
+只根据本片段判断，不要推测片段以外的信息。
+
+规则：
+- name 用本片段原文中出现的称呼，保持原文写法，不要翻译或改写。
+- 每个角色至少给出一条 evidence.quote，必须是本片段原文中逐字出现的一句话。
+- 不要编造引用。找不到原文依据的角色不要输出。
+- aliases 只填本片段原文明确写出的别名，例如“林默又名小默”。
+  仅仅是同一段里出现的另一个称呼，不算别名。
+- 不确定两个称呼是不是同一个人时，分别输出两个角色，不要合并。
+- 旁白、画外音、镜头提示不是角色。
+- 群体（众人、士兵们、村民们）不是角色。"""
+
+
+@dataclass
+class MergedCharacter:
+    """One character after deterministic merging across chunks."""
+
+    name: str
+    aliases: set[str] = field(default_factory=set)
+    gender: str = ""
+    description: str = ""
+    evidence: list[dict] = field(default_factory=list)
+    chunk_ids: set[str] = field(default_factory=set)
+    # Names seen in the same text that could be this character but were never
+    # stated to be. Surfaced as suggestions; never merged automatically.
+    ambiguous_with: set[str] = field(default_factory=set)
+
+
+def _create_character_extraction_agent(agent: Any = None):
+    if agent is not None:
+        return agent
+
+    from pydantic_ai import Agent
+
+    from novelvideo.config import (
+        get_newapi_structured_output_model_settings,
+        get_newapi_text_pydantic_model,
+    )
+
+    return Agent(
+        get_newapi_text_pydantic_model(
+            "CHARACTER_BUILD_MODEL",
+            "gemini-3-flash-preview",
+            capability="cognee.llm",
+        ),
+        system_prompt=CHARACTER_EXTRACTION_SYSTEM_PROMPT,
+        model_settings=get_newapi_structured_output_model_settings(),
+        output_type=ChunkCharacterOutput,
+        name="Structured Character Extractor",
+    )
+
+
+def normalize_character_name(value: str) -> str:
+    """Collapse spacing and punctuation noise without altering the name."""
+    cleaned = (value or "").replace("　", " ").strip()
+    cleaned = cleaned.strip("：:，,。.、·「」『』\"'()（）【】[]")
+    return " ".join(cleaned.split())
+
+
+def is_generic_address(name: str) -> bool:
+    return normalize_character_name(name) in GENERIC_ADDRESS_TERMS
+
+
+def find_explicit_aliases(text: str) -> set[tuple[str, str]]:
+    """Return alias pairs the text states outright.
+
+    Only an explicit statement licenses an alias link, because merging two names
+    rewrites a primary key that assets and REST paths already point at.
+    """
+    pairs: set[tuple[str, str]] = set()
+    for pattern in _ALIAS_PATTERNS:
+        for match in pattern.finditer(text or ""):
+            first = normalize_character_name(match.group("a"))
+            second = normalize_character_name(match.group("b"))
+            if first and second and first != second:
+                pairs.add((first, second))
+    return pairs
+
+
+def verify_evidence(
+    quote: str, chunk: SourceChunk
+) -> tuple[int, int] | None:
+    """Locate a quote inside the chunk and return its absolute source offsets.
+
+    A quote that is not present verbatim is rejected: this check is the only
+    thing standing between a model's imagination and the character table.
+    """
+    needle = (quote or "").strip()
+    if not needle:
+        return None
+    local = chunk.text.find(needle)
+    if local < 0:
+        # Whitespace inside a quote is not meaningful in Chinese prose, and
+        # models routinely normalize it. Retry ignoring it before rejecting.
+        compact_needle = re.sub(r"\s+", "", needle)
+        compact_text = re.sub(r"\s+", "", chunk.text)
+        if not compact_needle or compact_needle not in compact_text:
+            return None
+        return (chunk.source_start, chunk.source_end)
+    return (chunk.source_start + local, chunk.source_start + local + len(needle))
+
+
+async def extract_characters_from_chunks(
+    chunks: list[SourceChunk],
+    *,
+    agent: Any = None,
+    concurrency: int = 6,
+    on_log: Optional[Callable[[str], None]] = None,
+    on_chunk_done: Optional[Callable[[SourceChunk, ChunkCharacterOutput], Any]] = None,
+    on_chunk_failed: Optional[Callable[[SourceChunk, BaseException], Any]] = None,
+) -> list[MergedCharacter]:
+    """Extract and merge characters across chunks.
+
+    Chunks are independent, so they run in parallel up to ``concurrency``. A
+    chunk that fails is reported and skipped rather than failing the build: one
+    unparseable scene must not discard every other scene's characters.
+    """
+
+    def log(message: str) -> None:
+        if on_log:
+            on_log(message)
+
+    if not chunks:
+        return []
+
+    runner = _create_character_extraction_agent(agent)
+
+    async def analyse(chunk: SourceChunk) -> tuple[SourceChunk, ChunkCharacterOutput]:
+        result = await runner.run(
+            f"【片段 {chunk.section_label}】\n{chunk.text}"
+        )
+        output = result.output
+        if on_chunk_done:
+            await _maybe_await(on_chunk_done(chunk, output))
+        return chunk, output
+
+    def record_failure(chunk: SourceChunk, exc: BaseException) -> None:
+        log(f"⚠️ 片段 {chunk.section_label} 抽取失败，已跳过: {exc}")
+        if on_chunk_failed:
+            on_chunk_failed(chunk, exc)
+
+    outcomes = await map_bounded(
+        chunks, analyse, limit=concurrency, on_error=record_failure
+    )
+    succeeded = [outcome for outcome in outcomes if outcome is not None]
+    log(f"片段抽取完成: {len(succeeded)}/{len(chunks)} 成功")
+
+    return merge_character_candidates(succeeded)
+
+
+def merge_character_candidates(
+    outcomes: list[tuple[SourceChunk, ChunkCharacterOutput]],
+) -> list[MergedCharacter]:
+    """Merge per-chunk candidates using rules only, no model judgement.
+
+    Identical names merge. Explicit alias statements merge. Everything else stays
+    separate, because a wrong merge silently destroys data while a wrong split
+    is a visible duplicate the user can fix.
+    """
+    merged: dict[str, MergedCharacter] = {}
+    alias_pairs: set[tuple[str, str]] = set()
+
+    for chunk, output in outcomes:
+        alias_pairs |= find_explicit_aliases(chunk.text)
+
+        for candidate in output.characters:
+            name = normalize_character_name(candidate.name)
+            if not name or is_generic_address(name):
+                continue
+
+            verified: list[dict] = []
+            for item in candidate.evidence:
+                span = verify_evidence(item.quote, chunk)
+                if span is None:
+                    continue
+                verified.append(
+                    {
+                        "chunk_id": chunk.chunk_id,
+                        "source_start": span[0],
+                        "source_end": span[1],
+                        "evidence_kind": item.kind or "mention",
+                        "evidence_text": item.quote.strip(),
+                    }
+                )
+
+            # No verifiable quote means nothing in the source supports this
+            # character. Drop it rather than trusting the model's assertion.
+            if not verified:
+                continue
+
+            entry = merged.get(name)
+            if entry is None:
+                entry = MergedCharacter(name=name)
+                merged[name] = entry
+
+            entry.evidence.extend(verified)
+            entry.chunk_ids.add(chunk.chunk_id)
+            if not entry.gender and candidate.gender in {"male", "female"}:
+                entry.gender = candidate.gender
+            if not entry.description and candidate.description.strip():
+                entry.description = candidate.description.strip()
+
+            for alias in candidate.aliases:
+                normalized_alias = normalize_character_name(alias)
+                if not normalized_alias or normalized_alias == name:
+                    continue
+                # A model-proposed alias is only a suggestion unless the text
+                # states it. Record it as ambiguity for the user to resolve.
+                if (name, normalized_alias) in alias_pairs or (
+                    normalized_alias,
+                    name,
+                ) in alias_pairs:
+                    entry.aliases.add(normalized_alias)
+                elif not is_generic_address(normalized_alias):
+                    entry.ambiguous_with.add(normalized_alias)
+
+    _apply_explicit_alias_merges(merged, alias_pairs)
+    return sorted(merged.values(), key=lambda item: (-len(item.evidence), item.name))
+
+
+def _apply_explicit_alias_merges(
+    merged: dict[str, MergedCharacter], alias_pairs: set[tuple[str, str]]
+) -> None:
+    """Fold explicitly-stated aliases into their primary entry.
+
+    The entry with more evidence wins the primary name, so the canonical record
+    is the one the text actually develops rather than a passing nickname.
+    """
+    for first, second in alias_pairs:
+        left = merged.get(first)
+        right = merged.get(second)
+        if left is None or right is None or left is right:
+            # An alias statement naming someone who was never extracted still
+            # registers on whichever side exists.
+            if left is not None and second not in merged:
+                left.aliases.add(second)
+            elif right is not None and first not in merged:
+                right.aliases.add(first)
+            continue
+
+        primary, secondary = (
+            (left, right) if len(left.evidence) >= len(right.evidence) else (right, left)
+        )
+        primary.aliases.add(secondary.name)
+        primary.aliases |= secondary.aliases
+        primary.aliases.discard(primary.name)
+        primary.evidence.extend(secondary.evidence)
+        primary.chunk_ids |= secondary.chunk_ids
+        primary.ambiguous_with |= secondary.ambiguous_with
+        primary.ambiguous_with.discard(primary.name)
+        primary.ambiguous_with -= primary.aliases
+        if not primary.gender:
+            primary.gender = secondary.gender
+        if not primary.description:
+            primary.description = secondary.description
+        merged.pop(secondary.name, None)
+
+
+async def _maybe_await(value: Any) -> Any:
+    if hasattr(value, "__await__"):
+        return await value
+    return value

--- a/src/novelvideo/structured_extraction.py
+++ b/src/novelvideo/structured_extraction.py
@@ -663,3 +663,122 @@ async def adjudicate_characters(
     survivors = [item for item in merged if item.name not in removed]
     log(f"裁决完成: {len(merged)} → {len(survivors)} 个角色")
     return sorted(survivors, key=lambda item: (-len(item.evidence), item.name))
+
+
+# ── scene adjudication ──────────────────────────────────────────────────────
+
+
+class SameLocationGroup(BaseModel):
+    canonical_name: str = Field(description="该组的主名，必须来自候选列表")
+    alias_names: list[str] = Field(
+        default_factory=list, description="指向同一地点的其他候选名，必须来自候选列表"
+    )
+    reason: str = Field(default="", description="判定依据")
+
+
+class SceneAdjudication(BaseModel):
+    groups: list[SameLocationGroup] = Field(default_factory=list)
+
+
+SCENE_ADJUDICATION_SYSTEM_PROMPT = """你是场景归一裁决器。
+
+输入是从同一部剧本的场次头中解析出的地点候选，每个附带它在剧本中出现的场次数。
+
+你的任务只有一件：判断哪些候选其实是同一个物理地点，把它们归为一组并选出主名。
+
+规则：
+- 只能使用输入中出现过的候选名，不许发明新名字。
+- canonical_name 必须是该组候选之一，优先选出现场次最多、最完整具体的那个。
+- 同一地点的不同写法要合并，例如“舞蹈室镜子前”和“舞蹈室照镜子”，
+  “郑玉琴办公室”和“郑玉琴办公室内”，“学校教室”和“名门高级人才学院教室”。
+- 同一建筑里的不同房间是不同地点，绝不能合并：
+  “郑家别墅客厅”和“郑家别墅餐厅”是两个场景，“郑家别墅外”和“郑家别墅客厅”也是。
+- 时间、天气、损毁状态不构成新地点，但这里的候选都已经是基础地点，不用管这些。
+- 不确定就不要合并。多留一个重复场景只是资产冗余，错误合并会让两处戏共用一个场景图。"""
+
+
+def _create_scene_adjudication_agent(agent: Any = None):
+    if agent is not None:
+        return agent
+
+    from pydantic_ai import Agent
+
+    from novelvideo.config import (
+        get_newapi_structured_output_model_settings,
+        get_newapi_text_pydantic_model,
+    )
+
+    return Agent(
+        get_newapi_text_pydantic_model(
+            "SCENE_BUILD_MODEL",
+            "gemini-3-flash-preview",
+            capability="text.generate.agent",
+        ),
+        system_prompt=SCENE_ADJUDICATION_SYSTEM_PROMPT,
+        model_settings=get_newapi_structured_output_model_settings(),
+        output_type=SceneAdjudication,
+        name="Structured Scene Adjudicator",
+    )
+
+
+async def adjudicate_scenes(
+    scenes: list,
+    *,
+    occurrences: Optional[dict] = None,
+    agent: Any = None,
+    on_log: Optional[Callable[[str], None]] = None,
+) -> list:
+    """Fold differently-written spellings of one location into a single scene.
+
+    Scene headings are written by hand, so the same room appears as
+    "郑玉琴办公室" and "郑玉琴办公室内". Each spelling otherwise becomes its own
+    base scene with its own generated art.
+
+    Unlike character adjudication this never drops a candidate. A duplicate
+    scene is redundant art; a missing one leaves shots with no location asset,
+    and nothing in the UI would show what went missing.
+    """
+
+    def log(message: str) -> None:
+        if on_log:
+            on_log(message)
+
+    if len(scenes) < 2:
+        return scenes
+
+    counts = occurrences or {}
+    by_name = {scene.name: scene for scene in scenes}
+    listing = "\n".join(
+        f"- {scene.name}（出现 {counts.get(scene.name, 0)} 场）"
+        f"{'，别名 ' + '、'.join(scene.aliases) if scene.aliases else ''}"
+        for scene in scenes
+    )
+
+    try:
+        result = (await _create_scene_adjudication_agent(agent).run(
+            "以下是同一部剧本的地点候选：\n" + listing
+        )).output
+    except Exception as exc:  # noqa: BLE001 - degrade to the unmerged result
+        log(f"⚠️ 场景归一裁决失败，保留原始场景: {exc}")
+        return scenes
+
+    removed: set[str] = set()
+    for group in result.groups:
+        primary = by_name.get(str(group.canonical_name or "").strip())
+        if primary is None:
+            continue
+        for alias in group.alias_names:
+            secondary = by_name.get(str(alias or "").strip())
+            if secondary is None or secondary is primary or secondary.name in removed:
+                continue
+            merged_aliases = list(primary.aliases)
+            for candidate in [secondary.name, *secondary.aliases]:
+                if candidate != primary.name and candidate not in merged_aliases:
+                    merged_aliases.append(candidate)
+            primary.aliases = merged_aliases
+            removed.add(secondary.name)
+            log(f"  归并场景 {secondary.name} → {primary.name}")
+
+    survivors = [scene for scene in scenes if scene.name not in removed]
+    log(f"场景裁决完成: {len(scenes)} → {len(survivors)} 个")
+    return survivors

--- a/src/novelvideo/structured_extraction.py
+++ b/src/novelvideo/structured_extraction.py
@@ -337,8 +337,8 @@ def merge_character_candidates(
     """
     merged: dict[str, MergedCharacter] = {}
     alias_pairs: set[tuple[str, str]] = set()
-    # appellation -> character -> the chunks that attributed it there.
-    appellation_claims: dict[str, dict[str, set[str]]] = {}
+    # appellation -> character -> the source positions attributing it there.
+    appellation_claims: dict[str, dict[str, set[tuple[int, int]]]] = {}
 
     for chunk, output in outcomes:
         alias_pairs |= find_explicit_aliases(chunk.text)
@@ -391,12 +391,21 @@ def merge_character_candidates(
                     not normalized
                     or normalized == name
                     or is_generic_address(normalized)
-                    or verify_evidence(normalized, chunk) is None
                 ):
                     continue
+                # Votes are counted per position in the source, not per chunk.
+                # Chunks overlap, so one occurrence sitting in an overlap would
+                # otherwise be counted twice and clear the margin on its own.
+                local = chunk.text.find(normalized)
+                if local < 0:
+                    continue
+                span = (
+                    chunk.source_start + local,
+                    chunk.source_start + local + len(normalized),
+                )
                 appellation_claims.setdefault(normalized, {}).setdefault(
                     name, set()
-                ).add(chunk.chunk_id)
+                ).add(span)
 
             for alias in candidate.aliases:
                 normalized_alias = normalize_character_name(alias)
@@ -419,14 +428,16 @@ def merge_character_candidates(
 
 
 def _apply_appellation_claims(
-    merged: dict[str, MergedCharacter], claims: dict[str, dict[str, set[str]]]
+    merged: dict[str, MergedCharacter],
+    claims: dict[str, dict[str, set[tuple[int, int]]]],
 ) -> None:
     """Award a contested appellation to whoever the text repeatedly supports.
 
     One claimant is taken at face value. When several characters are offered the
-    same nickname, the winner is decided by how many *distinct chunks*
-    independently attributed it there — not by how much evidence each character
-    has overall, which would simply hand every ambiguous form to the lead.
+    same nickname, the winner is decided by how many *distinct positions in the
+    source* attributed it there — not by how much evidence each character has
+    overall, which would simply hand every ambiguous form to the lead, and not
+    by chunk count, since chunks overlap and one occurrence can fall in two.
 
     A win has to be decisive: at least two independent chunks, and a clear
     margin over the runner-up. Anything closer stays unassigned, because a wrong
@@ -448,7 +459,7 @@ def _apply_appellation_claims(
 
         ranked = sorted(live.items(), key=lambda kv: len(kv[1]), reverse=True)
         (winner, won), (_, runner_up) = ranked[0], ranked[1]
-        if len(won) < _APPELLATION_MIN_CHUNKS:
+        if len(won) < _APPELLATION_MIN_OCCURRENCES:
             continue
         if len(won) < max(len(runner_up) * 2, len(runner_up) + 1):
             continue
@@ -563,10 +574,10 @@ _ADJUDICATION_SAMPLE_QUOTES = 3
 _CONTEXT_WINDOW_EVIDENCE_THRESHOLD = 6
 _CONTEXT_WINDOW_CHARS = 220
 
-# A contested appellation needs support from this many independent chunks
-# before it is awarded to anyone. One chunk is one author's phrasing, which
-# is not enough to overrule a competing claim.
-_APPELLATION_MIN_CHUNKS = 2
+# A contested appellation needs this many distinct source positions before it
+# is awarded to anyone. A single occurrence is one turn of phrase, which is
+# not enough to overrule a competing claim.
+_APPELLATION_MIN_OCCURRENCES = 2
 
 
 class SamePersonGroup(BaseModel):

--- a/src/novelvideo/structured_extraction.py
+++ b/src/novelvideo/structured_extraction.py
@@ -251,6 +251,7 @@ async def extract_characters_from_chunks(
     concurrency: int | None = None,
     cached_outcomes: Optional[list] = None,
     source_text: str = "",
+    roster: Optional[set] = None,
     adjudicate: bool = True,
     adjudication_agent: Any = None,
     on_log: Optional[Callable[[str], None]] = None,
@@ -275,7 +276,7 @@ async def extract_characters_from_chunks(
         merged = merge_character_candidates(replayed)
         if adjudicate:
             merged = await adjudicate_characters(
-                merged, source_text=source_text,
+                merged, source_text=source_text, roster=roster,
                 agent=adjudication_agent, on_log=log,
             )
         return merged, []
@@ -319,7 +320,7 @@ async def extract_characters_from_chunks(
         # Rules cannot see across chunks; this can. One call over the candidate
         # set, not another pass over the source.
         merged = await adjudicate_characters(
-            merged, source_text=source_text,
+            merged, source_text=source_text, roster=roster,
             agent=adjudication_agent, on_log=log,
         )
     return merged, failures
@@ -525,10 +526,13 @@ async def _maybe_await(value: Any) -> Any:
 
 # ── ambiguity adjudication ──────────────────────────────────────────────────
 
-# A character carrying a large share of the evidence is load-bearing. The
-# adjudicator may fold names into it, but must never be able to delete it: one
-# bad call would silently drop a lead from the cast.
-_NON_CHARACTER_EVIDENCE_CEILING = 0.08
+# A candidate the model may fold into another. Anything better attested than
+# this stands on its own: a wrong merge destroys a character silently, while a
+# wrong split leaves a visible duplicate the user can remove.
+_MERGEABLE_EVIDENCE_CEILING = 2
+
+# Same idea for locations, counted in scenes rather than evidence spans.
+_MERGEABLE_SCENE_OCCURRENCES = 2
 
 # Enough of the text to recognise who is being talked about, without resending
 # the script.
@@ -633,10 +637,22 @@ def _adjudication_prompt(
     )
 
 
+def _roster_protects(name: str, roster: set[str]) -> bool:
+    """Whether a scene's cast list names this character.
+
+    A cast list is written by the author, not inferred, so a name appearing in
+    one is a fact about the script. Such a character is never merged away.
+    """
+    if not name:
+        return False
+    return any(name == entry or name in entry for entry in roster)
+
+
 async def adjudicate_characters(
     merged: list[MergedCharacter],
     *,
     source_text: str = "",
+    roster: Optional[set[str]] = None,
     agent: Any = None,
     on_log: Optional[Callable[[str], None]] = None,
 ) -> list[MergedCharacter]:
@@ -667,16 +683,46 @@ async def adjudicate_characters(
         log(f"⚠️ 归一裁决失败，保留规则归一结果: {exc}")
         return merged
 
-    total_evidence = sum(len(item.evidence) for item in merged) or 1
+    cast = roster or set()
     removed: set[str] = set()
 
+    def may_merge_away(candidate: MergedCharacter) -> bool:
+        """Whether this candidate is weak enough to be folded into another."""
+        if _roster_protects(candidate.name, cast):
+            return False
+        return len(candidate.evidence) <= _MERGEABLE_EVIDENCE_CEILING
+
     for group in result.groups:
-        primary = by_name.get(normalize_character_name(group.canonical_name))
-        if primary is None:
+        members = [
+            by_name[name]
+            for name in (
+                normalize_character_name(n)
+                for n in [group.canonical_name, *group.alias_names]
+            )
+            if name in by_name and by_name[name].name not in removed
+        ]
+        if len(members) < 2:
             continue
-        for alias in group.alias_names:
-            secondary = by_name.get(normalize_character_name(alias))
-            if secondary is None or secondary is primary or secondary.name in removed:
+
+        # The canonical name is decided here, not by the model: a cast-list name
+        # wins, then the best-attested one. Left to the model, a formal name can
+        # end up folded into a passing nickname.
+        primary = max(
+            members,
+            key=lambda item: (
+                _roster_protects(item.name, cast),
+                len(item.evidence),
+            ),
+        )
+        for secondary in members:
+            if secondary is primary or secondary.name in removed:
+                continue
+            if not may_merge_away(secondary):
+                log(
+                    f"  拒绝归并 {secondary.name} → {primary.name}："
+                    f"证据 {len(secondary.evidence)} 条"
+                    f"{'，且出现在场次人物栏' if _roster_protects(secondary.name, cast) else ''}"
+                )
                 continue
             primary.aliases.add(secondary.name)
             primary.aliases |= secondary.aliases
@@ -693,17 +739,14 @@ async def adjudicate_characters(
             removed.add(secondary.name)
             log(f"  归并 {secondary.name} → {primary.name}")
 
+    # Reported, never acted on. Every candidate here already survived
+    # verification against the source, so discarding one trades a visible
+    # duplicate for an invisible omission — the wrong way round for a first
+    # release. Surfacing the call lets the rule be tuned on real data first.
     for name in result.non_characters:
         item = by_name.get(normalize_character_name(name))
-        if item is None or item.name in removed:
-            continue
-        share = len(item.evidence) / total_evidence
-        if share > _NON_CHARACTER_EVIDENCE_CEILING:
-            # Too central to discard on one model's say-so.
-            log(f"  保留 {item.name}：证据占比 {share:.0%}，不按非角色丢弃")
-            continue
-        removed.add(item.name)
-        log(f"  丢弃非角色 {item.name}")
+        if item is not None and item.name not in removed:
+            log(f"  裁决认为不是角色（仅记录，未删除）：{item.name}")
 
     survivors = [item for item in merged if item.name not in removed]
     log(f"裁决完成: {len(merged)} → {len(survivors)} 个角色")
@@ -809,12 +852,31 @@ async def adjudicate_scenes(
 
     removed: set[str] = set()
     for group in result.groups:
-        primary = by_name.get(str(group.canonical_name or "").strip())
-        if primary is None:
+        members = [
+            by_name[name]
+            for name in (
+                str(n or "").strip()
+                for n in [group.canonical_name, *group.alias_names]
+            )
+            if name in by_name and by_name[name].name not in removed
+        ]
+        if len(members) < 2:
             continue
-        for alias in group.alias_names:
-            secondary = by_name.get(str(alias or "").strip())
-            if secondary is None or secondary is primary or secondary.name in removed:
+
+        # Decided here rather than by the model: the spelling the script uses
+        # most is the canonical one.
+        primary = max(members, key=lambda s: counts.get(s.name, 0))
+        for secondary in members:
+            if secondary is primary or secondary.name in removed:
+                continue
+            # A location the script keeps returning to is a real place, not a
+            # spelling variant. Folding one away would leave those scenes
+            # pointing at another room's art.
+            if counts.get(secondary.name, 0) > _MERGEABLE_SCENE_OCCURRENCES:
+                log(
+                    f"  拒绝归并场景 {secondary.name} → {primary.name}："
+                    f"出现 {counts.get(secondary.name, 0)} 场"
+                )
                 continue
             merged_aliases = list(primary.aliases)
             for candidate in [secondary.name, *secondary.aliases]:

--- a/src/novelvideo/structured_extraction.py
+++ b/src/novelvideo/structured_extraction.py
@@ -37,7 +37,31 @@ GENERIC_ADDRESS_TERMS = {
     "陛下", "殿下", "大人", "公子", "小姐", "夫人", "先生", "少爷",
     "掌柜", "伙计", "路人", "村民", "宫女", "太监", "将军", "丫鬟",
     "男人", "女人", "老人", "孩子", "少年", "少女", "他", "她",
+    # Role labels from a treatment or cast list, not names anyone is called by.
+    "女主", "男主", "主角", "配角", "反派",
+    "大小姐", "少爷", "小少爷", "校霸", "狗腿子", "保镖", "佣人",
 }
+
+# Job titles and honorifics that a script attaches to a name: "校长吴显德",
+# "孙海教授". A name plus only these tokens is the same person under a fuller
+# form, so the two may be merged.
+#
+# Kinship terms are deliberately absent. "郑玉琴的女儿" minus "郑玉琴" leaves a
+# kinship remainder, and that names a *different* person — merging on it would
+# collapse a parent and a child into one character.
+TITLE_TOKENS = (
+    "董事长", "总经理", "副总裁", "总裁", "副总", "总监", "经理", "主管",
+    "校长", "主任", "教授", "老师", "医生", "护士", "律师", "警官",
+    "管家", "秘书", "助理", "司机", "保安", "店长", "老板", "厂长",
+    "学校", "公司", "集团", "郑氏", "先生", "女士", "小姐", "太太",
+    # Scripts also prefix a name with the role a character plays in the story,
+    # as in "校霸张小倩" or "佣人王妈".
+    "校霸", "佣人", "保镖", "学生", "狗腿子", "项目",
+)
+
+# Pronouns and possessives a script puts in front of a kinship word, giving
+# "你妈" or "他的母亲". These are the same non-characters as the bare terms.
+_POSSESSIVE_PREFIX_RE = re.compile(r"^(?:你|我|他|她|您|咱|其)(?:的)?")
 
 # Explicit alias statements. Only these license an alias link; a model asserting
 # two names are the same without the text saying so is not enough.
@@ -127,7 +151,51 @@ def normalize_character_name(value: str) -> str:
 
 
 def is_generic_address(name: str) -> bool:
-    return normalize_character_name(name) in GENERIC_ADDRESS_TERMS
+    """Whether a name refers to a role rather than a specific person.
+
+    A possessive prefix does not make a kinship term specific: "你妈" and
+    "他的母亲" name whoever is on stage, exactly as "母亲" does.
+    """
+    normalized = normalize_character_name(name)
+    if normalized in GENERIC_ADDRESS_TERMS:
+        return True
+    stripped = _POSSESSIVE_PREFIX_RE.sub("", normalized, count=1)
+    return bool(stripped) and stripped in GENERIC_ADDRESS_TERMS
+
+
+def title_qualified_of(long_name: str, short_name: str) -> bool:
+    """Whether ``long_name`` is ``short_name`` plus only job titles.
+
+    Scripts routinely introduce someone as "校长吴显德" and then call them
+    "吴显德". Treating those as two people would create duplicate characters,
+    each with its own primary key and asset directory.
+    """
+    long_normalized = normalize_character_name(long_name)
+    short_normalized = normalize_character_name(short_name)
+    if (
+        not short_normalized
+        or long_normalized == short_normalized
+        or short_normalized not in long_normalized
+    ):
+        return False
+
+    remainder = long_normalized.replace(short_normalized, "", 1)
+    remainder = remainder.replace("的", "")
+    # Peel off known titles until nothing is left. Anything that survives is not
+    # a title, so the two names are not the same person.
+    changed = True
+    while remainder and changed:
+        changed = False
+        for token in TITLE_TOKENS:
+            if remainder.startswith(token):
+                remainder = remainder[len(token):]
+                changed = True
+                break
+            if remainder.endswith(token):
+                remainder = remainder[: -len(token)]
+                changed = True
+                break
+    return not remainder
 
 
 def find_explicit_aliases(text: str) -> set[tuple[str, str]]:
@@ -175,6 +243,9 @@ async def extract_characters_from_chunks(
     agent: Any = None,
     concurrency: int | None = None,
     cached_outcomes: Optional[list] = None,
+    source_text: str = "",
+    adjudicate: bool = True,
+    adjudication_agent: Any = None,
     on_log: Optional[Callable[[str], None]] = None,
     on_chunk_done: Optional[Callable[[SourceChunk, ChunkCharacterOutput], Any]] = None,
     on_chunk_failed: Optional[Callable[[SourceChunk, BaseException], Any]] = None,
@@ -194,7 +265,13 @@ async def extract_characters_from_chunks(
     if not chunks:
         # Everything was replayed from a previous run; merging still has to run,
         # because merging is what turns per-chunk candidates into characters.
-        return merge_character_candidates(replayed), []
+        merged = merge_character_candidates(replayed)
+        if adjudicate:
+            merged = await adjudicate_characters(
+                merged, source_text=source_text,
+                agent=adjudication_agent, on_log=log,
+            )
+        return merged, []
 
     runner = _create_character_extraction_agent(agent)
 
@@ -230,7 +307,15 @@ async def extract_characters_from_chunks(
 
     # Replayed chunks merge alongside fresh ones, so a resumed build produces
     # the same characters as an uninterrupted one.
-    return merge_character_candidates(replayed + succeeded), failures
+    merged = merge_character_candidates(replayed + succeeded)
+    if adjudicate:
+        # Rules cannot see across chunks; this can. One call over the candidate
+        # set, not another pass over the source.
+        merged = await adjudicate_characters(
+            merged, source_text=source_text,
+            agent=adjudication_agent, on_log=log,
+        )
+    return merged, failures
 
 
 def merge_character_candidates(
@@ -300,7 +385,53 @@ def merge_character_candidates(
                     entry.ambiguous_with.add(normalized_alias)
 
     _apply_explicit_alias_merges(merged, alias_pairs)
+    _apply_title_qualified_merges(merged)
     return sorted(merged.values(), key=lambda item: (-len(item.evidence), item.name))
+
+
+def _apply_title_qualified_merges(merged: dict[str, MergedCharacter]) -> None:
+    """Fold "校长吴显德" into "吴显德" and keep the fuller form as an alias.
+
+    Unlike the model-proposed aliases held back as suggestions, this is a purely
+    textual containment test with a closed title vocabulary, so it cannot merge
+    two people who merely share a surname.
+
+    The better-evidenced name wins, which is usually the one the script actually
+    uses in dialogue rather than the one-off formal introduction.
+    """
+    names = sorted(merged, key=len, reverse=True)
+    for long_name in names:
+        long_entry = merged.get(long_name)
+        if long_entry is None:
+            continue
+        for short_name in names:
+            short_entry = merged.get(short_name)
+            if (
+                short_entry is None
+                or short_entry is long_entry
+                or not title_qualified_of(long_name, short_name)
+            ):
+                continue
+
+            primary, secondary = (
+                (long_entry, short_entry)
+                if len(long_entry.evidence) >= len(short_entry.evidence)
+                else (short_entry, long_entry)
+            )
+            primary.aliases.add(secondary.name)
+            primary.aliases |= secondary.aliases
+            primary.aliases.discard(primary.name)
+            primary.evidence.extend(secondary.evidence)
+            primary.chunk_ids |= secondary.chunk_ids
+            primary.ambiguous_with |= secondary.ambiguous_with
+            primary.ambiguous_with.discard(primary.name)
+            primary.ambiguous_with -= primary.aliases
+            if not primary.gender:
+                primary.gender = secondary.gender
+            if not primary.description:
+                primary.description = secondary.description
+            merged.pop(secondary.name, None)
+            break
 
 
 def _apply_explicit_alias_merges(
@@ -345,3 +476,190 @@ async def _maybe_await(value: Any) -> Any:
     if hasattr(value, "__await__"):
         return await value
     return value
+
+
+# ── ambiguity adjudication ──────────────────────────────────────────────────
+
+# A character carrying a large share of the evidence is load-bearing. The
+# adjudicator may fold names into it, but must never be able to delete it: one
+# bad call would silently drop a lead from the cast.
+_NON_CHARACTER_EVIDENCE_CEILING = 0.08
+
+# Enough of the text to recognise who is being talked about, without resending
+# the script.
+_ADJUDICATION_SAMPLE_QUOTES = 3
+
+# Below this many mentions, a candidate is more likely an alias than a person in
+# its own right, so it gets source context rather than a bare quote.
+_CONTEXT_WINDOW_EVIDENCE_THRESHOLD = 6
+_CONTEXT_WINDOW_CHARS = 220
+
+
+class SamePersonGroup(BaseModel):
+    canonical_name: str = Field(description="该组的主名，必须来自候选列表")
+    alias_names: list[str] = Field(
+        default_factory=list, description="指向同一人的其他候选名，必须来自候选列表"
+    )
+    reason: str = Field(default="", description="判定依据，引用证据中的线索")
+
+
+class CharacterAdjudication(BaseModel):
+    groups: list[SamePersonGroup] = Field(default_factory=list)
+    non_characters: list[str] = Field(
+        default_factory=list, description="根本不是人物的候选，例如称号、群体、骂人的话"
+    )
+
+
+ADJUDICATION_SYSTEM_PROMPT = """你是角色归一裁决器。
+
+输入是从同一部作品中逐段抽取出的角色候选，每个候选附带它在原文中的出现次数和几条原文引用。
+
+你的任务只有两件：
+1. 判断哪些候选其实指向同一个人，把它们归为一组，并选出主名。
+2. 指出哪些候选根本不是人物。
+
+规则：
+- 只能使用输入中出现过的候选名，不许发明新名字。
+- canonical_name 必须是该组候选之一，优先选原文中出现次数最多、最像正式姓名的那个。
+- 只有证据确实支持时才合并。"陈总"和"陈青"要有线索表明是同一人才能合并。
+- 两个都有大量独立证据、且看不出关联的候选，不要合并。
+- 称号、职务、群体、骂人的话（如"大小姐""校霸""扫把星"）如果只是用来称呼某个已知角色，
+  应该并入那个角色；如果无法确定指向谁，放进 non_characters。
+- 不确定就不要合并，也不要放进 non_characters。漏合并只是留下重复项，错合并会毁掉数据。"""
+
+
+def _create_adjudication_agent(agent: Any = None):
+    if agent is not None:
+        return agent
+
+    from pydantic_ai import Agent
+
+    from novelvideo.config import (
+        get_newapi_structured_output_model_settings,
+        get_newapi_text_pydantic_model,
+    )
+
+    return Agent(
+        get_newapi_text_pydantic_model(
+            "CHARACTER_BUILD_MODEL",
+            "gemini-3-flash-preview",
+            capability="text.generate.agent",
+        ),
+        system_prompt=ADJUDICATION_SYSTEM_PROMPT,
+        model_settings=get_newapi_structured_output_model_settings(),
+        output_type=CharacterAdjudication,
+        name="Structured Character Adjudicator",
+    )
+
+
+def _adjudication_prompt(
+    merged: list[MergedCharacter], source_text: str = ""
+) -> str:
+    """Describe every candidate, with enough context to link nicknames to names.
+
+    A quote on its own rarely proves identity: "小阳，你又闯祸了" does not
+    contain "郑旭阳". What does prove it is the surrounding text, where the
+    formal name almost always appears nearby. Rarely-seen candidates therefore
+    get a window of the source around their occurrences — the same co-occurrence
+    signal a graph search would surface, taken straight from the text.
+    """
+    lines: list[str] = []
+    for item in merged:
+        detail = f"- {item.name}（出现 {len(item.evidence)} 次）"
+        if item.gender:
+            detail += f"，性别 {item.gender}"
+        if item.description:
+            detail += f"，{item.description}"
+        lines.append(detail)
+
+        rare = len(item.evidence) <= _CONTEXT_WINDOW_EVIDENCE_THRESHOLD
+        shown = item.evidence if rare else item.evidence[:_ADJUDICATION_SAMPLE_QUOTES]
+        for evidence in shown:
+            if rare and source_text:
+                start = max(0, int(evidence["source_start"]) - _CONTEXT_WINDOW_CHARS)
+                end = min(len(source_text), int(evidence["source_end"]) + _CONTEXT_WINDOW_CHARS)
+                window = source_text[start:end].replace("\n", " ")
+                lines.append(f"    上下文：…{window}…")
+            else:
+                lines.append(f"    原文：{evidence['evidence_text']}")
+    return (
+        "以下是同一部作品的角色候选。出现次数少的候选通常是某个主要角色的"
+        "昵称、职务或称号，请利用上下文判断它指向谁：\n" + "\n".join(lines)
+    )
+
+
+async def adjudicate_characters(
+    merged: list[MergedCharacter],
+    *,
+    source_text: str = "",
+    agent: Any = None,
+    on_log: Optional[Callable[[str], None]] = None,
+) -> list[MergedCharacter]:
+    """Resolve cross-chunk identity that per-chunk extraction cannot see.
+
+    Rules can merge identical names and stated aliases, but nothing in a single
+    chunk reveals that "郑太" is "郑玉琴" — that only shows up when the whole
+    candidate set is considered at once. This is one call over the candidates
+    and their evidence, not another pass over the source.
+
+    The adjudicator may only group names it was given, so it cannot invent a
+    character, and it cannot delete a well-evidenced one.
+    """
+
+    def log(message: str) -> None:
+        if on_log:
+            on_log(message)
+
+    if len(merged) < 2:
+        return merged
+
+    by_name = {item.name: item for item in merged}
+    try:
+        result = (await _create_adjudication_agent(agent).run(
+            _adjudication_prompt(merged, source_text)
+        )).output
+    except Exception as exc:  # noqa: BLE001 - degrade to the rule-only result
+        log(f"⚠️ 归一裁决失败，保留规则归一结果: {exc}")
+        return merged
+
+    total_evidence = sum(len(item.evidence) for item in merged) or 1
+    removed: set[str] = set()
+
+    for group in result.groups:
+        primary = by_name.get(normalize_character_name(group.canonical_name))
+        if primary is None:
+            continue
+        for alias in group.alias_names:
+            secondary = by_name.get(normalize_character_name(alias))
+            if secondary is None or secondary is primary or secondary.name in removed:
+                continue
+            primary.aliases.add(secondary.name)
+            primary.aliases |= secondary.aliases
+            primary.aliases.discard(primary.name)
+            primary.evidence.extend(secondary.evidence)
+            primary.chunk_ids |= secondary.chunk_ids
+            primary.ambiguous_with |= secondary.ambiguous_with
+            primary.ambiguous_with -= primary.aliases
+            primary.ambiguous_with.discard(primary.name)
+            if not primary.gender:
+                primary.gender = secondary.gender
+            if not primary.description:
+                primary.description = secondary.description
+            removed.add(secondary.name)
+            log(f"  归并 {secondary.name} → {primary.name}")
+
+    for name in result.non_characters:
+        item = by_name.get(normalize_character_name(name))
+        if item is None or item.name in removed:
+            continue
+        share = len(item.evidence) / total_evidence
+        if share > _NON_CHARACTER_EVIDENCE_CEILING:
+            # Too central to discard on one model's say-so.
+            log(f"  保留 {item.name}：证据占比 {share:.0%}，不按非角色丢弃")
+            continue
+        removed.add(item.name)
+        log(f"  丢弃非角色 {item.name}")
+
+    survivors = [item for item in merged if item.name not in removed]
+    log(f"裁决完成: {len(merged)} → {len(survivors)} 个角色")
+    return sorted(survivors, key=lambda item: (-len(item.evidence), item.name))

--- a/src/novelvideo/structured_extraction.py
+++ b/src/novelvideo/structured_extraction.py
@@ -439,7 +439,7 @@ def _apply_appellation_claims(
     overall, which would simply hand every ambiguous form to the lead, and not
     by chunk count, since chunks overlap and one occurrence can fall in two.
 
-    A win has to be decisive: at least two independent chunks, and a clear
+    A win has to be decisive: at least two distinct occurrences, and a clear
     margin over the runner-up. Anything closer stays unassigned, because a wrong
     alias resolves confidently to the wrong person while a missing one merely
     fails to resolve.

--- a/src/novelvideo/structured_extraction.py
+++ b/src/novelvideo/structured_extraction.py
@@ -22,7 +22,10 @@ from typing import Any, Callable, Optional
 from pydantic import BaseModel, Field
 
 from novelvideo.story_analysis import SourceChunk
-from novelvideo.utils.bounded_concurrency import map_bounded
+from novelvideo.utils.bounded_concurrency import (
+    default_llm_concurrency,
+    map_bounded,
+)
 
 # Titles and kinship terms refer to whoever is on stage at the time. The same
 # word in two chapters is routinely two different people, so they never merge
@@ -107,7 +110,7 @@ def _create_character_extraction_agent(agent: Any = None):
         get_newapi_text_pydantic_model(
             "CHARACTER_BUILD_MODEL",
             "gemini-3-flash-preview",
-            capability="cognee.llm",
+            capability="text.generate.agent",
         ),
         system_prompt=CHARACTER_EXTRACTION_SYSTEM_PROMPT,
         model_settings=get_newapi_structured_output_model_settings(),
@@ -170,11 +173,12 @@ async def extract_characters_from_chunks(
     chunks: list[SourceChunk],
     *,
     agent: Any = None,
-    concurrency: int = 6,
+    concurrency: int | None = None,
+    cached_outcomes: Optional[list] = None,
     on_log: Optional[Callable[[str], None]] = None,
     on_chunk_done: Optional[Callable[[SourceChunk, ChunkCharacterOutput], Any]] = None,
     on_chunk_failed: Optional[Callable[[SourceChunk, BaseException], Any]] = None,
-) -> list[MergedCharacter]:
+) -> tuple[list[MergedCharacter], list[tuple[SourceChunk, BaseException]]]:
     """Extract and merge characters across chunks.
 
     Chunks are independent, so they run in parallel up to ``concurrency``. A
@@ -186,8 +190,11 @@ async def extract_characters_from_chunks(
         if on_log:
             on_log(message)
 
+    replayed = list(cached_outcomes or [])
     if not chunks:
-        return []
+        # Everything was replayed from a previous run; merging still has to run,
+        # because merging is what turns per-chunk candidates into characters.
+        return merge_character_candidates(replayed), []
 
     runner = _create_character_extraction_agent(agent)
 
@@ -200,18 +207,30 @@ async def extract_characters_from_chunks(
             await _maybe_await(on_chunk_done(chunk, output))
         return chunk, output
 
+    failures: list[tuple[SourceChunk, BaseException]] = []
+
     def record_failure(chunk: SourceChunk, exc: BaseException) -> None:
         log(f"⚠️ 片段 {chunk.section_label} 抽取失败，已跳过: {exc}")
-        if on_chunk_failed:
-            on_chunk_failed(chunk, exc)
+        failures.append((chunk, exc))
 
     outcomes = await map_bounded(
-        chunks, analyse, limit=concurrency, on_error=record_failure
+        chunks,
+        analyse,
+        limit=default_llm_concurrency() if concurrency is None else concurrency,
+        on_error=record_failure,
     )
+    # Reported after the batch so the callback may be async without turning the
+    # error path inside map_bounded into an awaiting one.
+    for chunk, exc in failures:
+        if on_chunk_failed:
+            await _maybe_await(on_chunk_failed(chunk, exc))
+
     succeeded = [outcome for outcome in outcomes if outcome is not None]
     log(f"片段抽取完成: {len(succeeded)}/{len(chunks)} 成功")
 
-    return merge_character_candidates(succeeded)
+    # Replayed chunks merge alongside fresh ones, so a resumed build produces
+    # the same characters as an uninterrupted one.
+    return merge_character_candidates(replayed + succeeded), failures
 
 
 def merge_character_candidates(

--- a/src/novelvideo/structured_extraction.py
+++ b/src/novelvideo/structured_extraction.py
@@ -337,8 +337,8 @@ def merge_character_candidates(
     """
     merged: dict[str, MergedCharacter] = {}
     alias_pairs: set[tuple[str, str]] = set()
-    # appellation -> every character it was attributed to.
-    appellation_claims: dict[str, set[str]] = {}
+    # appellation -> character -> the chunks that attributed it there.
+    appellation_claims: dict[str, dict[str, set[str]]] = {}
 
     for chunk, output in outcomes:
         alias_pairs |= find_explicit_aliases(chunk.text)
@@ -394,7 +394,9 @@ def merge_character_candidates(
                     or verify_evidence(normalized, chunk) is None
                 ):
                     continue
-                appellation_claims.setdefault(normalized, set()).add(name)
+                appellation_claims.setdefault(normalized, {}).setdefault(
+                    name, set()
+                ).add(chunk.chunk_id)
 
             for alias in candidate.aliases:
                 normalized_alias = normalize_character_name(alias)
@@ -417,22 +419,40 @@ def merge_character_candidates(
 
 
 def _apply_appellation_claims(
-    merged: dict[str, MergedCharacter], claims: dict[str, set[str]]
+    merged: dict[str, MergedCharacter], claims: dict[str, dict[str, set[str]]]
 ) -> None:
-    """Record an appellation only when exactly one character claimed it.
+    """Award a contested appellation to whoever the text repeatedly supports.
 
-    Two characters claiming the same nickname is the model telling us it could
-    not attribute it. Keeping both would send episode-level alias resolution to
-    the wrong person, which is worse than having no alias at all — a missing
-    alias fails to resolve, a wrong one resolves confidently and incorrectly.
+    One claimant is taken at face value. When several characters are offered the
+    same nickname, the winner is decided by how many *distinct chunks*
+    independently attributed it there — not by how much evidence each character
+    has overall, which would simply hand every ambiguous form to the lead.
+
+    A win has to be decisive: at least two independent chunks, and a clear
+    margin over the runner-up. Anything closer stays unassigned, because a wrong
+    alias resolves confidently to the wrong person while a missing one merely
+    fails to resolve.
     """
     for appellation, owners in claims.items():
-        live = {name for name in owners if name in merged}
-        if len(live) != 1:
+        if appellation in merged:
+            # Already a character in its own right, not an alias for anyone.
             continue
-        owner = merged[next(iter(live))]
-        if appellation not in merged:
-            owner.aliases.add(appellation)
+        live = {
+            name: chunks for name, chunks in owners.items() if name in merged
+        }
+        if not live:
+            continue
+        if len(live) == 1:
+            merged[next(iter(live))].aliases.add(appellation)
+            continue
+
+        ranked = sorted(live.items(), key=lambda kv: len(kv[1]), reverse=True)
+        (winner, won), (_, runner_up) = ranked[0], ranked[1]
+        if len(won) < _APPELLATION_MIN_CHUNKS:
+            continue
+        if len(won) < max(len(runner_up) * 2, len(runner_up) + 1):
+            continue
+        merged[winner].aliases.add(appellation)
 
 
 def _apply_title_qualified_merges(merged: dict[str, MergedCharacter]) -> None:
@@ -542,6 +562,11 @@ _ADJUDICATION_SAMPLE_QUOTES = 3
 # its own right, so it gets source context rather than a bare quote.
 _CONTEXT_WINDOW_EVIDENCE_THRESHOLD = 6
 _CONTEXT_WINDOW_CHARS = 220
+
+# A contested appellation needs support from this many independent chunks
+# before it is awarded to anyone. One chunk is one author's phrasing, which
+# is not enough to overrule a competing claim.
+_APPELLATION_MIN_CHUNKS = 2
 
 
 class SamePersonGroup(BaseModel):

--- a/src/novelvideo/structured_extraction.py
+++ b/src/novelvideo/structured_extraction.py
@@ -80,6 +80,10 @@ class CharacterEvidence(BaseModel):
 class CharacterCandidate(BaseModel):
     name: str = Field(description="角色在本片段中的称呼，保持原文写法")
     aliases: list[str] = Field(default_factory=list, description="仅限本片段原文明确写出的别名")
+    appellations: list[str] = Field(
+        default_factory=list,
+        description="本片段中用来称呼该角色的其他说法（昵称、职务、称号），必须逐字出现在本片段原文中",
+    )
     gender: str = Field(default="", description="male / female / 空字符串表示未知")
     description: str = Field(default="", description="本片段支持的简短描述")
     evidence: list[CharacterEvidence] = Field(default_factory=list)
@@ -98,7 +102,10 @@ CHARACTER_EXTRACTION_SYSTEM_PROMPT = """你是剧本/小说的角色抽取器。
 - 每个角色至少给出一条 evidence.quote，必须是本片段原文中逐字出现的一句话。
 - 不要编造引用。找不到原文依据的角色不要输出。
 - aliases 只填本片段原文明确写出的别名，例如“林默又名小默”。
-  仅仅是同一段里出现的另一个称呼，不算别名。
+- appellations 填本片段中明显用来称呼这个角色的其他说法：昵称、职务、称号。
+  例如本片段里“郑太”“郑总”都指郑玉琴，就写进郑玉琴的 appellations。
+  每一个都必须逐字出现在本片段原文中，不要编造。
+  只有在本片段的上下文里能看出指向该角色时才填；看不出来就不要填。
 - 不确定两个称呼是不是同一个人时，分别输出两个角色，不要合并。
 - 旁白、画外音、镜头提示不是角色。
 - 群体（众人、士兵们、村民们）不是角色。"""
@@ -329,6 +336,8 @@ def merge_character_candidates(
     """
     merged: dict[str, MergedCharacter] = {}
     alias_pairs: set[tuple[str, str]] = set()
+    # appellation -> every character it was attributed to.
+    appellation_claims: dict[str, set[str]] = {}
 
     for chunk, output in outcomes:
         alias_pairs |= find_explicit_aliases(chunk.text)
@@ -370,6 +379,22 @@ def merge_character_candidates(
             if not entry.description and candidate.description.strip():
                 entry.description = candidate.description.strip()
 
+            # An appellation is asserted with the whole chunk in view, which is
+            # far more reliable than guessing across chunks — but it still has
+            # to appear in the text, or it is not something anyone was called.
+            # Attribution is settled later: a packed chunk holds several
+            # characters, and the model does mix up who is called what.
+            for appellation in candidate.appellations:
+                normalized = normalize_character_name(appellation)
+                if (
+                    not normalized
+                    or normalized == name
+                    or is_generic_address(normalized)
+                    or verify_evidence(normalized, chunk) is None
+                ):
+                    continue
+                appellation_claims.setdefault(normalized, set()).add(name)
+
             for alias in candidate.aliases:
                 normalized_alias = normalize_character_name(alias)
                 if not normalized_alias or normalized_alias == name:
@@ -384,9 +409,29 @@ def merge_character_candidates(
                 elif not is_generic_address(normalized_alias):
                     entry.ambiguous_with.add(normalized_alias)
 
+    _apply_appellation_claims(merged, appellation_claims)
     _apply_explicit_alias_merges(merged, alias_pairs)
     _apply_title_qualified_merges(merged)
     return sorted(merged.values(), key=lambda item: (-len(item.evidence), item.name))
+
+
+def _apply_appellation_claims(
+    merged: dict[str, MergedCharacter], claims: dict[str, set[str]]
+) -> None:
+    """Record an appellation only when exactly one character claimed it.
+
+    Two characters claiming the same nickname is the model telling us it could
+    not attribute it. Keeping both would send episode-level alias resolution to
+    the wrong person, which is worse than having no alias at all — a missing
+    alias fails to resolve, a wrong one resolves confidently and incorrectly.
+    """
+    for appellation, owners in claims.items():
+        live = {name for name in owners if name in merged}
+        if len(live) != 1:
+            continue
+        owner = merged[next(iter(live))]
+        if appellation not in merged:
+            owner.aliases.add(appellation)
 
 
 def _apply_title_qualified_merges(merged: dict[str, MergedCharacter]) -> None:

--- a/src/novelvideo/structured_ingest.py
+++ b/src/novelvideo/structured_ingest.py
@@ -25,7 +25,7 @@ from novelvideo.utils.document_parsers import load_novel_text
 # results — different chunk ids, boundaries or offsets. A run is reused only
 # when source text, schema version, this version and the spine template all
 # match, so a bump simply starts a fresh plan rather than corrupting an old one.
-STRUCTURED_PIPELINE_VERSION = "structured_v1.1"
+STRUCTURED_PIPELINE_VERSION = "structured_v1"
 STRUCTURED_SCHEMA_VERSION = 1
 
 _PROGRESS = {

--- a/src/novelvideo/structured_ingest.py
+++ b/src/novelvideo/structured_ingest.py
@@ -25,7 +25,7 @@ from novelvideo.utils.document_parsers import load_novel_text
 # results — different chunk ids, boundaries or offsets. A run is reused only
 # when source text, schema version, this version and the spine template all
 # match, so a bump simply starts a fresh plan rather than corrupting an old one.
-STRUCTURED_PIPELINE_VERSION = "structured_v1"
+STRUCTURED_PIPELINE_VERSION = "structured_v1.1"
 STRUCTURED_SCHEMA_VERSION = 1
 
 _PROGRESS = {

--- a/src/novelvideo/structured_ingest.py
+++ b/src/novelvideo/structured_ingest.py
@@ -1,0 +1,124 @@
+"""Import for structured_v2 projects: no graph, no embedding, no vector index.
+
+The legacy import spends most of its wall clock inside ``cognee.add`` /
+``cognify`` / ``memify``, and every one of those calls goes through the shared
+embedding model.  Structured projects need none of it: extraction reads the
+source text directly, so import reduces to validating the upload, persisting it,
+and recording a deterministic chunk plan for later analysis.
+
+The validation order matches the legacy path deliberately, including the rule
+that ``novel.txt`` is written last.  That file is the public "import succeeded"
+marker: several routes treat its presence as proof the project is importable,
+so it must not appear while the import can still fail.
+"""
+
+from __future__ import annotations
+
+import uuid
+from pathlib import Path
+from typing import Any, Callable, Optional
+
+from novelvideo.story_analysis import chunk_source_text, source_sha256
+from novelvideo.utils.document_parsers import load_novel_text
+
+# Bump when the chunking contract changes in a way that invalidates stored
+# chunk results. Runs are reused only when text, schema and pipeline all match.
+STRUCTURED_PIPELINE_VERSION = "structured_v2.1"
+STRUCTURED_SCHEMA_VERSION = 1
+
+_PROGRESS = {
+    "read": 0.05,
+    "validated": 0.25,
+    "chunked": 0.60,
+    "planned": 0.85,
+    "save": 0.95,
+    "complete": 1.0,
+}
+
+
+async def ingest_source_text_structured(
+    store: Any,
+    novel_path: str,
+    *,
+    spine_template: str | None = None,
+    on_progress: Optional[Callable[[float, str], None]] = None,
+    on_log: Optional[Callable[[str], None]] = None,
+) -> dict:
+    """Validate, chunk and persist an import without building any graph.
+
+    ``store`` is a SQLiteStore (or anything exposing the same content and
+    analysis-run methods).
+    """
+
+    def report(progress: float, task: str) -> None:
+        if on_progress:
+            on_progress(progress, task)
+
+    def log(message: str) -> None:
+        if on_log:
+            on_log(message)
+
+    if not Path(novel_path).exists():
+        raise FileNotFoundError(f"文件不存在: {novel_path}")
+
+    report(_PROGRESS["read"], "读取并校验原文...")
+    log(f"读取文件: {novel_path}")
+    content = load_novel_text(novel_path)
+    if not content.strip():
+        raise ValueError("小说内容为空，无法导入")
+    log(f"文件读取完成: {len(content)} 字符")
+
+    template = str(spine_template or "").strip()
+    if template == "drama":
+        from novelvideo.utils.screenplay_quality import assess_screenplay_scene_headers
+
+        if assess_screenplay_scene_headers(content).status == "missing":
+            raise ValueError("精品剧必须包含场景头，请补充后重新导入")
+    report(_PROGRESS["validated"], "原文校验完成")
+
+    report(_PROGRESS["chunked"], "切分原文...")
+    chunks = chunk_source_text(content, template)
+    if not chunks:
+        raise ValueError("原文切分结果为空，无法分析")
+    section_type = chunks[0].section_type
+    log(f"确定性切分完成: {len(chunks)} 个片段（{section_type}）")
+
+    report(_PROGRESS["planned"], "记录分析计划...")
+    digest = source_sha256(content)
+    reused = await store.get_reusable_analysis_run(
+        source_sha256=digest,
+        schema_version=STRUCTURED_SCHEMA_VERSION,
+        pipeline_version=STRUCTURED_PIPELINE_VERSION,
+    )
+    if reused:
+        # Identical text analysed by identical code: keep the existing run so a
+        # re-import resumes its completed chunks instead of discarding them.
+        run_id = str(reused["run_id"])
+        log(f"复用已有分析计划: {run_id}")
+    else:
+        run_id = uuid.uuid4().hex
+        await store.start_analysis_run(
+            run_id=run_id,
+            pipeline_version=STRUCTURED_PIPELINE_VERSION,
+            schema_version=STRUCTURED_SCHEMA_VERSION,
+            spine_template=template,
+            source_sha256=digest,
+            source_length=len(content),
+            chunks=chunks,
+        )
+        log(f"分析计划已记录: {run_id}")
+
+    # novel.txt is the public success marker and therefore lands last.
+    report(_PROGRESS["save"], "保存导入结果...")
+    store.save_novel_content(content)
+    log("原文已保存")
+
+    report(_PROGRESS["complete"], "导入完成")
+    return {
+        "char_count": len(content),
+        "status": "source_ready",
+        "pipeline": "structured_v2",
+        "run_id": run_id,
+        "chunks": len(chunks),
+        "section_type": section_type,
+    }

--- a/src/novelvideo/structured_ingest.py
+++ b/src/novelvideo/structured_ingest.py
@@ -1,4 +1,4 @@
-"""Import for structured_v2 projects: no graph, no embedding, no vector index.
+"""Import for structured_v1 projects: no graph, no embedding, no vector index.
 
 The legacy import spends most of its wall clock inside ``cognee.add`` /
 ``cognify`` / ``memify``, and every one of those calls goes through the shared
@@ -21,9 +21,11 @@ from typing import Any, Callable, Optional
 from novelvideo.story_analysis import chunk_source_text, source_sha256
 from novelvideo.utils.document_parsers import load_novel_text
 
-# Bump when the chunking contract changes in a way that invalidates stored
-# chunk results. Runs are reused only when text, schema and pipeline all match.
-STRUCTURED_PIPELINE_VERSION = "structured_v2.1"
+# Bump when the chunking contract changes in a way that invalidates stored chunk
+# results — different chunk ids, boundaries or offsets. A run is reused only
+# when source text, schema version, this version and the spine template all
+# match, so a bump simply starts a fresh plan rather than corrupting an old one.
+STRUCTURED_PIPELINE_VERSION = "structured_v1"
 STRUCTURED_SCHEMA_VERSION = 1
 
 _PROGRESS = {
@@ -118,7 +120,7 @@ async def ingest_source_text_structured(
     return {
         "char_count": len(content),
         "status": "source_ready",
-        "pipeline": "structured_v2",
+        "pipeline": "structured_v1",
         "run_id": run_id,
         "chunks": len(chunks),
         "section_type": section_type,

--- a/src/novelvideo/structured_ingest.py
+++ b/src/novelvideo/structured_ingest.py
@@ -89,6 +89,7 @@ async def ingest_source_text_structured(
         source_sha256=digest,
         schema_version=STRUCTURED_SCHEMA_VERSION,
         pipeline_version=STRUCTURED_PIPELINE_VERSION,
+        spine_template=template,
     )
     if reused:
         # Identical text analysed by identical code: keep the existing run so a

--- a/src/novelvideo/task_backend/runners/graph_build.py
+++ b/src/novelvideo/task_backend/runners/graph_build.py
@@ -9,7 +9,7 @@ from novelvideo.model_gateway_runtime import model_gateway_scope_for_runner
 from novelvideo.novel_source import require_imported_novel
 from novelvideo.knowledge_pipeline import (
     KnowledgePipelineUnsupported,
-    is_structured_v2,
+    is_structured_pipeline,
 )
 from novelvideo.project_context import ProjectContext
 from novelvideo.task_backend.cancel import await_envelope_with_cancel_watch
@@ -46,10 +46,10 @@ def _progress(
 async def _load_store(ctx: ProjectContext):
     """Open the project store its knowledge pipeline calls for.
 
-    structured_v2 builds never touch the graph, so they use SQLiteStore directly
+    structured_v1 builds never touch the graph, so they use SQLiteStore directly
     rather than reaching through the Cognee facade.
     """
-    if is_structured_v2(ctx.state_dir):
+    if is_structured_pipeline(ctx.state_dir):
         from novelvideo.sqlite_store import SQLiteStore
 
         store = SQLiteStore(
@@ -85,7 +85,7 @@ async def _run_build_characters(ctx: ProjectContext) -> dict[str, Any]:
 
         def on_log(message: str) -> None:
             _progress(ctx, "build_characters", None, message)
-        if is_structured_v2(ctx.state_dir):
+        if is_structured_pipeline(ctx.state_dir):
             from novelvideo.structured_builders import build_characters_structured
 
             added = await build_characters_structured(
@@ -117,7 +117,7 @@ async def _run_build_scenes(ctx: ProjectContext) -> dict[str, Any]:
 
         def on_log(message: str) -> None:
             _progress(ctx, "build_scenes", None, message)
-        if is_structured_v2(ctx.state_dir):
+        if is_structured_pipeline(ctx.state_dir):
             from novelvideo.structured_builders import build_scenes_structured
 
             return await build_scenes_structured(
@@ -147,7 +147,7 @@ async def _run_build_props(ctx: ProjectContext) -> dict[str, Any]:
 
         def on_log(message: str) -> None:
             _progress(ctx, "build_props", None, message)
-        if is_structured_v2(ctx.state_dir):
+        if is_structured_pipeline(ctx.state_dir):
             from novelvideo.structured_builders import build_props_structured
 
             return await build_props_structured(
@@ -184,9 +184,9 @@ async def _run_build_episodes(
     # Defence in depth: the route rejects AI modes for structured projects
     # before enqueue, but a task queued before the project's track was known
     # must not reach a planner that needs the graph.
-    if is_structured_v2(ctx.state_dir) and planning_mode != "chapters":
+    if is_structured_pipeline(ctx.state_dir) and planning_mode != "chapters":
         raise KnowledgePipelineUnsupported(
-            "structured_v2 only supports deterministic chapter/episode mapping"
+            "structured_v1 only supports deterministic chapter/episode mapping"
         )
     store = await _load_store(ctx)
     try:

--- a/src/novelvideo/task_backend/runners/graph_build.py
+++ b/src/novelvideo/task_backend/runners/graph_build.py
@@ -44,13 +44,27 @@ def _progress(
 
 
 async def _load_store(ctx: ProjectContext):
-    from novelvideo.cognee import CogneeStore
+    """Open the project store its knowledge pipeline calls for.
 
-    store = CogneeStore(
-        ctx.owner_project_label,
-        output_dir=str(ctx.output_dir),
-        state_dir=str(ctx.state_dir),
-    )
+    structured_v2 builds never touch the graph, so they use SQLiteStore directly
+    rather than reaching through the Cognee facade.
+    """
+    if is_structured_v2(ctx.state_dir):
+        from novelvideo.sqlite_store import SQLiteStore
+
+        store = SQLiteStore(
+            ctx.owner_project_label,
+            output_dir=str(ctx.output_dir),
+            state_dir=str(ctx.state_dir),
+        )
+    else:
+        from novelvideo.cognee import CogneeStore
+
+        store = CogneeStore(
+            ctx.owner_project_label,
+            output_dir=str(ctx.output_dir),
+            state_dir=str(ctx.state_dir),
+        )
     await store.initialize()
     await store.load_graph_state()
     return store
@@ -66,11 +80,22 @@ async def _run_build_characters(ctx: ProjectContext) -> dict[str, Any]:
     require_imported_novel(ctx.output_dir)
     store = await _load_store(ctx)
     try:
+        def on_progress(progress: float | None, task: str) -> None:
+            _progress(ctx, "build_characters", progress, task)
+
+        def on_log(message: str) -> None:
+            _progress(ctx, "build_characters", None, message)
+        if is_structured_v2(ctx.state_dir):
+            from novelvideo.structured_builders import build_characters_structured
+
+            added = await build_characters_structured(
+                store, on_progress=on_progress, on_log=on_log
+            )
+            return {"characters": len(added), "added_characters": len(added)}
+
         characters = await store.build_characters_from_graph(
-            on_progress=lambda progress, task: _progress(
-                ctx, "build_characters", progress, task
-            ),
-            on_log=lambda message: _progress(ctx, "build_characters", None, message),
+            on_progress=on_progress,
+            on_log=on_log,
         )
         return {"characters": len(characters), "added_characters": len(characters)}
     finally:
@@ -87,11 +112,21 @@ async def _run_build_scenes(ctx: ProjectContext) -> dict[str, Any]:
     require_imported_novel(ctx.output_dir)
     store = await _load_store(ctx)
     try:
+        def on_progress(progress: float | None, task: str) -> None:
+            _progress(ctx, "build_scenes", progress, task)
+
+        def on_log(message: str) -> None:
+            _progress(ctx, "build_scenes", None, message)
+        if is_structured_v2(ctx.state_dir):
+            from novelvideo.structured_builders import build_scenes_structured
+
+            return await build_scenes_structured(
+                store, on_progress=on_progress, on_log=on_log
+            )
+
         scenes = await store.build_scenes_from_graph(
-            on_progress=lambda progress, task: _progress(
-                ctx, "build_scenes", progress, task
-            ),
-            on_log=lambda message: _progress(ctx, "build_scenes", None, message),
+            on_progress=on_progress,
+            on_log=on_log,
         )
         return {"scenes": len(scenes), "added_scenes": len(scenes)}
     finally:
@@ -107,11 +142,21 @@ def run_build_props(
 async def _run_build_props(ctx: ProjectContext) -> dict[str, Any]:
     store = await _load_store(ctx)
     try:
+        def on_progress(progress: float | None, task: str) -> None:
+            _progress(ctx, "build_props", progress, task)
+
+        def on_log(message: str) -> None:
+            _progress(ctx, "build_props", None, message)
+        if is_structured_v2(ctx.state_dir):
+            from novelvideo.structured_builders import build_props_structured
+
+            return await build_props_structured(
+                store, on_progress=on_progress, on_log=on_log
+            )
+
         props = await store.build_props_from_graph(
-            on_progress=lambda progress, task: _progress(
-                ctx, "build_props", progress, task
-            ),
-            on_log=lambda message: _progress(ctx, "build_props", None, message),
+            on_progress=on_progress,
+            on_log=on_log,
         )
         return {"props": len(props)}
     finally:

--- a/src/novelvideo/task_backend/runners/graph_build.py
+++ b/src/novelvideo/task_backend/runners/graph_build.py
@@ -7,6 +7,10 @@ from typing import Any
 
 from novelvideo.model_gateway_runtime import model_gateway_scope_for_runner
 from novelvideo.novel_source import require_imported_novel
+from novelvideo.knowledge_pipeline import (
+    KnowledgePipelineUnsupported,
+    is_structured_v2,
+)
 from novelvideo.project_context import ProjectContext
 from novelvideo.task_backend.cancel import await_envelope_with_cancel_watch
 from novelvideo.task_backend.registry import register_project_task_runner
@@ -132,6 +136,13 @@ async def _run_build_episodes(
     planning_mode = str(config.get("planning_mode", "ai"))
     generate_metadata = bool(config.get("generate_metadata", False))
     require_imported_novel(ctx.output_dir)
+    # Defence in depth: the route rejects AI modes for structured projects
+    # before enqueue, but a task queued before the project's track was known
+    # must not reach a planner that needs the graph.
+    if is_structured_v2(ctx.state_dir) and planning_mode != "chapters":
+        raise KnowledgePipelineUnsupported(
+            "structured_v2 only supports deterministic chapter/episode mapping"
+        )
     store = await _load_store(ctx)
     try:
 

--- a/src/novelvideo/task_backend/runners/ingest.py
+++ b/src/novelvideo/task_backend/runners/ingest.py
@@ -28,18 +28,32 @@ def run_ingest_fast(
 async def _run_ingest_fast(
     envelope: dict[str, Any], ctx: ProjectContext
 ) -> dict[str, Any]:
-    from novelvideo.cognee import CogneeStore
+    from novelvideo.knowledge_pipeline import is_structured_v2
 
     payload = envelope.get("payload") or {}
     novel_path = str(payload["novel_path"])
     config = dict(payload.get("config") or {})
     manager = get_task_manager()
 
-    store = CogneeStore(
-        ctx.owner_project_label,
-        output_dir=str(ctx.output_dir),
-        state_dir=str(ctx.state_dir),
-    )
+    # structured_v2 imports never build a graph, so they open the project with
+    # SQLiteStore directly rather than through the Cognee facade.
+    structured = is_structured_v2(ctx.state_dir)
+    if structured:
+        from novelvideo.sqlite_store import SQLiteStore
+
+        store = SQLiteStore(
+            ctx.owner_project_label,
+            output_dir=str(ctx.output_dir),
+            state_dir=str(ctx.state_dir),
+        )
+    else:
+        from novelvideo.cognee import CogneeStore
+
+        store = CogneeStore(
+            ctx.owner_project_label,
+            output_dir=str(ctx.output_dir),
+            state_dir=str(ctx.state_dir),
+        )
     await store.initialize()
 
     def update(progress: float | None, task: str) -> None:
@@ -59,6 +73,18 @@ async def _run_ingest_fast(
         )
 
     try:
+        if structured:
+            from novelvideo.structured_ingest import ingest_source_text_structured
+
+            return await ingest_source_text_structured(
+                store,
+                novel_path,
+                spine_template=str(config.get("spine_template") or "").strip()
+                or None,
+                on_progress=update,
+                on_log=lambda message: update(None, message),
+            )
+
         result = await store.ingest_novel_fast(
             novel_path,
             rebuild=bool(config.get("rebuild", False)),

--- a/src/novelvideo/task_backend/runners/ingest.py
+++ b/src/novelvideo/task_backend/runners/ingest.py
@@ -28,16 +28,16 @@ def run_ingest_fast(
 async def _run_ingest_fast(
     envelope: dict[str, Any], ctx: ProjectContext
 ) -> dict[str, Any]:
-    from novelvideo.knowledge_pipeline import is_structured_v2
+    from novelvideo.knowledge_pipeline import is_structured_pipeline
 
     payload = envelope.get("payload") or {}
     novel_path = str(payload["novel_path"])
     config = dict(payload.get("config") or {})
     manager = get_task_manager()
 
-    # structured_v2 imports never build a graph, so they open the project with
+    # structured_v1 imports never build a graph, so they open the project with
     # SQLiteStore directly rather than through the Cognee facade.
-    structured = is_structured_v2(ctx.state_dir)
+    structured = is_structured_pipeline(ctx.state_dir)
     if structured:
         from novelvideo.sqlite_store import SQLiteStore
 

--- a/src/novelvideo/utils/bounded_concurrency.py
+++ b/src/novelvideo/utils/bounded_concurrency.py
@@ -13,19 +13,41 @@ merging depends on chunk order to resolve ties deterministically.
 from __future__ import annotations
 
 import asyncio
+import os
 from typing import Any, Awaitable, Callable, Sequence, TypeVar
 
 T = TypeVar("T")
 R = TypeVar("R")
 
-DEFAULT_LIMIT = 6
+STRUCTURED_LLM_CONCURRENCY_ENV = "STRUCTURED_LLM_CONCURRENCY"
+
+# Matches COGNEE_LLM_CONCURRENCY's default. The gateway is the shared
+# bottleneck, so a second pool running deeper would trip the same rate limits
+# the Cognee pool is tuned to avoid.
+DEFAULT_LIMIT = 2
+
+
+def default_llm_concurrency() -> int:
+    """Slots for per-chunk LLM work, overridable per deployment."""
+    raw = os.getenv(STRUCTURED_LLM_CONCURRENCY_ENV, str(DEFAULT_LIMIT)).strip()
+    try:
+        value = int(raw)
+    except ValueError as exc:
+        raise ValueError(
+            f"{STRUCTURED_LLM_CONCURRENCY_ENV} must be a positive integer, got {raw!r}"
+        ) from exc
+    if value <= 0:
+        raise ValueError(
+            f"{STRUCTURED_LLM_CONCURRENCY_ENV} must be a positive integer, got {raw!r}"
+        )
+    return value
 
 
 async def map_bounded(
     items: Sequence[T],
     worker: Callable[[T], Awaitable[R]],
     *,
-    limit: int = DEFAULT_LIMIT,
+    limit: int | None = None,
     on_error: Callable[[T, BaseException], Any] | None = None,
 ) -> list[R | None]:
     """Run ``worker`` over ``items`` with at most ``limit`` calls in flight.
@@ -38,7 +60,8 @@ async def map_bounded(
     if not items:
         return []
 
-    semaphore = asyncio.Semaphore(max(1, int(limit)))
+    effective = default_llm_concurrency() if limit is None else int(limit)
+    semaphore = asyncio.Semaphore(max(1, effective))
 
     async def run(item: T) -> R | None:
         async with semaphore:

--- a/src/novelvideo/utils/bounded_concurrency.py
+++ b/src/novelvideo/utils/bounded_concurrency.py
@@ -1,0 +1,54 @@
+"""Bounded parallel mapping for per-chunk LLM work.
+
+Structured extraction runs one model call per source chunk, and a screenplay can
+carry well over a hundred scenes.  Running them serially makes a build take
+minutes of pure round-trip latency; running them all at once buries the gateway
+and trips rate limits.  Both extremes are avoided by mapping with a fixed number
+of slots in flight.
+
+Results keep the input order regardless of completion order, because downstream
+merging depends on chunk order to resolve ties deterministically.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Awaitable, Callable, Sequence, TypeVar
+
+T = TypeVar("T")
+R = TypeVar("R")
+
+DEFAULT_LIMIT = 6
+
+
+async def map_bounded(
+    items: Sequence[T],
+    worker: Callable[[T], Awaitable[R]],
+    *,
+    limit: int = DEFAULT_LIMIT,
+    on_error: Callable[[T, BaseException], Any] | None = None,
+) -> list[R | None]:
+    """Run ``worker`` over ``items`` with at most ``limit`` calls in flight.
+
+    A failing item yields ``None`` in its slot rather than cancelling the batch:
+    one unparseable scene must not discard the analysis of every other scene.
+    ``on_error`` is invoked for each failure so callers can record it against the
+    chunk that produced it.
+    """
+    if not items:
+        return []
+
+    semaphore = asyncio.Semaphore(max(1, int(limit)))
+
+    async def run(item: T) -> R | None:
+        async with semaphore:
+            try:
+                return await worker(item)
+            except asyncio.CancelledError:
+                raise
+            except BaseException as exc:  # noqa: BLE001 - reported, not swallowed
+                if on_error is not None:
+                    on_error(item, exc)
+                return None
+
+    return list(await asyncio.gather(*(run(item) for item in items)))

--- a/tests/test_cognee_pipeline_concurrency.py
+++ b/tests/test_cognee_pipeline_concurrency.py
@@ -401,7 +401,9 @@ async def test_episode_runner_persists_agent_plan_only_to_sqlite(monkeypatch):
         FakePlanner,
     )
 
-    ctx = SimpleNamespace(output_dir="/tmp/output")
+    # A real ProjectContext always carries state_dir; the runner reads it to
+    # resolve the project's knowledge pipeline.
+    ctx = SimpleNamespace(output_dir="/tmp/output", state_dir="/tmp/state")
     result = await graph_build._run_build_episodes(
         {"payload": {"config": {"target_episodes": 1}}},
         ctx,

--- a/tests/test_knowledge_pipeline_dual_track.py
+++ b/tests/test_knowledge_pipeline_dual_track.py
@@ -1,0 +1,232 @@
+"""Dual-track knowledge pipeline boundary.
+
+The contract this file defends:
+
+* legacy projects behave exactly as before, including projects that predate the
+  ``knowledge_pipeline`` field entirely;
+* structured_v2 projects can still use the store as a plain SQLite facade,
+  because most runners and API routes depend on it that way;
+* structured_v2 projects can never reach Cognee, an embedding binding, or the
+  graph — the attempt must raise rather than silently fall back.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from novelvideo.knowledge_pipeline import (
+    COGNEE_LEGACY,
+    KNOWLEDGE_PIPELINE_KEY,
+    KnowledgePipelineUnsupported,
+    STRUCTURED_V2,
+    is_structured_v2,
+    knowledge_pipeline_from_state_dir,
+)
+
+
+def _write_config(state_dir: Path, config: dict) -> None:
+    state_dir.mkdir(parents=True, exist_ok=True)
+    (state_dir / "project_config.json").write_text(
+        json.dumps(config, ensure_ascii=False), encoding="utf-8"
+    )
+
+
+# ── track resolution ─────────────────────────────────────────────────────────
+
+
+def test_missing_config_file_is_legacy(tmp_path):
+    assert knowledge_pipeline_from_state_dir(tmp_path) == COGNEE_LEGACY
+
+
+def test_project_without_the_field_is_legacy(tmp_path):
+    """Projects created before the field existed must not be reclassified."""
+    _write_config(tmp_path, {"user": "someone", "spine_template": "drama"})
+    assert knowledge_pipeline_from_state_dir(tmp_path) == COGNEE_LEGACY
+
+
+def test_embedding_bound_project_is_legacy(tmp_path):
+    _write_config(
+        tmp_path,
+        {
+            "user": "someone",
+            "cognee_embedding_model": "DC-cognee-embedding-v2",
+            "cognee_embedding_dimension": 1024,
+        },
+    )
+    assert knowledge_pipeline_from_state_dir(tmp_path) == COGNEE_LEGACY
+
+
+def test_explicit_structured_field_is_structured(tmp_path):
+    _write_config(tmp_path, {KNOWLEDGE_PIPELINE_KEY: STRUCTURED_V2})
+    assert is_structured_v2(tmp_path)
+
+
+def test_unknown_pipeline_value_falls_back_to_legacy(tmp_path):
+    """An unrecognised value must never be treated as structured."""
+    _write_config(tmp_path, {KNOWLEDGE_PIPELINE_KEY: "something-else"})
+    assert knowledge_pipeline_from_state_dir(tmp_path) == COGNEE_LEGACY
+
+
+def test_absent_embedding_keys_do_not_imply_structured(tmp_path):
+    """Missing embedding keys are not a usable signal.
+
+    ``ensure_cognee_embedding_binding_in_state_dir`` backfills them for legacy
+    projects, so only the explicit field can be trusted.
+    """
+    _write_config(tmp_path, {"user": "someone"})
+    assert not is_structured_v2(tmp_path)
+
+
+def test_default_project_config_does_not_carry_the_field():
+    """The field must never reach a project through the effective-config merge.
+
+    ``_effective_project_config`` merges the defaults over stored values, so a
+    default entry would silently reclassify every legacy project.
+    """
+    from novelvideo.project_config import _default_project_config
+
+    assert KNOWLEDGE_PIPELINE_KEY not in _default_project_config()
+
+
+def test_effective_config_merge_cannot_make_a_legacy_project_structured(tmp_path):
+    from novelvideo.project_config import load_project_config_from_state_dir
+
+    _write_config(tmp_path, {"user": "someone", "spine_template": "drama"})
+    effective = load_project_config_from_state_dir(tmp_path)
+    assert effective.get(KNOWLEDGE_PIPELINE_KEY, COGNEE_LEGACY) == COGNEE_LEGACY
+
+
+# ── store behaviour ──────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def structured_store(tmp_path):
+    from novelvideo.cognee.store import CogneeStore
+
+    state_dir = tmp_path / "user" / "structured"
+    _write_config(state_dir, {KNOWLEDGE_PIPELINE_KEY: STRUCTURED_V2})
+    return CogneeStore(
+        "user/structured",
+        output_dir=str(state_dir),
+        state_dir=str(state_dir),
+    )
+
+
+@pytest.fixture
+def legacy_store(tmp_path):
+    from novelvideo.cognee.store import CogneeStore
+
+    state_dir = tmp_path / "user" / "legacy"
+    _write_config(state_dir, {"user": "user"})
+    return CogneeStore(
+        "user/legacy",
+        output_dir=str(state_dir),
+        state_dir=str(state_dir),
+    )
+
+
+async def test_structured_initialize_never_binds_an_embedding_model(
+    structured_store, monkeypatch
+):
+    """The sentinel: initialize() must not reach any Cognee/embedding entry."""
+    import novelvideo.cognee.store as store_module
+
+    def _boom(*args, **kwargs):
+        raise AssertionError("structured_v2 must not touch Cognee or embeddings")
+
+    monkeypatch.setattr(
+        store_module, "ensure_cognee_embedding_binding_in_state_dir", _boom
+    )
+    monkeypatch.setattr(store_module, "init_cognee", _boom)
+    monkeypatch.setattr(store_module, "setup", _boom)
+
+    try:
+        await structured_store.initialize()
+    finally:
+        await structured_store.close()
+
+
+async def test_structured_initialize_writes_no_embedding_fields(structured_store):
+    from novelvideo.embedding_models import (
+        PROJECT_EMBEDDING_DIMENSION_KEY,
+        PROJECT_EMBEDDING_MODEL_KEY,
+    )
+
+    config_path = Path(structured_store.state_dir) / "project_config.json"
+    try:
+        await structured_store.initialize()
+    finally:
+        await structured_store.close()
+
+    config = json.loads(config_path.read_text(encoding="utf-8"))
+    assert PROJECT_EMBEDDING_MODEL_KEY not in config
+    assert PROJECT_EMBEDDING_DIMENSION_KEY not in config
+    assert config[KNOWLEDGE_PIPELINE_KEY] == STRUCTURED_V2
+
+
+async def test_structured_store_still_works_as_a_sqlite_facade(structured_store):
+    """Runners that only need SQLite must keep working after the default flips.
+
+    Portrait, prop/scene reference, script, sketch, video, verification and the
+    Freezone routes all construct a CogneeStore purely for SQLite access.
+    """
+    from novelvideo.cognee.pipeline import NovelCharacter
+
+    try:
+        await structured_store.initialize()
+        await structured_store.load_graph_state()
+
+        await structured_store.add_character(NovelCharacter(name="林默"))
+        assert structured_store.get_character("林默") is not None
+        assert structured_store.character_count == 1
+
+        structured_store.save_novel_content("正文")
+        assert structured_store.load_novel_content() == "正文"
+    finally:
+        await structured_store.close()
+
+
+@pytest.mark.parametrize(
+    "operation",
+    [
+        "search",
+        "ingest_novel_fast",
+        "build_characters_from_graph",
+        "build_scenes_from_graph",
+        "build_props_from_graph",
+        "get_graph_snapshot",
+        "materialize_graph_preview",
+    ],
+)
+async def test_structured_graph_capabilities_raise(structured_store, operation):
+    try:
+        await structured_store.initialize()
+        with pytest.raises(KnowledgePipelineUnsupported):
+            await getattr(structured_store, operation)("query")
+    finally:
+        await structured_store.close()
+
+
+async def test_structured_embedding_scope_raises(structured_store):
+    """Guarded too: entering the scope is how a binding gets created."""
+    try:
+        await structured_store.initialize()
+        with pytest.raises(KnowledgePipelineUnsupported):
+            structured_store.embedding_model_scope()
+    finally:
+        await structured_store.close()
+
+
+def test_uninitialized_structured_store_is_still_gated(structured_store):
+    """Stores built without initialize() must resolve the track lazily."""
+    with pytest.raises(KnowledgePipelineUnsupported):
+        structured_store.embedding_model_scope()
+
+
+def test_legacy_store_keeps_graph_capabilities(legacy_store):
+    """The gate must be invisible to legacy projects."""
+    assert legacy_store._cognee_enabled
+    legacy_store._require_cognee("graph search")

--- a/tests/test_knowledge_pipeline_dual_track.py
+++ b/tests/test_knowledge_pipeline_dual_track.py
@@ -4,9 +4,9 @@ The contract this file defends:
 
 * legacy projects behave exactly as before, including projects that predate the
   ``knowledge_pipeline`` field entirely;
-* structured_v2 projects can still use the store as a plain SQLite facade,
+* structured_v1 projects can still use the store as a plain SQLite facade,
   because most runners and API routes depend on it that way;
-* structured_v2 projects can never reach Cognee, an embedding binding, or the
+* structured_v1 projects can never reach Cognee, an embedding binding, or the
   graph — the attempt must raise rather than silently fall back.
 """
 
@@ -21,8 +21,8 @@ from novelvideo.knowledge_pipeline import (
     COGNEE_LEGACY,
     KNOWLEDGE_PIPELINE_KEY,
     KnowledgePipelineUnsupported,
-    STRUCTURED_V2,
-    is_structured_v2,
+    KNOWLEDGE_PIPELINE_STRUCTURED,
+    is_structured_pipeline,
     knowledge_pipeline_from_state_dir,
 )
 
@@ -60,8 +60,8 @@ def test_embedding_bound_project_is_legacy(tmp_path):
 
 
 def test_explicit_structured_field_is_structured(tmp_path):
-    _write_config(tmp_path, {KNOWLEDGE_PIPELINE_KEY: STRUCTURED_V2})
-    assert is_structured_v2(tmp_path)
+    _write_config(tmp_path, {KNOWLEDGE_PIPELINE_KEY: KNOWLEDGE_PIPELINE_STRUCTURED})
+    assert is_structured_pipeline(tmp_path)
 
 
 def test_unknown_pipeline_value_falls_back_to_legacy(tmp_path):
@@ -77,7 +77,7 @@ def test_absent_embedding_keys_do_not_imply_structured(tmp_path):
     projects, so only the explicit field can be trusted.
     """
     _write_config(tmp_path, {"user": "someone"})
-    assert not is_structured_v2(tmp_path)
+    assert not is_structured_pipeline(tmp_path)
 
 
 def test_default_project_config_does_not_carry_the_field():
@@ -107,7 +107,7 @@ def structured_store(tmp_path):
     from novelvideo.cognee.store import CogneeStore
 
     state_dir = tmp_path / "user" / "structured"
-    _write_config(state_dir, {KNOWLEDGE_PIPELINE_KEY: STRUCTURED_V2})
+    _write_config(state_dir, {KNOWLEDGE_PIPELINE_KEY: KNOWLEDGE_PIPELINE_STRUCTURED})
     return CogneeStore(
         "user/structured",
         output_dir=str(state_dir),
@@ -135,7 +135,7 @@ async def test_structured_initialize_never_binds_an_embedding_model(
     import novelvideo.cognee.store as store_module
 
     def _boom(*args, **kwargs):
-        raise AssertionError("structured_v2 must not touch Cognee or embeddings")
+        raise AssertionError("structured_v1 must not touch Cognee or embeddings")
 
     monkeypatch.setattr(
         store_module, "ensure_cognee_embedding_binding_in_state_dir", _boom
@@ -164,7 +164,7 @@ async def test_structured_initialize_writes_no_embedding_fields(structured_store
     config = json.loads(config_path.read_text(encoding="utf-8"))
     assert PROJECT_EMBEDDING_MODEL_KEY not in config
     assert PROJECT_EMBEDDING_DIMENSION_KEY not in config
-    assert config[KNOWLEDGE_PIPELINE_KEY] == STRUCTURED_V2
+    assert config[KNOWLEDGE_PIPELINE_KEY] == KNOWLEDGE_PIPELINE_STRUCTURED
 
 
 async def test_structured_store_still_works_as_a_sqlite_facade(structured_store):

--- a/tests/test_screenplay_normalizer.py
+++ b/tests/test_screenplay_normalizer.py
@@ -1,7 +1,6 @@
 import pytest
 
 from novelvideo.cognee.screenplay_normalizer import (
-    NormalizedSceneHeader,
     NormalizedSceneBlock,
     clean_scene_name_and_time,
     normalize_time_of_day,
@@ -231,87 +230,79 @@ class _FakeAgent:
 
 
 @pytest.mark.asyncio
-async def test_normalize_screenplay_scenes_uses_agent_output():
-    fake_agent = _FakeAgent(
-        NormalizedSceneHeader(
-            episode_number=3,
-            scene_no="1",
-            location="凤鸣皇城·苏鸾寝殿",
-            time_of_day="亥时",
-            interior_exterior="内",
-            aliases=["苏鸾寝殿"],
-            scene_type="interior",
-        )
-    )
+async def test_standard_headings_are_normalized_without_a_model_call():
+    """A standard heading already states location, time and interior/exterior.
+
+    Asking a model to restate them is a round trip per scene, and a heading is
+    about fourteen characters long.
+    """
+
+    class _NeverCalled:
+        async def run(self, prompt: str):
+            raise AssertionError("a standard heading must not reach the model")
 
     scenes = await normalize_screenplay_scenes(
-        "3-1、凤鸣皇城·苏鸾寝殿 亥时 内\n人物：苏糖、沈晚、锦绣\n△寝殿内，床帐放下。",
-        agent=fake_agent,
+        "1-1 寝殿 夜 内\n人物：悟空\n悟空：师父。\n"
+        "1-2 山门 日 外\n人物：悟空、童子\n△悟空走出山门。",
+        agent=_NeverCalled(),
     )
 
-    assert len(scenes) == 1
-    assert scenes[0].location == "凤鸣皇城·苏鸾寝殿"
-    assert scenes[0].time_of_day == "夜晚"
-    assert scenes[0].characters == ["苏糖", "沈晚", "锦绣"]
-    assert scenes[0].content_lines == ["△寝殿内，床帐放下。"]
-    assert "3-1、凤鸣皇城·苏鸾寝殿 亥时 内" in fake_agent.prompts[0]
-    assert "<scene_header>" in fake_agent.prompts[0]
-    assert "</scene_header>" in fake_agent.prompts[0]
-    assert "人物：苏糖、沈晚、锦绣" not in fake_agent.prompts[0]
-    assert "<scene_context>" in fake_agent.prompts[0]
-    assert "△寝殿内，床帐放下。" in fake_agent.prompts[0]
-    assert "location 是稳定物理地点" not in fake_agent.prompts[0]
+    assert [scene.location for scene in scenes] == ["寝殿", "山门"]
+    assert [scene.interior_exterior for scene in scenes] == ["内", "外"]
+    assert [scene.content_lines for scene in scenes] == [
+        ["悟空：师父。"],
+        ["△悟空走出山门。"],
+    ]
 
 
-@pytest.mark.asyncio
-async def test_normalize_screenplay_scenes_returns_empty_without_calling_agent():
-    fake_agent = _FakeAgent(NormalizedSceneHeader(location="不会调用"))
+async def test_headings_the_parser_cannot_resolve_go_to_the_model_in_one_batch():
+    from novelvideo.cognee.screenplay_normalizer import (
+        BatchSceneHeaderItem,
+        NormalizedSceneHeaderBatch,
+    )
 
-    scenes = await normalize_screenplay_scenes(" \n\t ", agent=fake_agent)
-
-    assert scenes == []
-    assert fake_agent.prompts == []
-
-
-@pytest.mark.asyncio
-async def test_normalize_screenplay_scenes_calls_agent_once_per_scene_block():
-    class _HeaderAgent:
+    class _BatchAgent:
         def __init__(self):
             self.prompts: list[str] = []
 
         async def run(self, prompt: str):
             self.prompts.append(prompt)
-            location = "寝殿" if "1-1" in prompt else "山门"
             return _FakeRunResult(
-                NormalizedSceneHeader(
-                    episode_number=1,
-                    scene_no=str(len(self.prompts)),
-                    location=location,
-                    time_of_day="夜晚" if location == "寝殿" else "白天",
-                    interior_exterior="内" if location == "寝殿" else "外",
+                NormalizedSceneHeaderBatch(
+                    scenes=[
+                        BatchSceneHeaderItem(
+                            index=0, episode_number=3, scene_no="1",
+                            location="凤鸣皇城·苏鸾寝殿", time_of_day="亥时",
+                            interior_exterior="内", aliases=["苏鸾寝殿"],
+                        ),
+                        BatchSceneHeaderItem(
+                            index=1, episode_number=3, scene_no="2",
+                            location="御花园", time_of_day="日",
+                            interior_exterior="外",
+                        ),
+                    ]
                 )
             )
 
-    fake_agent = _HeaderAgent()
+    agent = _BatchAgent()
+    # Neither heading states interior/exterior, so the parser cannot finish
+    # either one and both must travel to the model.
     scenes = await normalize_screenplay_scenes(
-        "1-1 寝殿 夜 内\n人物：悟空\n悟空：师父。\n"
-        "1-2 山门 日 外\n人物：悟空、童子\n△悟空走出山门。",
-        agent=fake_agent,
+        "3-1、凤鸣皇城·苏鸾寝殿\n人物：苏糖、沈晚、锦绣\n△寝殿内，床帐放下。\n"
+        "3-2、御花园\n人物：苏糖\n△苏糖走过回廊。",
+        agent=agent,
     )
 
+    # Both unresolved headings travelled in a single request.
+    assert len(agent.prompts) == 1
+    assert "凤鸣皇城·苏鸾寝殿" in agent.prompts[0]
+    assert "御花园" in agent.prompts[0]
+
     assert len(scenes) == 2
-    assert [scene.location for scene in scenes] == ["寝殿", "山门"]
-    assert [scene.content_lines for scene in scenes] == [
-        ["悟空：师父。"],
-        ["△悟空走出山门。"],
-    ]
-    assert len(fake_agent.prompts) == 2
-    assert "1-2 山门 日 外" not in fake_agent.prompts[0]
-    assert "悟空：师父。" in fake_agent.prompts[0]
-    assert "△悟空走出山门。" not in fake_agent.prompts[0]
-    assert "1-1 寝殿 夜 内" not in fake_agent.prompts[1]
-    assert "△悟空走出山门。" in fake_agent.prompts[1]
-    assert "悟空：师父。" not in fake_agent.prompts[1]
+    by_location = {scene.location: scene for scene in scenes}
+    assert by_location["凤鸣皇城·苏鸾寝殿"].time_of_day == "夜晚"
+    assert by_location["凤鸣皇城·苏鸾寝殿"].characters == ["苏糖", "沈晚", "锦绣"]
+    assert by_location["凤鸣皇城·苏鸾寝殿"].content_lines == ["△寝殿内，床帐放下。"]
 
 
 @pytest.mark.asyncio

--- a/tests/test_sqlite_schema_initialization.py
+++ b/tests/test_sqlite_schema_initialization.py
@@ -10,7 +10,10 @@ from pathlib import Path
 
 import pytest
 
-from novelvideo.sqlite_store import SQLiteStore
+from novelvideo.sqlite_store import (
+    _PROJECT_STORE_SCHEMA_VERSION,
+    SQLiteStore,
+)
 from novelvideo.task_state import TaskStateManager
 
 
@@ -309,7 +312,9 @@ def test_task_and_project_schema_initialize_safely_across_processes(tmp_path):
             ).fetchall()
         )
         assert components["task_state"] == 1
-        assert components["project_store"] == 1
+        # Track the constant rather than a literal, so a schema bump does
+        # not silently make this assertion stale.
+        assert components["project_store"] == _PROJECT_STORE_SCHEMA_VERSION
         tables = {
             row[0]
             for row in conn.execute(

--- a/tests/test_structured_builders.py
+++ b/tests/test_structured_builders.py
@@ -1,0 +1,496 @@
+"""structured_v2 project-level builds: characters, scenes, props.
+
+The rules under test are the conservative ones. A character name is at once a
+SQLite primary key, a REST identifier and an asset directory name, so the
+merging rules must refuse to guess, and evidence must be verifiable against the
+source or the candidate never reaches the table.
+"""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from novelvideo.knowledge_pipeline import KNOWLEDGE_PIPELINE_KEY, STRUCTURED_V2
+from novelvideo.story_analysis import SourceChunk, chunk_source_text
+from novelvideo.structured_extraction import (
+    CharacterCandidate,
+    CharacterEvidence,
+    ChunkCharacterOutput,
+    extract_characters_from_chunks,
+    find_explicit_aliases,
+    is_generic_address,
+    merge_character_candidates,
+    normalize_character_name,
+    verify_evidence,
+)
+
+NARRATED_TEXT = """第一章 归来
+
+林默回到阔别十年的故乡。街道还是老样子。
+他的母亲在门口等他。
+
+第二章 旧友
+
+林默又名小默，村里人都这么叫他。
+他在巷口遇见了苏晴。
+
+第三章 真相
+
+苏晴告诉林默一个秘密。
+他的母亲听完沉默了很久。
+"""
+
+
+def _chunk(text: str, *, chunk_id="c0", start=0) -> SourceChunk:
+    return SourceChunk(
+        chunk_id=chunk_id,
+        chunk_index=0,
+        section_type="chapter",
+        section_label="第一章",
+        source_start=start,
+        source_end=start + len(text),
+        text=text,
+    )
+
+
+def _candidate(name, *, quotes=(), aliases=(), gender="", description=""):
+    return CharacterCandidate(
+        name=name,
+        aliases=list(aliases),
+        gender=gender,
+        description=description,
+        evidence=[CharacterEvidence(quote=quote) for quote in quotes],
+    )
+
+
+# ── name normalization ──────────────────────────────────────────────────────
+
+
+def test_normalize_strips_punctuation_noise_without_altering_the_name():
+    assert normalize_character_name("　林默：") == "林默"
+    assert normalize_character_name("「苏晴」") == "苏晴"
+    assert normalize_character_name("林 默") == "林 默"
+
+
+def test_titles_and_kinship_terms_are_generic():
+    for term in ("母亲", "陛下", "医生", "他", "少年"):
+        assert is_generic_address(term)
+    assert not is_generic_address("林默")
+
+
+# ── evidence verification ───────────────────────────────────────────────────
+
+
+def test_evidence_resolves_to_absolute_source_offsets():
+    chunk = _chunk("林默回到故乡。", start=100)
+    span = verify_evidence("林默回到故乡。", chunk)
+    assert span == (100, 100 + len("林默回到故乡。"))
+
+
+def test_evidence_not_present_in_the_chunk_is_rejected():
+    """This check is what stops an invented character reaching the table."""
+    chunk = _chunk("林默回到故乡。")
+    assert verify_evidence("林默其实是皇帝的私生子。", chunk) is None
+
+
+def test_evidence_tolerates_whitespace_the_model_normalized():
+    chunk = _chunk("林默  回到   故乡。")
+    assert verify_evidence("林默 回到 故乡。", chunk) is not None
+
+
+def test_empty_quote_is_rejected():
+    assert verify_evidence("   ", _chunk("林默回到故乡。")) is None
+
+
+# ── explicit alias detection ────────────────────────────────────────────────
+
+
+def test_explicit_alias_statements_are_detected():
+    assert ("林默", "小默") in find_explicit_aliases("林默又名小默，村里人都这么叫他。")
+    assert ("萧玦", "陛下") in find_explicit_aliases("萧玦人称陛下。")
+
+
+def test_two_names_merely_appearing_together_is_not_an_alias():
+    """Co-occurrence is not identity — that is how wrong merges happen."""
+    assert find_explicit_aliases("林默看着苏晴，两人都没说话。") == set()
+
+
+# ── merging ─────────────────────────────────────────────────────────────────
+
+
+def test_identical_names_across_chunks_merge():
+    text_a = "林默回到故乡。"
+    text_b = "林默走进屋子。"
+    outcomes = [
+        (
+            _chunk(text_a, chunk_id="c0"),
+            ChunkCharacterOutput(characters=[_candidate("林默", quotes=[text_a])]),
+        ),
+        (
+            _chunk(text_b, chunk_id="c1", start=50),
+            ChunkCharacterOutput(characters=[_candidate("林默", quotes=[text_b])]),
+        ),
+    ]
+    merged = merge_character_candidates(outcomes)
+    assert [item.name for item in merged] == ["林默"]
+    assert len(merged[0].evidence) == 2
+    assert merged[0].chunk_ids == {"c0", "c1"}
+
+
+def test_candidates_without_verifiable_evidence_are_dropped():
+    text = "林默回到故乡。"
+    outcomes = [
+        (
+            _chunk(text),
+            ChunkCharacterOutput(
+                characters=[
+                    _candidate("林默", quotes=[text]),
+                    _candidate("皇帝", quotes=["林默是皇帝的儿子。"]),
+                ]
+            ),
+        )
+    ]
+    merged = merge_character_candidates(outcomes)
+    assert [item.name for item in merged] == ["林默"]
+
+
+def test_generic_address_terms_never_become_characters():
+    text = "他的母亲在门口等他。"
+    outcomes = [
+        (
+            _chunk(text),
+            ChunkCharacterOutput(characters=[_candidate("母亲", quotes=[text])]),
+        )
+    ]
+    assert merge_character_candidates(outcomes) == []
+
+
+def test_explicitly_stated_alias_merges_into_one_character():
+    text = "林默又名小默，村里人都这么叫他。"
+    outcomes = [
+        (
+            _chunk(text),
+            ChunkCharacterOutput(
+                characters=[
+                    _candidate("林默", quotes=[text]),
+                    _candidate("小默", quotes=[text]),
+                ]
+            ),
+        )
+    ]
+    merged = merge_character_candidates(outcomes)
+    assert len(merged) == 1
+    assert merged[0].name == "林默"
+    assert "小默" in merged[0].aliases
+
+
+def test_model_proposed_alias_without_textual_support_stays_a_suggestion():
+    """A wrong merge destroys data silently; a wrong split is a visible duplicate."""
+    text = "林默看着苏晴。"
+    outcomes = [
+        (
+            _chunk(text),
+            ChunkCharacterOutput(
+                characters=[_candidate("林默", quotes=[text], aliases=["苏晴"])]
+            ),
+        )
+    ]
+    merged = merge_character_candidates(outcomes)
+    assert merged[0].aliases == set()
+    assert "苏晴" in merged[0].ambiguous_with
+
+
+def test_same_generic_term_in_two_chunks_does_not_merge_into_one_person():
+    """"母亲" in chapter one and chapter three need not be the same woman."""
+    outcomes = [
+        (
+            _chunk("他的母亲在门口等他。", chunk_id="c0"),
+            ChunkCharacterOutput(
+                characters=[_candidate("母亲", quotes=["他的母亲在门口等他。"])]
+            ),
+        ),
+        (
+            _chunk("他的母亲听完沉默了。", chunk_id="c1", start=80),
+            ChunkCharacterOutput(
+                characters=[_candidate("母亲", quotes=["他的母亲听完沉默了。"])]
+            ),
+        ),
+    ]
+    assert merge_character_candidates(outcomes) == []
+
+
+def test_alias_merge_keeps_the_better_evidenced_name_as_primary():
+    alias_text = "林默又名小默。"
+    outcomes = [
+        (
+            _chunk(alias_text, chunk_id="c0"),
+            ChunkCharacterOutput(
+                characters=[
+                    _candidate("小默", quotes=[alias_text]),
+                    _candidate("林默", quotes=[alias_text]),
+                ]
+            ),
+        ),
+        (
+            _chunk("林默走进屋子。", chunk_id="c1", start=60),
+            ChunkCharacterOutput(
+                characters=[_candidate("林默", quotes=["林默走进屋子。"])]
+            ),
+        ),
+    ]
+    merged = merge_character_candidates(outcomes)
+    assert len(merged) == 1
+    assert merged[0].name == "林默"
+    assert merged[0].aliases == {"小默"}
+
+
+# ── extraction over chunks ──────────────────────────────────────────────────
+
+
+class FakeAgent:
+    """Returns a scripted output per chunk label, or raises for one of them."""
+
+    def __init__(self, by_label, fail_labels=()):
+        self.by_label = by_label
+        self.fail_labels = set(fail_labels)
+        self.seen = []
+
+    async def run(self, prompt: str):
+        label = next(
+            (key for key in list(self.by_label) + list(self.fail_labels) if key in prompt),
+            "",
+        )
+        self.seen.append(label)
+        if label in self.fail_labels:
+            raise RuntimeError("boom")
+        return SimpleNamespace(
+            output=self.by_label.get(label, ChunkCharacterOutput())
+        )
+
+
+async def test_extraction_runs_over_every_chunk():
+    chunks = chunk_source_text(NARRATED_TEXT, "narrated")
+    agent = FakeAgent(
+        {
+            "第一章": ChunkCharacterOutput(
+                characters=[_candidate("林默", quotes=["林默回到阔别十年的故乡。"])]
+            ),
+            "第二章": ChunkCharacterOutput(
+                characters=[_candidate("苏晴", quotes=["他在巷口遇见了苏晴。"])]
+            ),
+        }
+    )
+    merged = await extract_characters_from_chunks(chunks, agent=agent)
+    assert {item.name for item in merged} == {"林默", "苏晴"}
+
+
+async def test_one_failing_chunk_does_not_discard_the_others():
+    """A single unparseable scene must not take the whole build down with it."""
+    chunks = chunk_source_text(NARRATED_TEXT, "narrated")
+    agent = FakeAgent(
+        {
+            "第一章": ChunkCharacterOutput(
+                characters=[_candidate("林默", quotes=["林默回到阔别十年的故乡。"])]
+            )
+        },
+        fail_labels=["第二章"],
+    )
+    logs: list[str] = []
+    merged = await extract_characters_from_chunks(
+        chunks, agent=agent, on_log=logs.append
+    )
+    assert [item.name for item in merged] == ["林默"]
+    assert any("失败" in line for line in logs)
+
+
+async def test_extraction_is_bounded_but_not_serial():
+    """Chunks are independent, so they must not run one at a time."""
+    import asyncio
+
+    in_flight = 0
+    peak = 0
+
+    class SlowAgent:
+        async def run(self, prompt: str):
+            nonlocal in_flight, peak
+            in_flight += 1
+            peak = max(peak, in_flight)
+            await asyncio.sleep(0.01)
+            in_flight -= 1
+            return SimpleNamespace(output=ChunkCharacterOutput())
+
+    chunks = [
+        _chunk(f"片段{index}", chunk_id=f"c{index}", start=index * 10)
+        for index in range(12)
+    ]
+    await extract_characters_from_chunks(chunks, agent=SlowAgent(), concurrency=4)
+    assert peak > 1
+    assert peak <= 4
+
+
+# ── builders ────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+async def structured_store(tmp_path):
+    from novelvideo.sqlite_store import SQLiteStore
+
+    state_dir = tmp_path / "user" / "structured"
+    state_dir.mkdir(parents=True)
+    (state_dir / "project_config.json").write_text(
+        json.dumps({KNOWLEDGE_PIPELINE_KEY: STRUCTURED_V2, "spine_template": "narrated"}),
+        encoding="utf-8",
+    )
+    (state_dir / "novel.txt").write_text(NARRATED_TEXT, encoding="utf-8")
+    store = SQLiteStore(
+        "user/structured", output_dir=str(state_dir), state_dir=str(state_dir)
+    )
+    await store.initialize()
+    await store.load_graph_state()
+    try:
+        yield store, state_dir
+    finally:
+        await store.close()
+
+
+async def test_atomic_publish_leaves_nothing_behind_on_failure(structured_store):
+    """add_character commits per row; a build must publish all or nothing."""
+    from novelvideo.cognee.pipeline import NovelCharacter
+
+    store, _ = structured_store
+    db = await store._ensure_db()
+    original_execute = db.execute
+    calls = {"n": 0}
+
+    async def fail_on_second_insert(sql, *args, **kwargs):
+        if sql.strip().startswith("INSERT INTO characters"):
+            calls["n"] += 1
+            if calls["n"] == 2:
+                raise RuntimeError("boom")
+        return await original_execute(sql, *args, **kwargs)
+
+    db.execute = fail_on_second_insert
+    try:
+        with pytest.raises(RuntimeError):
+            await store.add_characters_atomic(
+                [NovelCharacter(name="林默"), NovelCharacter(name="苏晴")]
+            )
+    finally:
+        db.execute = original_execute
+
+    # The first insert must not survive the second one's failure.
+    assert await store.list_characters() == []
+
+
+async def test_atomic_publish_never_overwrites_an_existing_character(structured_store):
+    """An existing character may already carry portraits, identities and voice."""
+    from novelvideo.cognee.pipeline import NovelCharacter
+
+    store, _ = structured_store
+    await store.add_character(
+        NovelCharacter(name="林默", description="用户编辑过的描述", face_prompt="portrait")
+    )
+
+    added = await store.add_characters_atomic(
+        [NovelCharacter(name="林默", description="重扫生成的描述"), NovelCharacter(name="苏晴")]
+    )
+
+    assert added == ["苏晴"]
+    assert store.get_character("林默").description == "用户编辑过的描述"
+    assert store.get_character("林默").face_prompt == "portrait"
+
+
+async def test_narrated_scene_build_defers_instead_of_guessing(structured_store):
+    """Narrated source has no scene headings; a full sweep would invent places."""
+    from novelvideo.structured_builders import build_scenes_structured
+
+    store, _ = structured_store
+    result = await build_scenes_structured(store)
+    assert result["mode"] == "episode_on_demand"
+    assert result["added_scenes"] == 0
+    assert await store.list_scenes() == []
+
+
+async def test_prop_build_reports_deferral_rather_than_a_silent_zero(structured_store):
+    """"0 props" must not read as "the analysis found nothing"."""
+    from novelvideo.structured_builders import build_props_structured
+
+    store, _ = structured_store
+    result = await build_props_structured(store)
+    assert result["props"] == 0
+    assert result["mode"] == "episode_on_demand"
+    assert result["message"]
+
+
+async def test_character_build_publishes_and_records_evidence(
+    structured_store, monkeypatch
+):
+    from novelvideo import structured_builders
+    from novelvideo.structured_ingest import ingest_source_text_structured
+
+    store, state_dir = structured_store
+    source = state_dir / "source.txt"
+    source.write_text(NARRATED_TEXT, encoding="utf-8")
+    run = await ingest_source_text_structured(
+        store, str(source), spine_template="narrated"
+    )
+
+    agent = FakeAgent(
+        {
+            "第一章": ChunkCharacterOutput(
+                characters=[_candidate("林默", quotes=["林默回到阔别十年的故乡。"])]
+            )
+        }
+    )
+
+    real_extract = extract_characters_from_chunks
+
+    async def fake_extract(chunks, **kwargs):
+        kwargs.pop("agent", None)
+        return await real_extract(chunks, agent=agent, **kwargs)
+
+    monkeypatch.setattr(
+        "novelvideo.structured_extraction.extract_characters_from_chunks",
+        fake_extract,
+    )
+
+    added = await structured_builders.build_characters_structured(store)
+    assert added == ["林默"]
+
+    evidence = await store.list_entity_evidence("character", "林默")
+    assert evidence
+    assert evidence[0]["run_id"] == run["run_id"]
+    quoted = NARRATED_TEXT[
+        evidence[0]["source_start"] : evidence[0]["source_end"]
+    ]
+    assert quoted == "林默回到阔别十年的故乡。"
+
+
+async def test_character_build_never_touches_cognee(structured_store, monkeypatch):
+    import cognee
+
+    from novelvideo import structured_builders
+
+    def _boom(*args, **kwargs):
+        raise AssertionError("structured character build must not touch Cognee")
+
+    for name in ("add", "cognify", "memify", "search"):
+        monkeypatch.setattr(cognee, name, _boom, raising=False)
+
+    store, _ = structured_store
+    agent = FakeAgent({})
+
+    real_extract = extract_characters_from_chunks
+
+    async def fake_extract(chunks, **kwargs):
+        kwargs.pop("agent", None)
+        return await real_extract(chunks, agent=agent, **kwargs)
+
+    monkeypatch.setattr(
+        "novelvideo.structured_extraction.extract_characters_from_chunks",
+        fake_extract,
+    )
+    await structured_builders.build_characters_structured(store)

--- a/tests/test_structured_builders.py
+++ b/tests/test_structured_builders.py
@@ -1471,3 +1471,73 @@ async def test_replaying_a_build_cannot_split_an_alias_back_into_a_character(
 
     assert second == first, "a rebuild changed the cast for unchanged source"
     assert "苏晴" not in second
+
+
+def test_one_occurrence_in_an_overlap_counts_once():
+    """Chunks overlap, so a single mention can appear in two of them.
+
+    Counting chunks would let that one occurrence clear the two-to-one margin by
+    itself and hand the appellation to whoever happened to sit on the seam.
+    """
+    source = "郑玉琴走进客厅。刘管家喊了一声郑太。她没有回头。"
+    seam = source.index("郑太")
+    # Two chunks whose spans overlap across the mention, exactly as
+    # _split_oversized produces them.
+    left = SourceChunk(
+        chunk_id="c0", chunk_index=0, section_type="chapter", section_label="上",
+        source_start=0, source_end=seam + 6, text=source[: seam + 6],
+    )
+    right = SourceChunk(
+        chunk_id="c1", chunk_index=1, section_type="chapter", section_label="下",
+        source_start=seam - 4, source_end=len(source), text=source[seam - 4 :],
+    )
+    assert right.source_start < left.source_end, "the fixture must overlap"
+
+    def claim(chunk, owner):
+        return (
+            chunk,
+            ChunkCharacterOutput(
+                characters=[
+                    _candidate_with_appellations(owner, [chunk.text], ["郑太"])
+                ]
+            ),
+        )
+
+    # 郑玉琴 is claimed twice, but both are the same mention seen from either
+    # side of the seam. 刘管家 is claimed once, elsewhere.
+    elsewhere = _chunk("刘管家看着郑太离开。", chunk_id="c2", start=400)
+    outcomes = [
+        claim(left, "郑玉琴"),
+        claim(right, "郑玉琴"),
+        claim(elsewhere, "刘管家"),
+    ]
+
+    for item in merge_character_candidates(outcomes):
+        assert "郑太" not in item.aliases, (
+            "an overlapped mention was counted twice and won the vote"
+        )
+
+
+def test_the_same_appellation_at_two_real_positions_still_wins():
+    """Deduplicating by position must not silently disable voting."""
+    source = "郑玉琴走进客厅。郑太点头。稍后郑太又开口。"
+    first = _chunk(source[:12], chunk_id="c0", start=0)
+    second = _chunk(source[12:], chunk_id="c1", start=12)
+
+    def claim(chunk, owner):
+        return (
+            chunk,
+            ChunkCharacterOutput(
+                characters=[
+                    _candidate_with_appellations(owner, [chunk.text], ["郑太"])
+                ]
+            ),
+        )
+
+    outcomes = [
+        claim(first, "郑玉琴"),
+        claim(second, "郑玉琴"),
+        claim(_chunk("刘管家在门口。郑太走了。", chunk_id="c2", start=400), "刘管家"),
+    ]
+    merged = {m.name: m for m in merge_character_candidates(outcomes)}
+    assert merged["郑玉琴"].aliases == {"郑太"}

--- a/tests/test_structured_builders.py
+++ b/tests/test_structured_builders.py
@@ -1,4 +1,4 @@
-"""structured_v2 project-level builds: characters, scenes, props.
+"""structured_v1 project-level builds: characters, scenes, props.
 
 The rules under test are the conservative ones. A character name is at once a
 SQLite primary key, a REST identifier and an asset directory name, so the
@@ -13,7 +13,7 @@ from types import SimpleNamespace
 
 import pytest
 
-from novelvideo.knowledge_pipeline import KNOWLEDGE_PIPELINE_KEY, STRUCTURED_V2
+from novelvideo.knowledge_pipeline import KNOWLEDGE_PIPELINE_KEY, KNOWLEDGE_PIPELINE_STRUCTURED
 from novelvideo.story_analysis import SourceChunk, chunk_source_text
 from novelvideo.structured_extraction import (
     CharacterCandidate,
@@ -343,7 +343,7 @@ async def structured_store(tmp_path):
     state_dir = tmp_path / "user" / "structured"
     state_dir.mkdir(parents=True)
     (state_dir / "project_config.json").write_text(
-        json.dumps({KNOWLEDGE_PIPELINE_KEY: STRUCTURED_V2, "spine_template": "narrated"}),
+        json.dumps({KNOWLEDGE_PIPELINE_KEY: KNOWLEDGE_PIPELINE_STRUCTURED, "spine_template": "narrated"}),
         encoding="utf-8",
     )
     (state_dir / "novel.txt").write_text(NARRATED_TEXT, encoding="utf-8")
@@ -581,12 +581,16 @@ async def test_a_failed_chunk_leaves_the_run_partial(structured_store, monkeypat
 
     failed = await store.list_analysis_chunks(run["run_id"], status="failed")
     assert failed, "the failing chunk was not recorded"
+    from novelvideo.story_analysis import source_sha256
+    from novelvideo.structured_ingest import (
+        STRUCTURED_PIPELINE_VERSION,
+        STRUCTURED_SCHEMA_VERSION,
+    )
+
     stored = await store.get_reusable_analysis_run(
-        source_sha256=__import__("novelvideo.story_analysis", fromlist=["x"]).source_sha256(
-            NARRATED_TEXT
-        ),
-        schema_version=1,
-        pipeline_version="structured_v2.1",
+        source_sha256=source_sha256(NARRATED_TEXT),
+        schema_version=STRUCTURED_SCHEMA_VERSION,
+        pipeline_version=STRUCTURED_PIPELINE_VERSION,
         spine_template="narrated",
     )
     assert stored["status"] == "partial"
@@ -657,3 +661,90 @@ async def test_reuse_key_separates_drama_from_narrated(structured_store, tmp_pat
         store, str(source), spine_template=""
     )
     assert drama["run_id"] != narrated["run_id"]
+
+
+async def test_evidence_is_backfilled_when_the_characters_already_exist(
+    structured_store, monkeypatch
+):
+    """Publishing characters and writing evidence are two steps.
+
+    If the first succeeds and the second fails, a retry finds the characters
+    already present. Keying evidence on "newly added" would leave them without
+    provenance forever.
+    """
+    from novelvideo import structured_builders
+    from novelvideo.cognee.pipeline import NovelCharacter
+    from novelvideo.structured_extraction import extract_characters_from_chunks
+    from novelvideo.structured_ingest import ingest_source_text_structured
+
+    store, state_dir = structured_store
+    source = state_dir / "source.txt"
+    source.write_text(NARRATED_TEXT, encoding="utf-8")
+    await ingest_source_text_structured(store, str(source), spine_template="narrated")
+
+    # Stand in for a previous build that published the character but died
+    # before its evidence landed.
+    await store.add_character(NovelCharacter(name="林默"))
+    assert await store.list_entity_evidence("character", "林默") == []
+
+    agent = FakeAgent(
+        {
+            "第一章": ChunkCharacterOutput(
+                characters=[_candidate("林默", quotes=["林默回到阔别十年的故乡。"])]
+            )
+        }
+    )
+    real_extract = extract_characters_from_chunks
+
+    async def fake_extract(chunks, **kwargs):
+        kwargs.pop("agent", None)
+        return await real_extract(chunks, agent=agent, **kwargs)
+
+    monkeypatch.setattr(
+        "novelvideo.structured_extraction.extract_characters_from_chunks", fake_extract
+    )
+
+    added = await structured_builders.build_characters_structured(store)
+    assert added == []  # nothing new to publish
+    assert await store.list_entity_evidence("character", "林默"), (
+        "evidence was never backfilled for an already-published character"
+    )
+
+
+async def test_a_run_with_no_characters_is_still_closed_out(
+    structured_store, monkeypatch
+):
+    """A run left at "pending" tells the next build nothing about what remains."""
+    from novelvideo import structured_builders
+    from novelvideo.story_analysis import source_sha256
+    from novelvideo.structured_extraction import extract_characters_from_chunks
+    from novelvideo.structured_ingest import (
+        STRUCTURED_PIPELINE_VERSION,
+        STRUCTURED_SCHEMA_VERSION,
+        ingest_source_text_structured,
+    )
+
+    store, state_dir = structured_store
+    source = state_dir / "source.txt"
+    source.write_text(NARRATED_TEXT, encoding="utf-8")
+    await ingest_source_text_structured(store, str(source), spine_template="narrated")
+
+    agent = FakeAgent({})  # every chunk yields nothing
+    real_extract = extract_characters_from_chunks
+
+    async def fake_extract(chunks, **kwargs):
+        kwargs.pop("agent", None)
+        return await real_extract(chunks, agent=agent, **kwargs)
+
+    monkeypatch.setattr(
+        "novelvideo.structured_extraction.extract_characters_from_chunks", fake_extract
+    )
+    assert await structured_builders.build_characters_structured(store) == []
+
+    stored = await store.get_reusable_analysis_run(
+        source_sha256=source_sha256(NARRATED_TEXT),
+        schema_version=STRUCTURED_SCHEMA_VERSION,
+        pipeline_version=STRUCTURED_PIPELINE_VERSION,
+        spine_template="narrated",
+    )
+    assert stored["status"] == "completed"

--- a/tests/test_structured_builders.py
+++ b/tests/test_structured_builders.py
@@ -9,6 +9,7 @@ source or the candidate never reaches the table.
 from __future__ import annotations
 
 import json
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
@@ -890,3 +891,228 @@ async def test_a_single_candidate_needs_no_adjudication():
     merged = [_merged("郑玉琴", 96)]
     agent = AdjudicatorAgent(non_characters=["郑玉琴"])
     assert await adjudicate_characters(merged, agent=agent) == merged
+
+
+# ── scene adjudication ──────────────────────────────────────────────────────
+
+
+def _scene(name, *, aliases=()):
+    from novelvideo.models import NovelScene
+
+    return NovelScene(name=name, aliases=list(aliases))
+
+
+class SceneAdjudicatorAgent:
+    def __init__(self, groups=(), explode=False):
+        from novelvideo.structured_extraction import (
+            SameLocationGroup, SceneAdjudication,
+        )
+
+        self.explode = explode
+        self.prompt = ""
+        self.result = SceneAdjudication(
+            groups=[
+                SameLocationGroup(canonical_name=c, alias_names=list(a))
+                for c, a in groups
+            ]
+        )
+
+    async def run(self, prompt: str):
+        self.prompt = prompt
+        if self.explode:
+            raise RuntimeError("adjudicator unavailable")
+        return SimpleNamespace(output=self.result)
+
+
+async def test_scene_adjudication_merges_spellings_of_one_location():
+    """Hand-written headings spell one room several ways."""
+    from novelvideo.structured_extraction import adjudicate_scenes
+
+    scenes = [_scene("郑玉琴办公室"), _scene("郑玉琴办公室内")]
+    agent = SceneAdjudicatorAgent(groups=[("郑玉琴办公室", ["郑玉琴办公室内"])])
+
+    result = await adjudicate_scenes(scenes, agent=agent)
+    assert [s.name for s in result] == ["郑玉琴办公室"]
+    assert "郑玉琴办公室内" in result[0].aliases
+
+
+async def test_scene_adjudication_never_drops_a_location():
+    """A duplicate is redundant art; a missing scene leaves shots with no asset.
+
+    Unlike characters, there is no removal path here at all, so a model that
+    proposes nothing simply leaves every scene standing.
+    """
+    from novelvideo.structured_extraction import adjudicate_scenes
+
+    scenes = [_scene("郑家别墅客厅"), _scene("郑家别墅餐厅"), _scene("郑家别墅外")]
+    result = await adjudicate_scenes(scenes, agent=SceneAdjudicatorAgent())
+    assert {s.name for s in result} == {name.name for name in scenes}
+
+
+async def test_scene_adjudication_cannot_invent_a_location():
+    from novelvideo.structured_extraction import adjudicate_scenes
+
+    scenes = [_scene("郑玉琴办公室"), _scene("郑玉琴办公室内")]
+    agent = SceneAdjudicatorAgent(groups=[("查无此地", ["郑玉琴办公室内"])])
+
+    result = await adjudicate_scenes(scenes, agent=agent)
+    assert len(result) == 2
+
+
+async def test_scene_adjudication_failure_keeps_every_scene():
+    from novelvideo.structured_extraction import adjudicate_scenes
+
+    scenes = [_scene("郑玉琴办公室"), _scene("郑玉琴办公室内")]
+    logs: list[str] = []
+    result = await adjudicate_scenes(
+        scenes, agent=SceneAdjudicatorAgent(explode=True), on_log=logs.append
+    )
+    assert len(result) == 2
+    assert any("裁决失败" in line for line in logs)
+
+
+async def test_scene_prompt_reports_how_often_each_heading_is_used():
+    """The most-used spelling is the better canonical name."""
+    from novelvideo.structured_extraction import adjudicate_scenes
+
+    scenes = [_scene("主任办公室"), _scene("郑家别墅客厅")]
+    agent = SceneAdjudicatorAgent()
+    await adjudicate_scenes(
+        scenes, occurrences={"主任办公室": 18, "郑家别墅客厅": 16}, agent=agent
+    )
+    assert "出现 18 场" in agent.prompt
+    assert "出现 16 场" in agent.prompt
+
+
+def test_scene_heading_counts_come_from_the_script():
+    from novelvideo.structured_builders import _scene_heading_counts
+
+    script = (
+        "第一集\n\n"
+        "1-1 林家客厅 日 内\n人物：林默\n林默推开门。\n\n"
+        "1-2 巷口 夜 外\n人物：林默\n林默走过巷口。\n\n"
+        "1-3 林家客厅 夜 内\n人物：林默\n林默坐下。\n"
+    )
+    counts = _scene_heading_counts(script)
+    assert counts.get("林家客厅") == 2
+    assert counts.get("巷口") == 1
+
+
+# ── resume after an outage, and source-change invalidation ──────────────────
+
+
+class FlakyAgent:
+    """Fails for a set of chunk labels, then can be repaired."""
+
+    def __init__(self, outputs, failing=()):
+        self.outputs = outputs
+        self.failing = set(failing)
+        # Keep the label vocabulary stable across repair, so a recovered agent
+        # still recognises the chunk it previously refused.
+        self.labels = list(outputs) + list(failing)
+        self.calls: list[str] = []
+
+    def repair(self):
+        self.failing.clear()
+
+    async def run(self, prompt: str):
+        label = next((k for k in self.labels if k in prompt), "")
+        self.calls.append(label)
+        if label in self.failing:
+            raise RuntimeError("gateway down")
+        return SimpleNamespace(
+            output=self.outputs.get(label, ChunkCharacterOutput())
+        )
+
+
+async def _ingested(store, state_dir, text=NARRATED_TEXT):
+    from novelvideo.structured_ingest import ingest_source_text_structured
+
+    source = state_dir / "source.txt"
+    source.write_text(text, encoding="utf-8")
+    return await ingest_source_text_structured(
+        store, str(source), spine_template="narrated"
+    )
+
+
+def _patched_extract(monkeypatch, agent):
+    from novelvideo.structured_extraction import extract_characters_from_chunks
+
+    real = extract_characters_from_chunks
+
+    async def fake(chunks, **kwargs):
+        kwargs.pop("agent", None)
+        kwargs.setdefault("adjudicate", False)
+        return await real(chunks, agent=agent, **kwargs)
+
+    monkeypatch.setattr(
+        "novelvideo.structured_extraction.extract_characters_from_chunks", fake
+    )
+
+
+async def test_a_chunk_that_failed_is_retried_while_others_are_not(
+    structured_store, monkeypatch
+):
+    """An outage mid-build must cost only the chunks it actually broke."""
+    from novelvideo import structured_builders
+
+    store, state_dir = structured_store
+    run = await _ingested(store, state_dir)
+
+    agent = FlakyAgent(
+        outputs={
+            "第一章": ChunkCharacterOutput(
+                characters=[_candidate("林默", quotes=["林默回到阔别十年的故乡。"])]
+            ),
+            "第三章": ChunkCharacterOutput(
+                characters=[_candidate("苏晴", quotes=["苏晴告诉林默一个秘密。"])]
+            ),
+        },
+        failing=["第二章"],
+    )
+    _patched_extract(monkeypatch, agent)
+
+    await structured_builders.build_characters_structured(store)
+    assert len(agent.calls) == 3
+    failed = await store.list_analysis_chunks(run["run_id"], status="failed")
+    assert [row["chunk_id"] for row in failed] == ["chapter-0001"]
+
+    # The gateway comes back and the user clicks build again.
+    agent.repair()
+    agent.calls.clear()
+    await structured_builders.build_characters_structured(store)
+
+    assert agent.calls == ["第二章"], "a healthy chunk was paid for twice"
+    assert not await store.list_analysis_chunks(run["run_id"], status="failed")
+
+
+async def test_editing_the_source_discards_the_stored_plan(
+    structured_store, monkeypatch
+):
+    """A result produced from text that has since changed is not a result."""
+    from novelvideo import structured_builders
+
+    store, state_dir = structured_store
+    await _ingested(store, state_dir)
+
+    outputs = {
+        "第一章": ChunkCharacterOutput(
+            characters=[_candidate("林默", quotes=["林默回到阔别十年的故乡。"])]
+        )
+    }
+    agent = FlakyAgent(outputs=outputs)
+    _patched_extract(monkeypatch, agent)
+
+    await structured_builders.build_characters_structured(store)
+    first_calls = len(agent.calls)
+    assert first_calls > 0
+
+    # Rewriting novel.txt without re-importing: the hash no longer matches any
+    # recorded run, so nothing may be replayed.
+    (Path(store.project_dir) / "novel.txt").write_text(
+        NARRATED_TEXT + "\n第四章 结局\n\n他终于释怀。\n", encoding="utf-8"
+    )
+    agent.calls.clear()
+    await structured_builders.build_characters_structured(store)
+
+    assert agent.calls, "stale results were replayed for text that changed"

--- a/tests/test_structured_builders.py
+++ b/tests/test_structured_builders.py
@@ -283,7 +283,7 @@ async def test_extraction_runs_over_every_chunk():
             ),
         }
     )
-    merged, _ = await extract_characters_from_chunks(chunks, agent=agent)
+    merged, _ = await extract_characters_from_chunks(chunks, agent=agent, adjudicate=False)
     assert {item.name for item in merged} == {"林默", "苏晴"}
 
 
@@ -300,7 +300,7 @@ async def test_one_failing_chunk_does_not_discard_the_others():
     )
     logs: list[str] = []
     merged, failures = await extract_characters_from_chunks(
-        chunks, agent=agent, on_log=logs.append
+        chunks, agent=agent, on_log=logs.append, adjudicate=False
     )
     assert [item.name for item in merged] == ["林默"]
     assert any("失败" in line for line in logs)
@@ -328,7 +328,9 @@ async def test_extraction_is_bounded_but_not_serial():
         _chunk(f"片段{index}", chunk_id=f"c{index}", start=index * 10)
         for index in range(12)
     ]
-    await extract_characters_from_chunks(chunks, agent=SlowAgent(), concurrency=4)
+    await extract_characters_from_chunks(
+        chunks, agent=SlowAgent(), concurrency=4, adjudicate=False
+    )
     assert peak > 1
     assert peak <= 4
 
@@ -452,6 +454,7 @@ async def test_character_build_publishes_and_records_evidence(
 
     async def fake_extract(chunks, **kwargs):
         kwargs.pop("agent", None)
+        kwargs.setdefault("adjudicate", False)
         return await real_extract(chunks, agent=agent, **kwargs)
 
     monkeypatch.setattr(
@@ -489,6 +492,7 @@ async def test_character_build_never_touches_cognee(structured_store, monkeypatc
 
     async def fake_extract(chunks, **kwargs):
         kwargs.pop("agent", None)
+        kwargs.setdefault("adjudicate", False)
         return await real_extract(chunks, agent=agent, **kwargs)
 
     monkeypatch.setattr(
@@ -527,6 +531,7 @@ async def test_completed_chunks_are_replayed_instead_of_re_billed(
 
     async def fake_extract(chunks, **kwargs):
         kwargs.pop("agent", None)
+        kwargs.setdefault("adjudicate", False)
         return await real_extract(chunks, agent=agent, **kwargs)
 
     monkeypatch.setattr(
@@ -572,6 +577,7 @@ async def test_a_failed_chunk_leaves_the_run_partial(structured_store, monkeypat
 
     async def fake_extract(chunks, **kwargs):
         kwargs.pop("agent", None)
+        kwargs.setdefault("adjudicate", False)
         return await real_extract(chunks, agent=agent, **kwargs)
 
     monkeypatch.setattr(
@@ -698,6 +704,7 @@ async def test_evidence_is_backfilled_when_the_characters_already_exist(
 
     async def fake_extract(chunks, **kwargs):
         kwargs.pop("agent", None)
+        kwargs.setdefault("adjudicate", False)
         return await real_extract(chunks, agent=agent, **kwargs)
 
     monkeypatch.setattr(
@@ -734,6 +741,7 @@ async def test_a_run_with_no_characters_is_still_closed_out(
 
     async def fake_extract(chunks, **kwargs):
         kwargs.pop("agent", None)
+        kwargs.setdefault("adjudicate", False)
         return await real_extract(chunks, agent=agent, **kwargs)
 
     monkeypatch.setattr(
@@ -748,3 +756,137 @@ async def test_a_run_with_no_characters_is_still_closed_out(
         spine_template="narrated",
     )
     assert stored["status"] == "completed"
+
+
+# ── ambiguity adjudication ──────────────────────────────────────────────────
+
+
+def _merged(name, count, *, aliases=()):
+    from novelvideo.structured_extraction import MergedCharacter
+
+    return MergedCharacter(
+        name=name,
+        aliases=set(aliases),
+        evidence=[
+            {
+                "chunk_id": "c0",
+                "source_start": index,
+                "source_end": index + 1,
+                "evidence_kind": "mention",
+                "evidence_text": name,
+            }
+            for index in range(count)
+        ],
+    )
+
+
+class AdjudicatorAgent:
+    """Returns a scripted adjudication and records the prompt it received."""
+
+    def __init__(self, groups=(), non_characters=(), explode=False):
+        from novelvideo.structured_extraction import (
+            CharacterAdjudication,
+            SamePersonGroup,
+        )
+
+        self.explode = explode
+        self.prompt = ""
+        self.result = CharacterAdjudication(
+            groups=[
+                SamePersonGroup(canonical_name=c, alias_names=list(a))
+                for c, a in groups
+            ],
+            non_characters=list(non_characters),
+        )
+
+    async def run(self, prompt: str):
+        self.prompt = prompt
+        if self.explode:
+            raise RuntimeError("adjudicator unavailable")
+        return SimpleNamespace(output=self.result)
+
+
+async def test_adjudication_merges_a_nickname_into_its_character():
+    """Per-chunk extraction cannot see that 小阳 is 郑旭阳; this step can."""
+    from novelvideo.structured_extraction import adjudicate_characters
+
+    merged = [_merged("郑旭阳", 38), _merged("小阳", 1)]
+    agent = AdjudicatorAgent(groups=[("郑旭阳", ["小阳"])])
+
+    result = await adjudicate_characters(merged, agent=agent)
+    assert [item.name for item in result] == ["郑旭阳"]
+    assert result[0].aliases == {"小阳"}
+    assert len(result[0].evidence) == 39
+
+
+async def test_adjudication_cannot_invent_a_character():
+    """It may only group names it was given."""
+    from novelvideo.structured_extraction import adjudicate_characters
+
+    merged = [_merged("郑旭阳", 38), _merged("小阳", 1)]
+    agent = AdjudicatorAgent(groups=[("查无此人", ["小阳"])])
+
+    result = await adjudicate_characters(merged, agent=agent)
+    assert {item.name for item in result} == {"郑旭阳", "小阳"}
+
+
+async def test_adjudication_cannot_delete_a_load_bearing_character():
+    """One bad call must not silently drop a lead from the cast."""
+    from novelvideo.structured_extraction import adjudicate_characters
+
+    merged = [_merged("郑玉琴", 96), _merged("郑家悦", 96), _merged("路人", 1)]
+    agent = AdjudicatorAgent(non_characters=["郑玉琴", "路人"])
+
+    result = await adjudicate_characters(merged, agent=agent)
+    names = {item.name for item in result}
+    assert "郑玉琴" in names, "a lead was dropped on the model's say-so"
+    assert "路人" not in names
+
+
+async def test_adjudication_failure_keeps_the_rule_result():
+    """A degraded adjudicator must not lose the characters rules already found."""
+    from novelvideo.structured_extraction import adjudicate_characters
+
+    merged = [_merged("郑玉琴", 96), _merged("郑太", 5)]
+    logs: list[str] = []
+
+    result = await adjudicate_characters(
+        merged, agent=AdjudicatorAgent(explode=True), on_log=logs.append
+    )
+    assert {item.name for item in result} == {"郑玉琴", "郑太"}
+    assert any("裁决失败" in line for line in logs)
+
+
+async def test_rarely_seen_candidates_get_source_context():
+    """A bare quote rarely proves identity; the surrounding text usually does."""
+    from novelvideo.structured_extraction import adjudicate_characters
+
+    source = "▲郑旭阳走进来。郑玉琴皱眉。\n郑玉琴：小阳，你又闯祸了。\n"
+    start = source.index("小阳")
+    rare = _merged("小阳", 0)
+    rare.evidence.append(
+        {
+            "chunk_id": "c0",
+            "source_start": start,
+            "source_end": start + 2,
+            "evidence_kind": "dialogue",
+            "evidence_text": "小阳",
+        }
+    )
+    agent = AdjudicatorAgent()
+
+    await adjudicate_characters(
+        [_merged("郑旭阳", 38), rare], source_text=source, agent=agent
+    )
+    assert "上下文" in agent.prompt
+    # The formal name sits next to the nickname, which is what makes the link
+    # inferable at all.
+    assert "郑旭阳" in agent.prompt
+
+
+async def test_a_single_candidate_needs_no_adjudication():
+    from novelvideo.structured_extraction import adjudicate_characters
+
+    merged = [_merged("郑玉琴", 96)]
+    agent = AdjudicatorAgent(non_characters=["郑玉琴"])
+    assert await adjudicate_characters(merged, agent=agent) == merged

--- a/tests/test_structured_builders.py
+++ b/tests/test_structured_builders.py
@@ -1206,26 +1206,78 @@ def test_an_appellation_only_one_character_claims_becomes_an_alias():
     assert merged["刘管家"].aliases == set()
 
 
-def test_an_appellation_two_characters_claim_is_dropped():
-    """Two claimants means the model could not attribute it.
+def _claim(chunk_id, start, name, appellation, text):
+    return (
+        _chunk(text, chunk_id=chunk_id, start=start),
+        ChunkCharacterOutput(
+            characters=[_candidate_with_appellations(name, [text], [appellation])]
+        ),
+    )
 
-    A wrong alias resolves confidently to the wrong person, which is worse than
-    no alias at all.
+
+def test_a_contested_appellation_goes_to_whoever_the_text_keeps_supporting():
+    """Decided by how many independent chunks say so, not by overall evidence.
+
+    Ranking by total evidence would hand every ambiguous form to the lead,
+    which is the opposite of evidence-driven.
     """
     text = "郑玉琴走进客厅。刘管家喊了一声郑太。"
+    outcomes = [
+        _claim("c0", 0, "郑玉琴", "郑太", text),
+        _claim("c1", 60, "郑玉琴", "郑太", text),
+        _claim("c2", 120, "郑玉琴", "郑太", text),
+        _claim("c3", 180, "刘管家", "郑太", text),
+    ]
+    merged = {m.name: m for m in merge_character_candidates(outcomes)}
+    assert merged["郑玉琴"].aliases == {"郑太"}
+    assert merged["刘管家"].aliases == set()
+
+
+def test_a_contested_appellation_with_a_narrow_lead_is_dropped():
+    """Leading is not enough; three-to-two leaves it unassigned.
+
+    A wrong alias resolves confidently to the wrong person, while a missing one
+    merely fails to resolve — so a close call is left alone.
+    """
+    text = "郑玉琴走进客厅。刘管家喊了一声郑太。"
+    outcomes = [
+        _claim("c0", 0, "郑玉琴", "郑太", text),
+        _claim("c1", 60, "郑玉琴", "郑太", text),
+        _claim("c2", 120, "郑玉琴", "郑太", text),
+        _claim("c3", 180, "刘管家", "郑太", text),
+        _claim("c4", 240, "刘管家", "郑太", text),
+    ]
+    for item in merge_character_candidates(outcomes):
+        assert "郑太" not in item.aliases
+
+
+def test_a_contested_appellation_seen_in_only_one_chunk_is_dropped():
+    """One chunk is one author's phrasing, not grounds to overrule a rival."""
+    text = "郑玉琴走进客厅。刘管家喊了一声郑太。"
+    outcomes = [
+        _claim("c0", 0, "郑玉琴", "郑太", text),
+        _claim("c1", 60, "刘管家", "郑太", text),
+    ]
+    for item in merge_character_candidates(outcomes):
+        assert "郑太" not in item.aliases
+
+
+def test_an_appellation_that_is_itself_a_character_never_becomes_an_alias():
+    text = "郑玉琴走进客厅。刘管家跟在后面。"
     outcomes = [
         (
             _chunk(text),
             ChunkCharacterOutput(
                 characters=[
-                    _candidate_with_appellations("郑玉琴", [text], ["郑太"]),
-                    _candidate_with_appellations("刘管家", [text], ["郑太"]),
+                    _candidate_with_appellations("郑玉琴", [text], ["刘管家"]),
+                    _candidate("刘管家", quotes=[text]),
                 ]
             ),
         )
     ]
-    for item in merge_character_candidates(outcomes):
-        assert "郑太" not in item.aliases
+    merged = {m.name: m for m in merge_character_candidates(outcomes)}
+    assert "刘管家" in merged
+    assert merged["郑玉琴"].aliases == set()
 
 
 def test_an_appellation_absent_from_the_chunk_is_rejected():

--- a/tests/test_structured_builders.py
+++ b/tests/test_structured_builders.py
@@ -45,6 +45,18 @@ NARRATED_TEXT = """第一章 归来
 """
 
 
+def _padded(body: str) -> str:
+    """Pad a chapter past the packing target so it stays its own chunk."""
+    return body + "\n" + "闲笔叙述。" * 640 + "\n"
+
+
+NARRATED_MULTI = (
+    "第一章 归来\n\n" + _padded("林默回到阔别十年的故乡。他的母亲在门口等他。")
+    + "\n第二章 旧友\n\n" + _padded("林默又名小默，村里人都这么叫他。他在巷口遇见了苏晴。")
+    + "\n第三章 真相\n\n" + _padded("苏晴告诉林默一个秘密。他的母亲听完沉默了很久。")
+)
+
+
 def _chunk(text: str, *, chunk_id="c0", start=0) -> SourceChunk:
     return SourceChunk(
         chunk_id=chunk_id,
@@ -273,7 +285,7 @@ class FakeAgent:
 
 
 async def test_extraction_runs_over_every_chunk():
-    chunks = chunk_source_text(NARRATED_TEXT, "narrated")
+    chunks = chunk_source_text(NARRATED_MULTI, "narrated")
     agent = FakeAgent(
         {
             "第一章": ChunkCharacterOutput(
@@ -290,7 +302,7 @@ async def test_extraction_runs_over_every_chunk():
 
 async def test_one_failing_chunk_does_not_discard_the_others():
     """A single unparseable scene must not take the whole build down with it."""
-    chunks = chunk_source_text(NARRATED_TEXT, "narrated")
+    chunks = chunk_source_text(NARRATED_MULTI, "narrated")
     agent = FakeAgent(
         {
             "第一章": ChunkCharacterOutput(
@@ -349,7 +361,7 @@ async def structured_store(tmp_path):
         json.dumps({KNOWLEDGE_PIPELINE_KEY: KNOWLEDGE_PIPELINE_STRUCTURED, "spine_template": "narrated"}),
         encoding="utf-8",
     )
-    (state_dir / "novel.txt").write_text(NARRATED_TEXT, encoding="utf-8")
+    (state_dir / "novel.txt").write_text(NARRATED_MULTI, encoding="utf-8")
     store = SQLiteStore(
         "user/structured", output_dir=str(state_dir), state_dir=str(state_dir)
     )
@@ -438,7 +450,7 @@ async def test_character_build_publishes_and_records_evidence(
 
     store, state_dir = structured_store
     source = state_dir / "source.txt"
-    source.write_text(NARRATED_TEXT, encoding="utf-8")
+    source.write_text(NARRATED_MULTI, encoding="utf-8")
     run = await ingest_source_text_structured(
         store, str(source), spine_template="narrated"
     )
@@ -469,7 +481,7 @@ async def test_character_build_publishes_and_records_evidence(
     evidence = await store.list_entity_evidence("character", "林默")
     assert evidence
     assert evidence[0]["run_id"] == run["run_id"]
-    quoted = NARRATED_TEXT[
+    quoted = NARRATED_MULTI[
         evidence[0]["source_start"] : evidence[0]["source_end"]
     ]
     assert quoted == "林默回到阔别十年的故乡。"
@@ -516,7 +528,7 @@ async def test_completed_chunks_are_replayed_instead_of_re_billed(
 
     store, state_dir = structured_store
     source = state_dir / "source.txt"
-    source.write_text(NARRATED_TEXT, encoding="utf-8")
+    source.write_text(NARRATED_MULTI, encoding="utf-8")
     await ingest_source_text_structured(store, str(source), spine_template="narrated")
 
     outputs = {
@@ -561,7 +573,7 @@ async def test_a_failed_chunk_leaves_the_run_partial(structured_store, monkeypat
 
     store, state_dir = structured_store
     source = state_dir / "source.txt"
-    source.write_text(NARRATED_TEXT, encoding="utf-8")
+    source.write_text(NARRATED_MULTI, encoding="utf-8")
     run = await ingest_source_text_structured(
         store, str(source), spine_template="narrated"
     )
@@ -595,7 +607,7 @@ async def test_a_failed_chunk_leaves_the_run_partial(structured_store, monkeypat
     )
 
     stored = await store.get_reusable_analysis_run(
-        source_sha256=source_sha256(NARRATED_TEXT),
+        source_sha256=source_sha256(NARRATED_MULTI),
         schema_version=STRUCTURED_SCHEMA_VERSION,
         pipeline_version=STRUCTURED_PIPELINE_VERSION,
         spine_template="narrated",
@@ -622,13 +634,19 @@ def test_oversized_parts_keep_a_recognisable_section_label():
     assert all("第1章" in chunk.section_label for chunk in chunks)
 
 
-def test_a_short_chapter_is_not_split():
+def test_short_chapters_are_packed_into_one_call():
+    """A call costs the same round trip whether it carries 300 or 3000 chars."""
     chunks = chunk_source_text(NARRATED_TEXT, "narrated")
-    assert [chunk.chunk_id for chunk in chunks] == [
-        "chapter-0000",
-        "chapter-0001",
-        "chapter-0002",
-    ]
+    assert len(chunks) == 1
+    assert chunks[0].source_start == 0
+    assert chunks[0].text == NARRATED_TEXT
+
+
+def test_chapters_past_the_target_stay_separate():
+    chunks = chunk_source_text(NARRATED_MULTI, "narrated")
+    assert len(chunks) == 3
+    for chunk in chunks:
+        assert NARRATED_MULTI[chunk.source_start : chunk.source_end] == chunk.text
 
 
 def test_llm_concurrency_defaults_to_the_project_baseline(monkeypatch):
@@ -653,7 +671,7 @@ async def test_reuse_key_separates_drama_from_narrated(structured_store, tmp_pat
 
     store, state_dir = structured_store
     source = state_dir / "source.txt"
-    source.write_text(NARRATED_TEXT, encoding="utf-8")
+    source.write_text(NARRATED_MULTI, encoding="utf-8")
 
     narrated = await ingest_source_text_structured(
         store, str(source), spine_template="narrated"
@@ -686,7 +704,7 @@ async def test_evidence_is_backfilled_when_the_characters_already_exist(
 
     store, state_dir = structured_store
     source = state_dir / "source.txt"
-    source.write_text(NARRATED_TEXT, encoding="utf-8")
+    source.write_text(NARRATED_MULTI, encoding="utf-8")
     await ingest_source_text_structured(store, str(source), spine_template="narrated")
 
     # Stand in for a previous build that published the character but died
@@ -734,7 +752,7 @@ async def test_a_run_with_no_characters_is_still_closed_out(
 
     store, state_dir = structured_store
     source = state_dir / "source.txt"
-    source.write_text(NARRATED_TEXT, encoding="utf-8")
+    source.write_text(NARRATED_MULTI, encoding="utf-8")
     await ingest_source_text_structured(store, str(source), spine_template="narrated")
 
     agent = FakeAgent({})  # every chunk yields nothing
@@ -751,7 +769,7 @@ async def test_a_run_with_no_characters_is_still_closed_out(
     assert await structured_builders.build_characters_structured(store) == []
 
     stored = await store.get_reusable_analysis_run(
-        source_sha256=source_sha256(NARRATED_TEXT),
+        source_sha256=source_sha256(NARRATED_MULTI),
         schema_version=STRUCTURED_SCHEMA_VERSION,
         pipeline_version=STRUCTURED_PIPELINE_VERSION,
         spine_template="narrated",
@@ -1025,7 +1043,7 @@ class FlakyAgent:
         )
 
 
-async def _ingested(store, state_dir, text=NARRATED_TEXT):
+async def _ingested(store, state_dir, text=NARRATED_MULTI):
     from novelvideo.structured_ingest import ingest_source_text_structured
 
     source = state_dir / "source.txt"
@@ -1057,7 +1075,7 @@ async def test_a_chunk_that_failed_is_retried_while_others_are_not(
     from novelvideo import structured_builders
 
     store, state_dir = structured_store
-    run = await _ingested(store, state_dir)
+    run = await _ingested(store, state_dir, NARRATED_MULTI)
 
     agent = FlakyAgent(
         outputs={
@@ -1093,7 +1111,7 @@ async def test_editing_the_source_discards_the_stored_plan(
     from novelvideo import structured_builders
 
     store, state_dir = structured_store
-    await _ingested(store, state_dir)
+    await _ingested(store, state_dir, NARRATED_MULTI)
 
     outputs = {
         "第一章": ChunkCharacterOutput(
@@ -1110,9 +1128,89 @@ async def test_editing_the_source_discards_the_stored_plan(
     # Rewriting novel.txt without re-importing: the hash no longer matches any
     # recorded run, so nothing may be replayed.
     (Path(store.project_dir) / "novel.txt").write_text(
-        NARRATED_TEXT + "\n第四章 结局\n\n他终于释怀。\n", encoding="utf-8"
+        NARRATED_MULTI + "\n第四章 结局\n\n他终于释怀。\n", encoding="utf-8"
     )
     agent.calls.clear()
     await structured_builders.build_characters_structured(store)
 
     assert agent.calls, "stale results were replayed for text that changed"
+
+
+# ── appellations ────────────────────────────────────────────────────────────
+
+
+def _candidate_with_appellations(name, quotes, appellations):
+    c = _candidate(name, quotes=quotes)
+    c.appellations = list(appellations)
+    return c
+
+
+def test_an_appellation_only_one_character_claims_becomes_an_alias():
+    """Packed chunks hold several scenes, so nicknames surface alongside names."""
+    text = "郑玉琴走进客厅。刘管家喊了一声郑太。"
+    outcomes = [
+        (
+            _chunk(text),
+            ChunkCharacterOutput(
+                characters=[
+                    _candidate_with_appellations("郑玉琴", [text], ["郑太"]),
+                    _candidate("刘管家", quotes=[text]),
+                ]
+            ),
+        )
+    ]
+    merged = {m.name: m for m in merge_character_candidates(outcomes)}
+    assert merged["郑玉琴"].aliases == {"郑太"}
+    assert merged["刘管家"].aliases == set()
+
+
+def test_an_appellation_two_characters_claim_is_dropped():
+    """Two claimants means the model could not attribute it.
+
+    A wrong alias resolves confidently to the wrong person, which is worse than
+    no alias at all.
+    """
+    text = "郑玉琴走进客厅。刘管家喊了一声郑太。"
+    outcomes = [
+        (
+            _chunk(text),
+            ChunkCharacterOutput(
+                characters=[
+                    _candidate_with_appellations("郑玉琴", [text], ["郑太"]),
+                    _candidate_with_appellations("刘管家", [text], ["郑太"]),
+                ]
+            ),
+        )
+    ]
+    for item in merge_character_candidates(outcomes):
+        assert "郑太" not in item.aliases
+
+
+def test_an_appellation_absent_from_the_chunk_is_rejected():
+    text = "郑玉琴走进客厅。"
+    outcomes = [
+        (
+            _chunk(text),
+            ChunkCharacterOutput(
+                characters=[
+                    _candidate_with_appellations("郑玉琴", [text], ["女王陛下"])
+                ]
+            ),
+        )
+    ]
+    assert merge_character_candidates(outcomes)[0].aliases == set()
+
+
+def test_a_generic_appellation_is_not_recorded_as_an_alias():
+    text = "郑玉琴走进客厅。她的母亲在门口。"
+    outcomes = [
+        (
+            _chunk(text),
+            ChunkCharacterOutput(
+                characters=[
+                    _candidate_with_appellations("郑玉琴", [text], ["母亲"])
+                ]
+            ),
+        )
+    ]
+    assert merge_character_candidates(outcomes)[0].aliases == set()

--- a/tests/test_structured_builders.py
+++ b/tests/test_structured_builders.py
@@ -849,17 +849,59 @@ async def test_adjudication_cannot_invent_a_character():
     assert {item.name for item in result} == {"郑旭阳", "小阳"}
 
 
-async def test_adjudication_cannot_delete_a_load_bearing_character():
-    """One bad call must not silently drop a lead from the cast."""
+async def test_adjudication_never_deletes_a_candidate():
+    """Every candidate here already survived verification against the source.
+
+    Discarding one trades a visible duplicate for an invisible omission, which
+    is the wrong way round: the user can delete a duplicate but cannot see an
+    omission.
+    """
     from novelvideo.structured_extraction import adjudicate_characters
 
     merged = [_merged("郑玉琴", 96), _merged("郑家悦", 96), _merged("路人", 1)]
+    logs: list[str] = []
     agent = AdjudicatorAgent(non_characters=["郑玉琴", "路人"])
 
+    result = await adjudicate_characters(merged, agent=agent, on_log=logs.append)
+    assert {item.name for item in result} == {"郑玉琴", "郑家悦", "路人"}
+    assert any("仅记录，未删除" in line for line in logs)
+
+
+async def test_adjudication_cannot_merge_two_well_attested_characters():
+    """The model may not fold one lead into another, however it groups them."""
+    from novelvideo.structured_extraction import adjudicate_characters
+
+    merged = [_merged("郑玉琴", 96), _merged("郑家悦", 96)]
+    agent = AdjudicatorAgent(groups=[("郑玉琴", ["郑家悦"])])
+
     result = await adjudicate_characters(merged, agent=agent)
-    names = {item.name for item in result}
-    assert "郑玉琴" in names, "a lead was dropped on the model's say-so"
-    assert "路人" not in names
+    assert {item.name for item in result} == {"郑玉琴", "郑家悦"}
+
+
+async def test_a_character_named_in_a_cast_list_is_never_merged_away():
+    """A cast list is authored, not inferred, so it outranks the model."""
+    from novelvideo.structured_extraction import adjudicate_characters
+
+    merged = [_merged("郑玉琴", 96), _merged("王妈", 1)]
+    agent = AdjudicatorAgent(groups=[("郑玉琴", ["王妈"])])
+
+    result = await adjudicate_characters(
+        merged, roster={"佣人王妈"}, agent=agent
+    )
+    assert {item.name for item in result} == {"郑玉琴", "王妈"}
+
+
+async def test_the_canonical_name_is_chosen_by_the_code_not_the_model():
+    """Left to the model, a formal name can end up folded into a nickname."""
+    from novelvideo.structured_extraction import adjudicate_characters
+
+    merged = [_merged("郑旭阳", 38), _merged("小阳", 1)]
+    # The model nominates the nickname as canonical.
+    agent = AdjudicatorAgent(groups=[("小阳", ["郑旭阳"])])
+
+    result = await adjudicate_characters(merged, agent=agent)
+    assert [item.name for item in result] == ["郑旭阳"]
+    assert result[0].aliases == {"小阳"}
 
 
 async def test_adjudication_failure_keeps_the_rule_result():
@@ -1214,3 +1256,166 @@ def test_a_generic_appellation_is_not_recorded_as_an_alias():
         )
     ]
     assert merge_character_candidates(outcomes)[0].aliases == set()
+
+
+async def test_a_frequently_used_location_is_never_merged_away():
+    """A place the script keeps returning to is real, not a spelling variant.
+
+    Folding it away would leave those scenes pointing at another room's art.
+    """
+    from novelvideo.structured_extraction import adjudicate_scenes
+
+    scenes = [_scene("主任办公室"), _scene("郑家别墅客厅")]
+    agent = SceneAdjudicatorAgent(groups=[("主任办公室", ["郑家别墅客厅"])])
+
+    result = await adjudicate_scenes(
+        scenes, occurrences={"主任办公室": 18, "郑家别墅客厅": 16}, agent=agent
+    )
+    assert {s.name for s in result} == {"主任办公室", "郑家别墅客厅"}
+
+
+async def test_the_canonical_location_is_the_spelling_the_script_uses_most():
+    from novelvideo.structured_extraction import adjudicate_scenes
+
+    scenes = [_scene("郑玉琴办公室"), _scene("郑玉琴办公室内")]
+    # The model nominates the rarer spelling.
+    agent = SceneAdjudicatorAgent(groups=[("郑玉琴办公室内", ["郑玉琴办公室"])])
+
+    result = await adjudicate_scenes(
+        scenes,
+        occurrences={"郑玉琴办公室": 2, "郑玉琴办公室内": 1},
+        agent=agent,
+    )
+    assert [s.name for s in result] == ["郑玉琴办公室"]
+    assert "郑玉琴办公室内" in result[0].aliases
+
+
+async def test_a_completed_build_replays_without_any_model_call(
+    structured_store, monkeypatch
+):
+    """Caching chunk results is not enough on its own.
+
+    Merging is free, but adjudication is a further model call, and a second
+    adjudication can decide differently — an alias could reappear as its own
+    character and be inserted as a new row. A finished build therefore replays
+    its settled cast.
+    """
+    from novelvideo import structured_builders
+    from novelvideo.structured_extraction import (
+        CharacterAdjudication,
+    )
+
+    store, state_dir = structured_store
+    await _ingested(store, state_dir, NARRATED_MULTI)
+
+    extraction = FlakyAgent(
+        outputs={
+            "第一章": ChunkCharacterOutput(
+                characters=[_candidate("林默", quotes=["林默回到阔别十年的故乡。"])]
+            ),
+            "第二章": ChunkCharacterOutput(
+                characters=[_candidate("苏晴", quotes=["他在巷口遇见了苏晴。"])]
+            ),
+        }
+    )
+
+    class CountingAdjudicator:
+        def __init__(self):
+            self.calls = 0
+
+        async def run(self, prompt: str):
+            self.calls += 1
+            return SimpleNamespace(
+                output=CharacterAdjudication(groups=[])
+            )
+
+    adjudicator = CountingAdjudicator()
+    from novelvideo.structured_extraction import extract_characters_from_chunks
+
+    real = extract_characters_from_chunks
+
+    async def fake(chunks, **kwargs):
+        kwargs.pop("agent", None)
+        kwargs.pop("adjudication_agent", None)
+        return await real(chunks, agent=extraction, adjudication_agent=adjudicator, **kwargs)
+
+    monkeypatch.setattr(
+        "novelvideo.structured_extraction.extract_characters_from_chunks", fake
+    )
+
+    await structured_builders.build_characters_structured(store)
+    assert extraction.calls, "the first build should have done real work"
+    assert adjudicator.calls == 1
+
+    extraction.calls.clear()
+    await structured_builders.build_characters_structured(store)
+
+    assert extraction.calls == [], "chunks were re-extracted"
+    assert adjudicator.calls == 1, "adjudication ran again on a finished build"
+
+
+async def test_replaying_a_build_cannot_split_an_alias_back_into_a_character(
+    structured_store, monkeypatch
+):
+    """A second, differently-deciding adjudication must not add a row.
+
+    Without a stored final result, an alias folded in on the first run could
+    come back as its own candidate, and add_characters_atomic — which only
+    checks primary names — would insert it alongside the character that already
+    lists it as an alias.
+    """
+    from novelvideo import structured_builders
+    from novelvideo.structured_extraction import (
+        CharacterAdjudication, SamePersonGroup, extract_characters_from_chunks,
+    )
+
+    store, state_dir = structured_store
+    await _ingested(store, state_dir, NARRATED_MULTI)
+
+    extraction = FlakyAgent(
+        outputs={
+            "第一章": ChunkCharacterOutput(
+                characters=[_candidate("林默", quotes=["林默回到阔别十年的故乡。"])]
+            ),
+            "第二章": ChunkCharacterOutput(
+                characters=[_candidate("苏晴", quotes=["他在巷口遇见了苏晴。"])]
+            ),
+        }
+    )
+
+    class DriftingAdjudicator:
+        """Merges on the first call, then changes its mind."""
+
+        def __init__(self):
+            self.calls = 0
+
+        async def run(self, prompt: str):
+            self.calls += 1
+            groups = (
+                [SamePersonGroup(canonical_name="林默", alias_names=["苏晴"])]
+                if self.calls == 1
+                else []
+            )
+            return SimpleNamespace(output=CharacterAdjudication(groups=groups))
+
+    real = extract_characters_from_chunks
+
+    async def fake(chunks, **kwargs):
+        kwargs.pop("agent", None)
+        kwargs.pop("adjudication_agent", None)
+        return await real(
+            chunks, agent=extraction, adjudication_agent=DriftingAdjudicator(), **kwargs
+        )
+
+    monkeypatch.setattr(
+        "novelvideo.structured_extraction.extract_characters_from_chunks", fake
+    )
+
+    await structured_builders.build_characters_structured(store)
+    first = {c.name for c in await store.list_characters()}
+
+    await structured_builders.build_characters_structured(store)
+    second = {c.name for c in await store.list_characters()}
+
+    assert second == first, "a rebuild changed the cast for unchanged source"
+    assert "苏晴" not in second

--- a/tests/test_structured_builders.py
+++ b/tests/test_structured_builders.py
@@ -283,7 +283,7 @@ async def test_extraction_runs_over_every_chunk():
             ),
         }
     )
-    merged = await extract_characters_from_chunks(chunks, agent=agent)
+    merged, _ = await extract_characters_from_chunks(chunks, agent=agent)
     assert {item.name for item in merged} == {"林默", "苏晴"}
 
 
@@ -299,11 +299,13 @@ async def test_one_failing_chunk_does_not_discard_the_others():
         fail_labels=["第二章"],
     )
     logs: list[str] = []
-    merged = await extract_characters_from_chunks(
+    merged, failures = await extract_characters_from_chunks(
         chunks, agent=agent, on_log=logs.append
     )
     assert [item.name for item in merged] == ["林默"]
     assert any("失败" in line for line in logs)
+    # The failure is reported back so the caller can persist it against the run.
+    assert [chunk.section_label for chunk, _ in failures]
 
 
 async def test_extraction_is_bounded_but_not_serial():
@@ -494,3 +496,164 @@ async def test_character_build_never_touches_cognee(structured_store, monkeypatc
         fake_extract,
     )
     await structured_builders.build_characters_structured(store)
+
+
+# ── resume, chunk bounds and concurrency defaults ───────────────────────────
+
+
+async def test_completed_chunks_are_replayed_instead_of_re_billed(
+    structured_store, monkeypatch
+):
+    """A retry or a second click must not pay for every chunk again."""
+    from novelvideo import structured_builders
+    from novelvideo.structured_extraction import extract_characters_from_chunks
+    from novelvideo.structured_ingest import ingest_source_text_structured
+
+    store, state_dir = structured_store
+    source = state_dir / "source.txt"
+    source.write_text(NARRATED_TEXT, encoding="utf-8")
+    await ingest_source_text_structured(store, str(source), spine_template="narrated")
+
+    outputs = {
+        "第一章": ChunkCharacterOutput(
+            characters=[_candidate("林默", quotes=["林默回到阔别十年的故乡。"])]
+        ),
+        "第二章": ChunkCharacterOutput(
+            characters=[_candidate("苏晴", quotes=["他在巷口遇见了苏晴。"])]
+        ),
+    }
+    agent = FakeAgent(outputs)
+    real_extract = extract_characters_from_chunks
+
+    async def fake_extract(chunks, **kwargs):
+        kwargs.pop("agent", None)
+        return await real_extract(chunks, agent=agent, **kwargs)
+
+    monkeypatch.setattr(
+        "novelvideo.structured_extraction.extract_characters_from_chunks", fake_extract
+    )
+
+    first = await structured_builders.build_characters_structured(store)
+    assert set(first) == {"林默", "苏晴"}
+    first_calls = len(agent.seen)
+    assert first_calls > 0
+
+    agent.seen.clear()
+    second = await structured_builders.build_characters_structured(store)
+
+    # Everything was replayed from stored results, so no chunk went to the model.
+    assert agent.seen == []
+    # And the characters are unchanged: they already exist, so nothing is added.
+    assert second == []
+
+
+async def test_a_failed_chunk_leaves_the_run_partial(structured_store, monkeypatch):
+    """A partial run must not look finished to the next build."""
+    from novelvideo import structured_builders
+    from novelvideo.structured_extraction import extract_characters_from_chunks
+    from novelvideo.structured_ingest import ingest_source_text_structured
+
+    store, state_dir = structured_store
+    source = state_dir / "source.txt"
+    source.write_text(NARRATED_TEXT, encoding="utf-8")
+    run = await ingest_source_text_structured(
+        store, str(source), spine_template="narrated"
+    )
+
+    agent = FakeAgent(
+        {
+            "第一章": ChunkCharacterOutput(
+                characters=[_candidate("林默", quotes=["林默回到阔别十年的故乡。"])]
+            )
+        },
+        fail_labels=["第二章"],
+    )
+    real_extract = extract_characters_from_chunks
+
+    async def fake_extract(chunks, **kwargs):
+        kwargs.pop("agent", None)
+        return await real_extract(chunks, agent=agent, **kwargs)
+
+    monkeypatch.setattr(
+        "novelvideo.structured_extraction.extract_characters_from_chunks", fake_extract
+    )
+    await structured_builders.build_characters_structured(store)
+
+    failed = await store.list_analysis_chunks(run["run_id"], status="failed")
+    assert failed, "the failing chunk was not recorded"
+    stored = await store.get_reusable_analysis_run(
+        source_sha256=__import__("novelvideo.story_analysis", fromlist=["x"]).source_sha256(
+            NARRATED_TEXT
+        ),
+        schema_version=1,
+        pipeline_version="structured_v2.1",
+        spine_template="narrated",
+    )
+    assert stored["status"] == "partial"
+
+
+def test_an_oversized_chapter_is_split_further():
+    """A chapter boundary says where to cut, not how big the piece may be."""
+    text = "第一章 归来\n\n" + "林默回到故乡。" * 3000 + "\n\n第二章 旧友\n\n短章节。\n"
+    chunks = chunk_source_text(text, "narrated")
+
+    assert len(chunks) > 2
+    assert max(len(chunk.text) for chunk in chunks) <= 6000
+    for chunk in chunks:
+        assert text[chunk.source_start : chunk.source_end] == chunk.text
+    assert [chunk.chunk_index for chunk in chunks] == list(range(len(chunks)))
+
+
+def test_oversized_parts_keep_a_recognisable_section_label():
+    text = "第一章 归来\n\n" + "林默回到故乡。" * 3000
+    chunks = chunk_source_text(text, "narrated")
+    assert all(chunk.chunk_id.startswith("chapter-0000-p") for chunk in chunks)
+    assert all("第1章" in chunk.section_label for chunk in chunks)
+
+
+def test_a_short_chapter_is_not_split():
+    chunks = chunk_source_text(NARRATED_TEXT, "narrated")
+    assert [chunk.chunk_id for chunk in chunks] == [
+        "chapter-0000",
+        "chapter-0001",
+        "chapter-0002",
+    ]
+
+
+def test_llm_concurrency_defaults_to_the_project_baseline(monkeypatch):
+    """A second pool running deeper than COGNEE_LLM_CONCURRENCY would trip the
+    same gateway limits that setting exists to avoid."""
+    from novelvideo.utils.bounded_concurrency import default_llm_concurrency
+
+    monkeypatch.delenv("STRUCTURED_LLM_CONCURRENCY", raising=False)
+    assert default_llm_concurrency() == 2
+
+    monkeypatch.setenv("STRUCTURED_LLM_CONCURRENCY", "5")
+    assert default_llm_concurrency() == 5
+
+    monkeypatch.setenv("STRUCTURED_LLM_CONCURRENCY", "0")
+    with pytest.raises(ValueError):
+        default_llm_concurrency()
+
+
+async def test_reuse_key_separates_drama_from_narrated(structured_store, tmp_path):
+    """The same text chunked two ways must not share a chunk plan."""
+    from novelvideo.structured_ingest import ingest_source_text_structured
+
+    store, state_dir = structured_store
+    source = state_dir / "source.txt"
+    source.write_text(NARRATED_TEXT, encoding="utf-8")
+
+    narrated = await ingest_source_text_structured(
+        store, str(source), spine_template="narrated"
+    )
+    again = await ingest_source_text_structured(
+        store, str(source), spine_template="narrated"
+    )
+    assert again["run_id"] == narrated["run_id"]
+
+    # Same bytes, different spine: a fresh plan, not the chapter-based one.
+    drama = await ingest_source_text_structured(
+        store, str(source), spine_template=""
+    )
+    assert drama["run_id"] != narrated["run_id"]

--- a/tests/test_structured_ingest.py
+++ b/tests/test_structured_ingest.py
@@ -41,6 +41,25 @@ NARRATED_TEXT = """第一章 归来
 """
 
 
+def _padded(body: str) -> str:
+    """Pad a section past the packing target so it stays its own chunk."""
+    return body + "\n" + "闲笔叙述。" * 640 + "\n"
+
+
+DRAMA_LONG = (
+    "第一集\n\n"
+    + "1-1 林家客厅 日 内\n人物：林默、林母\n" + _padded("林默推开门。林母抬头看他。")
+    + "\n1-2 巷口 夜 外\n人物：林默\n" + _padded("林默独自走过巷口。")
+    + "\n1-3 林家客厅 夜 内\n人物：林默\n" + _padded("林默坐在沙发上发呆。")
+)
+
+NARRATED_LONG = (
+    "第一章 归来\n\n" + _padded("林默回到阔别十年的故乡。街道还是老样子。")
+    + "\n第二章 旧友\n\n" + _padded("他在巷口遇见了旧友。")
+    + "\n第三章 真相\n\n" + _padded("旧友告诉他一个秘密。")
+)
+
+
 def _write_config(state_dir: Path, config: dict) -> None:
     state_dir.mkdir(parents=True, exist_ok=True)
     (state_dir / "project_config.json").write_text(
@@ -64,34 +83,34 @@ def _assert_offsets_are_exact(chunks, text):
 
 
 def test_drama_chunks_split_on_scene_headings():
-    chunks = chunk_source_text(DRAMA_TEXT, "drama")
+    chunks = chunk_source_text(DRAMA_LONG, "drama")
     assert len(chunks) >= 3
     assert all(chunk.section_type == "scene" for chunk in chunks)
-    _assert_offsets_are_exact(chunks, DRAMA_TEXT)
+    _assert_offsets_are_exact(chunks, DRAMA_LONG)
 
 
 def test_drama_chunks_are_ordered_and_non_overlapping():
-    chunks = chunk_source_text(DRAMA_TEXT, "drama")
+    chunks = chunk_source_text(DRAMA_LONG, "drama")
     for earlier, later in zip(chunks, chunks[1:]):
         assert earlier.source_end <= later.source_start
 
 
 def test_drama_chunk_keeps_its_scene_body():
-    chunks = chunk_source_text(DRAMA_TEXT, "drama")
+    chunks = chunk_source_text(DRAMA_LONG, "drama")
     joined = [chunk.text for chunk in chunks]
     assert any("林母抬头看他" in text for text in joined)
     assert any("林默独自走过巷口" in text for text in joined)
 
 
 def test_narrated_chunks_split_on_chapters():
-    chunks = chunk_source_text(NARRATED_TEXT, "narrated")
+    chunks = chunk_source_text(NARRATED_LONG, "narrated")
     assert len(chunks) == 3
     assert all(chunk.section_type == "chapter" for chunk in chunks)
-    _assert_offsets_are_exact(chunks, NARRATED_TEXT)
+    _assert_offsets_are_exact(chunks, NARRATED_LONG)
 
 
 def test_narrated_chapter_offsets_land_on_chapter_starts():
-    chunks = chunk_source_text(NARRATED_TEXT, "narrated")
+    chunks = chunk_source_text(NARRATED_LONG, "narrated")
     assert chunks[0].text.startswith("第一章")
     assert chunks[1].text.startswith("第二章")
     assert "旧友告诉他一个秘密" in chunks[2].text
@@ -120,7 +139,7 @@ def test_empty_text_produces_no_chunks():
 
 
 def test_chunk_hash_tracks_content():
-    chunks = chunk_source_text(NARRATED_TEXT, "narrated")
+    chunks = chunk_source_text(NARRATED_LONG, "narrated")
     assert chunks[0].source_hash != chunks[1].source_hash
     assert len(chunks[0].source_hash) == 64
 
@@ -155,7 +174,7 @@ async def test_structured_import_records_run_and_chunks(structured_project, tmp_
 
     store, state_dir = structured_project
     novel = tmp_path / "novel.txt"
-    novel.write_text(NARRATED_TEXT, encoding="utf-8")
+    novel.write_text(NARRATED_LONG, encoding="utf-8")
 
     result = await ingest_source_text_structured(
         store, str(novel), spine_template="narrated"
@@ -167,7 +186,7 @@ async def test_structured_import_records_run_and_chunks(structured_project, tmp_
     assert result["section_type"] == "chapter"
 
     run = await store.get_reusable_analysis_run(
-        source_sha256=source_sha256(NARRATED_TEXT),
+        source_sha256=source_sha256(NARRATED_LONG),
         schema_version=STRUCTURED_SCHEMA_VERSION,
         pipeline_version=STRUCTURED_PIPELINE_VERSION,
         spine_template="narrated",
@@ -196,7 +215,7 @@ async def test_structured_import_never_touches_cognee(
 
     store, _ = structured_project
     novel = tmp_path / "novel.txt"
-    novel.write_text(NARRATED_TEXT, encoding="utf-8")
+    novel.write_text(NARRATED_LONG, encoding="utf-8")
 
     await ingest_source_text_structured(store, str(novel), spine_template="narrated")
 
@@ -212,7 +231,7 @@ async def test_structured_import_writes_no_embedding_fields(
 
     store, state_dir = structured_project
     novel = tmp_path / "novel.txt"
-    novel.write_text(NARRATED_TEXT, encoding="utf-8")
+    novel.write_text(NARRATED_LONG, encoding="utf-8")
 
     await ingest_source_text_structured(store, str(novel), spine_template="narrated")
 
@@ -227,7 +246,7 @@ async def test_reimporting_identical_text_reuses_the_run(structured_project, tmp
 
     store, _ = structured_project
     novel = tmp_path / "novel.txt"
-    novel.write_text(NARRATED_TEXT, encoding="utf-8")
+    novel.write_text(NARRATED_LONG, encoding="utf-8")
 
     first = await ingest_source_text_structured(
         store, str(novel), spine_template="narrated"
@@ -254,12 +273,12 @@ async def test_changing_the_text_starts_a_new_run(structured_project, tmp_path):
     store, _ = structured_project
     novel = tmp_path / "novel.txt"
 
-    novel.write_text(NARRATED_TEXT, encoding="utf-8")
+    novel.write_text(NARRATED_LONG, encoding="utf-8")
     first = await ingest_source_text_structured(
         store, str(novel), spine_template="narrated"
     )
 
-    novel.write_text(NARRATED_TEXT + "\n第四章 结局\n\n他终于释怀。\n", encoding="utf-8")
+    novel.write_text(NARRATED_LONG + "\n第四章 结局\n\n" + _padded("他终于释怀。"), encoding="utf-8")
     second = await ingest_source_text_structured(
         store, str(novel), spine_template="narrated"
     )
@@ -300,7 +319,7 @@ async def test_drama_import_chunks_by_scene(structured_project, tmp_path):
 
     store, _ = structured_project
     novel = tmp_path / "script.txt"
-    novel.write_text(DRAMA_TEXT, encoding="utf-8")
+    novel.write_text(DRAMA_LONG, encoding="utf-8")
 
     result = await ingest_source_text_structured(
         store, str(novel), spine_template="drama"
@@ -317,7 +336,7 @@ async def test_entity_evidence_round_trips(structured_project, tmp_path):
 
     store, _ = structured_project
     novel = tmp_path / "novel.txt"
-    novel.write_text(NARRATED_TEXT, encoding="utf-8")
+    novel.write_text(NARRATED_LONG, encoding="utf-8")
     result = await ingest_source_text_structured(
         store, str(novel), spine_template="narrated"
     )
@@ -349,7 +368,7 @@ async def test_replacing_evidence_does_not_accumulate_duplicates(
 
     store, _ = structured_project
     novel = tmp_path / "novel.txt"
-    novel.write_text(NARRATED_TEXT, encoding="utf-8")
+    novel.write_text(NARRATED_LONG, encoding="utf-8")
     result = await ingest_source_text_structured(
         store, str(novel), spine_template="narrated"
     )
@@ -512,3 +531,45 @@ async def test_legacy_project_still_accepts_ai_planning(tmp_path, monkeypatch):
     )
 
     assert response["ok"] is True
+
+
+def test_short_neighbouring_sections_are_packed_into_one_chunk():
+    """A call costs the same round trip whether it carries 300 or 3000 chars.
+
+    A screenplay of many short scenes would otherwise spend nearly all of its
+    build time waiting on round trips rather than reading text.
+    """
+    chunks = chunk_source_text(DRAMA_TEXT, "drama")
+    assert len(chunks) == 1
+    assert chunks[0].source_start == 0
+    assert chunks[0].text == DRAMA_TEXT
+    # Everyone named across the packed scenes is still carried.
+    assert "林母" in chunks[0].characters
+
+
+def test_packing_stops_at_the_target_size():
+    chunks = chunk_source_text(DRAMA_LONG, "drama")
+    # The "第一集" line before the first scene heading is its own preamble chunk.
+    assert len(chunks) == 4
+    for chunk in chunks:
+        assert DRAMA_LONG[chunk.source_start : chunk.source_end] == chunk.text
+
+
+def test_packing_never_loses_or_duplicates_source():
+    for text, spine in ((DRAMA_LONG, "drama"), (NARRATED_LONG, "narrated")):
+        chunks = chunk_source_text(text, spine)
+        assert chunks[0].source_start == 0
+        assert chunks[-1].source_end == len(text)
+        for earlier, later in zip(chunks, chunks[1:]):
+            assert earlier.source_end == later.source_start
+
+
+def test_text_before_the_first_scene_heading_is_still_analysed():
+    """A synopsis or cast list is the densest description a script has."""
+    script = (
+        "《测试剧》\n\n人物小传：\n【林默】：22岁，性格沉静。\n\n"
+        "1-1 林家客厅 日 内\n人物：林默\n林默推开门。\n"
+    )
+    chunks = chunk_source_text(script, "drama")
+    assert chunks[0].source_start == 0
+    assert "人物小传" in "".join(c.text for c in chunks)

--- a/tests/test_structured_ingest.py
+++ b/tests/test_structured_ingest.py
@@ -1,4 +1,4 @@
-"""structured_v2 import: deterministic chunking, no graph, resumable runs."""
+"""structured_v1 import: deterministic chunking, no graph, resumable runs."""
 
 from __future__ import annotations
 
@@ -7,7 +7,7 @@ from pathlib import Path
 
 import pytest
 
-from novelvideo.knowledge_pipeline import KNOWLEDGE_PIPELINE_KEY, STRUCTURED_V2
+from novelvideo.knowledge_pipeline import KNOWLEDGE_PIPELINE_KEY, KNOWLEDGE_PIPELINE_STRUCTURED
 from novelvideo.story_analysis import chunk_source_text, source_sha256
 
 DRAMA_TEXT = """第一集
@@ -133,7 +133,7 @@ async def structured_project(tmp_path):
     from novelvideo.sqlite_store import SQLiteStore
 
     state_dir = tmp_path / "user" / "structured"
-    _write_config(state_dir, {KNOWLEDGE_PIPELINE_KEY: STRUCTURED_V2})
+    _write_config(state_dir, {KNOWLEDGE_PIPELINE_KEY: KNOWLEDGE_PIPELINE_STRUCTURED})
     store = SQLiteStore(
         "user/structured",
         output_dir=str(state_dir),
@@ -161,7 +161,7 @@ async def test_structured_import_records_run_and_chunks(structured_project, tmp_
         store, str(novel), spine_template="narrated"
     )
 
-    assert result["pipeline"] == "structured_v2"
+    assert result["pipeline"] == "structured_v1"
     assert result["status"] == "source_ready"
     assert result["chunks"] == 3
     assert result["section_type"] == "chapter"
@@ -189,7 +189,7 @@ async def test_structured_import_never_touches_cognee(
     from novelvideo.structured_ingest import ingest_source_text_structured
 
     def _boom(*args, **kwargs):
-        raise AssertionError("structured_v2 import must not touch Cognee")
+        raise AssertionError("structured_v1 import must not touch Cognee")
 
     for name in ("add", "cognify", "memify", "search"):
         monkeypatch.setattr(cognee, name, _boom, raising=False)
@@ -387,7 +387,7 @@ async def test_structured_project_rejects_ai_planning_before_enqueue(
     from novelvideo.knowledge_pipeline import KnowledgePipelineUnsupported
 
     state_dir = tmp_path / "user" / "structured"
-    _write_config(state_dir, {KNOWLEDGE_PIPELINE_KEY: STRUCTURED_V2})
+    _write_config(state_dir, {KNOWLEDGE_PIPELINE_KEY: KNOWLEDGE_PIPELINE_STRUCTURED})
     project_dir = tmp_path / "out"
     project_dir.mkdir()
     (project_dir / "novel.txt").write_text(NARRATED_TEXT, encoding="utf-8")
@@ -401,7 +401,7 @@ async def test_structured_project_rejects_ai_planning_before_enqueue(
         )
 
     async def reject_enqueue(*_args, **_kwargs):
-        raise AssertionError("structured_v2 must not enqueue an AI planning task")
+        raise AssertionError("structured_v1 must not enqueue an AI planning task")
 
     monkeypatch.setattr(episodes, "resolve_project_scope", resolve_project_scope)
     monkeypatch.setattr(
@@ -430,7 +430,7 @@ async def test_structured_project_allows_deterministic_chapter_planning(
     from novelvideo.api.schemas import EpisodePlanRequest
 
     state_dir = tmp_path / "user" / "structured"
-    _write_config(state_dir, {KNOWLEDGE_PIPELINE_KEY: STRUCTURED_V2})
+    _write_config(state_dir, {KNOWLEDGE_PIPELINE_KEY: KNOWLEDGE_PIPELINE_STRUCTURED})
     project_dir = tmp_path / "out"
     project_dir.mkdir()
     (project_dir / "novel.txt").write_text(NARRATED_TEXT, encoding="utf-8")

--- a/tests/test_structured_ingest.py
+++ b/tests/test_structured_ingest.py
@@ -170,6 +170,7 @@ async def test_structured_import_records_run_and_chunks(structured_project, tmp_
         source_sha256=source_sha256(NARRATED_TEXT),
         schema_version=STRUCTURED_SCHEMA_VERSION,
         pipeline_version=STRUCTURED_PIPELINE_VERSION,
+        spine_template="narrated",
     )
     assert run is not None and run["run_id"] == result["run_id"]
 

--- a/tests/test_structured_ingest.py
+++ b/tests/test_structured_ingest.py
@@ -573,3 +573,32 @@ def test_text_before_the_first_scene_heading_is_still_analysed():
     chunks = chunk_source_text(script, "drama")
     assert chunks[0].source_start == 0
     assert "人物小传" in "".join(c.text for c in chunks)
+
+
+def test_text_before_the_first_chapter_marker_is_still_analysed():
+    """Prose sources carry a synopsis or cast list ahead of chapter one.
+
+    The screenplay path already kept it; the chapter path was dropping it, and
+    it is exactly the passage that names and describes the cast.
+    """
+    novel = (
+        "《测试小说》\n\n人物小传：\n【林默】：22岁，性格沉静。\n\n"
+        + NARRATED_LONG
+    )
+    chunks = chunk_source_text(novel, "narrated")
+    assert chunks[0].source_start == 0
+    assert "人物小传" in chunks[0].text
+
+
+def test_every_spine_covers_the_whole_source_without_gaps():
+    """Nothing may fall between two chunks, whichever way the source is cut."""
+    for text, spine in (
+        ("《剧》\n\n人物小传：\n【林默】\n\n" + DRAMA_LONG, "drama"),
+        ("《书》\n\n人物小传：\n【林默】\n\n" + NARRATED_LONG, "narrated"),
+    ):
+        chunks = chunk_source_text(text, spine)
+        assert chunks[0].source_start == 0
+        assert chunks[-1].source_end == len(text)
+        for earlier, later in zip(chunks, chunks[1:]):
+            assert earlier.source_end == later.source_start
+        assert sum(len(c.text) for c in chunks) == len(text)

--- a/tests/test_structured_ingest.py
+++ b/tests/test_structured_ingest.py
@@ -1,0 +1,513 @@
+"""structured_v2 import: deterministic chunking, no graph, resumable runs."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from novelvideo.knowledge_pipeline import KNOWLEDGE_PIPELINE_KEY, STRUCTURED_V2
+from novelvideo.story_analysis import chunk_source_text, source_sha256
+
+DRAMA_TEXT = """第一集
+
+1-1 林家客厅 日 内
+人物：林默、林母
+林默推开门。
+林母抬头看他。
+
+1-2 巷口 夜 外
+人物：林默
+林默独自走过巷口。
+
+1-3 林家客厅 夜 内
+人物：林默
+林默坐在沙发上发呆。
+"""
+
+NARRATED_TEXT = """第一章 归来
+
+林默回到阔别十年的故乡。
+街道还是老样子。
+
+第二章 旧友
+
+他在巷口遇见了旧友。
+
+第三章 真相
+
+旧友告诉他一个秘密。
+"""
+
+
+def _write_config(state_dir: Path, config: dict) -> None:
+    state_dir.mkdir(parents=True, exist_ok=True)
+    (state_dir / "project_config.json").write_text(
+        json.dumps(config, ensure_ascii=False), encoding="utf-8"
+    )
+
+
+# ── chunking ────────────────────────────────────────────────────────────────
+
+
+def _assert_offsets_are_exact(chunks, text):
+    """Every chunk must quote the source exactly at the offsets it reports.
+
+    This is what later extraction relies on to prove an entity is real, so a
+    drifting offset has to fail here rather than silently validate invented
+    evidence.
+    """
+    for chunk in chunks:
+        assert chunk.source_start < chunk.source_end
+        assert text[chunk.source_start : chunk.source_end] == chunk.text
+
+
+def test_drama_chunks_split_on_scene_headings():
+    chunks = chunk_source_text(DRAMA_TEXT, "drama")
+    assert len(chunks) >= 3
+    assert all(chunk.section_type == "scene" for chunk in chunks)
+    _assert_offsets_are_exact(chunks, DRAMA_TEXT)
+
+
+def test_drama_chunks_are_ordered_and_non_overlapping():
+    chunks = chunk_source_text(DRAMA_TEXT, "drama")
+    for earlier, later in zip(chunks, chunks[1:]):
+        assert earlier.source_end <= later.source_start
+
+
+def test_drama_chunk_keeps_its_scene_body():
+    chunks = chunk_source_text(DRAMA_TEXT, "drama")
+    joined = [chunk.text for chunk in chunks]
+    assert any("林母抬头看他" in text for text in joined)
+    assert any("林默独自走过巷口" in text for text in joined)
+
+
+def test_narrated_chunks_split_on_chapters():
+    chunks = chunk_source_text(NARRATED_TEXT, "narrated")
+    assert len(chunks) == 3
+    assert all(chunk.section_type == "chapter" for chunk in chunks)
+    _assert_offsets_are_exact(chunks, NARRATED_TEXT)
+
+
+def test_narrated_chapter_offsets_land_on_chapter_starts():
+    chunks = chunk_source_text(NARRATED_TEXT, "narrated")
+    assert chunks[0].text.startswith("第一章")
+    assert chunks[1].text.startswith("第二章")
+    assert "旧友告诉他一个秘密" in chunks[2].text
+
+
+def test_prose_without_chapter_markers_falls_back_to_windows():
+    """A malformed import must still produce analysable chunks."""
+    text = "没有任何章节标记的长文。" * 2000
+    chunks = chunk_source_text(text, "narrated")
+    assert chunks
+    assert all(chunk.section_type == "window" for chunk in chunks)
+    for chunk in chunks:
+        assert text[chunk.source_start : chunk.source_end] == chunk.text
+
+
+def test_window_fallback_overlaps_so_boundaries_are_not_lost():
+    text = "甲" * 20000
+    chunks = chunk_source_text(text, "narrated")
+    assert len(chunks) > 1
+    for earlier, later in zip(chunks, chunks[1:]):
+        assert later.source_start < earlier.source_end
+
+
+def test_empty_text_produces_no_chunks():
+    assert chunk_source_text("   \n  ", "drama") == []
+
+
+def test_chunk_hash_tracks_content():
+    chunks = chunk_source_text(NARRATED_TEXT, "narrated")
+    assert chunks[0].source_hash != chunks[1].source_hash
+    assert len(chunks[0].source_hash) == 64
+
+
+# ── import ──────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+async def structured_project(tmp_path):
+    from novelvideo.sqlite_store import SQLiteStore
+
+    state_dir = tmp_path / "user" / "structured"
+    _write_config(state_dir, {KNOWLEDGE_PIPELINE_KEY: STRUCTURED_V2})
+    store = SQLiteStore(
+        "user/structured",
+        output_dir=str(state_dir),
+        state_dir=str(state_dir),
+    )
+    await store.initialize()
+    try:
+        yield store, state_dir
+    finally:
+        await store.close()
+
+
+async def test_structured_import_records_run_and_chunks(structured_project, tmp_path):
+    from novelvideo.structured_ingest import (
+        STRUCTURED_PIPELINE_VERSION,
+        STRUCTURED_SCHEMA_VERSION,
+        ingest_source_text_structured,
+    )
+
+    store, state_dir = structured_project
+    novel = tmp_path / "novel.txt"
+    novel.write_text(NARRATED_TEXT, encoding="utf-8")
+
+    result = await ingest_source_text_structured(
+        store, str(novel), spine_template="narrated"
+    )
+
+    assert result["pipeline"] == "structured_v2"
+    assert result["status"] == "source_ready"
+    assert result["chunks"] == 3
+    assert result["section_type"] == "chapter"
+
+    run = await store.get_reusable_analysis_run(
+        source_sha256=source_sha256(NARRATED_TEXT),
+        schema_version=STRUCTURED_SCHEMA_VERSION,
+        pipeline_version=STRUCTURED_PIPELINE_VERSION,
+    )
+    assert run is not None and run["run_id"] == result["run_id"]
+
+    chunks = await store.list_analysis_chunks(result["run_id"])
+    assert len(chunks) == 3
+    assert [chunk["status"] for chunk in chunks] == ["pending"] * 3
+    assert [chunk["chunk_index"] for chunk in chunks] == [0, 1, 2]
+
+
+async def test_structured_import_never_touches_cognee(
+    structured_project, tmp_path, monkeypatch
+):
+    """The sentinel: import is where the legacy path spends its embedding time."""
+    import cognee
+
+    from novelvideo.structured_ingest import ingest_source_text_structured
+
+    def _boom(*args, **kwargs):
+        raise AssertionError("structured_v2 import must not touch Cognee")
+
+    for name in ("add", "cognify", "memify", "search"):
+        monkeypatch.setattr(cognee, name, _boom, raising=False)
+
+    store, _ = structured_project
+    novel = tmp_path / "novel.txt"
+    novel.write_text(NARRATED_TEXT, encoding="utf-8")
+
+    await ingest_source_text_structured(store, str(novel), spine_template="narrated")
+
+
+async def test_structured_import_writes_no_embedding_fields(
+    structured_project, tmp_path
+):
+    from novelvideo.embedding_models import (
+        PROJECT_EMBEDDING_DIMENSION_KEY,
+        PROJECT_EMBEDDING_MODEL_KEY,
+    )
+    from novelvideo.structured_ingest import ingest_source_text_structured
+
+    store, state_dir = structured_project
+    novel = tmp_path / "novel.txt"
+    novel.write_text(NARRATED_TEXT, encoding="utf-8")
+
+    await ingest_source_text_structured(store, str(novel), spine_template="narrated")
+
+    config = json.loads((state_dir / "project_config.json").read_text(encoding="utf-8"))
+    assert PROJECT_EMBEDDING_MODEL_KEY not in config
+    assert PROJECT_EMBEDDING_DIMENSION_KEY not in config
+
+
+async def test_reimporting_identical_text_reuses_the_run(structured_project, tmp_path):
+    """Resume must not discard completed chunk work for unchanged text."""
+    from novelvideo.structured_ingest import ingest_source_text_structured
+
+    store, _ = structured_project
+    novel = tmp_path / "novel.txt"
+    novel.write_text(NARRATED_TEXT, encoding="utf-8")
+
+    first = await ingest_source_text_structured(
+        store, str(novel), spine_template="narrated"
+    )
+    chunks = await store.list_analysis_chunks(first["run_id"])
+    await store.mark_analysis_chunk_done(
+        first["run_id"], chunks[0]["chunk_id"], json.dumps({"characters": ["林默"]})
+    )
+
+    second = await ingest_source_text_structured(
+        store, str(novel), spine_template="narrated"
+    )
+    assert second["run_id"] == first["run_id"]
+
+    after = await store.list_analysis_chunks(first["run_id"])
+    done = [chunk for chunk in after if chunk["status"] == "done"]
+    assert len(done) == 1
+    assert json.loads(done[0]["result_json"]) == {"characters": ["林默"]}
+
+
+async def test_changing_the_text_starts_a_new_run(structured_project, tmp_path):
+    from novelvideo.structured_ingest import ingest_source_text_structured
+
+    store, _ = structured_project
+    novel = tmp_path / "novel.txt"
+
+    novel.write_text(NARRATED_TEXT, encoding="utf-8")
+    first = await ingest_source_text_structured(
+        store, str(novel), spine_template="narrated"
+    )
+
+    novel.write_text(NARRATED_TEXT + "\n第四章 结局\n\n他终于释怀。\n", encoding="utf-8")
+    second = await ingest_source_text_structured(
+        store, str(novel), spine_template="narrated"
+    )
+
+    assert second["run_id"] != first["run_id"]
+    assert second["chunks"] == 4
+
+
+async def test_novel_txt_is_not_written_when_import_fails(structured_project, tmp_path):
+    """novel.txt is the public success marker and must not survive a failure."""
+    from novelvideo.structured_ingest import ingest_source_text_structured
+
+    store, state_dir = structured_project
+    novel = tmp_path / "script.txt"
+    novel.write_text("这是一段没有任何场景头的正文。\n", encoding="utf-8")
+
+    with pytest.raises(ValueError):
+        await ingest_source_text_structured(store, str(novel), spine_template="drama")
+
+    assert not (Path(store.project_dir) / "novel.txt").exists()
+
+
+async def test_empty_upload_is_rejected(structured_project, tmp_path):
+    from novelvideo.structured_ingest import ingest_source_text_structured
+
+    store, _ = structured_project
+    novel = tmp_path / "empty.txt"
+    novel.write_text("   \n\n", encoding="utf-8")
+
+    with pytest.raises(ValueError):
+        await ingest_source_text_structured(
+            store, str(novel), spine_template="narrated"
+        )
+
+
+async def test_drama_import_chunks_by_scene(structured_project, tmp_path):
+    from novelvideo.structured_ingest import ingest_source_text_structured
+
+    store, _ = structured_project
+    novel = tmp_path / "script.txt"
+    novel.write_text(DRAMA_TEXT, encoding="utf-8")
+
+    result = await ingest_source_text_structured(
+        store, str(novel), spine_template="drama"
+    )
+    assert result["section_type"] == "scene"
+    assert result["chunks"] >= 3
+
+
+# ── evidence ────────────────────────────────────────────────────────────────
+
+
+async def test_entity_evidence_round_trips(structured_project, tmp_path):
+    from novelvideo.structured_ingest import ingest_source_text_structured
+
+    store, _ = structured_project
+    novel = tmp_path / "novel.txt"
+    novel.write_text(NARRATED_TEXT, encoding="utf-8")
+    result = await ingest_source_text_structured(
+        store, str(novel), spine_template="narrated"
+    )
+
+    await store.replace_entity_evidence(
+        result["run_id"],
+        "character",
+        "林默",
+        [
+            {
+                "chunk_id": "chapter-0000",
+                "source_start": 0,
+                "source_end": 10,
+                "evidence_kind": "mention",
+                "evidence_text": "林默回到阔别十年的故乡",
+            }
+        ],
+    )
+    rows = await store.list_entity_evidence("character", "林默")
+    assert len(rows) == 1
+    assert rows[0]["evidence_text"] == "林默回到阔别十年的故乡"
+
+
+async def test_replacing_evidence_does_not_accumulate_duplicates(
+    structured_project, tmp_path
+):
+    """Re-running a chunk must not pile up repeated spans for one entity."""
+    from novelvideo.structured_ingest import ingest_source_text_structured
+
+    store, _ = structured_project
+    novel = tmp_path / "novel.txt"
+    novel.write_text(NARRATED_TEXT, encoding="utf-8")
+    result = await ingest_source_text_structured(
+        store, str(novel), spine_template="narrated"
+    )
+
+    evidence = [
+        {
+            "chunk_id": "chapter-0000",
+            "source_start": 0,
+            "source_end": 10,
+            "evidence_kind": "mention",
+            "evidence_text": "林默",
+        }
+    ]
+    await store.replace_entity_evidence(result["run_id"], "character", "林默", evidence)
+    await store.replace_entity_evidence(result["run_id"], "character", "林默", evidence)
+
+    assert len(await store.list_entity_evidence("character", "林默")) == 1
+
+
+# ── AI planning rejection ───────────────────────────────────────────────────
+
+
+async def test_structured_project_rejects_ai_planning_before_enqueue(
+    tmp_path, monkeypatch
+):
+    """Reject before enqueue so the user gets an answer, not a doomed task.
+
+    The AI planners read the Cognee graph, which structured projects do not
+    have, and enqueueing would reserve credit for work that cannot succeed.
+    """
+    from types import SimpleNamespace
+
+    from novelvideo.api.routes import episodes
+    from novelvideo.api.schemas import EpisodePlanRequest
+    from novelvideo.knowledge_pipeline import KnowledgePipelineUnsupported
+
+    state_dir = tmp_path / "user" / "structured"
+    _write_config(state_dir, {KNOWLEDGE_PIPELINE_KEY: STRUCTURED_V2})
+    project_dir = tmp_path / "out"
+    project_dir.mkdir()
+    (project_dir / "novel.txt").write_text(NARRATED_TEXT, encoding="utf-8")
+
+    async def resolve_project_scope(project, user, required_role="viewer"):
+        return SimpleNamespace(
+            ctx=SimpleNamespace(project_id="proj_1"),
+            output_dir=str(project_dir),
+            state_dir=str(state_dir),
+            project_dir=str(project_dir),
+        )
+
+    async def reject_enqueue(*_args, **_kwargs):
+        raise AssertionError("structured_v2 must not enqueue an AI planning task")
+
+    monkeypatch.setattr(episodes, "resolve_project_scope", resolve_project_scope)
+    monkeypatch.setattr(
+        episodes,
+        "get_task_backend",
+        lambda: SimpleNamespace(enqueue_project_task=reject_enqueue),
+    )
+
+    response = await episodes.plan_episodes(
+        project="proj_1",
+        body=EpisodePlanRequest(target_episodes=10, planning_mode="ai"),
+        user={"username": "admin"},
+    )
+
+    assert response["ok"] is False
+    assert response["code"] == KnowledgePipelineUnsupported.error_code
+
+
+async def test_structured_project_allows_deterministic_chapter_planning(
+    tmp_path, monkeypatch
+):
+    """The mode the frontend actually uses must keep working."""
+    from types import SimpleNamespace
+
+    from novelvideo.api.routes import episodes
+    from novelvideo.api.schemas import EpisodePlanRequest
+
+    state_dir = tmp_path / "user" / "structured"
+    _write_config(state_dir, {KNOWLEDGE_PIPELINE_KEY: STRUCTURED_V2})
+    project_dir = tmp_path / "out"
+    project_dir.mkdir()
+    (project_dir / "novel.txt").write_text(NARRATED_TEXT, encoding="utf-8")
+
+    enqueued = {}
+
+    async def resolve_project_scope(project, user, required_role="viewer"):
+        return SimpleNamespace(
+            ctx=SimpleNamespace(project_id="proj_1"),
+            output_dir=str(project_dir),
+            state_dir=str(state_dir),
+            project_dir=str(project_dir),
+        )
+
+    async def accept_enqueue(*_args, **kwargs):
+        enqueued.update(kwargs)
+        return SimpleNamespace(
+            task_state=SimpleNamespace(task_id="task_1"),
+            backend="celery",
+            queue="default",
+        )
+
+    monkeypatch.setattr(episodes, "resolve_project_scope", resolve_project_scope)
+    monkeypatch.setattr(
+        episodes,
+        "get_task_backend",
+        lambda: SimpleNamespace(enqueue_project_task=accept_enqueue),
+    )
+
+    response = await episodes.plan_episodes(
+        project="proj_1",
+        body=EpisodePlanRequest(target_episodes=10, planning_mode="chapters"),
+        user={"username": "admin"},
+    )
+
+    assert response["ok"] is True
+    assert enqueued["payload"]["config"]["planning_mode"] == "chapters"
+
+
+async def test_legacy_project_still_accepts_ai_planning(tmp_path, monkeypatch):
+    """The gate must be invisible to legacy projects."""
+    from types import SimpleNamespace
+
+    from novelvideo.api.routes import episodes
+    from novelvideo.api.schemas import EpisodePlanRequest
+
+    state_dir = tmp_path / "user" / "legacy"
+    _write_config(state_dir, {"user": "user"})
+    project_dir = tmp_path / "out"
+    project_dir.mkdir()
+    (project_dir / "novel.txt").write_text(NARRATED_TEXT, encoding="utf-8")
+
+    async def resolve_project_scope(project, user, required_role="viewer"):
+        return SimpleNamespace(
+            ctx=SimpleNamespace(project_id="proj_1"),
+            output_dir=str(project_dir),
+            state_dir=str(state_dir),
+            project_dir=str(project_dir),
+        )
+
+    async def accept_enqueue(*_args, **_kwargs):
+        return SimpleNamespace(
+            task_state=SimpleNamespace(task_id="task_1"),
+            backend="celery",
+            queue="default",
+        )
+
+    monkeypatch.setattr(episodes, "resolve_project_scope", resolve_project_scope)
+    monkeypatch.setattr(
+        episodes,
+        "get_task_backend",
+        lambda: SimpleNamespace(enqueue_project_task=accept_enqueue),
+    )
+
+    response = await episodes.plan_episodes(
+        project="proj_1",
+        body=EpisodePlanRequest(target_episodes=10, planning_mode="ai"),
+        user={"username": "admin"},
+    )
+
+    assert response["ok"] is True


### PR DESCRIPTION
## Summary

Structured-v2 project builds: characters from source text, scenes from screenplay headings, props deferred to per-episode planning. No graph, no embedding.

Stacked on #353 (which is stacked on #352). This is PR 3 of 4.

## Character extraction

The legacy path asks Cognee for graph context and lets a model name whoever it finds there. Structured extraction inverts that: the model sees one chunk at a time, may only report what that span supports, and **every candidate must quote the span it came from**. Quotes that cannot be located in the source are dropped, so a hallucinated name has no route into the character table.

## Merging refuses to guess

A character's name is at once a SQLite primary key, a REST identifier and an asset directory name. A wrong merge is expensive to undo; a wrong split is a visible duplicate the user can fix. So:

- Identical names merge.
- Explicitly stated aliases merge — `林默又名小默`, `萧玦人称陛下`. Only an explicit statement counts.
- A model-proposed alias with no textual support is recorded in `ambiguous_with` as a suggestion, never acted on. Co-occurrence is not identity.
- Titles and kinship terms (`母亲`, `陛下`, `医生`) refer to whoever is on stage at the time, so the same word in two chapters never merges on its own and never becomes an alias.
- On an alias merge, the better-evidenced name wins the primary slot, so the canonical record is the one the text actually develops rather than a passing nickname.

## Atomic publish

New `SQLiteStore.add_characters_atomic`. `add_character` commits per row, so a failure partway through leaves half a cast behind; structured builds publish all or nothing. Existing characters are **skipped, not overwritten** — one on disk may already carry user edits, a portrait, identities and voice bindings.

## Scenes and props

- **Screenplays**: built from scene headings, which already name every location. Existing base scenes and their derived plates are asset facts, so a rebuild adds what is missing and leaves the rest alone.
- **Narrated**: no comparable marker exists, so a full-text sweep would invent locations. Returns `episode_on_demand`; scenes accumulate per episode from each episode's own text.
- **Props**: `episode_on_demand` with an explicit message rather than a silent no-op, so callers do not read `0 props` as "the analysis found nothing". What matters about a prop is whether an episode gives it story weight — a full-text sweep cannot tell that from background furniture.

## Bounded concurrency for two serial loops

`normalize_screenplay_scenes` and the enrichment loop in `extract_scenes_from_script` were both one round trip per scene, serially, and a feature-length screenplay carries well over a hundred scenes. Both now map with a bounded number of calls in flight. A failing item yields `None` in its slot rather than cancelling the batch, so one unparseable scene does not discard every other scene's work.

**Correcting an earlier claim in the design discussion**: `normalize_screenplay_scenes` was *already* per-scene — it splits locally via `parse_scene_blocks` and calls the model per block. It never sent a whole script in one request. Only its serial iteration needed changing, so this is smaller than planned.

## Verification

- `uv run pytest -q` — 3640 passed, 16 skipped, 1 failed
- The single failure is `test_api_project_summary_paths::test_project_summary_counts_from_registered_state_dir`, which fails identically on the `staging` baseline and passes in isolation — pre-existing ordering pollution.
- `tests/test_structured_builders.py` — 24 new tests: offset-exact evidence verification, rejection of unlocatable quotes, every merge rule above (including that two `母亲` mentions in different chapters do not become one person), atomic publish rolling back on failure, existing characters surviving a rebuild untouched, narrated/prop deferral, and a sentinel that the character build never touches Cognee. Concurrency is asserted to be neither serial nor unbounded.
- `uv run ruff check src/ tests/` — clean

## Impact

`CHARACTER_BUILD_MODEL` is registered in `.env.example` and `official_defaults.py`, as the env ratchet requires for any new runtime env read. The two parallelized loops are shared with the legacy path — same prompts and same per-scene requests, only no longer serial. No project is `structured_v1` yet, so no build path changes for anything on disk today.



---

## 追加：review 修复（2 轮）

**第一轮（4 条，全部核实属实）**
- 并发默认 6 → 2（`STRUCTURED_LLM_CONCURRENCY` 可覆盖），三个调用点全部显式传参。原本两处没传 limit，导致共享的 legacy 场景路径从串行直接变成 6 并发。
- 断点续跑真正接上：已完成 chunk 从存储结果回放（并校验 `source_hash` 仍匹配），成败即时落库，有失败的 run 结束为 `partial`。`on_chunk_failed` 原本没 await，异步回调会被丢弃。
- 章节/场次超长时二次切分（同 overlap、offset 精确、`chunk_index` 重编号）。原本 6000 字上限只作用于无标记 fallback。
- 复用键加入 `spine_template`；`capability` 由 `cognee.llm` 改为 `text.generate.agent`。

**第二轮**
- 全局收口为首发 `structured_v1`：原先 `structured_v2`（轨道）+ `structured_v2.1`（契约）两套版本号并存，且 "v2" 暗示了一个不存在的 v1。因默认切换尚未合并，磁盘上不可能有旧值，无需迁移或兼容。
- `is_structured_v2` → `is_structured_pipeline`，`STRUCTURED_V2` → `KNOWLEDGE_PIPELINE_STRUCTURED`，使将来升版只改值不改标识符。两个常量刻意分开：一个记录项目轨道，一个记录产出 run 的切块契约，切块变更只动后者。
- 角色证据改为遍历 `merged` 而非 `added`：发布角色与写证据是两步，若前者成功后者失败，重试时角色已存在、`added` 为空，证据将永远补不上。重写是幂等的，且不触碰用户编辑过的角色字段。
- `finish_analysis_run` 移到发布之后，并覆盖"无角色"早退路径——原先该路径直接 return，run 永远停在 `pending`。
- `entity_evidence` 注释原称 character 和 scene 都有证据，实际只有 character，已收窄。

新增测试：续跑不重复计费、失败留 `partial`、超长章节切分与 offset 精确、短章节不切、并发默认值与 env 覆盖、drama/narrated 复用键隔离、角色已存在时证据补写、无角色时 run 仍关闭。

全量：**3658 passed**（唯一失败为 staging 基线既有的 `test_api_project_summary_paths`）。
