### PR TITLE
fix: chapter mapping must work on the store structured projects open

### DIFF
--- a/license-inventory.csv
+++ b/license-inventory.csv
@@ -2060,6 +2060,7 @@ tests/test_stage_asset_step_contract.py,Elastic-2.0,2026 SuperTale contributors,
 tests/test_storyboard_prompt_visual_authority.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_structured_builders.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_structured_ingest.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
+tests/test_structured_plan_episodes.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_style_template_manifest.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_superpower_model_config.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_task_backend_celery_metadata.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation

--- a/src/novelvideo/cognee/store.py
+++ b/src/novelvideo/cognee/store.py
@@ -39,7 +39,6 @@ from novelvideo.knowledge_pipeline import (
     KnowledgePipelineUnsupported,
     is_structured_pipeline,
 )
-from novelvideo.official_defaults import DEFAULT_COGNEE_LLM_MODEL
 from novelvideo.novel_source import require_imported_novel
 from novelvideo.project_config import ensure_cognee_embedding_binding_in_state_dir
 from novelvideo.sqlite_store import SQLiteStore
@@ -1099,114 +1098,20 @@ class CogneeStore:
         on_progress: Optional[Callable[[float, str], None]] = None,
         on_log: Optional[Callable[[str], None]] = None,
     ) -> List[NovelEpisode]:
