### PR TITLE
fix: close four determinism gaps in structured_v1

### DIFF
--- a/src/novelvideo/api/routes/projects.py
+++ b/src/novelvideo/api/routes/projects.py
@@ -29,6 +29,7 @@ from novelvideo.api.schemas import (
 )
 from novelvideo.config import ensure_project_dirs_at_paths
 from novelvideo.knowledge_pipeline import KNOWLEDGE_PIPELINE_KEY, KNOWLEDGE_PIPELINE_STRUCTURED
+from novelvideo.novel_source import has_imported_novel
 from novelvideo.ports import get_project_access, get_project_registry
 from novelvideo.ports.project import ProjectRecord
 from novelvideo.project_config import (
@@ -538,14 +539,15 @@ async def update_project(
     if body.spine_template is not None and body.spine_template != current_config.get(
         "spine_template", "drama"
     ):
-        store = await make_sqlite_store_for_context(ctx)
-        try:
-            imported = bool(store.get_all_episodes())
-        finally:
-            close = getattr(store, "close", None)
-            if close:
-                await close()
-        if imported:
+        # Locked by the imported text, not by episodes. Structured ingest
+        # records a chunk plan and writes novel.txt but creates no episodes, so
+        # an episode check leaves a window open between import and episode
+        # planning. Switching the template inside it silently invalidates the
+        # analysis run — it is keyed on the template, because the same novel
+        # chunked as a screenplay and as narrated prose are different plans —
+        # and the next character build finds none. It still runs, but with no
+        # chunk persistence, no resume, no final artifact and no evidence rows.
+        if has_imported_novel(ctx.output_dir):
             return JSONResponse(
                 status_code=400,
                 content={

--- a/src/novelvideo/sqlite_store.py
+++ b/src/novelvideo/sqlite_store.py
@@ -1776,8 +1776,12 @@ class SQLiteStore:
             novel_text = require_imported_novel(self.project_dir)
             log(f"原文加载完成: {len(novel_text)} 字符")
 
-        # 清理剧集内容
-        await self.clear_episode_contents()
+        # Everything below computes; nothing is written until the publish at
+        # the end. This used to clear every episode's raw_content and commit
+        # before it had even detected a chapter, then commit again per delete,
+        # per upsert and per episode body — so a cancelled task or a killed
+        # worker could leave a project with every episode blank, or half its
+        # episodes mapped, or metadata that did not match the text under it.
 
         # P1: 检测章节
         report(0.1, "检测章节结构...")
@@ -1841,25 +1845,33 @@ class SQLiteStore:
                 ep.scene_menu = old.scene_menu
                 ep.prop_menu = old.prop_menu
                 ep.sketch_colors_json = old.sketch_colors_json
+            # The body travels on the row, so the text and the metadata
+            # describing it land in the same write and cannot disagree.
+            ep.raw_content = chapter_contents.get(ep.number, "")
 
-        # 删除不再存在的旧剧集
-        old_numbers = set(self._episodes.keys())
-        removed = old_numbers - new_numbers
-        if removed:
-            await self.delete_episodes_by_numbers(removed)
-            log(f"已删除 {len(removed)} 个旧剧集")
-        self._episodes.clear()
+        removed = set(self._episodes.keys()) - new_numbers
 
-        # P3: 保存新剧集
+        # P3: 单事务发布
         report(0.88, "保存到数据库...")
         log("保存剧集到数据库...")
-        await self.add_episodes(episodes)
+        db = await self._ensure_db()
+        try:
+            if removed:
+                placeholders = ",".join("?" for _ in removed)
+                await db.execute(
+                    f"DELETE FROM episodes WHERE number IN ({placeholders})",
+                    sorted(removed),
+                )
+            await self._upsert_episodes(db, episodes)
+            await db.commit()
+        except BaseException:
+            await asyncio.shield(db.rollback())
+            raise
+        if removed:
+            log(f"已删除 {len(removed)} 个旧剧集")
 
-        # P3.5: 保存章节原文内容
-        for ep_num, content in chapter_contents.items():
-            await self.save_episode_content(ep_num, content)
-
-        # P4: 更新内存缓存
+        # P4: 更新内存缓存，只在写入确实落盘之后
+        self._episodes.clear()
         for ep in episodes:
             self._episodes[ep.number] = ep
 

--- a/src/novelvideo/structured_extraction.py
+++ b/src/novelvideo/structured_extraction.py
@@ -382,11 +382,10 @@ async def extract_characters_from_chunks(
     return merged, failures
 
 
-def _attested_names(outcomes: list[tuple[SourceChunk, ChunkCharacterOutput]]) -> str:
-    """The text a name has to appear somewhere in, plus the cast lists.
+def _source_of(outcomes: list[tuple[SourceChunk, ChunkCharacterOutput]]) -> str:
+    """The text a name has to appear in, plus the cast lists the author wrote.
 
-    Joined with a separator so a name cannot be formed by spanning the seam
-    between two chunks.
+    Joined with a separator so a name cannot be formed across a chunk seam.
     """
     parts: list[str] = []
     for chunk, _output in outcomes:
@@ -395,37 +394,43 @@ def _attested_names(outcomes: list[tuple[SourceChunk, ChunkCharacterOutput]]) ->
     return "\n\x00\n".join(parts)
 
 
-def name_is_attested(name: str, corpus: str) -> bool:
-    """Whether the source itself writes this name.
+def name_is_attested(name: str, source: str) -> bool:
+    """Whether the imported source writes this name at all.
 
-    Verifying the quote alone does not do it. A model can return a real
-    sentence from the text and attach a name that never appears anywhere:
+    Verifying the quote does not establish this. A model can return a real
+    sentence and attach a name that appears nowhere:
 
         text  : 林默回到了家
         model : name=王五, evidence="林默回到了家"
 
-    The quote verifies, so the candidate used to be accepted, and 王五 became a
-    row in the character table — a primary key, a REST identifier and an asset
-    directory, invented out of nothing.
+    The quote verifies, so 王五 used to be accepted, and became a row in the
+    character table — a primary key, a REST identifier and an asset directory,
+    invented out of nothing.
 
-    This catches invention, not misattribution: a name the source does write,
-    returned against a line about somebody else, still passes. Ruling that out
-    would take Chinese NER and word-boundary analysis, would still be wrong
-    sometimes, and would cost the cross-chunk recall described below.
+    Checked against the whole source rather than the chunk that proposed the
+    name, and that is the deliberate half of it. The stricter rule was measured
+    against stored per-chunk outputs on both spines and dropped nothing at all,
+    because the extraction prompt already asks for a form used in this span and
+    the model obeys — so it buys little. What it changes is the direction of
+    failure: in-chunk fails closed, and a misjudgement there deletes a real
+    character that someone then has to re-enter. Source-wide fails open, and a
+    misjudgement there files one quote against the wrong name — a provenance
+    record, not a rename.
 
-    Checked against the whole imported text rather than the chunk the candidate
-    came from, deliberately. A character is introduced by name once and referred
-    to as 她 or 郑太 for pages afterwards, and attributing those appellations
-    back to her is a thing this module is built to do. Requiring the name in the
-    chunk that mentions her would drop exactly those candidates and take
-    cross-chunk appellation resolution with them. Requiring it in the source
-    still leaves an invented name with no route in, which is the guarantee that
-    was missing.
+    Misattribution is not free, and it is worth naming what it can still do: an
+    appellation offered by a single owner is taken at face value, so a name
+    bound to the wrong line can put an alias on the wrong character. Only a
+    contested appellation has to win a vote. That is a model-quality risk, and
+    the way to reduce it is a better prompt or an adjudicator, not a guard that
+    deletes characters when it is wrong.
+
+    So the line drawn here is: invention cannot get in, misattribution can.
+    Moving it further needs Chinese NER and would still be wrong sometimes.
     """
     normalized = normalize_character_name(name)
     if not normalized:
         return False
-    return normalized in corpus or str(name or "").strip() in corpus
+    return normalized in source or str(name or "").strip() in source
 
 
 def merge_character_candidates(
@@ -439,14 +444,21 @@ def merge_character_candidates(
     """
     merged: dict[str, MergedCharacter] = {}
     alias_pairs: set[tuple[str, str]] = set()
-    # Every name any chunk proposed, so an alias statement in one chunk can
-    # still resolve a name that was only extracted in another.
+    # Only names that survive attestation may anchor an alias statement, and
+    # they are pooled across chunks so a statement in one chunk can still
+    # resolve a name another chunk established. Pooling the raw model output
+    # instead would let a bad capture anchor itself: the model proposing
+    # "家都知道林默" would license exactly the pair the anchoring exists to stop.
+    source = _source_of(outcomes)
+    # Only names that survive attestation may anchor an alias statement. Pooling
+    # raw model output instead would let a bad capture anchor itself.
     proposed_names = {
         candidate.name
         for _chunk, output in outcomes
         for candidate in output.characters
+        if name_is_attested(candidate.name, source)
+        and not is_generic_address(normalize_character_name(candidate.name))
     }
-    corpus = _attested_names(outcomes)
     # appellation -> character -> the source positions attributing it there.
     appellation_claims: dict[str, dict[str, set[tuple[int, int]]]] = {}
 
@@ -461,7 +473,7 @@ def merge_character_candidates(
             # The name needs its own attestation, not just a verifiable quote.
             # Otherwise a real sentence can carry an invented name into the
             # table, which is the exact failure the quote check exists to stop.
-            if not name_is_attested(name, corpus):
+            if not name_is_attested(name, source):
                 continue
 
             verified: list[dict] = []

--- a/src/novelvideo/structured_extraction.py
+++ b/src/novelvideo/structured_extraction.py
@@ -3,8 +3,15 @@
 The legacy path asks Cognee for graph context and lets a model name whoever it
 finds there.  Structured extraction inverts that: the model only reports what a
 specific span of text supports, and every candidate it returns must quote the
-span it came from.  Quotes that cannot be found in the source are dropped, so a
-hallucinated name has no route into the character table.
+span it came from.  A quote that is not in the chunk is dropped, and a name the
+imported source never writes is dropped, so a name invented outright has no
+route into the character table.
+
+What that does *not* establish is that the right quote was attached to the
+right name.  A model can pair a real name with a real sentence about someone
+else, and no check here can tell; the guards bound what may enter, not who a
+line is about.  Attribution is left to the conservative merging below and to
+whoever reads the result.
 
 Merging is deliberately conservative.  A character's name is simultaneously a
 SQLite primary key, a REST identifier and an asset directory name, so a wrong
@@ -274,8 +281,9 @@ def verify_evidence(
 ) -> tuple[int, int] | None:
     """Locate a quote inside the chunk and return its absolute source offsets.
 
-    A quote that is not present verbatim is rejected: this check is the only
-    thing standing between a model's imagination and the character table.
+    A quote that is not present verbatim is rejected. This establishes that the
+    line exists in this span, and nothing more — not that it is about the
+    character it was returned for.
     """
     needle = (quote or "").strip()
     if not needle:
@@ -399,6 +407,11 @@ def name_is_attested(name: str, corpus: str) -> bool:
     The quote verifies, so the candidate used to be accepted, and 王五 became a
     row in the character table — a primary key, a REST identifier and an asset
     directory, invented out of nothing.
+
+    This catches invention, not misattribution: a name the source does write,
+    returned against a line about somebody else, still passes. Ruling that out
+    would take Chinese NER and word-boundary analysis, would still be wrong
+    sometimes, and would cost the cross-chunk recall described below.
 
     Checked against the whole imported text rather than the chunk the candidate
     came from, deliberately. A character is introduced by name once and referred

--- a/src/novelvideo/structured_extraction.py
+++ b/src/novelvideo/structured_extraction.py
@@ -20,7 +20,7 @@ import json
 import re
 from dataclasses import dataclass, field
 from types import SimpleNamespace
-from typing import Any, Callable, Optional
+from typing import Any, Callable, Iterable, Optional
 
 from pydantic import BaseModel, Field
 
@@ -208,17 +208,62 @@ def title_qualified_of(long_name: str, short_name: str) -> bool:
     return not remainder
 
 
-def find_explicit_aliases(text: str) -> set[tuple[str, str]]:
+def _resolve_side(capture: str, known: dict[str, str], *, suffix: bool) -> str:
+    """Trim one side of an alias match down to a name that was actually found.
+
+    The patterns take 2-6 characters either side of the marker, and in running
+    prose that window opens mid-sentence: "大家都知道林默又名小默" captured
+    "家都知道林默" as a name. Matching against the names extraction really
+    produced turns that back into "林默"; ``suffix`` says which end of the
+    capture the name sits at, since the left side runs up to the marker and the
+    right side away from it.
+    """
+    text = normalize_character_name(capture)
+    if not text:
+        return ""
+    if text in known:
+        return known[text]
+    best = ""
+    for candidate in known:
+        matches = text.endswith(candidate) if suffix else text.startswith(candidate)
+        if matches and len(candidate) > len(best):
+            best = candidate
+    return known.get(best, "")
+
+
+def find_explicit_aliases(
+    text: str, known_names: Iterable[str] = ()
+) -> set[tuple[str, str]]:
     """Return alias pairs the text states outright.
 
     Only an explicit statement licenses an alias link, because merging two names
     rewrites a primary key that assets and REST paths already point at.
+
+    Both sides must resolve to a name the extraction actually found. The
+    patterns cannot tell where a name begins in running prose, so an unresolved
+    capture is prose, not a name — and an alias built from prose is written to
+    the character table as though the text had stated it.
+
+    The cost is a real alias going unrecorded when only one of its two names was
+    ever extracted. That is the trade this module makes everywhere: a missing
+    alias leaves a visible duplicate someone can merge, a wrong one silently
+    renames a character.
     """
+    known = {
+        normalized: normalized
+        for normalized in (
+            normalize_character_name(name) for name in known_names
+        )
+        if normalized
+    }
+    if not known:
+        return set()
+
     pairs: set[tuple[str, str]] = set()
     for pattern in _ALIAS_PATTERNS:
         for match in pattern.finditer(text or ""):
-            first = normalize_character_name(match.group("a"))
-            second = normalize_character_name(match.group("b"))
+            first = _resolve_side(match.group("a"), known, suffix=True)
+            second = _resolve_side(match.group("b"), known, suffix=False)
             if first and second and first != second:
                 pairs.add((first, second))
     return pairs
@@ -329,6 +374,47 @@ async def extract_characters_from_chunks(
     return merged, failures
 
 
+def _attested_names(outcomes: list[tuple[SourceChunk, ChunkCharacterOutput]]) -> str:
+    """The text a name has to appear somewhere in, plus the cast lists.
+
+    Joined with a separator so a name cannot be formed by spanning the seam
+    between two chunks.
+    """
+    parts: list[str] = []
+    for chunk, _output in outcomes:
+        parts.append(chunk.text)
+        parts.extend(str(listed) for listed in (chunk.characters or []))
+    return "\n\x00\n".join(parts)
+
+
+def name_is_attested(name: str, corpus: str) -> bool:
+    """Whether the source itself writes this name.
+
+    Verifying the quote alone does not do it. A model can return a real
+    sentence from the text and attach a name that never appears anywhere:
+
+        text  : 林默回到了家
+        model : name=王五, evidence="林默回到了家"
+
+    The quote verifies, so the candidate used to be accepted, and 王五 became a
+    row in the character table — a primary key, a REST identifier and an asset
+    directory, invented out of nothing.
+
+    Checked against the whole imported text rather than the chunk the candidate
+    came from, deliberately. A character is introduced by name once and referred
+    to as 她 or 郑太 for pages afterwards, and attributing those appellations
+    back to her is a thing this module is built to do. Requiring the name in the
+    chunk that mentions her would drop exactly those candidates and take
+    cross-chunk appellation resolution with them. Requiring it in the source
+    still leaves an invented name with no route in, which is the guarantee that
+    was missing.
+    """
+    normalized = normalize_character_name(name)
+    if not normalized:
+        return False
+    return normalized in corpus or str(name or "").strip() in corpus
+
+
 def merge_character_candidates(
     outcomes: list[tuple[SourceChunk, ChunkCharacterOutput]],
 ) -> list[MergedCharacter]:
@@ -340,15 +426,29 @@ def merge_character_candidates(
     """
     merged: dict[str, MergedCharacter] = {}
     alias_pairs: set[tuple[str, str]] = set()
+    # Every name any chunk proposed, so an alias statement in one chunk can
+    # still resolve a name that was only extracted in another.
+    proposed_names = {
+        candidate.name
+        for _chunk, output in outcomes
+        for candidate in output.characters
+    }
+    corpus = _attested_names(outcomes)
     # appellation -> character -> the source positions attributing it there.
     appellation_claims: dict[str, dict[str, set[tuple[int, int]]]] = {}
 
     for chunk, output in outcomes:
-        alias_pairs |= find_explicit_aliases(chunk.text)
+        alias_pairs |= find_explicit_aliases(chunk.text, proposed_names)
 
         for candidate in output.characters:
             name = normalize_character_name(candidate.name)
             if not name or is_generic_address(name):
+                continue
+
+            # The name needs its own attestation, not just a verifiable quote.
+            # Otherwise a real sentence can carry an invented name into the
+            # table, which is the exact failure the quote check exists to stop.
+            if not name_is_attested(name, corpus):
                 continue
 
             verified: list[dict] = []

--- a/tests/test_project_spine_template.py
+++ b/tests/test_project_spine_template.py
@@ -5,7 +5,6 @@ from types import SimpleNamespace
 import pytest
 
 from novelvideo.api.schemas import IngestStart, ProjectUpdate
-from novelvideo.models import NovelEpisode
 
 pytestmark = pytest.mark.m03
 
@@ -229,10 +228,59 @@ async def test_update_project_rejects_spine_template_change_after_import(
         lambda state_dir, config=None, **kwargs: saved.update(config or {}),
     )
 
-    async def make_imported_store(ctx):
-        return _EpisodeStore([NovelEpisode(number=1, title="第一集")])
+    # Imported means the source text is on disk, not that episodes exist.
+    # Structured ingest writes novel.txt and records a chunk plan but creates
+    # no episodes, so an episode check left the template switchable in between —
+    # and the analysis run, which is keyed on the template, was silently
+    # orphaned by the switch.
+    monkeypatch.setattr(projects, "has_imported_novel", lambda _output_dir: True)
 
-    monkeypatch.setattr(projects, "make_sqlite_store_for_context", make_imported_store)
+    response = await projects.update_project(
+        "demo",
+        ProjectUpdate(spine_template="narrated"),
+        {"username": "alice"},
+    )
+
+    assert isinstance(response, JSONResponse)
+    assert response.status_code == 400
+    assert saved["spine_template"] == "drama"
+
+
+@pytest.mark.asyncio
+async def test_update_project_rejects_the_switch_before_any_episode_exists(
+    monkeypatch, tmp_path
+):
+    """The window the old check left open.
+
+    Structured ingest creates no episodes, so between import and episode
+    planning the type could still be changed. Afterwards the character build
+    finds no analysis run for the new template: it still runs, but with no chunk
+    persistence, no resume, no final artifact and no evidence rows.
+    """
+    from fastapi.responses import JSONResponse
+
+    from novelvideo.api.routes import projects
+
+    saved = {"spine_template": "drama"}
+
+    monkeypatch.setattr(projects, "resolve_project_context", _ctx_resolver(tmp_path))
+    monkeypatch.setattr(projects, "require_project_home_node", lambda *a, **k: None)
+    monkeypatch.setattr(
+        projects,
+        "load_project_config_from_state_dir",
+        lambda state_dir, **_kwargs: {"visual_style": "chinese_period_drama", **saved},
+    )
+    monkeypatch.setattr(
+        projects,
+        "save_project_config_in_state_dir",
+        lambda state_dir, config=None, **kwargs: saved.update(config or {}),
+    )
+
+    async def make_empty_store(ctx):
+        return _EpisodeStore([])
+
+    monkeypatch.setattr(projects, "make_sqlite_store_for_context", make_empty_store)
+    monkeypatch.setattr(projects, "has_imported_novel", lambda _output_dir: True)
 
     response = await projects.update_project(
         "demo",

--- a/tests/test_structured_builders.py
+++ b/tests/test_structured_builders.py
@@ -122,8 +122,115 @@ def test_empty_quote_is_rejected():
 
 
 def test_explicit_alias_statements_are_detected():
-    assert ("林默", "小默") in find_explicit_aliases("林默又名小默，村里人都这么叫他。")
-    assert ("萧玦", "陛下") in find_explicit_aliases("萧玦人称陛下。")
+    assert ("林默", "小默") in find_explicit_aliases(
+        "林默又名小默，村里人都这么叫他。", ["林默", "小默"]
+    )
+    assert ("萧玦", "陛下") in find_explicit_aliases("萧玦人称陛下。", ["萧玦", "陛下"])
+
+
+def test_an_alias_statement_mid_sentence_does_not_swallow_the_prose():
+    """The patterns take 2-6 characters either side and cannot see where a name
+    begins, so in running prose the window opens mid-sentence."""
+    assert find_explicit_aliases(
+        "大家都知道林默又名小默，昨天回家。", ["林默", "小默"]
+    ) == {("林默", "小默")}
+    assert find_explicit_aliases("据说林默也叫小默。", ["林默", "小默"]) == {
+        ("林默", "小默")
+    }
+    # And forwards, where nothing punctuates the end of the second name.
+    assert find_explicit_aliases("林默又名小默昨天回家", ["林默", "小默"]) == {
+        ("林默", "小默")
+    }
+
+
+def test_a_pair_neither_side_of_which_was_extracted_is_dropped():
+    """An unresolved capture is prose, not a name.
+
+    Left in, it reaches the character table as an alias the text never stated —
+    "家都知道林默" was being persisted as one.
+    """
+    assert find_explicit_aliases("大家都知道林默又名小默。") == set()
+    assert find_explicit_aliases("大家都知道林默又名小默。", ["小默"]) == set()
+
+
+def test_an_invented_name_cannot_ride_in_on_a_real_quote():
+    """The module promises a hallucinated name has no route into the table.
+
+    Verifying the quote alone did not deliver that: a real sentence with a name
+    attached that appears nowhere in the source was accepted.
+    """
+    chunk = _chunk("林默回到了家", chunk_id="c0", start=0)
+    invented = ChunkCharacterOutput(
+        characters=[
+            CharacterCandidate(
+                name="王五", evidence=[CharacterEvidence(quote="林默回到了家")]
+            )
+        ]
+    )
+    assert merge_character_candidates([(chunk, invented)]) == []
+
+
+def test_a_name_the_source_writes_elsewhere_is_still_accepted():
+    """Attestation is against the source, not the chunk.
+
+    A character is named once and called 她 or 郑太 for pages after; requiring
+    the name in the chunk that mentions her would drop exactly the candidates
+    cross-chunk appellation resolution depends on.
+    """
+    named = _chunk("郑玉琴走进客厅。", chunk_id="c0", start=0)
+    pronoun = _chunk("郑太点了点头。", chunk_id="c1", start=8)
+    outcomes = [
+        (
+            named,
+            ChunkCharacterOutput(
+                characters=[
+                    CharacterCandidate(
+                        name="郑玉琴",
+                        evidence=[CharacterEvidence(quote="郑玉琴走进客厅。")],
+                    )
+                ]
+            ),
+        ),
+        (
+            pronoun,
+            ChunkCharacterOutput(
+                characters=[
+                    CharacterCandidate(
+                        name="郑玉琴",
+                        evidence=[CharacterEvidence(quote="郑太点了点头。")],
+                    )
+                ]
+            ),
+        ),
+    ]
+    assert [item.name for item in merge_character_candidates(outcomes)] == ["郑玉琴"]
+
+
+def test_a_name_only_the_scene_heading_lists_is_accepted():
+    """A screenplay names its cast in the heading; the body may only say 他."""
+    chunk = SourceChunk(
+        chunk_id="c0",
+        chunk_index=0,
+        section_type="scene",
+        section_label="第1场",
+        source_start=0,
+        source_end=5,
+        text="他推开门。",
+        characters=["林默"],
+    )
+    outcomes = [
+        (
+            chunk,
+            ChunkCharacterOutput(
+                characters=[
+                    CharacterCandidate(
+                        name="林默", evidence=[CharacterEvidence(quote="他推开门。")]
+                    )
+                ]
+            ),
+        )
+    ]
+    assert [item.name for item in merge_character_candidates(outcomes)] == ["林默"]
 
 
 def test_two_names_merely_appearing_together_is_not_an_alias():

--- a/tests/test_structured_plan_episodes.py
+++ b/tests/test_structured_plan_episodes.py
@@ -252,3 +252,55 @@ def test_the_template_lock_follows_the_imported_text(tmp_path, monkeypatch):
     source = inspect.getsource(projects.update_project)
     assert "has_imported_novel(ctx.output_dir)" in source
     assert "get_all_episodes()" not in source
+
+
+async def test_legacy_gets_the_same_atomic_publish(tmp_path, monkeypatch):
+    """The seven-write mapping was legacy's bug first.
+
+    CogneeStore delegates now, so the fix reaches existing projects too — but
+    only if the delegate really is the same code path, which is what this pins.
+    """
+    from novelvideo.cognee.store import CogneeStore
+
+    state_dir = _project(tmp_path, structured=False)
+    sqlite = await _sqlite_store(state_dir)
+    store = CogneeStore.__new__(CogneeStore)
+    store.project_name = "user/legacy"
+    store.dataset_name = "novelvideo_user/legacy"
+    store._db = None
+    store._characters = {}
+    store._episodes = {}
+    store._alias_index = {}
+    store.project_dir = str(state_dir)
+    store.state_dir = str(state_dir)
+    store.db_path = str(state_dir / "data.db")
+    store.sqlite_store = sqlite
+
+    try:
+        store.save_novel_content(CHAPTERED)
+        await store.build_episodes_from_chapters()
+        await sqlite.patch_episode(2, identity_ids=["林默:default"])
+
+        real_upsert = sqlite._upsert_episodes
+
+        async def fail_midway(db, episodes):
+            await real_upsert(db, episodes[:1])
+            raise RuntimeError("worker killed")
+
+        monkeypatch.setattr(sqlite, "_upsert_episodes", fail_midway)
+        with pytest.raises(RuntimeError):
+            await store.build_episodes_from_chapters(
+                novel_text="第一章 别的\n\n完全不同的正文。\n"
+            )
+
+        # Same three episodes, same bodies, planning intact — a legacy project
+        # is no longer left blank or half-mapped by a cancelled task.
+        assert [
+            (await sqlite.get_episode_from_graph(n)).number for n in (1, 2, 3)
+        ] == [1, 2, 3]
+        assert (await sqlite.get_episode_from_graph(2)).identity_ids == [
+            "林默:default"
+        ]
+        assert "陈舟" in await sqlite.load_episode_content(2)
+    finally:
+        await sqlite.close()

--- a/tests/test_structured_plan_episodes.py
+++ b/tests/test_structured_plan_episodes.py
@@ -170,3 +170,85 @@ async def test_legacy_keeps_the_method_and_its_cache(tmp_path):
         assert store.get_episode(3).title == "第3集"
     finally:
         await sqlite.close()
+
+
+# ── the mapping is one write, not seven ─────────────────────────────────────
+
+
+async def test_a_failed_publish_leaves_the_previous_mapping_intact(
+    structured_store, monkeypatch
+):
+    """It used to clear every episode's text and commit before detecting a
+    chapter, then commit again per delete, per upsert and per body. A cancelled
+    task could leave a project with every episode blank, or half of them mapped,
+    or metadata that did not match the text under it.
+    """
+    await structured_store.build_episodes_from_chapters()
+    await structured_store.patch_episode(2, identity_ids=["林默:default"])
+
+    real_upsert = structured_store._upsert_episodes
+
+    async def fail_midway(db, episodes):
+        await real_upsert(db, episodes[:1])
+        raise RuntimeError("worker killed")
+
+    monkeypatch.setattr(structured_store, "_upsert_episodes", fail_midway)
+    with pytest.raises(RuntimeError):
+        await structured_store.build_episodes_from_chapters(
+            novel_text="第一章 别的\n\n完全不同的正文。\n"
+        )
+
+    # Nothing of the failed run survives: same three episodes, same bodies, and
+    # the planning already done on episode 2 is untouched.
+    episodes = [
+        await structured_store.get_episode_from_graph(n) for n in (1, 2, 3)
+    ]
+    assert [episode.number for episode in episodes] == [1, 2, 3]
+    assert episodes[1].identity_ids == ["林默:default"]
+    assert "陈舟" in await structured_store.load_episode_content(2)
+
+
+async def test_a_remap_to_fewer_chapters_drops_the_extras(structured_store):
+    await structured_store.build_episodes_from_chapters()
+
+    await structured_store.build_episodes_from_chapters(
+        novel_text="第一章 归来\n\n林默回到阔别十年的故乡。\n"
+    )
+
+    assert await structured_store.get_episode_from_graph(1) is not None
+    assert await structured_store.get_episode_from_graph(3) is None
+
+
+async def test_the_body_lands_with_the_row_that_describes_it(structured_store):
+    """Text and metadata are written together, so they cannot disagree."""
+    await structured_store.build_episodes_from_chapters()
+    await structured_store.close()
+
+    reopened = await _sqlite_store(Path(structured_store.state_dir))
+    try:
+        for number, marker in ((1, "林默"), (2, "陈舟"), (3, "争执")):
+            episode = await reopened.get_episode_from_graph(number)
+            assert episode is not None
+            assert marker in await reopened.load_episode_content(number)
+    finally:
+        await reopened.close()
+
+
+# ── the project type is locked by the import, not by episodes ───────────────
+
+
+def test_the_template_lock_follows_the_imported_text(tmp_path, monkeypatch):
+    """Structured ingest creates no episodes, so an episode check left a window.
+
+    The analysis run is keyed on the spine template — the same novel chunked as
+    a screenplay and as narrated prose are different plans — so switching inside
+    that window silently orphans it. The next character build still runs, but
+    with no chunk persistence, no resume, no final artifact and no evidence.
+    """
+    import inspect
+
+    from novelvideo.api.routes import projects
+
+    source = inspect.getsource(projects.update_project)
+    assert "has_imported_novel(ctx.output_dir)" in source
+    assert "get_all_episodes()" not in source


### PR DESCRIPTION
From the full structured_v1 review. All four reproduce; none of them is "the model should have done better" — each is a program guard or a transaction boundary that does not hold.

## 1. A character name needed no attestation

The module states a hallucinated name has no route into the character table, but only the evidence *quote* was verified. Reproduced:

```python
text  : 林默回到了家
model : name=王五, evidence="林默回到了家"
→ 王五 accepted
```

The quote verifies, so the name rode in — and a name here is simultaneously a SQLite primary key, a REST identifier and an asset directory.

**Fix**: the name is checked against the imported source as well. A scene heading's cast list counts too — the author wrote those names, and the body may only ever say 他.

**Why source-wide and not in-chunk.** In-chunk is the tighter rule and it also closes a second case: a real name returned against a line about somebody else. I built it and measured it, replaying the stored per-chunk outputs of both spines with no model calls — it dropped **0 candidates and 0 characters** on each, because the extraction prompt already asks for a form used in this span and the model obeys.

So it costs nothing measurable and buys little measurable. What it does change is the direction of failure. In-chunk is fail-closed: a misjudgement deletes a real character someone then has to re-enter. Source-wide is fail-open: a misjudgement files one quote against the wrong name — a provenance record, not a rename. Zero cost on one 33k screenplay is thin evidence to put behind a fail-closed gate on material nobody has run yet, so the looser rule ships.

**What that leaves open, stated plainly in the module**: invention cannot get in, misattribution can. And misattribution is not free — an appellation offered by a single owner is taken at face value (only a *contested* one is voted on), so a misattributed name can put an alias on the wrong character. That is a model-quality risk; the lever is a better prompt or an adjudicator, not a guard that deletes characters when it is wrong. Closing it properly would need Chinese NER and would still be wrong sometimes.

## 2. The alias patterns grabbed prose

They take 2–6 Chinese characters either side of the marker and cannot see where a name begins:

```
大家都知道林默又名小默  →  ("家都知道林默", "小默")
据说林默也叫小默        →  ("据说林默", "小默")
林默又名小默昨天回家    →  ("林默", "小默昨天回")
```

`_apply_explicit_alias_merges` then persists the unmatched side as an alias on whichever side does exist, so `家都知道林默` was reaching the table as a stated alias.

**Fix**: both sides must resolve to a name the extraction actually found, matching at whichever end of the capture the name sits. Names are pooled across all chunks first, so a statement in one chunk still resolves a name only another extracted.

The cost is a real alias going unrecorded when only one of its two names was ever extracted — the trade this module makes everywhere: a missing alias leaves a visible duplicate someone can merge, a wrong one silently renames a character.

## 3. The project type was switchable after import

The lock checked for episodes. Structured ingest writes `novel.txt` and records a chunk plan but creates **no episodes**, so the template stayed switchable between import and episode planning.

The analysis run is keyed on the template — same novel as screenplay vs. as narrated prose are different chunk plans. Switching inside that window orphans it, and the next character build still succeeds *quietly*, with no chunk persistence, no resume, no final artifact and no evidence rows.

**Fix**: lock on `has_imported_novel`. Switching means re-importing, which is what the error message already said.

## 4. Chapter mapping was seven writes

It cleared every episode's `raw_content` and committed *before detecting a chapter*, then committed again per delete, per upsert and per body. A cancelled task could leave every episode blank, or half of them mapped, or metadata not matching the text under it.

**Fix**: compute then publish. One transaction deletes what no longer exists and upserts the rest; the body travels on the row (`_upsert_episodes` already writes `raw_content`), so text and metadata cannot disagree. Cache updated only after the write lands.

This predates structured_v1 on the legacy path, but #362 made chapter mapping the only way a structured project gets episodes at all.

## Deliberately not done

**A global concurrency cap or a build mutex.** `STRUCTURED_LLM_CONCURRENCY=2` is per-`map_bounded`, so character and scene builds running together are 4 in flight, worst case ~16 across the CE global lane limit. That is unremarkable for a hosted text model — the thing that actually serialized was the Cognee embedding channel, which this track does not have. And `build_scenes_structured` never reads the character table (its `characters` come from the script's scene headings), so there is no data dependency to enforce: a mutex would turn a ~110s overlapped first build into a 185s serial one and buy no correctness.

The gate that *is* worth having is #351 — scene *planning* during scene *building* — because `_compile_scenes` reads `list_scenes()` and would plan against a half-written catalogue. That is a dependency, not load. Separate PR, needs a rebase.

## Tests

- 6 new in `test_structured_builders.py`: the invented name, a name attested elsewhere in the source, a name only the scene heading lists, mid-sentence alias captures in both directions, and a pair neither side of which was extracted.
- 4 new in `test_structured_plan_episodes.py`: a failed publish leaving the previous mapping and its planning intact, a remap to fewer chapters, body-with-row, and the template lock.
- 1 new in `test_project_spine_template.py` for the window that was open; the existing lock test now drives the imported-text signal.

- 1 new in `test_structured_plan_episodes.py` pinning the atomic mapping on the **legacy** track — that bug was legacy's first, and the fix only reaches existing projects while `CogneeStore` really delegates to the same code. Both transaction tests fail against the pre-fix implementation.

`ruff` clean. Full suite **3807 passed**, 16 skipped.
