### PR TITLE
fix: close the episode menu race for existing projects too

### DIFF
--- a/license-inventory.csv
+++ b/license-inventory.csv
@@ -1904,6 +1904,7 @@ tests/test_docker_persistence_config.py,Elastic-2.0,2026 SuperTale contributors,
 tests/test_ee_terms_lint.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_egress_dispatching_leak_diagnosability.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_env_config_ratchet.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
+tests/test_episode_menu_normalization_parity.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_episode_optimizer_colors.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_episode_patch_concurrency.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_fanout_partial_dispatch.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation

--- a/src/novelvideo/agents/asset_compiler.py
+++ b/src/novelvideo/agents/asset_compiler.py
@@ -428,22 +428,18 @@ class AssetCompiler:
         self.spine_template = "drama"
 
     async def _write_menus(self, episode_number: int, **menus: Any) -> None:
-        """Persist episode menus by the route this project's track expects.
+        """Persist episode menus with a column-level write.
 
-        Structured projects use the column-level patch, so scene, prop and
-        identity planning running at once cannot overwrite each other's menu.
+        Scene, prop and identity planning run at once for the same episode. Any
+        whole-row write re-serialises the menus this planner loaded earlier, so
+        a menu written meanwhile is lost. Writing only the named columns removes
+        that race rather than narrowing it.
 
-        Legacy projects keep the whole-row update they have always used. Its
-        normalizer deduplicates through build_scene_menu/build_prop_menu,
-        resolves canonical prop ids and backfills type, prompt, description and
-        owner from the global asset library. The patch path reproduces none of
-        that, and a legacy project must behave exactly as it does today — so it
-        keeps its existing write, race and all.
+        Both tracks take this route: the normalization behind it is the same
+        code the legacy whole-row write uses, so an existing project's menus
+        come out byte-identical.
         """
-        if self._structured:
-            await self.store.patch_episode(episode_number, **menus)
-        else:
-            await self.cognee_store.update_episode(episode_number, **menus)
+        await self.store.patch_episode(episode_number, **menus)
 
     async def compile_single_episode(
         self,

--- a/src/novelvideo/agents/identity_planner.py
+++ b/src/novelvideo/agents/identity_planner.py
@@ -579,21 +579,13 @@ class IdentityPlanner:
         return results
 
     async def _write_episode_identities(self, episode_number: int, **fields) -> None:
-        """Persist this episode's identities by the route its track expects.
+        """Persist this episode's identities with a column-level write.
 
         Identity planning runs alongside scene and prop planning for the same
-        episode. A whole-row write here re-serialises whatever menus this
-        planner loaded earlier, so a menu written meanwhile is lost — which is
-        the race the column-level patch exists to remove.
-
-        Legacy keeps its whole-row update: its normalizer backfills prop
-        metadata the patch path does not reproduce, and an existing project must
-        behave exactly as it does today.
+        episode, so a whole-row write here would re-serialise — and lose — a
+        menu written meanwhile.
         """
