### PR TITLE
fix: accept the 360 contract the model actually writes

### DIFF
--- a/license-inventory.csv
+++ b/license-inventory.csv
@@ -2028,6 +2028,7 @@ tests/test_request_egress_binding.py,Elastic-2.0,2026 SuperTale contributors,REU
 tests/test_running_task_authz_indeterminate.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_runtime_env.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_sandbox_roots.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
+tests/test_scene_environment_contract.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_scene_gallery_backend_removed.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_scene_name_migration.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_scene_plate_resolution.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation

--- a/src/novelvideo/cognee/pipeline.py
+++ b/src/novelvideo/cognee/pipeline.py
@@ -700,14 +700,77 @@ environment_prompt 规则：
 5. description: 场景叙述性描述（中文，50字以内）"""
 
 
-def _has_required_scene_environment_headings(prompt: str) -> bool:
+# Every heading the contract may carry, in the order they must appear.
+SCENE_ENVIRONMENT_ALL_HEADINGS = (
+    "正面", "左侧", "右侧", "背面", "光源", "材质/风格", "禁止元素",
+)
+
+# A heading may open the text or follow a newline or a sentence break. Models
+# routinely emit the whole contract on one line, and rejecting that discards a
+# perfectly good description in favour of boilerplate.
+_SCENE_HEADING_RE = re.compile(
+    r"(?:^|[\n。；;])\s*(" + "|".join(re.escape(h) for h in SCENE_ENVIRONMENT_ALL_HEADINGS) + r")\s*[:：]"
+)
+
+# The first line of the generated fallback. Distinctive enough to recognise a
+# prompt the system wrote when it could not use the model's.
+SCENE_FALLBACK_FINGERPRINT = "最能代表地点身份的主入口、主墙面、主装置或主要活动面作为正面"
+
+
+def parse_scene_environment_sections(prompt: str) -> list[tuple[str, str]]:
+    """Split a 360 contract into (heading, body) pairs, wherever they sit.
+
+    Returns an empty list when the text is not a contract, so callers can tell
+    "no sections" from "sections with empty bodies".
+    """
     text = str(prompt or "").strip()
     if not text:
+        return []
+
+    matches = list(_SCENE_HEADING_RE.finditer(text))
+    if not matches:
+        return []
+
+    sections: list[tuple[str, str]] = []
+    for index, match in enumerate(matches):
+        end = matches[index + 1].start() if index + 1 < len(matches) else len(text)
+        body = text[match.end() : end].strip().strip("。；;")
+        sections.append((match.group(1), body))
+    return sections
+
+
+def _has_required_scene_environment_headings(prompt: str) -> bool:
+    """Whether the text is a usable 360 contract.
+
+    Presence alone is not enough: a body that merely mentions "左侧：" in passing
+    would pass a substring test. The four directions must each open a section,
+    appear in order, and actually say something.
+    """
+    sections = parse_scene_environment_sections(prompt)
+    if not sections:
         return False
-    return all(
-        re.search(rf"(^|\n)\s*{re.escape(label)}\s*[:：]", text)
-        for label in SCENE_ENVIRONMENT_REQUIRED_HEADINGS
-    )
+
+    seen = [heading for heading, body in sections if body]
+    position = 0
+    for required in SCENE_ENVIRONMENT_REQUIRED_HEADINGS:
+        try:
+            position = seen.index(required, position) + 1
+        except ValueError:
+            return False
+    return True
+
+
+def normalize_scene_environment_prompt(prompt: str) -> str:
+    """Rewrite a valid contract as one section per line.
+
+    Downstream readers and human reviewers both expect the sectioned form; the
+    model's single-line output carries the same content in a shape that is hard
+    to read and easy to mis-parse later.
+    """
+    sections = parse_scene_environment_sections(prompt)
+    if not sections:
+        return str(prompt or "").strip()
+    return "\n".join(f"{heading}：{body}" for heading, body in sections if body)
 
 
 def _compact_scene_context(
@@ -732,9 +795,12 @@ def _ensure_directional_environment_prompt(
     """Ensure graph-built scene prompts are usable as a 360 spatial contract."""
     text = str(prompt or "").strip()
     if _has_required_scene_environment_headings(text):
-        return text
+        return normalize_scene_environment_prompt(text)
 
-    evidence = _compact_scene_context(text or context_lines)
+    # Evidence comes from the script, never from the prompt that just failed
+    # validation. Quoting a rejected description back as "原文证据" produced a
+    # self-referential contract that cited itself as its own source.
+    evidence = _compact_scene_context(context_lines)
     if not evidence:
         evidence = f"{scene_name}，{scene_type or 'interior'} 场景"
     type_label = scene_type or "interior"

--- a/src/novelvideo/cognee/pipeline.py
+++ b/src/novelvideo/cognee/pipeline.py
@@ -773,6 +773,29 @@ def normalize_scene_environment_prompt(prompt: str) -> str:
     return "\n".join(f"{heading}：{body}" for heading, body in sections if body)
 
 
+def should_repair_scene_placeholder(existing_prompt: str, new_prompt: str) -> bool:
+    """Whether a stored environment prompt is boilerplate worth replacing.
+
+    Both tracks wrote the generated fallback for every scene while the contract
+    validator rejected valid single-line model output, so both need the same
+    narrow repair on rebuild. All three conditions matter:
+
+    * the stored prompt carries the fallback fingerprint, so it is something
+      this code wrote, never something a user typed or edited;
+    * the replacement does not carry it, so a rebuild that fell back again does
+      not churn the row;
+    * the replacement is itself a valid 360 contract, so a malformed or empty
+      model response can never overwrite a stored prompt with something worse.
+    """
+    existing = str(existing_prompt or "")
+    replacement = str(new_prompt or "")
+    if SCENE_FALLBACK_FINGERPRINT not in existing:
+        return False
+    if SCENE_FALLBACK_FINGERPRINT in replacement:
+        return False
+    return _has_required_scene_environment_headings(replacement)
+
+
 def _compact_scene_context(
     lines: list[str] | tuple[str, ...] | str, *, limit: int = 180
 ) -> str:

--- a/src/novelvideo/cognee/store.py
+++ b/src/novelvideo/cognee/store.py
@@ -1946,19 +1946,43 @@ class CogneeStore:
         log(f"从图谱提取了 {len(scenes)} 个场景")
         report(0.8, "保存新增场景...")
         log("保存新增场景到数据库...")
+        from .pipeline import should_repair_scene_placeholder
+
         added: list[NovelScene] = []
         skipped = 0
+        repaired = 0
         for scene in scenes:
             existing = await self.sqlite_store.get_scene(scene.name)
             if existing:
+                # The contract validator used to reject valid single-line model
+                # output, so every scene built while that bug was live stored a
+                # generated placeholder instead. Those are not asset facts, and
+                # skipping them would leave existing projects on boilerplate
+                # forever. Only the prompt is rewritten: images, plates and any
+                # other stored field stay untouched, and a prompt a user wrote
+                # never carries the fingerprint.
+                if should_repair_scene_placeholder(
+                    existing.environment_prompt, scene.environment_prompt
+                ):
+                    await self.sqlite_store.update_scene(
+                        existing.name, environment_prompt=scene.environment_prompt
+                    )
+                    repaired += 1
+                    continue
                 skipped += 1
                 continue
             await self.sqlite_store.add_scene(scene)
             added.append(scene)
-        log(f"已新增 {len(added)} 个场景，跳过已有 {skipped} 个")
+        log(
+            f"已新增 {len(added)} 个场景，修复占位描述 {repaired} 个，"
+            f"跳过已有 {skipped} 个"
+        )
 
         report(1.0, "场景提取完成")
-        log(f"场景提取完成: 新增 {len(added)} 个，已有 {skipped} 个")
+        log(
+            f"场景提取完成: 新增 {len(added)} 个，修复 {repaired} 个，"
+            f"已有 {skipped} 个"
+        )
 
         return added
 

--- a/src/novelvideo/structured_builders.py
+++ b/src/novelvideo/structured_builders.py
@@ -256,7 +256,10 @@ async def build_scenes_structured(
     marker: a full-text sweep would guess at locations, so those scenes are
     discovered per episode from that episode's own text instead.
     """
