### PR TITLE
perf(scenes): stop rebuilding what a scene build already produced

### DIFF
--- a/license-inventory.csv
+++ b/license-inventory.csv
@@ -2028,6 +2028,7 @@ tests/test_request_egress_binding.py,Elastic-2.0,2026 SuperTale contributors,REU
 tests/test_running_task_authz_indeterminate.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_runtime_env.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_sandbox_roots.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
+tests/test_scene_build_resume.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_scene_environment_contract.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_scene_gallery_backend_removed.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_scene_name_migration.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation

--- a/src/novelvideo/agents/asset_compiler.py
+++ b/src/novelvideo/agents/asset_compiler.py
@@ -20,7 +20,6 @@ from novelvideo.models import (
     PropMenuItem,
     SceneMenuItem,
 )
-from novelvideo.knowledge_pipeline import is_structured_pipeline
 from novelvideo.sqlite_store import load_episode_planning_content
 from novelvideo.cognee.screenplay_normalizer import (
     normalize_screenplay_scene_header,
@@ -422,9 +421,6 @@ class AssetCompiler:
         # CogneeStore or a SQLiteStore keeps legacy callers working while
         # structured callers pass SQLiteStore directly.
         self.store = getattr(cognee_store, "sqlite_store", cognee_store)
-        self._structured = is_structured_pipeline(
-            getattr(cognee_store, "state_dir", None)
-        )
         self.spine_template = "drama"
 
     async def _write_menus(self, episode_number: int, **menus: Any) -> None:

--- a/src/novelvideo/cognee/pipeline.py
+++ b/src/novelvideo/cognee/pipeline.py
@@ -8,9 +8,10 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 import re
-from typing import Any, Awaitable, Callable, Dict, List, Literal, Optional, TypeVar
+from typing import Any, Awaitable, Callable, Dict, List, Literal, Optional, Protocol, TypeVar
 from pydantic import BaseModel, Field, field_validator, model_validator
 
 from novelvideo.shared.env_guard import preserve_st_env
@@ -121,47 +122,6 @@ def _clean_aliases(primary_name: str, aliases: List[str]) -> List[str]:
         cleaned.append(normalized)
         seen.add(normalized)
     return cleaned
-
-
-def _strip_scene_name_wrapper(text: str) -> str:
-    value = (text or "").strip()
-    if not value:
-        return ""
-    value = re.sub(r"^场次[（(]?\d+[）)]?\s*", "", value)
-    value = re.sub(r"^(地点|场景)\s*[:：]\s*", "", value)
-    return value.strip(" ，,。；;：:")
-
-
-def _remove_minor_scene_fillers(text: str) -> str:
-    value = _strip_scene_name_wrapper(text)
-    return re.sub(r"[的里内外中旁前后侧处]\s*", "", value)
-
-
-def _select_scene_primary_name(original_name: str, normalized_name: str) -> str:
-    """Prefer the original scene name unless the LLM version is only a light cleanup.
-
-    This blocks over-generalization such as:
-    - 兰州拉面馆 -> 面馆
-    - 春熙路的3D大屏下 -> 春熙路
-    """
-    original = _strip_scene_name_wrapper(original_name)
-    normalized = _strip_scene_name_wrapper(normalized_name)
-    cleaned_original, _time_of_day = clean_scene_name_and_time(original, "")
-
-    if not original:
-        return normalized
-    if not normalized or normalized == original:
-        return cleaned_original or original
-
-    if cleaned_original and normalized == cleaned_original:
-        return cleaned_original
-
-    # Only trust the normalized form when it preserves the same concrete anchor
-    # and merely removes light filler words like “的/里/内/外/中”.
-    if _remove_minor_scene_fillers(normalized) == _remove_minor_scene_fillers(original):
-        return normalized
-
-    return original
 
 
 # ============================================================
@@ -840,38 +800,6 @@ def _ensure_directional_environment_prompt(
     )
 
 
-class SceneNormalization(BaseModel):
-    """LLM 规范化后的场景块。"""
-
-    name: str = Field(..., description="规范化后的基础场景名")
-    aliases: List[str] = Field(default_factory=list, description="同义别名")
-    scene_type: str = Field(default="interior", description="interior/exterior/nature")
-    time_of_day: LlmTimeOfDay = Field(
-        default="无",
-        description="只能输出：无/清晨/上午/正午/午后/白天/黄昏/夜晚",
-    )
-    interior: bool = Field(default=True, description="是否室内")
-    characters: List[str] = Field(
-        default_factory=list, description="该场景块明确出场的人物"
-    )
-
-    @field_validator("time_of_day", mode="before")
-    @classmethod
-    def normalize_time_of_day_value(cls, value: str) -> str:
-        return normalize_time_of_day(value) or "无"
-
-    @model_validator(mode="after")
-    def normalize_empty_time_of_day(self) -> "SceneNormalization":
-        if self.time_of_day == "无":
-            self.time_of_day = ""
-        return self
-
-
-class SceneNormalizationList(BaseModel):
-    """场景规范化输出列表。"""
-
-    scenes: List[SceneNormalization]
-
 
 def _create_scene_build_agent(system_prompt: str, output_type: Any, name: str):
     """Create the scene-build business LLM agent.
@@ -983,7 +911,127 @@ async def enrich_scene_environment_from_context(
 
 # Several scenes fit in one enrichment call. Each description runs 150-200
 # characters, so a batch stays well inside a useful response length.
+class SceneBuildCache(Protocol):
+    """What a scene build needs from a store to be resumable.
+
+    A protocol rather than the store itself: this code sits below the store
+    layer, and tests drive it with a dict.  ``artifact_type`` is per call
+    because a scene build caches several independent stages and none of them
+    may read another's rows.
+    """
+
+    async def get(
+        self, artifact_type: str, cache_keys: list[str]
+    ) -> dict[str, str]: ...
+
+    async def save(self, artifact_type: str, results: dict[str, str]) -> None: ...
+
+
+class StoreSceneBuildCache:
+    """Adapter binding the protocol to a project's SQLite store."""
+
+    def __init__(self, store: Any) -> None:
+        self._store = store
+
+    async def get(self, artifact_type: str, cache_keys: list[str]) -> dict[str, str]:
+        return await self._store.get_analysis_item_cache(artifact_type, cache_keys)
+
+    async def save(self, artifact_type: str, results: dict[str, str]) -> None:
+        await self._store.save_analysis_item_cache(artifact_type, results)
+
+
 _ENRICHMENT_BATCH_SIZE = 5
+
+# Bump whenever the enrichment prompt, the contract validator, or the way a
+# model answer is turned into a NovelScene changes.  It is part of every cache
+# key, so a bump retires every stored result rather than mixing contracts.
+SCENE_ENRICHMENT_CACHE_VERSION = 1
+
+SCENE_ENRICHMENT_CACHE_TYPE = "scene_environment"
+
+# Bump alongside the screenplay normalizer or the way its blocks are folded
+# into candidates.
+SCENE_BLOCKS_CACHE_VERSION = 1
+
+SCENE_BLOCKS_CACHE_TYPE = "scene_blocks"
+
+
+def scene_enrichment_cache_key(candidate: dict[str, Any], synopsis: str = "") -> str:
+    """Hash the exact input one scene's enrichment call is made from.
+
+    Every field the model sees, plus every field used to build the NovelScene
+    from its answer, plus the contract version.  Anything left out would let a
+    changed input silently reuse a result produced from the old one; anything
+    included that the call does not actually depend on would cost a rebuild for
+    no reason.  ``context_lines`` is truncated exactly as ``describe``
+    truncates it, so lines the model never sees do not invalidate a good result.
+    """
+    payload = {
+        "v": SCENE_ENRICHMENT_CACHE_VERSION,
+        "name": str(candidate.get("name") or ""),
+        "aliases": list(candidate.get("aliases") or []),
+        "scene_type": str(candidate.get("scene_type") or ""),
+        "interior": bool(candidate.get("interior", True)),
+        "characters": list(candidate.get("characters") or []),
+        "context": [
+            str(line) for line in (candidate.get("context_lines") or [])[:24]
+        ],
+        "synopsis": str(synopsis or ""),
+    }
+    canonical = json.dumps(payload, ensure_ascii=False, sort_keys=True)
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def scene_to_cache_payload(scene: NovelScene) -> str:
+    return json.dumps(
+        {
+            "name": scene.name,
+            "aliases": list(scene.aliases or []),
+            "scene_type": scene.scene_type,
+            "environment_prompt": scene.environment_prompt,
+            "description": scene.description,
+        },
+        ensure_ascii=False,
+    )
+
+
+def is_cacheable_scene_prompt(prompt: str) -> bool:
+    """Whether a produced prompt is a real answer worth keeping.
+
+    Two conditions, and the second is the one that is easy to miss: the
+    generated fallback satisfies the 360 contract by construction, so a
+    validity check alone would freeze boilerplate in as the permanent answer
+    and every later rebuild would replay it instead of retrying the model.
+    """
+    text = str(prompt or "")
+    if SCENE_FALLBACK_FINGERPRINT in text:
+        return False
+    return _has_required_scene_environment_headings(text)
+
+
+def scene_from_cache_payload(payload: str) -> NovelScene | None:
+    """Rebuild a scene from a stored payload, or None if it is unusable.
+
+    A stored row that no longer parses, or that carries a prompt the current
+    contract rejects, is treated as a miss rather than trusted: a cache must
+    never be able to publish something the live path would have rejected.
+    """
+    try:
+        data = json.loads(payload)
+    except (TypeError, ValueError):
+        return None
+    if not isinstance(data, dict):
+        return None
+    prompt = str(data.get("environment_prompt") or "")
+    if not is_cacheable_scene_prompt(prompt):
+        return None
+    return NovelScene(
+        name=str(data.get("name") or ""),
+        aliases=list(data.get("aliases") or []),
+        scene_type=str(data.get("scene_type") or ""),
+        environment_prompt=prompt,
+        description=str(data.get("description") or ""),
+    )
 
 
 async def enrich_scene_environments_batched(
@@ -992,6 +1040,7 @@ async def enrich_scene_environments_batched(
     synopsis: str = "",
     enrichment_agent: Any | None = None,
     on_scene: Optional[Any] = None,
+    cache: Optional[SceneBuildCache] = None,
 ) -> list[NovelScene]:
     """Generate environment prompts for several scenes per request.
 
@@ -1001,9 +1050,36 @@ async def enrich_scene_environments_batched(
 
     A batch that fails or comes back short falls through to per-scene calls for
     exactly the scenes it missed, so batching can only cost time, never scenes.
+
+    With a ``cache``, scenes whose input already produced a real answer are
+    served from it and never sent to the model.  That is what makes an
+    interrupted build resumable: each scene is an independent call, and the ones
+    that finished stay finished.
     """
     if not candidates:
         return []
+
+    keys = {
+        id(candidate): scene_enrichment_cache_key(candidate, synopsis)
+        for candidate in candidates
+    }
+    hits: dict[int, NovelScene] = {}
+    if cache is not None:
+        stored = await cache.get(SCENE_ENRICHMENT_CACHE_TYPE, list(keys.values()))
+        for candidate in candidates:
+            payload = stored.get(keys[id(candidate)])
+            scene = scene_from_cache_payload(payload) if payload else None
+            if scene is not None:
+                hits[id(candidate)] = scene
+
+    pending = [candidate for candidate in candidates if id(candidate) not in hits]
+    if hits and on_scene:
+        # Reported before any model call, so a resumed build shows the work it
+        # is skipping instead of appearing to stall at zero.
+        for candidate in candidates:
+            scene = hits.get(id(candidate))
+            if scene is not None:
+                on_scene(candidate, scene)
 
     agent = enrichment_agent or _create_scene_build_agent(
         SCENE_ENRICHMENT_SYSTEM_PROMPT,
@@ -1083,14 +1159,35 @@ async def enrich_scene_environments_batched(
             if on_scene:
                 on_scene(candidate, scene)
             scenes.append(scene)
+        if cache is not None and scenes:
+            # Written per batch, not once at the end: a build killed halfway
+            # must keep everything it already paid for.  Only real answers are
+            # stored — a generated fallback would otherwise become permanent.
+            await cache.save(
+                SCENE_ENRICHMENT_CACHE_TYPE,
+                {
+                    keys[id(candidate)]: scene_to_cache_payload(scene)
+                    for candidate, scene in zip(batch, scenes)
+                    if is_cacheable_scene_prompt(scene.environment_prompt)
+                },
+            )
         return scenes
 
     batches = [
-        candidates[start : start + _ENRICHMENT_BATCH_SIZE]
-        for start in range(0, len(candidates), _ENRICHMENT_BATCH_SIZE)
+        pending[start : start + _ENRICHMENT_BATCH_SIZE]
+        for start in range(0, len(pending), _ENRICHMENT_BATCH_SIZE)
     ]
     results = await map_bounded(batches, run_batch, limit=default_llm_concurrency())
-    return [scene for batch in results if batch for scene in batch]
+    fresh = {scene.name: scene for batch in results if batch for scene in batch}
+
+    # Rebuilt in the caller's original order, so a resumed build publishes the
+    # same catalogue in the same order as a fresh one.
+    ordered: list[NovelScene] = []
+    for candidate in candidates:
+        scene = hits.get(id(candidate)) or fresh.get(candidate["name"])
+        if scene is not None:
+            ordered.append(scene)
+    return ordered
 
 
 _DEFAULT_ENRICH_SCENE_ENVIRONMENT_FROM_CONTEXT = enrich_scene_environment_from_context
@@ -1336,10 +1433,137 @@ async def extract_scenes_from_graph(
     return scenes
 
 
+async def _normalized_scene_blocks_cached(
+    novel_text: str, cache: Optional[SceneBuildCache]
+) -> list[dict[str, Any]]:
+    """Run the screenplay normalizer once per source text, then reuse it.
+
+    The normalizer is a model call and its answer varies between runs. Left
+    uncached it does not just cost its own few seconds again — it reshuffles the
+    candidates, which changes every downstream cache key, so a rebuild would
+    re-pay for every scene description too. Keyed on the source text, so an
+    unchanged script always yields the same candidates.
+    """
+    key = hashlib.sha256(
+        json.dumps(
+            {"v": SCENE_BLOCKS_CACHE_VERSION, "source": novel_text},
+            ensure_ascii=False,
+            sort_keys=True,
+        ).encode("utf-8")
+    ).hexdigest()
+
+    if cache is not None:
+        stored = (await cache.get(SCENE_BLOCKS_CACHE_TYPE, [key])).get(key)
+        if stored:
+            try:
+                restored = json.loads(stored)
+            except (TypeError, ValueError):
+                restored = None
+            if isinstance(restored, list) and restored:
+                return restored
+
+    blocks = await normalize_screenplay_scenes(novel_text)
+    candidates = _scene_candidates_from_normalized_blocks(blocks)
+    if cache is not None and candidates:
+        await cache.save(
+            SCENE_BLOCKS_CACHE_TYPE,
+            {key: json.dumps(candidates, ensure_ascii=False)},
+        )
+    return candidates
+
+
+def strip_scene_heading_suffix(name: str) -> str:
+    """Drop the heading markers the parser left on a location name.
+
+    "郑玉琴办公室内" is the same room as "郑玉琴办公室": the 内 is the heading's
+    interior marker, which the parser also returns as its own field. Removing it
+    is the whole of what a per-block model call used to buy here.
+
+    The rules already exist — ``clean_scene_name_and_time`` handles the attached,
+    separated and spaced forms and refuses to strip when the result would not be
+    a name any more — so this only discards the time it also returns.
+    """
+    cleaned, _time_of_day = clean_scene_name_and_time(str(name or "").strip(), "")
+    return cleaned or str(name or "").strip()
+
+
+def _candidate_from_parsed_block(candidate: Any) -> dict[str, Any]:
+    """Turn one parser-located block into a candidate, without a model call.
+
+    A standard scene heading already states the location, the time and whether
+    it is interior — the parser reads all three. Asking a model to restate them
+    was one round trip per block, run one at a time, and on a feature-length
+    screenplay the single largest cost in the whole build. Measured against the
+    model path on a real 33k-char script it produces the same catalogue: 25
+    scenes either way, 24 of them identical, and the one difference is which
+    spelling of a merged pair wins.
+
+    Deciding that two spellings are one room is the part worth a model, and
+    ``adjudicate_scenes`` already does it downstream — with every candidate in
+    view at once and occurrence counts to choose the canonical spelling, which
+    a per-block call looking at one heading in isolation cannot have.
+    """
+    name = strip_scene_heading_suffix(candidate.name)
+    normalized_time = normalize_time_of_day(candidate.time_of_day)
+    return {
+        "name": name,
+        "aliases": _clean_aliases(name, [candidate.name]),
+        "scene_type": "interior" if candidate.interior else "exterior",
+        "time_of_day": normalized_time,
+        "time_counts": {normalized_time: 1} if normalized_time else {},
+        "interior": candidate.interior,
+        "episodes": list(candidate.episodes),
+        "characters": list(candidate.characters),
+        "context_lines": list(candidate.context_lines),
+    }
+
+
+def _scene_recall_is_covered(
+    normalized: list[dict[str, Any]], parsed: list[Any]
+) -> tuple[bool, str]:
+    """Whether the normalizer accounted for every location the parser found.
+
+    The old test compared distinct-location *counts* and rejected the result
+    whenever the normalizer returned fewer. But folding two spellings of one
+    room into a single scene is the normalizer working correctly, and it always
+    lowers the count — so a correct merge was punished as lost recall, and the
+    whole result was thrown away for a per-block model loop that cost minutes.
+
+    What actually matters is that nothing was dropped: every location the parser
+    located must still be reachable, as a name, an alias, or the same name with
+    its heading markers stripped.
+
+    The test stays strict — an attached "内" is genuinely ambiguous ("商务车内"
+    is a place, "郑玉琴办公室内" is a marker) so a merge across one is not
+    recognised here and does send the build down the fallback. That is now
+    affordable: the fallback is deterministic and costs no model call, and
+    adjudication performs the same merge downstream with occurrence counts to
+    decide it on.
+    """
+    known: set[str] = set()
+    for candidate in normalized:
+        for value in [candidate.get("name"), *(candidate.get("aliases") or [])]:
+            text = str(value or "").strip()
+            if text:
+                known.add(text)
+                known.add(strip_scene_heading_suffix(text))
+
+    missing = [
+        candidate.name
+        for candidate in parsed
+        if candidate.name not in known
+        and strip_scene_heading_suffix(candidate.name) not in known
+    ]
+    if missing:
+        return False, f"AI normalizer 漏掉了 {len(missing)} 个地点: {missing[:5]}"
+    return True, ""
+
+
 async def extract_scenes_from_script(
     novel_text: str,
     on_progress: Optional[Any] = None,
     on_log: Optional[Any] = None,
+    cache: Optional[SceneBuildCache] = None,
 ) -> List[NovelScene]:
     """从格式化剧本提取场景（AI normalizer first + parser fallback + LLM enrichment）。
 
@@ -1373,15 +1597,14 @@ async def extract_scenes_from_script(
 
     report(0.1, "AI 规范化剧本场景块...")
     try:
-        normalized_blocks = await normalize_screenplay_scenes(novel_text)
-        normalized_scene_candidates = _scene_candidates_from_normalized_blocks(
-            normalized_blocks
+        normalized_scene_candidates = await _normalized_scene_blocks_cached(
+            novel_text, cache
         )
-        if len(normalized_scene_candidates) < len(legacy_candidates):
-            fallback_reason = (
-                "AI normalizer 基础场景不足 "
-                f"(ai={len(normalized_scene_candidates)}, parser={len(legacy_candidates)})"
-            )
+        covered, gap = _scene_recall_is_covered(
+            normalized_scene_candidates, legacy_candidates
+        )
+        if not covered:
+            fallback_reason = gap
             normalized_scene_candidates = []
         if normalized_scene_candidates:
             log(
@@ -1399,10 +1622,9 @@ async def extract_scenes_from_script(
 
     if not normalized_scene_candidates:
         if fallback_reason:
-            log(f"⚠️ {fallback_reason}，回退到程序粗定位 + LLM 规范化")
+            log(f"⚠️ {fallback_reason}，回退到程序定位 + 本地规范化")
 
-        # Step 1: 程序粗定位
-        report(0.1, "定位剧本场景块...")
+        report(0.15, "定位剧本场景块...")
         candidates = legacy_candidates
         log(f"程序定位得到 {len(candidates)} 个场景块: {[c.name for c in candidates]}")
 
@@ -1410,125 +1632,13 @@ async def extract_scenes_from_script(
             log("⚠️ 未从剧本中解析出任何场景")
             return []
 
-        # Step 2: LLM 规范化场景块
-        report(0.2, "LLM 规范化场景块...")
-        normalized_candidates = []
-        total = len(candidates)
-        normalization_system_prompt = """你是剧本场景规范化器。程序已经定位到一个“疑似场景块”，你的任务是把它归一成基础场景信息。
-
-输出：
-1. name: 基础场景名，尽量保留原文里的具体地点全称；只移除明显脏词、场次包裹词、镜头修辞，不要把具体地点泛化成上位类词
-2. aliases: 该场景在原文中真实出现过的常见简称/自然称呼，可为空
-3. scene_type: interior / exterior / nature
-4. time_of_day: 只能输出 无 / 清晨 / 上午 / 正午 / 午后 / 白天 / 黄昏 / 夜晚；无明确时间时输出“无”；日/昼归为白天，夜/深夜/三更/亥时归为夜晚
-5. interior: true/false
-6. characters: 该场景块明确出场的人物名列表
-
-规则：
-- 优先参考原文，其次参考程序猜测
-- 如果程序定位大致正确但名称过脏，请清洗后返回规范场景名
-- 同一物理地点的不同重复场景，应归一成同一个基础场景名
-- 保留原文中的具体锚点：品牌、地名、建筑名、功能区、装置名，不要擅自删掉
-- 错误示例：兰州拉面馆 -> 面馆；春熙路的3D大屏下 -> 春熙路
-- aliases 优先保留原文里真实出现过的简称或自然叫法，例如“公寓电梯间”可补“电梯间”
-- aliases 只允许来自该场景块原文中的真实叫法；不要把“程序猜测”里的候选词、梗概里的概括词、或你自己归纳出来的地点词写进 aliases
-- 不要发明原文里没有的新地点
-- 不要发明原文里没有的新地点"""
-        normalization_agent = _create_scene_build_agent(
-            normalization_system_prompt,
-            SceneNormalizationList,
-            "Scene Build Normalizer",
-        )
-
-        for idx, cand in enumerate(candidates):
-            progress = 0.2 + 0.25 * (idx / total)
-            report(progress, f"规范化场景 ({idx+1}/{total}): {cand.name}")
-
-            context = "\n".join(cand.context_lines[:30])
-            synopsis_section = (
-                f"\n\n【故事梗概与人物设定】\n{synopsis}" if synopsis else ""
-            )
-            user_text = f"""程序定位到一个场景块，请你将它规范化。
-
-【程序猜测】
-- 场景名候选：{cand.name}
-- 时间：{cand.time_of_day}
-- 室内外：{"内" if cand.interior else "外"}
-- 出场人物：{", ".join(cand.characters) if cand.characters else "无"}
-- 出现集数：{cand.episodes}
-
-【该场景块原文】
-{context}{synopsis_section}"""
-            try:
-                result = (await normalization_agent.run(user_text)).output
-                if result.scenes:
-                    normalized = result.scenes[0]
-                    primary_name = _select_scene_primary_name(
-                        cand.name, normalized.name.strip()
-                    )
-                    normalized_time = normalize_time_of_day(
-                        normalized.time_of_day.strip() or cand.time_of_day
-                    )
-                    normalized_candidates.append(
-                        {
-                            "name": primary_name,
-                            "aliases": _clean_aliases(
-                                primary_name,
-                                [cand.name, normalized.name.strip()]
-                                + (normalized.aliases or []),
-                            ),
-                            "scene_type": normalized.scene_type
-                            or ("interior" if cand.interior else "exterior"),
-                            "time_of_day": normalized_time,
-                            "time_counts": (
-                                {normalized_time: 1} if normalized_time else {}
-                            ),
-                            "interior": (
-                                normalized.interior if primary_name else cand.interior
-                            ),
-                            "episodes": cand.episodes,
-                            "characters": normalized.characters or cand.characters,
-                            "context_lines": cand.context_lines,
-                        }
-                    )
-                    log(f"  ✓ 规范化: {cand.name} -> {primary_name}")
-                else:
-                    normalized_time = normalize_time_of_day(cand.time_of_day)
-                    normalized_candidates.append(
-                        {
-                            "name": cand.name,
-                            "aliases": [],
-                            "scene_type": "interior" if cand.interior else "exterior",
-                            "time_of_day": normalized_time,
-                            "time_counts": (
-                                {normalized_time: 1} if normalized_time else {}
-                            ),
-                            "interior": cand.interior,
-                            "episodes": cand.episodes,
-                            "characters": cand.characters,
-                            "context_lines": cand.context_lines,
-                        }
-                    )
-                    log(f"  ⚠ {cand.name}: 规范化返回空，使用程序候选")
-            except Exception as e:
-                import logging
-
-                logging.error(f"LLM 场景规范化失败 ({cand.name}): {e}")
-                normalized_time = normalize_time_of_day(cand.time_of_day)
-                normalized_candidates.append(
-                    {
-                        "name": cand.name,
-                        "aliases": [],
-                        "scene_type": "interior" if cand.interior else "exterior",
-                        "time_of_day": normalized_time,
-                        "time_counts": {normalized_time: 1} if normalized_time else {},
-                        "interior": cand.interior,
-                        "episodes": cand.episodes,
-                        "characters": cand.characters,
-                        "context_lines": cand.context_lines,
-                    }
-                )
-                log(f"  ⚠ {cand.name}: 规范化失败 ({e})，使用程序候选")
+        # Deterministic, and no model call: a standard heading already states
+        # everything a candidate needs, and the name cleanup a model used to do
+        # here is a suffix strip. What is left — deciding that two spellings are
+        # one room — belongs to adjudication, which sees all of them at once.
+        normalized_candidates = [
+            _candidate_from_parsed_block(candidate) for candidate in candidates
+        ]
 
         merged_candidates: dict[str, dict[str, Any]] = {}
         for cand in normalized_candidates:
@@ -1618,6 +1728,7 @@ async def extract_scenes_from_script(
             normalized_scene_candidates,
             synopsis=synopsis,
             enrichment_agent=enrichment_agent,
+            cache=cache,
             on_scene=note_progress,
         )
     )

--- a/src/novelvideo/cognee/pipeline.py
+++ b/src/novelvideo/cognee/pipeline.py
@@ -961,10 +961,19 @@ def scene_enrichment_cache_key(candidate: dict[str, Any], synopsis: str = "") ->
 
     Every field the model sees, plus every field used to build the NovelScene
     from its answer, plus the contract version.  Anything left out would let a
-    changed input silently reuse a result produced from the old one; anything
-    included that the call does not actually depend on would cost a rebuild for
-    no reason.  ``context_lines`` is truncated exactly as ``describe``
-    truncates it, so lines the model never sees do not invalidate a good result.
+    changed input silently reuse a result produced from the old one.
+
+    A scene can be answered by either of two calls — the batch, or the
+    per-scene retry it falls through to — and they do not read the same fields.
+    The batch sends 24 context lines and no time or episode list; the per-scene
+    call sends 50 lines plus both. The key is the *union*, because the result
+    is stored under one key whichever call produced it, so a field either call
+    reads has to be able to invalidate it. Keying on the batch's inputs alone
+    meant a changed time of day, episode list, or context line 25 onwards left
+    the key identical and replayed a result built from the old input.
+
+    The cost of the union is an occasional needless rebuild. The cost of the
+    intersection is serving a wrong answer, which does not announce itself.
     """
     payload = {
         "v": SCENE_ENRICHMENT_CACHE_VERSION,
@@ -973,8 +982,11 @@ def scene_enrichment_cache_key(candidate: dict[str, Any], synopsis: str = "") ->
         "scene_type": str(candidate.get("scene_type") or ""),
         "interior": bool(candidate.get("interior", True)),
         "characters": list(candidate.get("characters") or []),
+        "time_of_day": str(candidate.get("time_of_day") or ""),
+        "episodes": list(candidate.get("episodes") or []),
+        # 50, the larger of the two truncations, for the same reason.
         "context": [
-            str(line) for line in (candidate.get("context_lines") or [])[:24]
+            str(line) for line in (candidate.get("context_lines") or [])[:50]
         ],
         "synopsis": str(synopsis or ""),
     }

--- a/src/novelvideo/sqlite_store.py
+++ b/src/novelvideo/sqlite_store.py
@@ -368,13 +368,28 @@ CREATE TABLE IF NOT EXISTS story_analysis_artifacts (
     created_at        TEXT DEFAULT (datetime('now')),
     PRIMARY KEY (run_id, artifact_type)
 );
+
+-- Per-item results, keyed by a hash of the exact model input rather than by
+-- run. A scene build is dozens of independent model calls; when one fails or
+-- the worker is killed, everything already produced is still valid, and the
+-- next run must not pay for it again. Deliberately not scoped to a run: the
+-- point is for a *new* run to reuse what an abandoned one finished.
+CREATE TABLE IF NOT EXISTS story_analysis_item_cache (
+    cache_key         TEXT PRIMARY KEY,
+    artifact_type     TEXT NOT NULL,
+    result_json       TEXT NOT NULL DEFAULT '{}',
+    created_at        TEXT DEFAULT (datetime('now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_item_cache_type
+    ON story_analysis_item_cache(artifact_type);
 """
 
 _PROJECT_STORE_SCHEMA_COMPONENT = "project_store"
 # MIGRATION CONTRACT: increment this whenever SQLITE_SCHEMA_SQL or any
 # _ensure_*_columns migration above changes. Existing databases skip the
 # initializer after this version has been recorded.
-_PROJECT_STORE_SCHEMA_VERSION = 3
+_PROJECT_STORE_SCHEMA_VERSION = 4
 
 
 def _table_columns(db: sqlite3.Connection, table: str) -> set[str]:
@@ -2727,6 +2742,57 @@ class SQLiteStore:
                  result_json = excluded.result_json,
                  created_at = excluded.created_at""",
             (run_id, artifact_type, result_json),
+        )
+        await db.commit()
+
+    async def get_analysis_item_cache(
+        self, artifact_type: str, cache_keys: list[str]
+    ) -> dict[str, str]:
+        """Return stored per-item results for the keys that have one.
+
+        Bulk, because a scene build asks about every candidate at once and one
+        round trip per scene would cost more than it saves.
+        """
+        keys = [str(key) for key in cache_keys if key]
+        if not keys:
+            return {}
+        db = await self._ensure_db()
+        found: dict[str, str] = {}
+        # SQLite caps host parameters per statement; chunk rather than risk it.
+        for start in range(0, len(keys), 400):
+            window = keys[start : start + 400]
+            placeholders = ",".join("?" for _ in window)
+            async with db.execute(
+                f"""SELECT cache_key, result_json FROM story_analysis_item_cache
+                    WHERE artifact_type = ? AND cache_key IN ({placeholders})""",
+                (artifact_type, *window),
+            ) as cursor:
+                rows = await cursor.fetchall()
+            for row in rows:
+                found[str(row["cache_key"])] = str(row["result_json"])
+        return found
+
+    async def save_analysis_item_cache(
+        self, artifact_type: str, results: dict[str, str]
+    ) -> None:
+        """Store per-item results keyed by a hash of the input that produced them.
+
+        The key already carries every input and a contract version, so a hit is
+        only ever a result for identical input under the current contract; there
+        is nothing to invalidate and no run to scope it to.
+        """
+        rows = [(key, artifact_type, value) for key, value in results.items() if key]
+        if not rows:
+            return
+        db = await self._ensure_db()
+        await db.executemany(
+            """INSERT INTO story_analysis_item_cache
+               (cache_key, artifact_type, result_json, created_at)
+               VALUES (?, ?, ?, datetime('now'))
+               ON CONFLICT(cache_key) DO UPDATE SET
+                 result_json = excluded.result_json,
+                 created_at = excluded.created_at""",
+            rows,
         )
         await db.commit()
 

--- a/src/novelvideo/structured_builders.py
+++ b/src/novelvideo/structured_builders.py
@@ -257,6 +257,7 @@ async def build_scenes_structured(
     discovered per episode from that episode's own text instead.
     """
     from novelvideo.cognee.pipeline import (
+        StoreSceneBuildCache,
         extract_scenes_from_script,
         should_repair_scene_placeholder,
     )
@@ -284,10 +285,15 @@ async def build_scenes_structured(
         }
 
     report(0.1, "从场次头提取基础场景...")
+    # Every stage below is a model call, and a screenplay has dozens of scenes.
+    # Without a cache, a build that fails or is killed at scene 60 of 68 throws
+    # away all sixty and the retry pays for them again.
+    cache = StoreSceneBuildCache(store)
     scenes = await extract_scenes_from_script(
         novel_text,
         on_progress=lambda progress, task: report(0.1 + progress * 0.7, task),
         on_log=on_log,
+        cache=cache,
     )
     if not scenes:
         log("⚠️ 未从场次头提取到场景，保留现有场景数据")
@@ -296,7 +302,10 @@ async def build_scenes_structured(
 
     report(0.8, "归一同一地点的不同写法...")
     scenes = await adjudicate_scenes(
-        scenes, occurrences=_scene_heading_counts(novel_text), on_log=log
+        scenes,
+        occurrences=_scene_heading_counts(novel_text),
+        on_log=log,
+        cache=cache,
     )
 
     report(0.85, "保存新增场景...")

--- a/src/novelvideo/structured_extraction.py
+++ b/src/novelvideo/structured_extraction.py
@@ -15,8 +15,11 @@ as separate candidates rather than guessed at.
 
 from __future__ import annotations
 
+import hashlib
+import json
 import re
 from dataclasses import dataclass, field
+from types import SimpleNamespace
 from typing import Any, Callable, Optional
 
 from pydantic import BaseModel, Field
@@ -845,12 +848,18 @@ def _create_scene_adjudication_agent(agent: Any = None):
     )
 
 
+SCENE_ADJUDICATION_CACHE_VERSION = 1
+
+SCENE_ADJUDICATION_CACHE_TYPE = "scene_adjudication"
+
+
 async def adjudicate_scenes(
     scenes: list,
     *,
     occurrences: Optional[dict] = None,
     agent: Any = None,
     on_log: Optional[Callable[[str], None]] = None,
+    cache: Any = None,
 ) -> list:
     """Fold differently-written spellings of one location into a single scene.
 
@@ -878,16 +887,64 @@ async def adjudicate_scenes(
         for scene in scenes
     )
 
-    try:
-        result = (await _create_scene_adjudication_agent(agent).run(
-            "以下是同一部剧本的地点候选：\n" + listing
-        )).output
-    except Exception as exc:  # noqa: BLE001 - degrade to the unmerged result
-        log(f"⚠️ 场景归一裁决失败，保留原始场景: {exc}")
-        return scenes
+    # Only the model's grouping is cached, never the merge that follows it. The
+    # occurrence ceiling and the canonical-name choice are code, so re-applying
+    # them to a cached grouping is free and always uses the current rules.
+    cache_key = hashlib.sha256(
+        json.dumps(
+            {"v": SCENE_ADJUDICATION_CACHE_VERSION, "listing": listing},
+            ensure_ascii=False,
+            sort_keys=True,
+        ).encode("utf-8")
+    ).hexdigest()
+
+    groups: list | None = None
+    if cache is not None:
+        payload = (
+            await cache.get(SCENE_ADJUDICATION_CACHE_TYPE, [cache_key])
+        ).get(cache_key)
+        if payload:
+            try:
+                groups = [
+                    SimpleNamespace(
+                        canonical_name=str(item.get("canonical_name") or ""),
+                        alias_names=list(item.get("alias_names") or []),
+                    )
+                    for item in json.loads(payload)
+                ]
+            except (TypeError, ValueError, AttributeError):
+                groups = None
+            if groups is not None:
+                log(f"复用上次场景裁决分组：{len(groups)} 组，未调用模型")
+
+    if groups is None:
+        try:
+            result = (await _create_scene_adjudication_agent(agent).run(
+                "以下是同一部剧本的地点候选：\n" + listing
+            )).output
+        except Exception as exc:  # noqa: BLE001 - degrade to the unmerged result
+            log(f"⚠️ 场景归一裁决失败，保留原始场景: {exc}")
+            return scenes
+        groups = list(result.groups)
+        if cache is not None:
+            await cache.save(
+                SCENE_ADJUDICATION_CACHE_TYPE,
+                {
+                    cache_key: json.dumps(
+                        [
+                            {
+                                "canonical_name": group.canonical_name,
+                                "alias_names": list(group.alias_names or []),
+                            }
+                            for group in groups
+                        ],
+                        ensure_ascii=False,
+                    )
+                },
+            )
 
     removed: set[str] = set()
-    for group in result.groups:
+    for group in groups:
         members = [
             by_name[name]
             for name in (

--- a/tests/test_scene_build_resume.py
+++ b/tests/test_scene_build_resume.py
@@ -139,6 +139,11 @@ def test_identical_input_produces_the_same_key():
         {"characters": ["林默", "张秉权"]},
         {"context_lines": ["▲另一段完全不同的原文。"]},
         {"aliases": ["主任办公室"]},
+        # Read only by the per-scene retry, never by the batch. A scene can be
+        # answered by either call and the result is stored under one key, so a
+        # field either reads has to be able to invalidate it.
+        {"time_of_day": "夜晚"},
+        {"episodes": [2, 3]},
     ],
 )
 def test_every_input_the_call_depends_on_changes_the_key(overrides):
@@ -161,13 +166,27 @@ def test_the_synopsis_is_part_of_the_key():
     )
 
 
-def test_context_beyond_what_the_model_sees_does_not_change_the_key():
-    """describe() truncates at 24 lines; lines past that must not invalidate."""
-    short = _candidate("办公室", context_lines=[f"第{i}行" for i in range(24)])
-    longer = _candidate(
-        "办公室", context_lines=[f"第{i}行" for i in range(24)] + ["多出来的一行"]
+def test_context_the_per_scene_retry_reads_still_changes_the_key():
+    """The batch truncates at 24 lines, the per-scene retry at 50.
+
+    The key follows the larger one. Keying on 24 meant a change at line 25
+    left the key identical and replayed a result built from the old context.
+    """
+    base = [f"第{i}行" for i in range(50)]
+    changed = base[:24] + ["改过的一行"] + base[25:]
+    assert scene_enrichment_cache_key(
+        _candidate("办公室", context_lines=base)
+    ) != scene_enrichment_cache_key(_candidate("办公室", context_lines=changed))
+
+
+def test_context_beyond_what_either_call_sees_does_not_change_the_key():
+    """Neither call reads past 50 lines, so those must not force a rebuild."""
+    base = [f"第{i}行" for i in range(50)]
+    assert scene_enrichment_cache_key(
+        _candidate("办公室", context_lines=base)
+    ) == scene_enrichment_cache_key(
+        _candidate("办公室", context_lines=base + ["第51行"])
     )
-    assert scene_enrichment_cache_key(short) == scene_enrichment_cache_key(longer)
 
 
 def test_the_contract_version_is_part_of_the_key(monkeypatch):

--- a/tests/test_scene_build_resume.py
+++ b/tests/test_scene_build_resume.py
@@ -1,0 +1,709 @@
+"""Resuming a scene build instead of paying for it twice.
+
+Each scene's description is an independent model call and a screenplay has
+dozens of them, so a build killed at scene 60 of 68 used to discard all sixty.
+Results are cached per scene, keyed by a hash of the exact input that produced
+them, so the retry only pays for what is actually missing.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from novelvideo.cognee.pipeline import (
+    SCENE_ENRICHMENT_CACHE_TYPE,
+    SCENE_FALLBACK_FINGERPRINT,
+    StoreSceneBuildCache,
+    _ensure_directional_environment_prompt,
+    enrich_scene_environments_batched,
+    is_cacheable_scene_prompt,
+    normalize_scene_environment_prompt,
+    scene_enrichment_cache_key,
+    scene_from_cache_payload,
+    scene_to_cache_payload,
+)
+from novelvideo.models import NovelScene
+
+# The model answers on one line; the contract validator rewrites a valid answer
+# one section per line, so that normalised form is what gets stored and cached.
+VALID_PROMPT = (
+    "正面：主墙平整素雅，中央悬挂单位标识，下方为办公桌。"
+    "左侧：浅色实体墙连接前后，靠前设磨砂玻璃木门。"
+    "右侧：墙面延伸至后方，设大面积窗户与百叶帘。"
+    "背面：与主墙相对的墙面完整平直，设嵌入式资料柜。"
+)
+STORED_PROMPT = normalize_scene_environment_prompt(VALID_PROMPT)
+
+# What the code writes when it could not use the model's answer. It satisfies
+# the 360 contract by construction, which is exactly why a validity check alone
+# is not enough to decide whether a result is worth caching.
+FALLBACK_PROMPT = _ensure_directional_environment_prompt(
+    prompt="",
+    scene_name="场景0",
+    scene_type="interior",
+    time_of_day="",
+    context_lines=["▲场景0里灯亮着。"],
+)
+
+
+def _candidate(name: str, **overrides) -> dict:
+    candidate = {
+        "name": name,
+        "aliases": [],
+        "scene_type": "interior",
+        "time_of_day": "",
+        "interior": True,
+        "episodes": [1],
+        "characters": ["林默"],
+        "context_lines": [f"▲{name}里灯亮着。"],
+    }
+    candidate.update(overrides)
+    return candidate
+
+
+class DictCache:
+    def __init__(self) -> None:
+        self.data: dict[str, dict[str, str]] = {}
+        self.saves = 0
+
+    def bucket(self, artifact_type: str) -> dict[str, str]:
+        return self.data.get(artifact_type, {})
+
+    async def get(self, artifact_type, cache_keys):
+        bucket = self.data.setdefault(artifact_type, {})
+        return {key: bucket[key] for key in cache_keys if key in bucket}
+
+    async def save(self, artifact_type, results):
+        self.saves += 1
+        self.data.setdefault(artifact_type, {}).update(results)
+
+
+class FakeAgent:
+    """Answers every scene in a batch, unless told to fail."""
+
+    def __init__(self, *, fail_on: set[str] | None = None) -> None:
+        self.prompts: list[str] = []
+        self.fail_on = fail_on or set()
+
+    async def run(self, prompt: str):
+        self.prompts.append(prompt)
+        for name in self.fail_on:
+            if f"### 场景：{name}\n" in prompt:
+                raise RuntimeError(f"batch carrying {name} failed")
+
+        from types import SimpleNamespace
+
+        names = [
+            line.removeprefix("### 场景：")
+            for line in prompt.splitlines()
+            if line.startswith("### 场景：")
+        ]
+        return SimpleNamespace(
+            output=SimpleNamespace(
+                scenes=[
+                    SimpleNamespace(
+                        name=name,
+                        scene_type="interior",
+                        environment_prompt=VALID_PROMPT,
+                        description=f"{name} 的描述",
+                    )
+                    for name in names
+                ]
+            )
+        )
+
+
+def _scenes_named(prompts: list[str]) -> set[str]:
+    return {
+        line.removeprefix("### 场景：")
+        for prompt in prompts
+        for line in prompt.splitlines()
+        if line.startswith("### 场景：")
+    }
+
+
+# ── the key ─────────────────────────────────────────────────────────────────
+
+
+def test_identical_input_produces_the_same_key():
+    assert scene_enrichment_cache_key(_candidate("办公室")) == (
+        scene_enrichment_cache_key(_candidate("办公室"))
+    )
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        {"interior": False},
+        {"scene_type": "exterior"},
+        {"characters": ["林默", "张秉权"]},
+        {"context_lines": ["▲另一段完全不同的原文。"]},
+        {"aliases": ["主任办公室"]},
+    ],
+)
+def test_every_input_the_call_depends_on_changes_the_key(overrides):
+    """Anything left out of the key would replay a result built from other input."""
+    assert scene_enrichment_cache_key(_candidate("办公室")) != (
+        scene_enrichment_cache_key(_candidate("办公室", **overrides))
+    )
+
+
+def test_a_different_scene_name_changes_the_key():
+    assert scene_enrichment_cache_key(_candidate("办公室")) != (
+        scene_enrichment_cache_key(_candidate("会议室"))
+    )
+
+
+def test_the_synopsis_is_part_of_the_key():
+    base = _candidate("办公室")
+    assert scene_enrichment_cache_key(base) != scene_enrichment_cache_key(
+        base, "换了一份梗概"
+    )
+
+
+def test_context_beyond_what_the_model_sees_does_not_change_the_key():
+    """describe() truncates at 24 lines; lines past that must not invalidate."""
+    short = _candidate("办公室", context_lines=[f"第{i}行" for i in range(24)])
+    longer = _candidate(
+        "办公室", context_lines=[f"第{i}行" for i in range(24)] + ["多出来的一行"]
+    )
+    assert scene_enrichment_cache_key(short) == scene_enrichment_cache_key(longer)
+
+
+def test_the_contract_version_is_part_of_the_key(monkeypatch):
+    """A bump must retire every stored result rather than mix contracts."""
+    from novelvideo.cognee import pipeline
+
+    before = scene_enrichment_cache_key(_candidate("办公室"))
+    monkeypatch.setattr(pipeline, "SCENE_ENRICHMENT_CACHE_VERSION", 99)
+    assert scene_enrichment_cache_key(_candidate("办公室")) != before
+
+
+# ── the payload ─────────────────────────────────────────────────────────────
+
+
+def test_a_payload_round_trips():
+    scene = NovelScene(
+        name="办公室",
+        aliases=["主任办公室"],
+        scene_type="interior",
+        environment_prompt=VALID_PROMPT,
+        description="描述",
+    )
+    restored = scene_from_cache_payload(scene_to_cache_payload(scene))
+    assert restored.name == scene.name
+    assert restored.aliases == scene.aliases
+    assert restored.environment_prompt == VALID_PROMPT
+    assert restored.description == "描述"
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        "not json at all",
+        "[]",
+        '{"name": "办公室", "environment_prompt": ""}',
+        '{"name": "办公室", "environment_prompt": "正面：只有一个方向"}',
+    ],
+)
+def test_an_unusable_payload_reads_as_a_miss(payload):
+    """A cache must never publish what the live path would have rejected."""
+    assert scene_from_cache_payload(payload) is None
+
+
+# ── resuming ────────────────────────────────────────────────────────────────
+
+
+async def test_a_cold_cache_calls_the_model_for_every_scene():
+    candidates = [_candidate(f"场景{i}") for i in range(7)]
+    cache = DictCache()
+    agent = FakeAgent()
+
+    scenes = await enrich_scene_environments_batched(
+        candidates, enrichment_agent=agent, cache=cache
+    )
+
+    assert [scene.name for scene in scenes] == [c["name"] for c in candidates]
+    assert _scenes_named(agent.prompts) == {c["name"] for c in candidates}
+    assert len(cache.bucket(SCENE_ENRICHMENT_CACHE_TYPE)) == 7
+
+
+async def test_a_second_run_over_unchanged_input_calls_no_model_at_all():
+    candidates = [_candidate(f"场景{i}") for i in range(7)]
+    cache = DictCache()
+    await enrich_scene_environments_batched(
+        candidates, enrichment_agent=FakeAgent(), cache=cache
+    )
+
+    second = FakeAgent()
+    scenes = await enrich_scene_environments_batched(
+        candidates, enrichment_agent=second, cache=cache
+    )
+
+    assert second.prompts == []
+    assert [scene.name for scene in scenes] == [c["name"] for c in candidates]
+    assert all(scene.environment_prompt == STORED_PROMPT for scene in scenes)
+
+
+async def test_a_retry_only_pays_for_the_scenes_that_are_missing():
+    """The point of the whole thing: an interrupted build resumes."""
+    candidates = [_candidate(f"场景{i}") for i in range(7)]
+    cache = DictCache()
+
+    # First attempt: the batch carrying 场景5 fails, so it falls back per scene
+    # — and that per-scene call fails too, leaving boilerplate uncached.
+    async def failing_per_scene(**kwargs):
+        # Exactly what the real per-scene path produces when it too fails.
+        return NovelScene(
+            name=kwargs["scene_name"],
+            scene_type="interior",
+            environment_prompt=_ensure_directional_environment_prompt(
+                prompt="",
+                scene_name=kwargs["scene_name"],
+                scene_type="interior",
+                time_of_day="",
+                context_lines=list(kwargs.get("context_lines") or []),
+            ),
+        )
+
+    from novelvideo.cognee import pipeline
+
+    original = pipeline.enrich_scene_environment_from_context
+    pipeline.enrich_scene_environment_from_context = failing_per_scene
+    try:
+        await enrich_scene_environments_batched(
+            candidates, enrichment_agent=FakeAgent(fail_on={"场景5"}), cache=cache
+        )
+    finally:
+        pipeline.enrich_scene_environment_from_context = original
+
+    # 场景5 and 场景6 shared the failed batch; neither result is usable, so
+    # neither was cached.
+    assert len(cache.bucket(SCENE_ENRICHMENT_CACHE_TYPE)) == 5
+
+    retry = FakeAgent()
+    scenes = await enrich_scene_environments_batched(
+        candidates, enrichment_agent=retry, cache=cache
+    )
+
+    assert _scenes_named(retry.prompts) == {"场景5", "场景6"}
+    assert [scene.name for scene in scenes] == [c["name"] for c in candidates]
+    assert all(scene.environment_prompt == STORED_PROMPT for scene in scenes)
+
+
+async def test_results_are_written_per_batch_not_once_at_the_end():
+    """A build killed halfway must keep everything it already paid for."""
+    candidates = [_candidate(f"场景{i}") for i in range(12)]
+    cache = DictCache()
+
+    await enrich_scene_environments_batched(
+        candidates, enrichment_agent=FakeAgent(), cache=cache
+    )
+
+    assert cache.saves > 1
+
+
+async def test_a_failed_scene_is_never_cached():
+    """Boilerplate must not be frozen in as the permanent answer."""
+    candidates = [_candidate("场景0")]
+    cache = DictCache()
+
+    async def failing_per_scene(**kwargs):
+        # Exactly what the real per-scene path produces when it too fails.
+        return NovelScene(
+            name=kwargs["scene_name"],
+            scene_type="interior",
+            environment_prompt=_ensure_directional_environment_prompt(
+                prompt="",
+                scene_name=kwargs["scene_name"],
+                scene_type="interior",
+                time_of_day="",
+                context_lines=list(kwargs.get("context_lines") or []),
+            ),
+        )
+
+    from novelvideo.cognee import pipeline
+
+    original = pipeline.enrich_scene_environment_from_context
+    pipeline.enrich_scene_environment_from_context = failing_per_scene
+    try:
+        await enrich_scene_environments_batched(
+            candidates, enrichment_agent=FakeAgent(fail_on={"场景0"}), cache=cache
+        )
+    finally:
+        pipeline.enrich_scene_environment_from_context = original
+
+    assert cache.bucket(SCENE_ENRICHMENT_CACHE_TYPE) == {}
+
+
+async def test_cached_scenes_are_reported_as_progress():
+    """A resumed build must not look like it is stalled at zero."""
+    candidates = [_candidate(f"场景{i}") for i in range(4)]
+    cache = DictCache()
+    await enrich_scene_environments_batched(
+        candidates, enrichment_agent=FakeAgent(), cache=cache
+    )
+
+    seen: list[str] = []
+    await enrich_scene_environments_batched(
+        candidates,
+        enrichment_agent=FakeAgent(),
+        cache=cache,
+        on_scene=lambda candidate, scene: seen.append(candidate["name"]),
+    )
+    assert seen == [c["name"] for c in candidates]
+
+
+async def test_without_a_cache_nothing_changes():
+    """The cache is optional; the legacy call path passes none."""
+    candidates = [_candidate(f"场景{i}") for i in range(3)]
+    agent = FakeAgent()
+    scenes = await enrich_scene_environments_batched(candidates, enrichment_agent=agent)
+    assert [scene.name for scene in scenes] == [c["name"] for c in candidates]
+    assert _scenes_named(agent.prompts) == {c["name"] for c in candidates}
+
+
+# ── the store behind the cache ──────────────────────────────────────────────
+
+
+async def test_the_store_cache_survives_reopening_the_project(tmp_path):
+    """Resuming happens in a new process, so the cache has to be on disk."""
+    from novelvideo.sqlite_store import SQLiteStore
+
+    state_dir = tmp_path / "user" / "project"
+    state_dir.mkdir(parents=True)
+
+    store = SQLiteStore(
+        "user/project", output_dir=str(state_dir), state_dir=str(state_dir)
+    )
+    await store.initialize()
+    try:
+        await StoreSceneBuildCache(store).save(
+            SCENE_ENRICHMENT_CACHE_TYPE, {"k1": "v1", "k2": "v2"}
+        )
+    finally:
+        await store.close()
+
+    reopened = SQLiteStore(
+        "user/project", output_dir=str(state_dir), state_dir=str(state_dir)
+    )
+    await reopened.initialize()
+    try:
+        cache = StoreSceneBuildCache(reopened)
+        assert await cache.get(
+            SCENE_ENRICHMENT_CACHE_TYPE, ["k1", "k2", "missing"]
+        ) == {"k1": "v1", "k2": "v2"}
+    finally:
+        await reopened.close()
+
+
+async def test_the_store_cache_is_not_scoped_to_a_run(tmp_path):
+    """A new run must reuse what an abandoned one finished."""
+    from novelvideo.sqlite_store import SQLiteStore
+
+    state_dir = tmp_path / "user" / "project"
+    state_dir.mkdir(parents=True)
+    store = SQLiteStore(
+        "user/project", output_dir=str(state_dir), state_dir=str(state_dir)
+    )
+    await store.initialize()
+    try:
+        await store.save_analysis_item_cache(SCENE_ENRICHMENT_CACHE_TYPE, {"k": "v"})
+        assert await store.get_analysis_item_cache(
+            SCENE_ENRICHMENT_CACHE_TYPE, ["k"]
+        ) == {"k": "v"}
+        # A different artifact type must not see it.
+        assert await store.get_analysis_item_cache("characters", ["k"]) == {}
+    finally:
+        await store.close()
+
+
+async def test_the_store_cache_handles_more_keys_than_sqlite_allows_parameters(
+    tmp_path,
+):
+    """A feature-length screenplay can exceed the host-parameter cap."""
+    from novelvideo.sqlite_store import SQLiteStore
+
+    state_dir = tmp_path / "user" / "project"
+    state_dir.mkdir(parents=True)
+    store = SQLiteStore(
+        "user/project", output_dir=str(state_dir), state_dir=str(state_dir)
+    )
+    await store.initialize()
+    try:
+        entries = {f"key{i}": f"value{i}" for i in range(1500)}
+        await store.save_analysis_item_cache(SCENE_ENRICHMENT_CACHE_TYPE, entries)
+        found = await store.get_analysis_item_cache(
+            SCENE_ENRICHMENT_CACHE_TYPE, list(entries)
+        )
+        assert found == entries
+    finally:
+        await store.close()
+
+
+# ── end to end through the builder ──────────────────────────────────────────
+
+
+async def test_build_scenes_structured_passes_the_projects_own_cache(
+    tmp_path, monkeypatch
+):
+    """The wiring, not the mechanism: a builder with no cache resumes nothing."""
+    import json
+
+    from novelvideo import structured_builders
+    from novelvideo.cognee import pipeline
+    from novelvideo.knowledge_pipeline import (
+        KNOWLEDGE_PIPELINE_KEY,
+        KNOWLEDGE_PIPELINE_STRUCTURED,
+    )
+    from novelvideo.sqlite_store import SQLiteStore
+
+    state_dir = tmp_path / "user" / "project"
+    state_dir.mkdir(parents=True)
+    (state_dir / "project_config.json").write_text(
+        json.dumps(
+            {
+                KNOWLEDGE_PIPELINE_KEY: KNOWLEDGE_PIPELINE_STRUCTURED,
+                "spine_template": "drama",
+            },
+            ensure_ascii=False,
+        ),
+        encoding="utf-8",
+    )
+    store = SQLiteStore(
+        "user/project", output_dir=str(state_dir), state_dir=str(state_dir)
+    )
+    await store.initialize()
+    await store.load_graph_state()
+    store.save_novel_content("第1场 主任办公室 日 内\n▲张秉权翻看文件。\n")
+
+    seen: dict = {}
+
+    async def fake_extract(novel_text, on_progress=None, on_log=None, cache=None):
+        seen["cache"] = cache
+        return [
+            NovelScene(
+                name="主任办公室",
+                scene_type="interior",
+                environment_prompt=VALID_PROMPT,
+            )
+        ]
+
+    monkeypatch.setattr(pipeline, "extract_scenes_from_script", fake_extract)
+    try:
+        result = await structured_builders.build_scenes_structured(store)
+        assert result["added_scenes"] == 1
+        assert isinstance(seen["cache"], StoreSceneBuildCache)
+        # It has to be this project's store, not a detached one.
+        await seen["cache"].save(SCENE_ENRICHMENT_CACHE_TYPE, {"probe": "value"})
+        assert await store.get_analysis_item_cache(
+            SCENE_ENRICHMENT_CACHE_TYPE, ["probe"]
+        ) == {"probe": "value"}
+    finally:
+        await store.close()
+
+
+# ── what may be cached ──────────────────────────────────────────────────────
+
+
+def test_a_real_answer_is_cacheable():
+    assert is_cacheable_scene_prompt(STORED_PROMPT)
+
+
+def test_the_generated_fallback_is_never_cacheable():
+    """It satisfies the contract by construction, so validity alone is no test.
+
+    Caching it would freeze boilerplate in as the permanent answer: every later
+    rebuild would replay it and never retry the model.
+    """
+    assert SCENE_FALLBACK_FINGERPRINT in FALLBACK_PROMPT
+    assert not is_cacheable_scene_prompt(FALLBACK_PROMPT)
+
+
+def test_a_stored_fallback_reads_back_as_a_miss():
+    """Belt and braces: even if one were stored, it must not be replayed."""
+    scene = NovelScene(
+        name="场景0", scene_type="interior", environment_prompt=FALLBACK_PROMPT
+    )
+    assert scene_from_cache_payload(scene_to_cache_payload(scene)) is None
+
+
+@pytest.mark.parametrize("prompt", ["", "   ", "正面：只有一个方向", "没有分区的描述"])
+def test_an_invalid_prompt_is_never_cacheable(prompt):
+    assert not is_cacheable_scene_prompt(prompt)
+
+
+# ── the stage that used to cost the most ────────────────────────────────────
+
+
+def _parsed(name, **overrides):
+    from types import SimpleNamespace
+
+    block = {
+        "name": name,
+        "time_of_day": "夜",
+        "interior": True,
+        "episodes": [1],
+        "characters": ["林默"],
+        "context_lines": [f"▲{name}里灯亮着。"],
+    }
+    block.update(overrides)
+    return SimpleNamespace(**block)
+
+
+def test_a_parsed_block_becomes_a_candidate_with_no_model_call():
+    """A standard heading already states everything a candidate needs."""
+    from novelvideo.cognee.pipeline import _candidate_from_parsed_block
+
+    candidate = _candidate_from_parsed_block(_parsed("主任办公室", interior=True))
+    assert candidate["name"] == "主任办公室"
+    assert candidate["scene_type"] == "interior"
+    assert candidate["time_of_day"] == "夜晚"
+    assert candidate["characters"] == ["林默"]
+    assert candidate["context_lines"] == ["▲主任办公室里灯亮着。"]
+
+
+def test_an_exterior_block_keeps_its_type():
+    from novelvideo.cognee.pipeline import _candidate_from_parsed_block
+
+    assert (
+        _candidate_from_parsed_block(_parsed("郑家别墅外", interior=False))["scene_type"]
+        == "exterior"
+    )
+
+
+# ── the recall guard ────────────────────────────────────────────────────────
+
+
+def test_a_faithful_normalization_is_accepted():
+    from novelvideo.cognee.pipeline import _scene_recall_is_covered
+
+    covered, gap = _scene_recall_is_covered(
+        [{"name": "主任办公室", "aliases": []}, {"name": "楼梯间", "aliases": []}],
+        [_parsed("主任办公室"), _parsed("楼梯间")],
+    )
+    assert covered, gap
+
+
+def test_a_location_kept_only_as_an_alias_still_counts_as_covered():
+    """Folding a spelling into an alias is the normalizer working, not a loss."""
+    from novelvideo.cognee.pipeline import _scene_recall_is_covered
+
+    covered, _ = _scene_recall_is_covered(
+        [{"name": "主任办公室", "aliases": ["主任的办公室"]}],
+        [_parsed("主任办公室"), _parsed("主任的办公室")],
+    )
+    assert covered
+
+
+def test_a_heading_marker_difference_alone_is_not_a_loss():
+    from novelvideo.cognee.pipeline import _scene_recall_is_covered
+
+    covered, _ = _scene_recall_is_covered(
+        [{"name": "演武场外墙", "aliases": []}],
+        [_parsed("演武场外墙·夜")],
+    )
+    assert covered
+
+
+def test_a_dropped_location_trips_the_guard():
+    """The one thing the guard exists to catch."""
+    from novelvideo.cognee.pipeline import _scene_recall_is_covered
+
+    covered, gap = _scene_recall_is_covered(
+        [{"name": "主任办公室", "aliases": []}],
+        [_parsed("主任办公室"), _parsed("郑氏集团实验室")],
+    )
+    assert not covered
+    assert "郑氏集团实验室" in gap
+
+
+def test_fewer_scenes_alone_no_longer_trips_the_guard():
+    """The old test compared counts, so a correct merge read as lost recall.
+
+    That rejection cost a per-block model call for every scene in the script —
+    on a real screenplay, more than half the build's wall clock — to rebuild a
+    catalogue the normalizer had already produced.
+    """
+    from novelvideo.cognee.pipeline import _scene_recall_is_covered
+
+    normalized = [{"name": "主任办公室", "aliases": ["主任办公室·夜"]}]
+    parsed = [_parsed("主任办公室"), _parsed("主任办公室·夜")]
+    assert len(normalized) < len(parsed)
+    covered, _ = _scene_recall_is_covered(normalized, parsed)
+    assert covered
+
+
+# ── the screenplay normalizer, cached by source ─────────────────────────────
+
+
+async def test_the_normalizer_runs_once_per_source_text(monkeypatch):
+    """Not for its own few seconds, but for what its variance costs downstream.
+
+    Its answer differs between runs, so left uncached it reshuffles the
+    candidates — and every scene-description key derived from them misses.
+    """
+    from novelvideo.cognee import pipeline
+
+    calls = {"n": 0}
+
+    async def fake_normalize(_text):
+        calls["n"] += 1
+        return ["block"]
+
+    monkeypatch.setattr(pipeline, "normalize_screenplay_scenes", fake_normalize)
+    monkeypatch.setattr(
+        pipeline,
+        "_scene_candidates_from_normalized_blocks",
+        lambda _blocks: [_candidate("主任办公室")],
+    )
+
+    cache = DictCache()
+    first = await pipeline._normalized_scene_blocks_cached("剧本正文", cache)
+    second = await pipeline._normalized_scene_blocks_cached("剧本正文", cache)
+
+    assert calls["n"] == 1
+    assert first == second
+
+
+async def test_changed_source_text_runs_the_normalizer_again(monkeypatch):
+    from novelvideo.cognee import pipeline
+
+    calls = {"n": 0}
+
+    async def fake_normalize(_text):
+        calls["n"] += 1
+        return ["block"]
+
+    monkeypatch.setattr(pipeline, "normalize_screenplay_scenes", fake_normalize)
+    monkeypatch.setattr(
+        pipeline,
+        "_scene_candidates_from_normalized_blocks",
+        lambda _blocks: [_candidate("主任办公室")],
+    )
+
+    cache = DictCache()
+    await pipeline._normalized_scene_blocks_cached("剧本正文", cache)
+    await pipeline._normalized_scene_blocks_cached("改过的剧本正文", cache)
+    assert calls["n"] == 2
+
+
+async def test_an_empty_normalization_is_not_cached(monkeypatch):
+    """Nothing produced by a call that came back empty is worth replaying."""
+    from novelvideo.cognee import pipeline
+
+    calls = {"n": 0}
+
+    async def fake_normalize(_text):
+        calls["n"] += 1
+        return []
+
+    monkeypatch.setattr(pipeline, "normalize_screenplay_scenes", fake_normalize)
+    monkeypatch.setattr(
+        pipeline, "_scene_candidates_from_normalized_blocks", lambda _blocks: []
+    )
+
+    cache = DictCache()
+    await pipeline._normalized_scene_blocks_cached("剧本正文", cache)
+    await pipeline._normalized_scene_blocks_cached("剧本正文", cache)
+    assert calls["n"] == 2

--- a/tests/test_screenplay_normalizer.py
+++ b/tests/test_screenplay_normalizer.py
@@ -20,19 +20,15 @@ def test_normalize_time_of_day_maps_classical_terms_to_closed_choices():
 
 
 def test_time_of_day_agent_outputs_expose_closed_enum_schema():
-    from novelvideo.cognee import pipeline
 
     expected = ["无", "清晨", "上午", "正午", "午后", "白天", "黄昏", "夜晚"]
 
     block_schema = NormalizedSceneBlock.model_json_schema()["properties"]["time_of_day"]
-    scene_schema = pipeline.SceneNormalization.model_json_schema()["properties"]["time_of_day"]
 
     assert block_schema["enum"] == expected
-    assert scene_schema["enum"] == expected
 
 
 def test_time_of_day_agent_no_value_round_trips_to_internal_empty_string():
-    from novelvideo.cognee import pipeline
 
     block = NormalizedSceneBlock(
         episode_number=3,
@@ -47,22 +43,11 @@ def test_time_of_day_agent_no_value_round_trips_to_internal_empty_string():
         evidence_lines=[],
         content_lines=[],
     )
-    scene = pipeline.SceneNormalization(
-        name="凤鸣皇城·苏鸾寝殿",
-        aliases=[],
-        scene_type="interior",
-        time_of_day="无",
-        interior=True,
-        characters=[],
-    )
-
     assert block.time_of_day == ""
     assert block.interior_exterior == ""
-    assert scene.time_of_day == ""
 
 
 def test_time_of_day_agent_outputs_normalize_before_literal_validation():
-    from novelvideo.cognee import pipeline
 
     block = NormalizedSceneBlock(
         episode_number=3,
@@ -77,17 +62,7 @@ def test_time_of_day_agent_outputs_normalize_before_literal_validation():
         evidence_lines=[],
         content_lines=[],
     )
-    scene = pipeline.SceneNormalization(
-        name="凤鸣皇城·苏鸾寝殿",
-        aliases=[],
-        scene_type="interior",
-        time_of_day="凌晨",
-        interior=True,
-        characters=[],
-    )
-
     assert block.time_of_day == "夜晚"
-    assert scene.time_of_day == "夜晚"
 
 
 def test_clean_scene_name_and_time_removes_trailing_classical_time():
@@ -165,16 +140,35 @@ def test_normalized_scene_block_validator_cleans_location_time():
     assert block.time_of_day == "夜晚"
 
 
-def test_select_scene_primary_name_accepts_time_suffix_cleanup():
-    from novelvideo.cognee.pipeline import _select_scene_primary_name
+def test_scene_heading_suffix_strip_removes_time_markers():
+    """The name cleanup a per-block model call used to be needed for."""
+    from novelvideo.cognee.pipeline import strip_scene_heading_suffix
 
-    assert _select_scene_primary_name("演武场外墙·夜", "演武场外墙") == "演武场外墙"
-    assert _select_scene_primary_name("演武场外墙・夜", "演武场外墙") == "演武场外墙"
-    assert (
-        _select_scene_primary_name("凤鸣皇城·废弃粮仓夜", "凤鸣皇城·废弃粮仓")
-        == "凤鸣皇城·废弃粮仓"
-    )
-    assert _select_scene_primary_name("兰州拉面馆", "面馆") == "兰州拉面馆"
+    assert strip_scene_heading_suffix("演武场外墙·夜") == "演武场外墙"
+    assert strip_scene_heading_suffix("演武场外墙・夜") == "演武场外墙"
+    assert strip_scene_heading_suffix("凤鸣皇城·废弃粮仓夜") == "凤鸣皇城·废弃粮仓"
+
+
+def test_scene_heading_suffix_strip_never_generalizes_a_location():
+    """It removes heading markers, never part of the place itself."""
+    from novelvideo.cognee.pipeline import strip_scene_heading_suffix
+
+    assert strip_scene_heading_suffix("兰州拉面馆") == "兰州拉面馆"
+    assert strip_scene_heading_suffix("春熙路的3D大屏下") == "春熙路的3D大屏下"
+
+
+def test_an_attached_interior_marker_is_left_for_adjudication():
+    """"商务车内" is a place; "郑玉琴办公室内" is a marker. One rule cannot tell.
+
+    Deciding between them needs every candidate in view at once — whether a
+    sibling spelling exists, and which one the script uses more — which is what
+    adjudication has and a name-cleanup rule does not.
+    """
+    from novelvideo.cognee.pipeline import strip_scene_heading_suffix
+
+    assert strip_scene_heading_suffix("商务车内") == "商务车内"
+    assert strip_scene_heading_suffix("郑家别墅外") == "郑家别墅外"
+    assert strip_scene_heading_suffix("郑玉琴办公室内") == "郑玉琴办公室内"
 
 
 def test_scene_candidates_fill_missing_episode_from_raw_header():

--- a/tests/test_screenplay_normalizer.py
+++ b/tests/test_screenplay_normalizer.py
@@ -387,27 +387,6 @@ async def test_extract_scenes_from_script_falls_back_when_ai_returns_partial_blo
             )
         ]
 
-    class FakeLegacyNormalizerAgent:
-        async def run(self, prompt: str):
-            if "御花园" in prompt:
-                scene = pipeline.SceneNormalization(
-                    name="凤鸣皇城·御花园",
-                    aliases=["御花园"],
-                    scene_type="exterior",
-                    time_of_day="清晨",
-                    interior=False,
-                    characters=["苏糖", "沈晚"],
-                )
-            else:
-                scene = pipeline.SceneNormalization(
-                    name="凤鸣皇城·苏鸾寝殿",
-                    aliases=["苏鸾寝殿"],
-                    scene_type="interior",
-                    time_of_day="深夜",
-                    interior=True,
-                    characters=["苏糖"],
-                )
-            return _FakeRunResult(pipeline.SceneNormalizationList(scenes=[scene]))
 
     async def fake_enrich_scene_environment_from_context(**kwargs):
         return NovelScene(
@@ -419,11 +398,6 @@ async def test_extract_scenes_from_script_falls_back_when_ai_returns_partial_blo
         )
 
     monkeypatch.setattr(pipeline, "normalize_screenplay_scenes", fake_normalize)
-    monkeypatch.setattr(
-        pipeline,
-        "_create_scene_build_agent",
-        lambda *_args, **_kwargs: FakeLegacyNormalizerAgent(),
-    )
     monkeypatch.setattr(
         pipeline,
         "enrich_scene_environment_from_context",
@@ -453,17 +427,6 @@ async def test_extract_scenes_from_script_falls_back_when_ai_returns_empty(monke
     async def fake_normalize(_text: str):
         return []
 
-    class FakeLegacyNormalizerAgent:
-        async def run(self, prompt: str):
-            scene = pipeline.SceneNormalization(
-                name="凤鸣皇城·苏鸾寝殿",
-                aliases=["苏鸾寝殿"],
-                scene_type="interior",
-                time_of_day="亥时",
-                interior=True,
-                characters=["苏糖", "沈晚"],
-            )
-            return _FakeRunResult(pipeline.SceneNormalizationList(scenes=[scene]))
 
     async def fake_enrich_scene_environment_from_context(**kwargs):
         return NovelScene(
@@ -474,11 +437,6 @@ async def test_extract_scenes_from_script_falls_back_when_ai_returns_empty(monke
         )
 
     monkeypatch.setattr(pipeline, "normalize_screenplay_scenes", fake_normalize)
-    monkeypatch.setattr(
-        pipeline,
-        "_create_scene_build_agent",
-        lambda *_args, **_kwargs: FakeLegacyNormalizerAgent(),
-    )
     monkeypatch.setattr(
         pipeline,
         "enrich_scene_environment_from_context",
@@ -530,27 +488,6 @@ async def test_extract_scenes_from_script_falls_back_when_ai_merges_distinct_loc
             ),
         ]
 
-    class FakeLegacyNormalizerAgent:
-        async def run(self, prompt: str):
-            if "御花园" in prompt:
-                scene = pipeline.SceneNormalization(
-                    name="凤鸣皇城·御花园",
-                    aliases=["御花园"],
-                    scene_type="exterior",
-                    time_of_day="清晨",
-                    interior=False,
-                    characters=["苏糖", "沈晚"],
-                )
-            else:
-                scene = pipeline.SceneNormalization(
-                    name="凤鸣皇城·苏鸾寝殿",
-                    aliases=["苏鸾寝殿"],
-                    scene_type="interior",
-                    time_of_day="深夜",
-                    interior=True,
-                    characters=["苏糖"],
-                )
-            return _FakeRunResult(pipeline.SceneNormalizationList(scenes=[scene]))
 
     async def fake_enrich_scene_environment_from_context(**kwargs):
         return NovelScene(
@@ -562,11 +499,6 @@ async def test_extract_scenes_from_script_falls_back_when_ai_merges_distinct_loc
         )
 
     monkeypatch.setattr(pipeline, "normalize_screenplay_scenes", fake_normalize)
-    monkeypatch.setattr(
-        pipeline,
-        "_create_scene_build_agent",
-        lambda *_args, **_kwargs: FakeLegacyNormalizerAgent(),
-    )
     monkeypatch.setattr(
         pipeline,
         "enrich_scene_environment_from_context",


### PR DESCRIPTION
Depends on nothing; #360 (partial character artifact) is separate and independent.

## Measured

Same 33k-char screenplay, three consecutive builds:

| | cold | 2nd | 3rd | placeholder prompts |
|---|---|---|---|---|
| before | 176.5s | 158.2s | 192.9s | varied 0–8 |
| after | **74.8s** | **22.3s** | **0.0s** | **0** |

## Two causes

### 1. The recall guard was wrong

`extract_scenes_from_script` ran the screenplay normalizer, then discarded its result whenever it returned fewer distinct base scenes than the parser found:

```python
if len(normalized_scene_candidates) < len(legacy_candidates):
```

Folding two spellings of one room into a single scene is the normalizer working correctly, and it always lowers that count. On this script it produced 27 to the parser's 28 — the difference being a correct merge — so the whole result was thrown away.

Rejection dropped the build into a per-block LLM loop, **one call per scene block, run one at a time**. That was 51s, the largest single stage, to rebuild a catalogue the normalizer had already produced.

The guard now checks what it meant to: every location the parser found must still be reachable, as a name, an alias, or the same name with heading markers stripped. It also names what went missing rather than printing two counts — and on this script it does find 4 genuinely dropped locations, which the count comparison was only catching by accident.

### 2. The fallback did not need a model

A standard heading states location, time and interior/exterior; the parser reads all three. The name cleanup the model added is a suffix strip, and `clean_scene_name_and_time` already does it with rules that refuse to strip when the result would stop being a name. Deciding two spellings are one room is the part worth a model, and `adjudicate_scenes` already does it downstream — with every candidate in view and occurrence counts to pick the canonical spelling, which a per-block call looking at one heading in isolation cannot have.

Measured against the model path on the same script: **25 scenes either way, 24 identical**, the one difference being which spelling of a merged pair wins.

An attached `内` is deliberately left alone — `商务车内` is a place, `郑玉琴办公室内` is a marker, and no local rule can tell them apart. Adjudication can, and does.

## Caching

Three stages, keyed by sha256 of the exact input plus a contract version, in a new `story_analysis_item_cache` table (schema 3 → 4). Deliberately **not** scoped to a run — the point is for a new run to reuse what an abandoned one finished.

| type | keyed on | why |
|---|---|---|
| `scene_blocks` | source text | not for its own seconds but its *variance*: an uncached normalizer reshuffles candidates and every downstream key misses |
| `scene_environment` | exactly what the enrichment call sees | the resumable unit; `context_lines` truncated as the prompt truncates them |
| `scene_adjudication` | the candidate listing | only the model's grouping; the occurrence ceiling and canonical-name choice stay code and re-run every time |

### Nothing produced by a failure is cached

The generated fallback satisfies the 360 contract by construction, so a validity check alone would freeze boilerplate in as the permanent answer and no rebuild would ever retry. `is_cacheable_scene_prompt` rejects it by fingerprint as well, on write *and* on read.

The effect is that failed scenes retry on the next build instead of being frozen — which is why the third run reaches 0 placeholder prompts. The build converges.

## Legacy

Untouched. `extract_scenes_from_script` is called only by `structured_builders`; legacy uses `extract_scenes_from_graph`. No planner changed — `asset_compiler` and `identity_planner` carry no behaviour change here (the one edit is deleting `AssetCompiler._structured`, which was assigned and never read).

## Removed as orphaned

`SceneNormalization`, `SceneNormalizationList`, `_select_scene_primary_name`, `_strip_scene_name_wrapper`, `_remove_minor_scene_fillers` — all only reachable from the deleted loop. Their behaviour that still matters was ported onto `strip_scene_heading_suffix` with tests, including the cases that guarded against over-generalization.

## Tests

43 in `tests/test_scene_build_resume.py`: cache keys (what changes them, what must not), payload round trip, cold/warm/interrupted runs, the fallback-fingerprint guard driven with the *real* generated fallback, the recall guard, parser-block candidates, and the store cache across a reopen.

`ruff` clean. Full suite 3787 passed, 16 skipped.