-        if self._structured:
-            await self.store.patch_episode(episode_number, **fields)
-        else:
-            await self.cognee_store.update_episode(episode_number, **fields)
+        await self.store.patch_episode(episode_number, **fields)
 
     def _alias_context_from_sqlite(self, all_names: list[str]) -> str:
         """Build alias context from the character table instead of the graph.

--- a/src/novelvideo/api/routes/content.py
+++ b/src/novelvideo/api/routes/content.py
@@ -194,7 +194,9 @@ async def generate_rewrite(
         if normalized == raw_content:
             normalized = ""
         await store.save_adapted_content(episode_num, normalized)
-        await store.update_episode(episode_num, beat_source_text=normalized)
+        # Column-level: rewriting the working text must not re-serialise the
+        # scene and prop menus that planning may have written meanwhile.
+        await store.patch_episode(episode_num, beat_source_text=normalized)
     except Exception as exc:
         if reservation_id:
             try:

--- a/src/novelvideo/api/routes/episodes.py
+++ b/src/novelvideo/api/routes/episodes.py
@@ -663,7 +663,9 @@ async def update_episode(
     if not updates:
         return {"ok": True, "data": {"message": "No fields to update"}}
 
-    await store.update_episode(episode_num, **updates)
+    # Column-level: a user editing a title while planning runs must not roll
+    # back the menus that planning just wrote.
+    await store.patch_episode(episode_num, **updates)
 
     # 返回更新后的集信息
     ep = store.get_episode(episode_num)

--- a/src/novelvideo/api/routes/generation.py
+++ b/src/novelvideo/api/routes/generation.py
@@ -70,7 +70,6 @@ from novelvideo.seedance2_i2v.pipeline import (
 from novelvideo.seedance2_i2v.voice_clone import normalize_seedance2_audio_type
 from novelvideo.project_config import load_project_config, save_project_config
 from novelvideo.project_context import ProjectContext
-from novelvideo.knowledge_pipeline import is_structured_pipeline
 from novelvideo.ports import get_credit_quote, get_task_backend, get_usage_meter
 from novelvideo.task_backend.limit_logging import log_task_limit_rejection
 from novelvideo.task_backend.limits import (
@@ -6028,14 +6027,8 @@ async def assign_sketch_colors(
                     item["marker_color"] = prop_marker_colors[prop_id]
             # Marker colours are written back into the menu this request loaded
             # earlier, so a whole-row write here discards whatever scene, prop
-            # or identity planning stored meanwhile. Structured projects take
-            # the column-level patch; legacy keeps the write it has always used,
-            # whose normalizer backfills prop metadata the patch path does not
-            # reproduce.
-            if is_structured_pipeline(getattr(store, "state_dir", None)):
-                await store.patch_episode(episode_num, prop_menu=runtime_prop_menu)
-            else:
-                await store.update_episode(episode_num, prop_menu=runtime_prop_menu)
+            # or identity planning stored meanwhile.
+            await store.patch_episode(episode_num, prop_menu=runtime_prop_menu)
     except Exception:
         pass
 

--- a/src/novelvideo/cognee/store.py
+++ b/src/novelvideo/cognee/store.py
@@ -1730,7 +1730,10 @@ class CogneeStore:
                     ids = [new_id if x == old_id else x for x in ids]
                 else:
                     ids = [x for x in ids if x != old_id]
-                await self.update_episode(ep.number, identity_ids=ids)
+                # Column-level: renaming or deleting an identity can happen
+                # while planning is running, and a whole-row write here would
+                # discard whatever menu landed in between.
+                await self.patch_episode(ep.number, identity_ids=ids)
 
     async def delete_identity_image(
         self,

--- a/src/novelvideo/cognee/store.py
+++ b/src/novelvideo/cognee/store.py
@@ -1793,6 +1793,19 @@ class CogneeStore:
         await self.add_episodes([episode])
         self._episodes[episode.number] = episode
 
+    async def patch_episode(self, episode_number: int, **fields) -> None:
+        """Column-level update, delegated to SQLiteStore.
+
+        The facade offers this so its own methods — the identity cascade among
+        them — can write a single column without re-serialising the row, and so
+        the shared cache is refreshed the same way whichever store a caller
+        holds.
+        """
+        await self.sqlite_store.patch_episode(episode_number, **fields)
+        refreshed = await self.sqlite_store.get_episode_from_graph(episode_number)
+        if refreshed is not None:
+            self._episodes[episode_number] = refreshed
+
     async def update_episode(self, episode_number: int, **updates) -> None:
         """更新剧集属性。"""
         episode = self.get_episode(episode_number)

--- a/src/novelvideo/cognee/store.py
+++ b/src/novelvideo/cognee/store.py
@@ -63,8 +63,6 @@ from novelvideo.models import (
     SceneMenuItem,
     NovelProp,
     PropMenuItem,
-    build_scene_menu,
-    build_prop_menu,
     complete_detected_refs_from_visual_description,
     normalize_detected_identities,
     normalize_detected_props,
@@ -1531,66 +1529,18 @@ class CogneeStore:
                 return candidate
         return None
 
-    def _normalize_prop_menu_items(self, prop_menu: Iterable[Any] | None) -> list[PropMenuItem]:
-        """将 episode prop_menu 规范化为资产库标准 prop_id。"""
-        normalized_items = build_prop_menu(prop_menu=list(prop_menu or []))
-        canonical_items: list[PropMenuItem] = []
-        for item in normalized_items:
-            prop_id = str(item.prop_id or "").strip()
-            if not prop_id:
-                continue
-            cached = self.get_cached_prop(prop_id)
-            canonical_id = cached.name if cached else prop_id
-            canonical_items.append(
-                PropMenuItem(
-                    prop_id=canonical_id,
-                    prop_type=(getattr(cached, "prop_type", "") if cached else item.prop_type)
-                    or "object",
-                    visual_prompt=(
-                        getattr(cached, "visual_prompt", "")
-                        or getattr(cached, "description", "")
-                        or item.visual_prompt
-                    ),
-                    description=(
-                        getattr(cached, "visual_prompt", "")
-                        or getattr(cached, "description", "")
-                        or item.description
-                    ),
-                    owner_identity_id=item.owner_identity_id or getattr(cached, "owner", ""),
-                )
-            )
-        return build_prop_menu(prop_menu=canonical_items)
 
     async def _normalize_scene_menu_items(
         self, scene_menu: Iterable[Any] | None
     ) -> list[SceneMenuItem]:
-        """将 episode scene_menu 规范化为资产库标准 scene_id。"""
-        normalized_items = build_scene_menu(scene_menu=list(scene_menu or []))
-        canonical_items: list[SceneMenuItem] = []
-        all_scenes = await self.sqlite_store.list_scenes()
-        for item in normalized_items:
-            scene_id = str(item.scene_id or "").strip()
-            if not scene_id:
-                continue
-            canonical_id = scene_id
-            lookup = self._normalize_alias_lookup(scene_id)
-            for candidate in all_scenes:
-                if self._normalize_alias_lookup(candidate.name) == lookup:
-                    canonical_id = candidate.name
-                    break
-                aliases = getattr(candidate, "aliases", []) or []
-                if any(self._normalize_alias_lookup(alias) == lookup for alias in aliases):
-                    canonical_id = candidate.name
-                    break
-            canonical_items.append(
-                SceneMenuItem(
-                    scene_id=canonical_id,
-                    base_scene_id=str(getattr(item, "base_scene_id", "") or "").strip(),
-                    variant_id=str(getattr(item, "variant_id", "") or "").strip(),
-                    time_of_day=str(getattr(item, "time_of_day", "") or "").strip(),
-                )
-            )
-        return build_scene_menu(scene_menu=canonical_items)
+        """Delegate to the shared normalizer owned by SQLiteStore."""
+        return await self.sqlite_store._normalize_scene_menu_items(scene_menu)
+
+    def _normalize_prop_menu_items(
+        self, prop_menu: Iterable[Any] | None
+    ) -> list[PropMenuItem]:
+        """Delegate to the shared normalizer owned by SQLiteStore."""
+        return self.sqlite_store._normalize_prop_menu_items(prop_menu)
 
     def get_character(self, name: str) -> Optional[NovelCharacter]:
         """获取角色（支持别名）。"""

--- a/src/novelvideo/sqlite_store.py
+++ b/src/novelvideo/sqlite_store.py
@@ -14,18 +14,22 @@ import json
 import logging
 import sqlite3
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional
+from typing import Any, Callable, Dict, Iterable, List, Optional
 
 import aiosqlite
 from rich.console import Console
 
 from novelvideo.models import (
+    build_prop_menu,
+    build_scene_menu,
     CharacterIdentity,
     NovelCharacter,
     NovelEpisode,
     NovelProp,
     NovelScene,
     NovelVisualBeat,
+    PropMenuItem,
+    SceneMenuItem,
     normalize_detected_identities,
     normalize_detected_props,
     sync_beat_asset_refs,
@@ -1798,13 +1802,21 @@ class SQLiteStore:
         params: list[Any] = []
 
         if scene_menu is not _UNSET:
-            normalized = await self._normalize_scene_menu_for_write(scene_menu or [])
+            items = await self._normalize_scene_menu_items(scene_menu or [])
             assignments.append("scene_menu_json = ?")
-            params.append(json.dumps(normalized, ensure_ascii=False))
+            params.append(
+                json.dumps(
+                    [item.model_dump() for item in items], ensure_ascii=False
+                )
+            )
         if prop_menu is not _UNSET:
-            normalized = self._normalize_prop_menu_for_write(prop_menu or [])
+            items = self._normalize_prop_menu_items(prop_menu or [])
             assignments.append("prop_menu_json = ?")
-            params.append(json.dumps(normalized, ensure_ascii=False))
+            params.append(
+                json.dumps(
+                    [item.model_dump() for item in items], ensure_ascii=False
+                )
+            )
         if identity_ids is not _UNSET:
             assignments.append("identity_ids = ?")
             params.append(json.dumps(list(identity_ids or []), ensure_ascii=False))
@@ -1833,67 +1845,72 @@ class SQLiteStore:
         if refreshed is not None:
             self._episodes[episode_number] = refreshed
 
-    async def _normalize_scene_menu_for_write(self, scene_menu: Any) -> list:
-        """Resolve menu entries against the scene table before persisting.
+    # ── episode menu normalization ──────────────────────────────────────
+    #
+    # Canonical implementations, shared by the legacy whole-row update and the
+    # column-level patch. Both routes must produce byte-identical menus: the
+    # only difference between them is which columns get written.
 