-        """从小说章节结构创建剧集（章节映射模式）。"""
-        from novelvideo.cognee.chapter_detector import ChapterDetector
+        """从小说章节结构创建剧集（章节映射模式）。
 
-        def report(progress: float, task: str):
-            if on_progress:
-                on_progress(progress, task)
-
-        def log(message: str):
-            if on_log:
-                on_log(message)
-            console.print(f"[dim]{message}[/dim]")
-
-        # 获取小说原文
-        if novel_text is None:
-            log("从文件加载原文...")
-            novel_text = require_imported_novel(self.project_dir)
-            log(f"原文加载完成: {len(novel_text)} 字符")
-
-        # 清理剧集内容
-        await self.clear_episode_contents()
-
-        # P1: 检测章节
-        report(0.1, "检测章节结构...")
-        log("检测章节结构...")
-        detector = ChapterDetector()
-        chapters = detector.detect(novel_text)
-
-        if not chapters:
-            raise ValueError("未检测到章节标记，请使用 AI 规划模式")
-
-        log(f"检测到 {len(chapters)} 个章节")
-
-        episodes = []
-        chapter_contents = {}  # 收集章节内容，最后统一写入
-        total = len(chapters)
-
-        for i, chapter in enumerate(chapters):
-            progress = 0.1 + (i / total) * 0.7
-            report(progress, f"处理第 {chapter.number} 章...")
-
-            # 收集章节内容（稍后写入，避免与 _delete_old_episodes 冲突）
-            chapter_contents[chapter.number] = chapter.content
-
-            if generate_metadata:
-                log(f"为第 {chapter.number} 章生成元数据...")
-                metadata = await self._generate_episode_metadata(chapter.number, chapter.content)
-            else:
-                summary = chapter.content[:200].strip()
-                if len(chapter.content) > 200:
-                    summary += "..."
-                metadata = {
-                    "title": f"第{chapter.number}集",
-                    "summary": summary,
-                    "conflict": "",
-                    "cliffhanger": "",
-                    "key_events": [],
-                    "characters": [],
-                }
-
-            episode = NovelEpisode(
-                number=chapter.number,
-                title=metadata.get("title", f"第{chapter.number}集"),
-                chapter_start=chapter.number,
-                chapter_end=chapter.number,
-                content_summary=metadata.get("summary", ""),
-                main_conflict=metadata.get("conflict", ""),
-                cliffhanger=metadata.get("cliffhanger", ""),
-                key_events=metadata.get("key_events", []),
-                character_names=metadata.get("characters", []),
-            )
-            episodes.append(episode)
-
-        # P2: 合并剧集（保留已有的已规划资产字段）
-        report(0.82, "合并剧集数据...")
-        log("合并剧集数据（保留身份、场景、道具和颜色）...")
-        new_numbers = {ep.number for ep in episodes}
-        for ep in episodes:
-            old = self._episodes.get(ep.number)
-            if old:
-                ep.identity_ids = old.identity_ids
-                ep.scene_menu = old.scene_menu
-                ep.prop_menu = old.prop_menu
-                ep.sketch_colors_json = old.sketch_colors_json
-
-        # 删除不再存在的旧剧集
-        old_numbers = set(self._episodes.keys())
-        removed = old_numbers - new_numbers
-        if removed:
-            await self.sqlite_store.delete_episodes_by_numbers(removed)
-            log(f"已删除 {len(removed)} 个旧剧集")
-        self._episodes.clear()
-
-        # P3: 保存新剧集
-        report(0.88, "保存到数据库...")
-        log("保存剧集到数据库...")
-        await self.add_episodes(episodes)
-
-        # P3.5: 保存章节原文内容
-        for ep_num, content in chapter_contents.items():
-            await self.save_episode_content(ep_num, content)
-
-        # P4: 更新内存缓存
-        for ep in episodes:
-            self._episodes[ep.number] = ep
-
-        report(1.0, "章节映射完成")
-        log(f"章节映射完成: {len(episodes)} 集")
-
+        Chapter mapping reads the source text and writes SQLite; it never
+        touches the graph, so the implementation lives on SQLiteStore where
+        both tracks can reach it. This stays as a delegate so legacy callers
+        and the in-memory episode cache behave exactly as before.
+        """
+        episodes = await self.sqlite_store.build_episodes_from_chapters(
+            novel_text=novel_text,
+            generate_metadata=generate_metadata,
+            on_progress=on_progress,
+            on_log=on_log,
+        )
+        self._sync_sqlite_caches()
         return episodes
 
     async def build_episodes_from_events(
@@ -1398,55 +1303,6 @@ class CogneeStore:
                     assignments[ep_num] = []
                 assignments[ep_num].append(event.event_id)
             return assignments
-
-    async def _generate_episode_metadata(self, episode_num: int, content: str) -> dict:
-        """使用 LLM 生成剧集元数据。"""
-        try:
-            import litellm
-
-            truncated = content[:8000] if len(content) > 8000 else content
-
-            prompt = f"""请分析以下章节内容，提取关键信息。
-
-章节内容：
-{truncated}
-
-请用 JSON 格式返回以下信息：
-{{
-    "title": "一个吸引人的标题（10字以内）",
-    "summary": "内容摘要（50-100字）",
-    "conflict": "主要冲突或矛盾",
-    "cliffhanger": "结尾悬念（如果有）",
-    "key_events": ["关键事件1", "关键事件2"],
-    "characters": ["出场角色1", "出场角色2"]
-}}
-
-只返回 JSON，不要有其他内容。"""
-
-            response = await litellm.acompletion(
-                model=os.environ.get("LLM_MODEL", "").strip()
-                or DEFAULT_COGNEE_LLM_MODEL,
-                messages=[{"role": "user", "content": prompt}],
-                temperature=0.3,
-                response_format={"type": "json_object"},
-                **get_newapi_structured_output_litellm_kwargs(),
-            )
-
-            import json
-
-            result = json.loads(response.choices[0].message.content)
-            return result
-
-        except Exception as e:
-            console.print(f"[yellow]元数据生成失败: {e}，使用默认值[/yellow]")
-            return {
-                "title": f"第{episode_num}集",
-                "summary": content[:200] + "..." if len(content) > 200 else content,
-                "conflict": "",
-                "cliffhanger": "",
-                "key_events": [],
-                "characters": [],
-            }
 
     async def add_episodes(self, episodes: List[NovelEpisode]) -> None:
         """批量添加剧集到 SQLite。"""

--- a/src/novelvideo/sqlite_store.py
+++ b/src/novelvideo/sqlite_store.py
@@ -12,6 +12,7 @@ import functools
 import inspect
 import json
 import logging
+import os
 import sqlite3
 from pathlib import Path
 from typing import Any, Callable, Dict, Iterable, List, Optional
@@ -34,7 +35,11 @@ from novelvideo.models import (
     normalize_detected_props,
     sync_beat_asset_refs,
 )
-from novelvideo.novel_source import load_imported_novel_content
+from novelvideo.novel_source import (
+    load_imported_novel_content,
+    require_imported_novel,
+)
+from novelvideo.official_defaults import DEFAULT_COGNEE_LLM_MODEL
 from novelvideo.sqlite_pragmas import configure_sqlite_connection_async
 from novelvideo.sqlite_schema import ensure_sqlite_schema
 from novelvideo.utils.asset_names import (
@@ -1723,6 +1728,183 @@ class SQLiteStore:
             await asyncio.shield(db.rollback())
             raise
         self._episodes.update({episode.number: episode for episode in episodes})
+
+    async def build_episodes_from_chapters(
+        self,
+        novel_text: str = None,
+        generate_metadata: bool = False,
+        on_progress: Optional[Callable[[float, str], None]] = None,
+        on_log: Optional[Callable[[str], None]] = None,
+    ) -> List[NovelEpisode]:
+        """从小说章节结构创建剧集（章节映射模式）。
+
+        Deterministic: chapter markers in the source text become episodes, one
+        per chapter. It reads the imported novel and writes SQLite and touches
+        no graph, which is why it lives here rather than on the Cognee facade —
+        structured projects open a SQLiteStore directly and could not reach it
+        there. CogneeStore delegates, so legacy behaviour is unchanged.
+        """
+        from novelvideo.cognee.chapter_detector import ChapterDetector
+
+        def report(progress: float, task: str):
+            if on_progress:
+                on_progress(progress, task)
+
+        def log(message: str):
+            if on_log:
+                on_log(message)
+            console.print(f"[dim]{message}[/dim]")
+
+        # 获取小说原文
+        if novel_text is None:
+            log("从文件加载原文...")
+            novel_text = require_imported_novel(self.project_dir)
+            log(f"原文加载完成: {len(novel_text)} 字符")
+
+        # 清理剧集内容
+        await self.clear_episode_contents()
+
+        # P1: 检测章节
+        report(0.1, "检测章节结构...")
+        log("检测章节结构...")
+        detector = ChapterDetector()
+        chapters = detector.detect(novel_text)
+
+        if not chapters:
+            raise ValueError("未检测到章节标记，请使用 AI 规划模式")
+
+        log(f"检测到 {len(chapters)} 个章节")
+
+        episodes = []
+        chapter_contents = {}  # 收集章节内容，最后统一写入
+        total = len(chapters)
+
+        for i, chapter in enumerate(chapters):
+            progress = 0.1 + (i / total) * 0.7
+            report(progress, f"处理第 {chapter.number} 章...")
+
+            # 收集章节内容（稍后写入，避免与 _delete_old_episodes 冲突）
+            chapter_contents[chapter.number] = chapter.content
+
+            if generate_metadata:
+                log(f"为第 {chapter.number} 章生成元数据...")
+                metadata = await self._generate_episode_metadata(chapter.number, chapter.content)
+            else:
+                summary = chapter.content[:200].strip()
+                if len(chapter.content) > 200:
+                    summary += "..."
+                metadata = {
+                    "title": f"第{chapter.number}集",
+                    "summary": summary,
+                    "conflict": "",
+                    "cliffhanger": "",
+                    "key_events": [],
+                    "characters": [],
+                }
+
+            episode = NovelEpisode(
+                number=chapter.number,
+                title=metadata.get("title", f"第{chapter.number}集"),
+                chapter_start=chapter.number,
+                chapter_end=chapter.number,
+                content_summary=metadata.get("summary", ""),
+                main_conflict=metadata.get("conflict", ""),
+                cliffhanger=metadata.get("cliffhanger", ""),
+                key_events=metadata.get("key_events", []),
+                character_names=metadata.get("characters", []),
+            )
+            episodes.append(episode)
+
+        # P2: 合并剧集（保留已有的已规划资产字段）
+        report(0.82, "合并剧集数据...")
+        log("合并剧集数据（保留身份、场景、道具和颜色）...")
+        new_numbers = {ep.number for ep in episodes}
+        for ep in episodes:
+            old = self._episodes.get(ep.number)
+            if old:
+                ep.identity_ids = old.identity_ids
+                ep.scene_menu = old.scene_menu
+                ep.prop_menu = old.prop_menu
+                ep.sketch_colors_json = old.sketch_colors_json
+
+        # 删除不再存在的旧剧集
+        old_numbers = set(self._episodes.keys())
+        removed = old_numbers - new_numbers
+        if removed:
+            await self.delete_episodes_by_numbers(removed)
+            log(f"已删除 {len(removed)} 个旧剧集")
+        self._episodes.clear()
+
+        # P3: 保存新剧集
+        report(0.88, "保存到数据库...")
+        log("保存剧集到数据库...")
+        await self.add_episodes(episodes)
+
+        # P3.5: 保存章节原文内容
+        for ep_num, content in chapter_contents.items():
+            await self.save_episode_content(ep_num, content)
+
+        # P4: 更新内存缓存
+        for ep in episodes:
+            self._episodes[ep.number] = ep
+
+        report(1.0, "章节映射完成")
+        log(f"章节映射完成: {len(episodes)} 集")
+
+        return episodes
+
+    async def _generate_episode_metadata(self, episode_num: int, content: str) -> dict:
+        """使用 LLM 生成剧集元数据。"""
+        try:
+            import litellm
+
+            from novelvideo.config import (
+                get_newapi_structured_output_litellm_kwargs,
+            )
+
+            truncated = content[:8000] if len(content) > 8000 else content
+
+            prompt = f"""请分析以下章节内容，提取关键信息。
+
+章节内容：
+{truncated}
+
+请用 JSON 格式返回以下信息：
+{{
+    "title": "一个吸引人的标题（10字以内）",
+    "summary": "内容摘要（50-100字）",
+    "conflict": "主要冲突或矛盾",
+    "cliffhanger": "结尾悬念（如果有）",
+    "key_events": ["关键事件1", "关键事件2"],
+    "characters": ["出场角色1", "出场角色2"]
+}}
+
+只返回 JSON，不要有其他内容。"""
+
+            response = await litellm.acompletion(
+                model=os.environ.get("LLM_MODEL", "").strip()
+                or DEFAULT_COGNEE_LLM_MODEL,
+                messages=[{"role": "user", "content": prompt}],
+                temperature=0.3,
+                response_format={"type": "json_object"},
+                **get_newapi_structured_output_litellm_kwargs(),
+            )
+
+            import json
+
+            result = json.loads(response.choices[0].message.content)
+            return result
+
+        except Exception as e:
+            console.print(f"[yellow]元数据生成失败: {e}，使用默认值[/yellow]")
+            return {
+                "title": f"第{episode_num}集",
+                "summary": content[:200] + "..." if len(content) > 200 else content,
+                "conflict": "",
+                "cliffhanger": "",
+                "key_events": [],
+                "characters": [],
+            }
 
     async def replace_episodes(self, episodes: List[NovelEpisode]) -> None:
         """Atomically replace every episode row and refresh the cache."""

--- a/tests/test_structured_plan_episodes.py
+++ b/tests/test_structured_plan_episodes.py
@@ -1,0 +1,172 @@
+"""Chapter mapping has to work on the store each track actually opens.
+
+structured_v1 builds and planning open a SQLiteStore directly — they have no
+graph to reach through the Cognee facade for. Chapter mapping is deterministic
+and touches no graph, but it lived on CogneeStore, so the plan-episodes runner
+raised AttributeError for every structured project. Nothing caught it because
+the tests drove the store classes rather than the runner's own store loading.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from novelvideo.knowledge_pipeline import (
+    KNOWLEDGE_PIPELINE_KEY,
+    KNOWLEDGE_PIPELINE_STRUCTURED,
+)
+
+CHAPTERED = (
+    "第一章 归来\n\n林默回到阔别十年的故乡。\n\n"
+    "第二章 旧友\n\n他在巷口遇见了陈舟。\n\n"
+    "第三章 对峙\n\n两人在旧屋前争执起来。\n"
+)
+
+
+def _project(tmp_path: Path, *, structured: bool) -> Path:
+    state_dir = tmp_path / "user" / ("structured" if structured else "legacy")
+    state_dir.mkdir(parents=True)
+    config = {"user": "eric", "spine_template": "narrated"}
+    if structured:
+        config[KNOWLEDGE_PIPELINE_KEY] = KNOWLEDGE_PIPELINE_STRUCTURED
+    (state_dir / "project_config.json").write_text(
+        json.dumps(config, ensure_ascii=False), encoding="utf-8"
+    )
+    return state_dir
+
+
+async def _sqlite_store(state_dir: Path):
+    from novelvideo.sqlite_store import SQLiteStore
+
+    store = SQLiteStore(
+        "user/project", output_dir=str(state_dir), state_dir=str(state_dir)
+    )
+    await store.initialize()
+    await store.load_graph_state()
+    return store
+
+
+@pytest.fixture
+async def structured_store(tmp_path):
+    store = await _sqlite_store(_project(tmp_path, structured=True))
+    store.save_novel_content(CHAPTERED)
+    try:
+        yield store
+    finally:
+        await store.close()
+
+
+# ── the store structured projects actually open ─────────────────────────────
+
+
+async def test_chapter_mapping_works_on_the_sqlite_store(structured_store):
+    episodes = await structured_store.build_episodes_from_chapters()
+
+    assert [episode.number for episode in episodes] == [1, 2, 3]
+    assert [episode.title for episode in episodes] == ["第1集", "第2集", "第3集"]
+
+
+async def test_the_episodes_are_actually_persisted(structured_store, tmp_path):
+    await structured_store.build_episodes_from_chapters()
+    await structured_store.close()
+
+    reopened = await _sqlite_store(Path(structured_store.state_dir))
+    try:
+        stored = await reopened.get_episode_from_graph(2)
+        assert stored is not None
+        assert "陈舟" in await reopened.load_episode_content(2)
+    finally:
+        await reopened.close()
+
+
+async def test_planned_assets_survive_a_remap(structured_store):
+    """Re-running chapter mapping must not discard planning already done."""
+    await structured_store.build_episodes_from_chapters()
+    await structured_store.patch_episode(
+        2, identity_ids=["林默:default"], scene_menu=[{"scene_id": "巷口"}]
+    )
+
+    await structured_store.build_episodes_from_chapters()
+
+    episode = await structured_store.get_episode_from_graph(2)
+    assert episode.identity_ids == ["林默:default"]
+    assert episode.scene_menu
+
+
+# ── the runner, which is where the gap was ──────────────────────────────────
+
+
+async def test_the_plan_episodes_runner_works_for_a_structured_project(tmp_path):
+    """The regression itself: the runner opens SQLiteStore for structured.
+
+    Testing the store classes alone is what let this through — the runner picks
+    a different one per track, and only one of them had the method.
+    """
+    from novelvideo.task_backend.runners import graph_build
+
+    state_dir = _project(tmp_path, structured=True)
+    store = await _sqlite_store(state_dir)
+    store.save_novel_content(CHAPTERED)
+    await store.close()
+
+    ctx = graph_build.ProjectContext(
+        project_id="p1",
+        project_name="project",
+        owner_type="user",
+        owner_id="1",
+        owner_username="user",
+        requester_user_id="1",
+        requester_username="user",
+        requester_principals=(),
+        effective_role="owner",
+        home_node_id="node",
+        output_dir=state_dir,
+        state_dir=state_dir,
+        runtime_dir=state_dir,
+        is_home_node=True,
+    )
+    loaded = await graph_build._load_store(ctx)
+    try:
+        episodes = await loaded.build_episodes_from_chapters(generate_metadata=False)
+        assert [episode.number for episode in episodes] == [1, 2, 3]
+    finally:
+        await loaded.close()
+
+
+# ── legacy ──────────────────────────────────────────────────────────────────
+
+
+async def test_legacy_keeps_the_method_and_its_cache(tmp_path):
+    """CogneeStore delegates now; callers and its episode cache must not care."""
+    from novelvideo.cognee.store import CogneeStore
+
+    state_dir = _project(tmp_path, structured=False)
+    sqlite = await _sqlite_store(state_dir)
+    # Built the way the legacy suite builds one, so Cognee initialization — which
+    # needs a gateway key — is not what this test is about.
+    store = CogneeStore.__new__(CogneeStore)
+    store.project_name = "user/legacy"
+    store.dataset_name = "novelvideo_user/legacy"
+    store._db = None
+    store._characters = {}
+    store._episodes = {}
+    store._alias_index = {}
+    store.project_dir = str(state_dir)
+    store.state_dir = str(state_dir)
+    store.db_path = str(state_dir / "data.db")
+    store.sqlite_store = sqlite
+
+    try:
+        store.save_novel_content(CHAPTERED)
+        episodes = await store.build_episodes_from_chapters()
+
+        assert [episode.number for episode in episodes] == [1, 2, 3]
+        # The in-memory cache the facade keeps must reflect the write, or the
+        # next reader on this instance sees the pre-mapping world.
+        assert store.get_episode(3) is not None
+        assert store.get_episode(3).title == "第3集"
+    finally:
+        await sqlite.close()


### PR DESCRIPTION
Found while testing the planners end to end on real data. **Plan-episodes was broken for every structured project.**

## The bug

```
AttributeError: 'SQLiteStore' object has no attribute 'build_episodes_from_chapters'
```

`_load_store` in the plan-episodes runner opens a **SQLiteStore** for structured projects — they have no graph to reach through the Cognee facade for. But `build_episodes_from_chapters` lived on `CogneeStore`.

Chapter mapping is the *only* episode mode structured projects are allowed — the runner raises `KnowledgePipelineUnsupported` for anything else:

```python
if is_structured_pipeline(ctx.state_dir) and planning_mode != "chapters":
    raise KnowledgePipelineUnsupported(...)
```

So this was the whole feature, not an edge case. And plan-episodes gates everything after it: no episodes means no identity planning, no scene planning, no prop planning.

## The fix

The method touches no graph — it is chapter detection plus SQLite writes. Moved it and `_generate_episode_metadata` to `SQLiteStore` where both tracks can reach them; `CogneeStore` keeps a delegate that refreshes its episode cache exactly as before, so legacy is unchanged.

## Why nothing caught it

The tests drove the store classes directly. The two tracks diverge precisely at *which store the runner opens*, so a test that constructs a store itself can never see the gap. `test_the_plan_episodes_runner_works_for_a_structured_project` goes through `graph_build._load_store`.

## Tests

5 in `tests/test_structured_plan_episodes.py`: chapter mapping on the SQLite store, persistence across a reopen, planned assets surviving a remap, the runner's own store loading, and legacy keeping both the method and its in-memory episode cache.

## Verified on real data

43 episodes mapped from the test screenplay, then identity/scene/prop planning all ran through on EP1 and EP2.

`ruff` clean. Full suite 3747 passed, 16 skipped.