### PR TITLE
fix: never store a partial character run as its final result

### DIFF
--- a/src/novelvideo/structured_builders.py
+++ b/src/novelvideo/structured_builders.py
@@ -169,7 +169,12 @@ async def build_characters_structured(
         return []
     log(f"归一后得到 {len(merged)} 个角色候选")
 
-    if run_id:
+    # A partial run must never store its cast as the run's final result. The
+    # replay guard only checks that no chunk is still pending, so once the
+    # failed chunks succeed on a later attempt, a stale artifact written here
+    # would be replayed instead — publishing a cast that is missing exactly the
+    # characters those chunks were carrying.
+    if run_id and not failures:
         await store.save_analysis_artifact(
             run_id,
             "characters",

--- a/tests/test_structured_builders.py
+++ b/tests/test_structured_builders.py
@@ -615,6 +615,49 @@ async def test_a_failed_chunk_leaves_the_run_partial(structured_store, monkeypat
     assert stored["status"] == "partial"
 
 
+async def test_a_partial_run_never_stores_its_cast_as_the_final_result(
+    structured_store, monkeypatch
+):
+    """The replay guard only checks that nothing is still pending.
+
+    So once the failed chunks succeed on a later attempt, an artifact written by
+    the partial run would be replayed instead of the freshly built cast — and it
+    is missing exactly the characters those chunks were carrying.
+    """
+    from novelvideo import structured_builders
+    from novelvideo.structured_extraction import extract_characters_from_chunks
+    from novelvideo.structured_ingest import ingest_source_text_structured
+
+    store, state_dir = structured_store
+    source = state_dir / "source.txt"
+    source.write_text(NARRATED_MULTI, encoding="utf-8")
+    run = await ingest_source_text_structured(
+        store, str(source), spine_template="narrated"
+    )
+
+    agent = FakeAgent(
+        {
+            "第一章": ChunkCharacterOutput(
+                characters=[_candidate("林默", quotes=["林默回到阔别十年的故乡。"])]
+            )
+        },
+        fail_labels=["第二章"],
+    )
+    real_extract = extract_characters_from_chunks
+
+    async def fake_extract(chunks, **kwargs):
+        kwargs.pop("agent", None)
+        kwargs.setdefault("adjudicate", False)
+        return await real_extract(chunks, agent=agent, **kwargs)
+
+    monkeypatch.setattr(
+        "novelvideo.structured_extraction.extract_characters_from_chunks", fake_extract
+    )
+    await structured_builders.build_characters_structured(store)
+
+    assert await store.get_analysis_artifact(run["run_id"], "characters") == ""
+
+
 def test_an_oversized_chapter_is_split_further():
     """A chapter boundary says where to cut, not how big the piece may be."""
     text = "第一章 归来\n\n" + "林默回到故乡。" * 3000 + "\n\n第二章 旧友\n\n短章节。\n"


### PR DESCRIPTION
## The bug

`build_characters_structured` caches a finished run's adjudicated cast so a rebuild replays it instead of paying for another adjudication call. The replay guard is:

```python
if run_id and not pending:
    stored = await store.get_analysis_artifact(run_id, "characters")
```

`not pending` only means no chunk is *currently* outstanding. It cannot distinguish a cast that settled from one that was cut short.

A run where some chunks failed still wrote the artifact. That is not immediately visible, because the failed chunks stay pending and the artifact is not replayed. But once those chunks succeed on a later attempt, nothing is pending any more — and the stale artifact is replayed in place of the freshly built cast, missing exactly the characters those chunks were carrying. Silently.

## The fix

One condition: write the artifact only when the run completed.

```python
if run_id and not failures:
```

## Test

`test_a_partial_run_never_stores_its_cast_as_the_final_result` drives a build where one chunk's label fails, then asserts no artifact was written for the run.

## Verification

`ruff` clean. Full suite green.

## Scope

Found while working on scene build caching, but it is an independent correctness bug in the character path, so it is here on its own rather than buried in that change.