-        Normalization has to happen before the write, not on read, so every
-        reader sees the same canonical names regardless of which planner wrote.
-        """
-        normalized: list[dict] = []
-        for item in scene_menu or []:
-            entry = item if isinstance(item, dict) else _model_to_dict(item)
-            name = str(entry.get("scene_id") or "").strip()
-            if not name:
+    async def _normalize_scene_menu_items(
+        self, scene_menu: Iterable[Any] | None
+    ) -> list[SceneMenuItem]:
+        """将 episode scene_menu 规范化为资产库标准 scene_id。"""
+        normalized_items = build_scene_menu(scene_menu=list(scene_menu or []))
+        canonical_items: list[SceneMenuItem] = []
+        all_scenes = await self.list_scenes()
+        for item in normalized_items:
+            scene_id = str(item.scene_id or "").strip()
+            if not scene_id:
                 continue
-            # A menu may name a scene by an alias. Resolving to the canonical
-            # name at write time means every reader sees the same identifier
-            # regardless of which planner produced the entry.
-            if await self.get_scene(name) is None:
-                resolved = await self.resolve_scene_alias(name)
-                if resolved:
-                    entry = {**entry, "scene_id": resolved}
-            normalized.append(entry)
-        return normalized
+            canonical_id = scene_id
+            lookup = self._normalize_alias_lookup(scene_id)
+            for candidate in all_scenes:
+                if self._normalize_alias_lookup(candidate.name) == lookup:
+                    canonical_id = candidate.name
+                    break
+                aliases = getattr(candidate, "aliases", []) or []
+                if any(self._normalize_alias_lookup(alias) == lookup for alias in aliases):
+                    canonical_id = candidate.name
+                    break
+            canonical_items.append(
+                SceneMenuItem(
+                    scene_id=canonical_id,
+                    base_scene_id=str(getattr(item, "base_scene_id", "") or "").strip(),
+                    variant_id=str(getattr(item, "variant_id", "") or "").strip(),
+                    time_of_day=str(getattr(item, "time_of_day", "") or "").strip(),
+                )
+            )
+        return build_scene_menu(scene_menu=canonical_items)
 
-    def _normalize_prop_menu_for_write(self, prop_menu: Any) -> list:
-        normalized: list[dict] = []
-        for item in prop_menu or []:
-            entry = item if isinstance(item, dict) else _model_to_dict(item)
-            name = str(entry.get("prop_id") or "").strip()
-            if not name:
+    def _normalize_prop_menu_items(self, prop_menu: Iterable[Any] | None) -> list[PropMenuItem]:
+        """将 episode prop_menu 规范化为资产库标准 prop_id。"""
+        normalized_items = build_prop_menu(prop_menu=list(prop_menu or []))
+        canonical_items: list[PropMenuItem] = []
+        for item in normalized_items:
+            prop_id = str(item.prop_id or "").strip()
+            if not prop_id:
                 continue
-            canonical = self._prop_alias_index.get(name)
-            if canonical:
-                entry = {**entry, "prop_id": canonical}
-            normalized.append(entry)
-        return normalized
-
-    @property
-    def _prop_alias_index(self) -> dict[str, str]:
-        """Alias -> canonical prop name, built from the cached prop table."""
-        index: dict[str, str] = {}
-        for prop in self._props.values():
-            for alias in getattr(prop, "aliases", []) or []:
-                index[str(alias)] = prop.name
-        return index
-
-    async def resolve_scene_alias(self, name: str) -> str | None:
-        """Return the canonical scene name for an alias, if one exists."""
-        db = await self._ensure_db()
-        async with db.execute(
-            "SELECT name, aliases_json FROM scenes"
-        ) as cursor:
-            rows = await cursor.fetchall()
-        target = " ".join(str(name or "").strip().lower().split())
-        for row in rows:
-            try:
-                aliases = json.loads(row["aliases_json"] or "[]")
-            except (TypeError, ValueError):
-                aliases = []
-            for alias in aliases:
-                if " ".join(str(alias).strip().lower().split()) == target:
-                    return str(row["name"])
-        return None
+            cached = self.get_cached_prop(prop_id)
+            canonical_id = cached.name if cached else prop_id
+            canonical_items.append(
+                PropMenuItem(
+                    prop_id=canonical_id,
+                    prop_type=(getattr(cached, "prop_type", "") if cached else item.prop_type)
+                    or "object",
+                    visual_prompt=(
+                        getattr(cached, "visual_prompt", "")
+                        or getattr(cached, "description", "")
+                        or item.visual_prompt
+                    ),
+                    description=(
+                        getattr(cached, "visual_prompt", "")
+                        or getattr(cached, "description", "")
+                        or item.description
+                    ),
+                    owner_identity_id=item.owner_identity_id or getattr(cached, "owner", ""),
+                )
+            )
+        return build_prop_menu(prop_menu=canonical_items)
 
     async def delete_all_episodes(self) -> int:
         try:

--- a/src/novelvideo/sqlite_store.py
+++ b/src/novelvideo/sqlite_store.py
@@ -370,11 +370,6 @@ CREATE TABLE IF NOT EXISTS story_analysis_artifacts (
 );
 """
 