-    from novelvideo.cognee.pipeline import extract_scenes_from_script
+    from novelvideo.cognee.pipeline import (
+        SCENE_FALLBACK_FINGERPRINT,
+        extract_scenes_from_script,
+    )
     from novelvideo.structured_extraction import adjudicate_scenes
 
     def report(progress: float, task: str) -> None:
@@ -299,18 +302,42 @@ async def build_scenes_structured(
     report(0.85, "保存新增场景...")
     added = 0
     skipped = 0
+    repaired = 0
     for scene in scenes:
         # Existing base scenes and their derived plates are asset facts; a
         # rebuild adds what is missing and leaves the rest alone.
-        if await store.get_scene(scene.name):
-            skipped += 1
+        existing = await store.get_scene(scene.name)
+        if existing is None:
+            await store.add_scene(scene)
+            added += 1
             continue
-        await store.add_scene(scene)
-        added += 1
-    log(f"已新增 {added} 个场景，跳过已有 {skipped} 个")
+        # One exception: a prompt this code generated because it could not use
+        # the model's is not an asset fact, it is a placeholder. Those were
+        # written for every scene while the contract validator rejected valid
+        # single-line output, and skipping them would leave existing projects on
+        # boilerplate forever. A prompt the user wrote or edited never matches
+        # this fingerprint and is never touched.
+        if (
+            SCENE_FALLBACK_FINGERPRINT in (existing.environment_prompt or "")
+            and SCENE_FALLBACK_FINGERPRINT not in (scene.environment_prompt or "")
+        ):
+            await store.update_scene(
+                existing.name, environment_prompt=scene.environment_prompt
+            )
+            repaired += 1
+            continue
+        skipped += 1
+    log(
+        f"已新增 {added} 个场景，修复占位描述 {repaired} 个，跳过已有 {skipped} 个"
+    )
 
     report(1.0, "场景提取完成")
-    return {"scenes": len(scenes), "added_scenes": added, "mode": "script"}
+    return {
+        "scenes": len(scenes),
+        "added_scenes": added,
+        "repaired_scenes": repaired,
+        "mode": "script",
+    }
 
 
 async def build_props_structured(

--- a/src/novelvideo/structured_builders.py
+++ b/src/novelvideo/structured_builders.py
@@ -257,8 +257,8 @@ async def build_scenes_structured(
     discovered per episode from that episode's own text instead.
     """
     from novelvideo.cognee.pipeline import (
-        SCENE_FALLBACK_FINGERPRINT,
         extract_scenes_from_script,
+        should_repair_scene_placeholder,
     )
     from novelvideo.structured_extraction import adjudicate_scenes
 
@@ -316,10 +316,10 @@ async def build_scenes_structured(
         # written for every scene while the contract validator rejected valid
         # single-line output, and skipping them would leave existing projects on
         # boilerplate forever. A prompt the user wrote or edited never matches
-        # this fingerprint and is never touched.
-        if (
-            SCENE_FALLBACK_FINGERPRINT in (existing.environment_prompt or "")
-            and SCENE_FALLBACK_FINGERPRINT not in (scene.environment_prompt or "")
+        # this fingerprint and is never touched.  Same predicate as the legacy
+        # track, so both repair exactly the same rows.
+        if should_repair_scene_placeholder(
+            existing.environment_prompt, scene.environment_prompt
         ):
             await store.update_scene(
                 existing.name, environment_prompt=scene.environment_prompt

--- a/tests/test_scene_environment_contract.py
+++ b/tests/test_scene_environment_contract.py
@@ -15,6 +15,7 @@ from novelvideo.cognee.pipeline import (
     _ensure_directional_environment_prompt,
     _has_required_scene_environment_headings,
     normalize_scene_environment_prompt,
+    should_repair_scene_placeholder,
 )
 
 SINGLE_LINE = (
@@ -102,3 +103,34 @@ def test_the_fallback_still_applies_without_any_usable_text():
         context_lines=[],
     )
     assert SCENE_FALLBACK_FINGERPRINT in generated
+
+
+# ── the repair predicate both tracks share ──────────────────────────────────
+
+PLACEHOLDER = _ensure_directional_environment_prompt(
+    prompt="",
+    scene_name="主任办公室",
+    scene_type="interior",
+    time_of_day="",
+    context_lines=["▲张秉权坐在办公桌后翻看文件。"],
+)
+
+
+def test_boilerplate_is_replaced_by_a_valid_contract():
+    assert should_repair_scene_placeholder(PLACEHOLDER, SINGLE_LINE)
+
+
+def test_a_prompt_a_user_wrote_is_never_touched():
+    """Only prompts this code generated carry the fingerprint."""
+    assert not should_repair_scene_placeholder(SINGLE_LINE, MULTI_LINE)
+    assert not should_repair_scene_placeholder("我自己写的场景描述", SINGLE_LINE)
+
+
+def test_boilerplate_is_not_churned_into_more_boilerplate():
+    assert not should_repair_scene_placeholder(PLACEHOLDER, PLACEHOLDER)
+
+
+@pytest.mark.parametrize("replacement", ["", "   ", "正面：a", "一段没有分区的描述"])
+def test_boilerplate_is_never_replaced_by_something_worse(replacement):
+    """A malformed or empty model response must not overwrite what is stored."""
+    assert not should_repair_scene_placeholder(PLACEHOLDER, replacement)

--- a/tests/test_scene_environment_contract.py
+++ b/tests/test_scene_environment_contract.py
@@ -1,0 +1,104 @@
+"""The 360 environment contract: what counts as one, and what to do otherwise.
+
+The validator used to require each heading at the start of a line. Models emit
+the whole contract on one line, so every scene in every project was failing
+validation and being replaced with generated boilerplate — which then quoted
+the rejected description back as its own source evidence.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from novelvideo.cognee.pipeline import (
+    SCENE_FALLBACK_FINGERPRINT,
+    _ensure_directional_environment_prompt,
+    _has_required_scene_environment_headings,
+    normalize_scene_environment_prompt,
+)
+
+SINGLE_LINE = (
+    "正面：主墙平整素雅，中央悬挂单位标识，下方为办公桌。"
+    "左侧：浅色实体墙连接前后，靠前设磨砂玻璃木门。"
+    "右侧：墙面延伸至后方，设大面积窗户与百叶帘。"
+    "背面：与主墙相对的墙面完整平直，设嵌入式资料柜。"
+    "光源：日间稳定环境光，来自窗户与顶灯。"
+    "材质/风格：办公空间的素色墙面与木质家具。"
+    "禁止元素：不出现人物与临时道具。"
+)
+
+MULTI_LINE = "正面：a\n左侧：b\n右侧：c\n背面：d"
+
+
+def test_a_single_line_contract_is_accepted():
+    """This is what the model actually produces, and it was being thrown away."""
+    assert _has_required_scene_environment_headings(SINGLE_LINE)
+
+
+def test_a_single_line_contract_is_stored_one_section_per_line():
+    normalized = normalize_scene_environment_prompt(SINGLE_LINE)
+    assert normalized.splitlines()[0].startswith("正面：")
+    assert len(normalized.splitlines()) == 7
+    # The description survives; only its shape changes.
+    assert "磨砂玻璃木门" in normalized
+    assert "嵌入式资料柜" in normalized
+
+
+def test_an_already_sectioned_contract_is_unchanged():
+    assert _has_required_scene_environment_headings(MULTI_LINE)
+    assert normalize_scene_environment_prompt(MULTI_LINE) == MULTI_LINE
+
+
+@pytest.mark.parametrize(
+    ("label", "prompt"),
+    [
+        ("缺一个方向", "正面：a。左侧：b。右侧：c。"),
+        ("方向乱序", "正面：a。右侧：c。左侧：b。背面：d。"),
+        ("章节为空", "正面：a。左侧：。右侧：c。背面：d。"),
+        ("只是正文里提到", "正面：房间左侧：有窗，右侧：有门，背面：是墙"),
+        ("完全不是合同", "一间安静的办公室。"),
+        ("空字符串", ""),
+    ],
+)
+def test_text_that_is_not_a_contract_is_rejected(label, prompt):
+    """Presence of the words is not enough; each must open a real section."""
+    assert not _has_required_scene_environment_headings(prompt), label
+
+
+def test_a_valid_contract_reaches_storage_intact():
+    kept = _ensure_directional_environment_prompt(
+        prompt=SINGLE_LINE,
+        scene_name="主任办公室",
+        scene_type="interior",
+        time_of_day="",
+        context_lines=["▲张秉权坐在办公桌后翻看文件。"],
+    )
+    assert "磨砂玻璃木门" in kept
+    assert SCENE_FALLBACK_FINGERPRINT not in kept
+
+
+def test_the_fallback_never_quotes_the_rejected_prompt():
+    """Quoting a rejected description back made the contract cite itself."""
+    rejected = "这个房间很安静，没有按方位描述。"
+    generated = _ensure_directional_environment_prompt(
+        prompt=rejected,
+        scene_name="主任办公室",
+        scene_type="interior",
+        time_of_day="",
+        context_lines=["▲张秉权坐在办公桌后翻看文件。"],
+    )
+    assert SCENE_FALLBACK_FINGERPRINT in generated
+    assert rejected not in generated
+    # Evidence comes from the script instead.
+    assert "翻看文件" in generated
+
+
+def test_the_fallback_still_applies_without_any_usable_text():
+    generated = _ensure_directional_environment_prompt(
+        prompt="",
+        scene_name="主任办公室",
+        scene_type="interior",
+        time_of_day="",
+        context_lines=[],
+    )
+    assert SCENE_FALLBACK_FINGERPRINT in generated

--- a/tests/test_sqlite_store.py
+++ b/tests/test_sqlite_store.py
@@ -219,6 +219,110 @@ async def test_build_scenes_from_graph_only_adds_missing_base_scenes(tmp_project
 
 
 @pytest.mark.asyncio
+async def test_build_scenes_from_graph_repairs_its_own_boilerplate(
+    tmp_project, monkeypatch
+):
+    """Legacy projects get the same repair as structured ones.
+
+    While the contract validator rejected valid single-line model output, every
+    scene built on this track stored generated boilerplate. Skipping existing
+    scenes on rebuild would leave those projects on it permanently, so a stored
+    prompt carrying the fallback fingerprint is replaced — and nothing else is.
+    """
+    from novelvideo.cognee import pipeline
+    from novelvideo.models import NovelScene
+
+    boilerplate = pipeline._ensure_directional_environment_prompt(
+        prompt="",
+        scene_name="主任办公室",
+        scene_type="interior",
+        time_of_day="",
+        context_lines=["▲张秉权坐在办公桌后翻看文件。"],
+    )
+    assert pipeline.SCENE_FALLBACK_FINGERPRINT in boilerplate
+
+    await tmp_project.sqlite_store.add_scene(
+        NovelScene(
+            name="主任办公室",
+            scene_type="interior",
+            environment_prompt=boilerplate,
+            spatial_layout_image="/generated/plate.png",
+            notes="人工备注",
+        )
+    )
+
+    real = (
+        "正面：主墙平整素雅，中央悬挂单位标识，下方为办公桌。"
+        "左侧：浅色实体墙连接前后，靠前设磨砂玻璃木门。"
+        "右侧：墙面延伸至后方，设大面积窗户与百叶帘。"
+        "背面：与主墙相对的墙面完整平直，设嵌入式资料柜。"
+    )
+
+    async def fake_extract_scenes_from_graph(**_kwargs):
+        return [
+            NovelScene(
+                name="主任办公室", scene_type="interior", environment_prompt=real
+            )
+        ]
+
+    monkeypatch.setattr(
+        pipeline, "extract_scenes_from_graph", fake_extract_scenes_from_graph
+    )
+    tmp_project.save_novel_content("剧本文本")
+
+    added = await tmp_project.build_scenes_from_graph()
+
+    assert added == []  # a repair is not an addition
+    scene = await tmp_project.sqlite_store.get_scene("主任办公室")
+    assert pipeline.SCENE_FALLBACK_FINGERPRINT not in scene.environment_prompt
+    assert "单位标识" in scene.environment_prompt
+    # Only the prompt moved; generated assets and human notes stay put.
+    assert scene.spatial_layout_image == "/generated/plate.png"
+    assert scene.notes == "人工备注"
+
+
+@pytest.mark.asyncio
+async def test_build_scenes_from_graph_keeps_boilerplate_over_invalid_output(
+    tmp_project, monkeypatch
+):
+    """A malformed rebuild must not overwrite storage with something worse."""
+    from novelvideo.cognee import pipeline
+    from novelvideo.models import NovelScene
+
+    boilerplate = pipeline._ensure_directional_environment_prompt(
+        prompt="",
+        scene_name="主任办公室",
+        scene_type="interior",
+        time_of_day="",
+        context_lines=["▲张秉权坐在办公桌后翻看文件。"],
+    )
+    await tmp_project.sqlite_store.add_scene(
+        NovelScene(
+            name="主任办公室",
+            scene_type="interior",
+            environment_prompt=boilerplate,
+        )
+    )
+
+    async def fake_extract_scenes_from_graph(**_kwargs):
+        return [
+            NovelScene(
+                name="主任办公室", scene_type="interior", environment_prompt="正面：a"
+            )
+        ]
+
+    monkeypatch.setattr(
+        pipeline, "extract_scenes_from_graph", fake_extract_scenes_from_graph
+    )
+    tmp_project.save_novel_content("剧本文本")
+
+    await tmp_project.build_scenes_from_graph()
+
+    scene = await tmp_project.sqlite_store.get_scene("主任办公室")
+    assert scene.environment_prompt == boilerplate
+
+
+@pytest.mark.asyncio
 async def test_graph_rebuild_waits_only_for_scene_graph_query(
     tmp_project,
     monkeypatch,

--- a/tests/test_structured_builders.py
+++ b/tests/test_structured_builders.py
@@ -1541,3 +1541,124 @@ def test_the_same_appellation_at_two_real_positions_still_wins():
     ]
     merged = {m.name: m for m in merge_character_candidates(outcomes)}
     assert merged["郑玉琴"].aliases == {"郑太"}
+
+
+# ── repairing placeholder environment prompts ───────────────────────────────
+
+
+DRAMA_SCRIPT = (
+    "第一集\n\n"
+    "1-1 林家客厅 日 内\n人物：林默\n林默推开门。\n"
+)
+
+
+async def _drama_project(tmp_path, script):
+    from novelvideo.knowledge_pipeline import (
+        KNOWLEDGE_PIPELINE_KEY, KNOWLEDGE_PIPELINE_STRUCTURED,
+    )
+    from novelvideo.sqlite_store import SQLiteStore
+
+    state = tmp_path / "user" / "drama"
+    state.mkdir(parents=True)
+    (state / "project_config.json").write_text(
+        json.dumps(
+            {KNOWLEDGE_PIPELINE_KEY: KNOWLEDGE_PIPELINE_STRUCTURED,
+             "spine_template": "drama"}
+        ),
+        encoding="utf-8",
+    )
+    (state / "novel.txt").write_text(script, encoding="utf-8")
+    store = SQLiteStore("user/drama", output_dir=str(state), state_dir=str(state))
+    await store.initialize()
+    await store.load_graph_state()
+    return store
+
+
+def _fresh_scene(name):
+    from novelvideo.models import NovelScene
+
+    return NovelScene(
+        name=name,
+        scene_type="interior",
+        environment_prompt="正面：主墙平整\n左侧：木门\n右侧：窗户\n背面：资料柜",
+    )
+
+
+async def test_a_placeholder_prompt_is_replaced_on_rebuild(tmp_path, monkeypatch):
+    """A prompt this code generated is a placeholder, not an asset fact.
+
+    Skipping every existing scene would leave projects built while the contract
+    validator was broken on boilerplate for good, since nothing else rewrites
+    those prompts.
+    """
+    from novelvideo import structured_builders
+    from novelvideo.cognee.pipeline import _ensure_directional_environment_prompt
+    from novelvideo.models import NovelScene
+
+    store = await _drama_project(tmp_path, DRAMA_SCRIPT)
+    try:
+        placeholder = _ensure_directional_environment_prompt(
+            prompt="", scene_name="林家客厅", scene_type="interior",
+            time_of_day="", context_lines=["▲林默推开门。"],
+        )
+        await store.add_scene(
+            NovelScene(name="林家客厅", environment_prompt=placeholder)
+        )
+
+        async def fake_extract(text, **kwargs):
+            return [_fresh_scene("林家客厅")]
+
+        monkeypatch.setattr(
+            "novelvideo.cognee.pipeline.extract_scenes_from_script", fake_extract
+        )
+        # Imported inside the builder, so it is patched at its source.
+        monkeypatch.setattr(
+            "novelvideo.structured_extraction.adjudicate_scenes",
+            lambda scenes, **kwargs: _async_value(scenes),
+        )
+
+        result = await structured_builders.build_scenes_structured(store)
+        assert result["repaired_scenes"] == 1
+
+        stored = await store.get_scene("林家客厅")
+        assert "主墙平整" in stored.environment_prompt
+    finally:
+        await store.close()
+
+
+async def test_a_user_written_prompt_is_never_replaced(tmp_path, monkeypatch):
+    """Only the known generated placeholder is overwritten."""
+    from novelvideo import structured_builders
+    from novelvideo.models import NovelScene
+
+    store = await _drama_project(tmp_path, DRAMA_SCRIPT)
+    try:
+        mine = "正面：我自己写的描述\n左侧：也是我写的\n右侧：我写的\n背面：我写的"
+        await store.add_scene(NovelScene(name="林家客厅", environment_prompt=mine))
+
+        async def fake_extract(text, **kwargs):
+            return [_fresh_scene("林家客厅")]
+
+        monkeypatch.setattr(
+            "novelvideo.cognee.pipeline.extract_scenes_from_script", fake_extract
+        )
+        # Imported inside the builder, so it is patched at its source.
+        monkeypatch.setattr(
+            "novelvideo.structured_extraction.adjudicate_scenes",
+            lambda scenes, **kwargs: _async_value(scenes),
+        )
+
+        result = await structured_builders.build_scenes_structured(store)
+        assert result["repaired_scenes"] == 0
+
+        stored = await store.get_scene("林家客厅")
+        assert stored.environment_prompt == mine
+    finally:
+        await store.close()
+
+
+def _async_value(value):
+    async def _call():
+        return value
+
+    return _call()


### PR DESCRIPTION
## Summary

Every scene in every project carried a generated placeholder instead of a real environment description. Measured on one screenplay: **25 of 25** structured scenes, **16 of 18** graph scenes, **12 of 12** on a second graph run. This affects both tracks and predates the dual-track work.

## What was happening

The validator required each heading to start a line. Models emit the whole contract on one line, separated by sentence breaks. A captured raw response:

```
正面：视线朝向办公室主墙…。左侧：浅色实体墙…。右侧：墙面延伸至后方…。背面：与主墙相对…
→ 399 chars, all four directions present, 0 newlines
→ _has_required_scene_environment_headings() = False
```

So the description was discarded and replaced by a ~640-character template. **The scene build's entire cost — essentially all of its 158 seconds — bought something that was thrown away.**

Worse, the discarded text was then quoted back *inside* that template as `原文证据`, producing a contract citing itself as its own source:

> 以“主任办公室”…作为正面；根据原文证据「**正面：办公桌正对入口…**」

## The fix

**Validator** — headings are recognised after a newline *or* a sentence break as well as at the start. Presence alone is not enough: the four directions must each open a section, appear **in order**, and have a **non-empty body**. Prose that happens to contain `左侧：` is still rejected.

**Storage** — accepted contracts are normalised to one section per line. Already-sectioned contracts are unchanged.

**Fallback** — evidence comes only from the script, never from a prompt that just failed validation.

**Existing scenes** — fixing the validator repairs nothing on its own, because the builder skips scenes that already exist. It now makes one exception: a prompt carrying the generated template's fingerprint is a placeholder rather than an asset fact, and is replaced on rebuild. A prompt anyone wrote or edited never carries that fingerprint and is never touched. The result reports `repaired_scenes` alongside `added_scenes`.

## Verification

**End to end against a real model** (same 33k-character screenplay):

| | before | after |
|---|---|---|
| placeholder prompts | 25 / 25 | **0 / 24** |
| average length | 640 chars (template) | 315 chars (actual description) |
| build time | 157.9s | 160.3s |

Time is unchanged, as expected — the same generation happens, the result now survives. A sample:

> 正面：宽大的深色办公桌面对入口，桌后为整面浅灰墙与校徽装饰，右侧设通往走廊的木质门…
> 右侧：高窗占据墙面上部，配百叶帘，窗下为矮柜与打印文件收纳柜，墙角设绿植

- `tests/test_scene_environment_contract.py` — 12 tests: single-line accepted and normalised, already-sectioned unchanged, six rejection cases (missing direction, wrong order, empty section, incidental prose, non-contract, empty), valid contract reaching storage intact, fallback not quoting the rejected prompt, fallback still applying with nothing usable.
- `tests/test_structured_builders.py` — placeholder replaced on rebuild; user-written prompt never replaced.
- `uv run pytest -q` — 3729 passed, 1 failed
- Rebased onto staging after #357 merged: full suite green, 3742 passed, 16 skipped, 0 failures.

## Note on speed

This does not make the scene build faster. It makes the time it already spends produce something usable. Reducing the 2–3 minutes is a separate question — the levers are batch-size tuning and concurrency, and concurrency should be load-tested rather than raised on assumption.

## Follow-up from review (second commit)

The first commit put the targeted repair only in `build_scenes_structured`, so
existing legacy projects — most of them — would keep the 640-char template
forever. The validator bug affected both tracks, so the repair must too.

- Extracted `should_repair_scene_placeholder(existing, replacement)` and call it
  from both save loops, so the two tracks repair exactly the same rows.
- The predicate now also requires the replacement to pass contract validation,
  so a malformed or empty model response can never overwrite a stored prompt
  with something worse.
- Legacy `build_scenes_from_graph` applies it: only `environment_prompt` moves,
  and a repair is not counted as an addition. Plates, images and human notes are
  untouched; a prompt a user wrote never carries the fingerprint.
- Tests: 4 for the shared predicate, 2 legacy regression tests (repair fires and
  preserves assets; invalid output leaves storage alone).