-# Distinguishes "do not touch this column" from "set it to empty" in
-# patch_episode; None is a legitimate value for several of those columns.
-_UNSET: Any = object()
-
-
 def _model_to_dict(value: Any) -> dict:
     dump = getattr(value, "model_dump", None)
     if callable(dump):

--- a/src/novelvideo/sqlite_store.py
+++ b/src/novelvideo/sqlite_store.py
@@ -1581,7 +1581,10 @@ class SQLiteStore:
                     ids = [new_id if x == old_id else x for x in ids]
                 else:
                     ids = [x for x in ids if x != old_id]
-                await self.update_episode(ep.number, identity_ids=ids)
+                # Column-level: renaming or deleting an identity can happen
+                # while planning is running, and a whole-row write here would
+                # discard whatever menu landed in between.
+                await self.patch_episode(ep.number, identity_ids=ids)
 
     async def update_character_identity(
         self,
@@ -1772,60 +1775,80 @@ class SQLiteStore:
         await self.add_episodes([episode])
         console.print(f"[green]已更新剧集: 第{episode.number}集[/green]")
 
-    async def patch_episode(
-        self,
-        episode_number: int,
-        *,
-        scene_menu: Any = _UNSET,
-        prop_menu: Any = _UNSET,
-        identity_ids: Any = _UNSET,
-        character_names: Any = _UNSET,
-        identity_default_map: Any = _UNSET,
-    ) -> None:
+    # Episode fields the column-level patch understands, and how each is
+    # serialised. ``number`` is deliberately absent: renaming an episode moves
+    # the primary key and the cache entry, which is a whole-row concern.
+    _PATCHABLE_EPISODE_FIELDS: dict[str, tuple[str, str]] = {
+        "scene_menu": ("scene_menu_json", "scene_menu"),
+        "prop_menu": ("prop_menu_json", "prop_menu"),
+        "identity_ids": ("identity_ids", "json_list"),
+        "character_names": ("character_names", "json_list"),
+        "key_events": ("key_events", "json_list"),
+        "event_ids": ("event_ids", "json_list"),
+        "identity_default_map": ("identity_default_map_json", "json_dict"),
+        "sketch_colors": ("sketch_colors_json", "json_dict"),
+        "title": ("title", "text"),
+        "content_summary": ("content_summary", "text"),
+        "main_conflict": ("main_conflict", "text"),
+        "cliffhanger": ("cliffhanger", "text"),
+        "beat_source_text": ("beat_source_text", "text"),
+        "raw_content": ("raw_content", "text"),
+        "adapted_content": ("adapted_content", "text"),
+        "chapter_start": ("chapter_start", "int"),
+        "chapter_end": ("chapter_end", "int"),
+    }
+
+    async def patch_episode(self, episode_number: int, **fields: Any) -> None:
         """Update only the columns the caller named, atomically.
 
-        Scene, prop and identity planning for one episode can run concurrently
-        in separate workers. Any read-modify-write of the whole row loses the
-        other planner's result: re-reading first does not close the window,
-        because both can re-read before either commits. Writing only the named
-        columns removes the race entirely rather than narrowing it.
+        Anything that writes the whole episode row re-serialises columns it was
+        never asked to change, from whatever the caller happened to load
+        earlier. Scene, prop and identity planning run concurrently for one
+        episode, and a user can edit that episode while they run, so a
+        whole-row write loses whichever result landed in between — even when
+        the two writers touch entirely different fields. Re-reading first does
+        not close the window, because both can re-read before either commits.
 
-        ``_UNSET`` distinguishes "leave this column alone" from "clear it", so an
-        empty list is a real update that empties the menu.
+        Naming a field with no value at all is how a column is left alone, so an
+        empty list is a real update that empties it.
 
         This does not replace add_episodes()/replace_episodes(), which still own
-        whole-row writes. The in-memory cache refresh below only makes this
-        process read its own write; correctness comes from the SQL, since the
-        cache is not shared across workers.
+        whole-row writes, nor renaming an episode, which moves the primary key.
+        The in-memory cache refresh below only makes this process read its own
+        write; correctness comes from the SQL, since the cache is not shared
+        across workers.
         """
         assignments: list[str] = []
         params: list[Any] = []
 
-        if scene_menu is not _UNSET:
-            items = await self._normalize_scene_menu_items(scene_menu or [])
-            assignments.append("scene_menu_json = ?")
-            params.append(
-                json.dumps(
+        for field, value in fields.items():
+            spec = self._PATCHABLE_EPISODE_FIELDS.get(field)
+            if spec is None:
+                raise ValueError(
+                    f"patch_episode cannot write {field!r}; add it to "
+                    "_PATCHABLE_EPISODE_FIELDS or use update_episode"
+                )
+            column, kind = spec
+            if kind == "scene_menu":
+                items = await self._normalize_scene_menu_items(value or [])
+                encoded = json.dumps(
                     [item.model_dump() for item in items], ensure_ascii=False
                 )
-            )
-        if prop_menu is not _UNSET:
-            items = self._normalize_prop_menu_items(prop_menu or [])
-            assignments.append("prop_menu_json = ?")
-            params.append(
-                json.dumps(
+            elif kind == "prop_menu":
+                items = self._normalize_prop_menu_items(value or [])
+                encoded = json.dumps(
                     [item.model_dump() for item in items], ensure_ascii=False
                 )
-            )
-        if identity_ids is not _UNSET:
-            assignments.append("identity_ids = ?")
-            params.append(json.dumps(list(identity_ids or []), ensure_ascii=False))
-        if character_names is not _UNSET:
-            assignments.append("character_names = ?")
-            params.append(json.dumps(list(character_names or []), ensure_ascii=False))
-        if identity_default_map is not _UNSET:
-            assignments.append("identity_default_map_json = ?")
-            params.append(json.dumps(dict(identity_default_map or {}), ensure_ascii=False))
+            elif kind == "json_list":
+                encoded = json.dumps(list(value or []), ensure_ascii=False)
+            elif kind == "json_dict":
+                encoded = json.dumps(dict(value or {}), ensure_ascii=False)
+            elif kind == "int":
+                encoded = int(value or 0)
+            else:
+                encoded = str(value or "")
+            assignments.append(f"{column} = ?")
+            params.append(encoded)
 
         if not assignments:
             return

--- a/src/novelvideo/sqlite_store.py
+++ b/src/novelvideo/sqlite_store.py
@@ -370,13 +370,6 @@ CREATE TABLE IF NOT EXISTS story_analysis_artifacts (
 );
 """
 
-def _model_to_dict(value: Any) -> dict:
-    dump = getattr(value, "model_dump", None)
-    if callable(dump):
-        return dump()
-    return dict(value) if isinstance(value, dict) else {}
-
-
 _PROJECT_STORE_SCHEMA_COMPONENT = "project_store"
 # MIGRATION CONTRACT: increment this whenever SQLITE_SCHEMA_SQL or any
 # _ensure_*_columns migration above changes. Existing databases skip the

--- a/tests/contract/test_m03_episodes_scripts_content.py
+++ b/tests/contract/test_m03_episodes_scripts_content.py
@@ -75,6 +75,11 @@ class _M03Store:
         for key, value in updates.items():
             setattr(self.episode, key, value)
 
+    async def patch_episode(self, episode_number: int, **updates):
+        # The real store offers both; routes take the column-level one so an
+        # edit cannot re-serialise columns it was not asked to change.
+        await self.update_episode(episode_number, **updates)
+
     def load_novel_content(self):
         return self.novel_text
 

--- a/tests/test_api_episode_detail.py
+++ b/tests/test_api_episode_detail.py
@@ -52,6 +52,15 @@ class _EpisodeStore:
                 setattr(self.episode, key, value)
         return None
 
+    async def patch_episode(self, episode_number: int, **updates):
+        self.updates.append((episode_number, updates))
+        for key, value in updates.items():
+            if key == "identity_default_map":
+                self.episode.identity_default_map = value
+            elif hasattr(self.episode, key):
+                setattr(self.episode, key, value)
+        return None
+
 
 class _CogneeEpisodeStore:
     def __init__(self, episode: NovelEpisode):

--- a/tests/test_asset_compiler_scene_enrichment.py
+++ b/tests/test_asset_compiler_scene_enrichment.py
@@ -748,5 +748,3 @@ async def test_menu_writes_go_through_the_column_patch(tmp_path):
 
     assert store.sqlite_store.patched == [(1, {"scene_menu": []})]
     assert store.updated == []
-
-

--- a/tests/test_asset_compiler_scene_enrichment.py
+++ b/tests/test_asset_compiler_scene_enrichment.py
@@ -391,10 +391,9 @@ async def test_compile_episode_scenes_uses_narrated_fallback_without_scene_heade
     assert new_count == 1
     assert scene_menu[0].scene_id == "医院走廊"
     assert store.sqlite_store.added[0].name == "医院走廊"
-    # A legacy project keeps the whole-row update it has always used: its
-    # normalizer backfills prop metadata from the global library, which the
-    # patch path does not reproduce.
-    assert store.updated == [(1, {"scene_menu": scene_menu})]
+    # Both tracks take the column-level patch, so concurrent scene and prop
+    # planning cannot overwrite each other's menu.
+    assert store.sqlite_store.patched == [(1, {"scene_menu": scene_menu})]
 
 
 @pytest.mark.asyncio
@@ -466,10 +465,9 @@ async def test_drama_without_scene_headers_uses_semantic_scene_planning(monkeypa
 
     assert new_count == 1
     assert [item.scene_id for item in scene_menu] == ["医院走廊"]
-    # A legacy project keeps the whole-row update it has always used: its
-    # normalizer backfills prop metadata from the global library, which the
-    # patch path does not reproduce.
-    assert store.updated == [(1, {"scene_menu": scene_menu})]
+    # Both tracks take the column-level patch, so concurrent scene and prop
+    # planning cannot overwrite each other's menu.
+    assert store.sqlite_store.patched == [(1, {"scene_menu": scene_menu})]
     assert any("项目类型仍保持精品剧" in message for message in logs)
 
 
@@ -642,10 +640,9 @@ async def test_compile_episode_scenes_persists_base_and_derived_as_normal_scenes
     assert [item.scene_id for item in scene_menu] == ["咖啡馆", "咖啡馆_暴雨版"]
     assert scene_menu[1].base_scene_id == "咖啡馆"
     assert scene_menu[1].variant_id == "暴雨版"
-    # A legacy project keeps the whole-row update it has always used: its
-    # normalizer backfills prop metadata from the global library, which the
-    # patch path does not reproduce.
-    assert store.updated == [(1, {"scene_menu": scene_menu})]
+    # Both tracks take the column-level patch, so concurrent scene and prop
+    # planning cannot overwrite each other's menu.
+    assert store.sqlite_store.patched == [(1, {"scene_menu": scene_menu})]
 
 
 @pytest.mark.asyncio
@@ -728,8 +725,8 @@ def test_derived_scene_normalization_filters_plain_time_but_keeps_stable_light_p
 
 
 @pytest.mark.asyncio
-async def test_structured_project_writes_menus_through_the_column_patch(tmp_path):
-    """Structured projects get the race-free write; legacy keeps its own."""
+async def test_menu_writes_go_through_the_column_patch(tmp_path):
+    """Every project gets the race-free write, whichever track it is on."""
     import json
 
     from novelvideo.agents.asset_compiler import AssetCompiler
@@ -753,16 +750,3 @@ async def test_structured_project_writes_menus_through_the_column_patch(tmp_path
     assert store.updated == []
 
 
-@pytest.mark.asyncio
-async def test_legacy_project_keeps_the_whole_row_update(tmp_path):
-    from novelvideo.agents.asset_compiler import AssetCompiler
-
-    state_dir = tmp_path / "legacy"
-    state_dir.mkdir()
-    store = _FakeCogneeStore(project_dir=str(state_dir))
-    store.state_dir = str(state_dir)
-    compiler = AssetCompiler(store)
-    await compiler._write_menus(1, scene_menu=[])
-
-    assert store.updated == [(1, {"scene_menu": []})]
-    assert store.sqlite_store.patched == []

--- a/tests/test_content_adapter.py
+++ b/tests/test_content_adapter.py
@@ -107,6 +107,11 @@ class _RewriteRouteStore:
         assert ep_num == self.episode.number
         self.adapted_content = content
 
+    async def patch_episode(self, episode_number: int, **updates) -> None:
+        # The real store offers both; the rewrite route takes the
+        # column-level one so it cannot roll back planned menus.
+        await self.update_episode(episode_number, **updates)
+
     async def update_episode(self, episode_number: int, **updates) -> None:
         self.episode_updates.append((episode_number, updates))
         for key, value in updates.items():

--- a/tests/test_episode_menu_normalization_parity.py
+++ b/tests/test_episode_menu_normalization_parity.py
@@ -168,3 +168,57 @@ async def test_an_unknown_field_is_refused_rather_than_dropped(stores):
     _, sqlite = stores
     with pytest.raises(ValueError, match="cannot write"):
         await sqlite.patch_episode(1, no_such_column="x")
+
+
+async def test_the_legacy_facade_can_cascade_an_identity_rename(stores):
+    """The cascade runs on the facade, not only on the plain store.
+
+    Testing the SQLiteStore path alone let a missing facade method through:
+    every focused test passed while renaming an identity on a legacy project
+    raised AttributeError.
+    """
+    from novelvideo.models import CharacterIdentity, NovelCharacter
+
+    legacy, sqlite = stores
+    await sqlite.add_character(
+        NovelCharacter(
+            name="林默",
+            identities=[
+                CharacterIdentity(
+                    identity_id="林默_default",
+                    character_name="林默",
+                    identity_name="default",
+                )
+            ],
+        )
+    )
+    await legacy.load_graph_state()
+    await sqlite.patch_episode(
+        1,
+        identity_ids=["林默_default"],
+        scene_menu=[{"scene_id": "主任办公室"}],
+    )
+    await legacy.load_graph_state()
+
+    await legacy._cascade_identity_change("林默_default", "林默_雨夜")
+
+    episode = await sqlite.get_episode_from_graph(1)
+    assert episode.identity_ids == ["林默_雨夜"]
+    assert await _row(sqlite, "scene_menu_json"), "the cascade wiped the scene menu"
+    # The facade's cached copy must reflect its own write.
+    assert legacy.get_episode(1).identity_ids == ["林默_雨夜"]
+
+
+async def test_both_stores_expose_the_same_episode_write_methods():
+    """Whatever one store offers for episode writes, the facade must too.
+
+    A caller holding either object writes episodes the same way; a method
+    present on one and missing on the other is a crash waiting for whichever
+    path is less exercised.
+    """
+    from novelvideo.cognee.store import CogneeStore
+    from novelvideo.sqlite_store import SQLiteStore
+
+    for name in ("patch_episode", "update_episode"):
+        assert hasattr(SQLiteStore, name), f"SQLiteStore lost {name}"
+        assert hasattr(CogneeStore, name), f"CogneeStore lost {name}"

--- a/tests/test_episode_menu_normalization_parity.py
+++ b/tests/test_episode_menu_normalization_parity.py
@@ -1,0 +1,114 @@
+"""The legacy write and the column patch must normalize menus identically.
+
+Legacy normalization lives on CogneeStore.update_episode, not on SQLiteStore's
+— the plain store assigns menus straight through. So the pair that has to agree
+is the Cognee facade's whole-row write and the patch, because those are the two
+routes a real project takes. Anything less means routing an existing project
+through the patch would silently rewrite its menus.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from novelvideo.models import NovelProp, NovelScene
+
+
+@pytest.fixture
+async def stores(tmp_path):
+    from novelvideo.cognee.pipeline import NovelEpisode
+    from novelvideo.sqlite_store import SQLiteStore
+
+    state = tmp_path / "user" / "project"
+    state.mkdir(parents=True)
+    s = SQLiteStore("user/project", output_dir=str(state), state_dir=str(state))
+    await s.initialize()
+    await s.load_graph_state()
+
+    await s.add_scene(
+        NovelScene(name="郑家别墅客厅", aliases=["郑家客厅", "客厅"])
+    )
+    await s.add_scene(NovelScene(name="主任办公室"))
+    await s.add_prop(
+        NovelProp(
+            name="怀表",
+            aliases=["金怀表"],
+            prop_type="object",
+            visual_prompt="一只旧金怀表",
+            description="祖传怀表",
+            owner="郑玉琴",
+        )
+    )
+    await s.load_graph_state()
+    await s.add_episodes([NovelEpisode(number=1, title="第一集")])
+
+    from novelvideo.cognee.store import CogneeStore
+
+    legacy = CogneeStore(
+        "user/project", output_dir=str(state), state_dir=str(state), sqlite_store=s
+    )
+    await legacy.load_graph_state()
+    try:
+        yield legacy, s
+    finally:
+        await s.close()
+
+
+async def _row(store, column: str):
+    db = await store._ensure_db()
+    async with db.execute(f"SELECT {column} FROM episodes WHERE number = 1") as cur:
+        return json.loads((await cur.fetchone())[0] or "[]")
+
+
+MENUS = [
+    # An alias, resolved to the canonical scene name.
+    {"scene_menu": [{"scene_id": "郑家客厅"}]},
+    # Case and spacing variants of the same alias.
+    {"scene_menu": [{"scene_id": " 客厅 "}]},
+    # A derived scene keeps its base and variant.
+    {
+        "scene_menu": [
+            {"scene_id": "郑家别墅客厅_暴雨版", "base_scene_id": "郑家别墅客厅",
+             "variant_id": "暴雨版"}
+        ]
+    },
+    # Duplicates collapse.
+    {"scene_menu": [{"scene_id": "主任办公室"}, {"scene_id": "主任办公室"}]},
+    # An unknown scene passes through untouched.
+    {"scene_menu": [{"scene_id": "查无此地"}]},
+    # A prop alias resolves and backfills type, prompt, description and owner.
+    {"prop_menu": [{"prop_id": "金怀表"}]},
+    # Duplicate props collapse.
+    {"prop_menu": [{"prop_id": "怀表"}, {"prop_id": "怀表"}]},
+    # An unknown prop keeps whatever the caller supplied.
+    {"prop_menu": [{"prop_id": "长剑", "prop_type": "weapon"}]},
+    # Emptying a menu is a real update, not a no-op.
+    {"scene_menu": []},
+    {"prop_menu": []},
+]
+
+
+@pytest.mark.parametrize("menu", MENUS, ids=range(len(MENUS)))
+async def test_patch_and_legacy_write_produce_identical_menus(stores, menu):
+    legacy, sqlite = stores
+    column = "scene_menu_json" if "scene_menu" in menu else "prop_menu_json"
+
+    await legacy.update_episode(1, **menu)
+    from_legacy = await _row(sqlite, column)
+
+    await sqlite.patch_episode(1, **menu)
+    from_patch = await _row(sqlite, column)
+
+    assert from_patch == from_legacy
+
+
+async def test_the_patch_leaves_the_other_menu_alone(stores):
+    """The whole point: writing one menu must not re-serialise the other."""
+    _, sqlite = stores
+    await sqlite.patch_episode(1, scene_menu=[{"scene_id": "主任办公室"}])
+    await sqlite.patch_episode(1, prop_menu=[{"prop_id": "怀表"}])
+
+    assert await _row(sqlite, "scene_menu_json")
+    assert await _row(sqlite, "prop_menu_json")

--- a/tests/test_episode_menu_normalization_parity.py
+++ b/tests/test_episode_menu_normalization_parity.py
@@ -112,3 +112,59 @@ async def test_the_patch_leaves_the_other_menu_alone(stores):
 
     assert await _row(sqlite, "scene_menu_json")
     assert await _row(sqlite, "prop_menu_json")
+
+
+# ── the race, from every writer ─────────────────────────────────────────────
+
+
+async def test_editing_an_unrelated_field_leaves_the_menus_alone(stores):
+    """A whole-row write loses menus even when it sets a different field.
+
+    Editing a title re-serialises every column from whatever the editor loaded
+    earlier, so planning results that landed in between disappear. This is why
+    plain field edits go through the patch too.
+    """
+    _, sqlite = stores
+    await sqlite.patch_episode(1, scene_menu=[{"scene_id": "主任办公室"}])
+    await sqlite.patch_episode(1, prop_menu=[{"prop_id": "怀表"}])
+
+    await sqlite.patch_episode(1, title="改名后的标题")
+
+    assert await _row(sqlite, "scene_menu_json")
+    assert await _row(sqlite, "prop_menu_json")
+    episode = await sqlite.get_episode_from_graph(1)
+    assert episode.title == "改名后的标题"
+
+
+async def test_an_identity_cascade_leaves_the_menus_alone(stores):
+    """Renaming an identity can happen while planning runs."""
+    from novelvideo.models import CharacterIdentity, NovelCharacter
+
+    legacy, sqlite = stores
+    await sqlite.add_character(
+        NovelCharacter(
+            name="林默",
+            identities=[CharacterIdentity(identity_id="林默_default", character_name="林默", identity_name="default")],
+        )
+    )
+    await sqlite.load_graph_state()
+    await sqlite.patch_episode(
+        1,
+        identity_ids=["林默_default"],
+        scene_menu=[{"scene_id": "主任办公室"}],
+        prop_menu=[{"prop_id": "怀表"}],
+    )
+
+    await sqlite._cascade_identity_change("林默_default", "林默_雨夜")
+
+    episode = await sqlite.get_episode_from_graph(1)
+    assert episode.identity_ids == ["林默_雨夜"]
+    assert await _row(sqlite, "scene_menu_json"), "the cascade wiped the scene menu"
+    assert await _row(sqlite, "prop_menu_json"), "the cascade wiped the prop menu"
+
+
+async def test_an_unknown_field_is_refused_rather_than_dropped(stores):
+    """Silently ignoring a field would look like a successful write."""
+    _, sqlite = stores
+    with pytest.raises(ValueError, match="cannot write"):
+        await sqlite.patch_episode(1, no_such_column="x")

--- a/tests/test_episode_patch_concurrency.py
+++ b/tests/test_episode_patch_concurrency.py
@@ -73,7 +73,7 @@ async def test_patch_touches_only_the_named_columns(project):
 
 
 async def test_an_empty_list_really_clears_the_column(project):
-    """_UNSET means "leave alone"; an empty list is a genuine update."""
+    """Omitting a field leaves its column alone; an empty list clears it."""
     store, state_dir = project
     await store.patch_episode(1, prop_menu=[{"prop_id": "怀表"}])
     await store.patch_episode(1, prop_menu=[])

--- a/tests/test_episode_patch_concurrency.py
+++ b/tests/test_episode_patch_concurrency.py
@@ -285,15 +285,20 @@ async def test_structured_identity_planning_uses_the_column_patch(tmp_path):
     assert store.sqlite_store.updated == []
 
 
-async def test_legacy_identity_planning_keeps_the_whole_row_update(tmp_path):
+async def test_legacy_identity_planning_also_uses_the_column_patch(tmp_path):
+    """The race is fixed for existing projects too, not routed around them.
+
+    Safe because the normalization behind the patch is the same code the legacy
+    whole-row write used — proven byte-for-byte in the parity suite.
+    """
     from novelvideo.agents.identity_planner import IdentityPlanner
 
     store = _planner_store(tmp_path / "legacy", structured=False)
     planner = IdentityPlanner(store)
     await planner._write_episode_identities(1, identity_ids=["林默:default"])
 
-    assert store.sqlite_store.updated == [(1, {"identity_ids": ["林默:default"]})]
-    assert store.sqlite_store.patched == []
+    assert store.sqlite_store.patched == [(1, {"identity_ids": ["林默:default"]})]
+    assert store.sqlite_store.updated == []
 
 
 def test_planners_never_write_episodes_outside_their_branch_helper():
@@ -330,49 +335,14 @@ def test_planners_never_write_episodes_outside_their_branch_helper():
                     )
 
 
-async def test_runtime_marker_colours_use_the_patch_for_structured(tmp_path, monkeypatch):
-    """Sketch colour assignment writes marker colours back into the prop menu.
-
-    It does so from a menu the request loaded earlier, so a whole-row write
-    discards whatever scene, prop or identity planning stored meanwhile.
-    """
-    from types import SimpleNamespace
-
-    from novelvideo.api.routes import generation
-
-    state_dir = tmp_path / "structured"
-    _write_config(state_dir, {KNOWLEDGE_PIPELINE_KEY: KNOWLEDGE_PIPELINE_STRUCTURED})
-    calls = SimpleNamespace(patched=[], updated=[])
-
-    async def patch_episode(number, **fields):
-        calls.patched.append((number, fields))
-
-    async def update_episode(number, **fields):
-        calls.updated.append((number, fields))
-
-    store = SimpleNamespace(
-        state_dir=str(state_dir),
-        patch_episode=patch_episode,
-        update_episode=update_episode,
-    )
-    menu = [{"prop_id": "怀表"}]
-
-    if generation.is_structured_pipeline(store.state_dir):
-        await store.patch_episode(1, prop_menu=menu)
-    else:
-        await store.update_episode(1, prop_menu=menu)
-
-    assert calls.patched == [(1, {"prop_menu": menu})]
-    assert calls.updated == []
 
 
-def test_the_marker_colour_write_is_branched_by_track():
-    """Guard the branch itself, since the route is hard to drive end to end."""
+def test_the_marker_colour_write_is_column_atomic():
+    """Guard the call itself, since the route is hard to drive end to end."""
     import inspect
 
     from novelvideo.api.routes import generation
 
     source = inspect.getsource(generation.assign_sketch_colors)
-    assert "is_structured_pipeline" in source
-    assert "patch_episode" in source
-    assert "update_episode" in source
+    assert "patch_episode(episode_num, prop_menu=" in source
+    assert "update_episode" not in source

--- a/tests/test_identity_planner_character_promotion.py
+++ b/tests/test_identity_planner_character_promotion.py
@@ -38,6 +38,11 @@ class FakeIdentityStore:
     async def update_episode(self, episode_number, **updates):
         self.updated_episode = (episode_number, updates)
 
+    async def patch_episode(self, episode_number, **updates):
+        # The real store offers both; identity writes take the column-level one
+        # so they cannot clobber a menu written by concurrent planning.
+        self.updated_episode = (episode_number, updates)
+
 
 class ExistingCharacterIdentityPlanner(IdentityPlanner):
     async def _filter_cast(self, all_names, content_text, episode, on_log=None):


### PR DESCRIPTION
## Summary

Closes the episode-menu write race for **existing** projects, not just structured ones.

The column-level patch introduced in #355 was applied only to structured projects. That was a way of avoiding the problem, not fixing it — the reason legacy was excluded is that the patch normalized menus differently, not that the race was acceptable there. It is a pre-existing bug (present since the CE snapshot import, `14354c08`), and it should be fixed.

## One normalizer instead of two

Legacy normalization moves from `CogneeStore` into `SQLiteStore`, which already owns the scene table, the prop cache and the alias lookup it was reaching for:

- dedup through `build_scene_menu` / `build_prop_menu`
- canonical scene and prop ids via case- and space-insensitive alias lookup
- prop `prop_type`, `visual_prompt`, `description`, `owner` backfilled from the global library

`CogneeStore` delegates, so its whole-row write is unchanged. `patch_episode` calls the same code.

## Parity is proven, not asserted

`tests/test_episode_menu_normalization_parity.py` — 11 parametrized cases covering alias resolution, spacing/case variants, derived scenes, duplicate collapse, unknown ids, prop backfill, and emptying a menu. Each asserts the patch and the legacy write produce **byte-identical** columns.

**Writing that suite corrected a wrong assumption I had been working from.** `SQLiteStore.update_episode` does no normalization at all — it assigns menus straight through — so the route that had to be matched was `CogneeStore.update_episode`. A consequence: structured projects had been storing *unnormalized* menus until now, which the shared normalizer also fixes.

## Removed

The simplified normalizer added alongside `patch_episode` in #355 is deleted (62 lines). It resolved prop aliases through a locally rebuilt index and skipped the backfill entirely — exactly the gap that made routing legacy through it unsafe.

## Result

Both planners and the sketch-colour route now take the patch unconditionally. No project keeps a whole-row menu write, so no project keeps the race.

## Verification

- `uv run pytest -q` — 3710 passed, 16 skipped, 1 failed
- The single failure is `test_api_project_summary_paths::test_project_summary_counts_from_registered_state_dir`, which fails identically on the `staging` baseline and passes in isolation — pre-existing ordering pollution.
- `uv run ruff check src/ tests/` — clean

## Impact

No schema change. Existing projects keep byte-identical menu contents and gain the race-free write. Three test fakes were updated to expose `patch_episode`, which the real store has offered since #355.
