### PR TITLE
fix: do not charge for a scene build a narrated project cannot use

### DIFF
--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -1430,6 +1430,7 @@
       "derivedFrom": "Derived from {{base}}",
       "emptyTitle": "No scenes yet",
       "emptyDescription": "Create a scene or extract scenes from the project graph.",
+      "emptyDescriptionPerEpisode": "Scenes for narrated projects are created automatically when you plan each episode, or you can add them by hand.",
       "building": "Building scenes...",
       "buildingEmpty": {
         "title": "Building scenes",

--- a/frontend/public/locales/zh/translation.json
+++ b/frontend/public/locales/zh/translation.json
@@ -1430,6 +1430,7 @@
       "derivedFrom": "派生自 {{base}}",
       "emptyTitle": "暂无场景数据",
       "emptyDescription": "新建场景，或从图谱自动提取项目场景。",
+      "emptyDescriptionPerEpisode": "解说剧的场景会在规划各集场景时自动创建，也可以手动添加。",
       "building": "构建场景中...",
       "buildingEmpty": {
         "title": "正在构建场景",

--- a/frontend/src/__tests__/components/assets/scenes-panel-build-visibility.test.tsx
+++ b/frontend/src/__tests__/components/assets/scenes-panel-build-visibility.test.tsx
@@ -1,0 +1,152 @@
+// SPDX-License-Identifier: Elastic-2.0
+// Copyright (c) 2026 ClaymoreLab
+import { render, screen } from "@testing-library/react";
+import i18next from "i18next";
+import { I18nextProvider, initReactI18next } from "react-i18next";
+import { beforeAll, describe, expect, it, vi } from "vitest";
+
+import {
+  AssetHeaderActionsSlotProvider,
+  AssetHeaderActionsTarget,
+} from "@/components/assets/asset-header-actions-slot";
+import { ScenesPanel } from "@/components/assets/scenes-panel";
+
+const projectState = vi.hoisted(() => ({
+  sceneBuildSupported: undefined as boolean | undefined,
+}));
+const mutation = vi.hoisted(() => () => ({ mutateAsync: vi.fn(), isPending: false }));
+const emptyQuery = vi.hoisted(() => () => ({ data: undefined, isLoading: false }));
+
+vi.mock("@/lib/queries/projects", () => ({
+  useProject: () => ({
+    data: {
+      ok: true,
+      data:
+        projectState.sceneBuildSupported === undefined
+          ? {}
+          : { scene_build_supported: projectState.sceneBuildSupported },
+    },
+    isLoading: false,
+  }),
+}));
+
+vi.mock("@/lib/queries/scenes", () => ({
+  useScenes: () => ({ isLoading: false, data: { ok: true, data: [] }, refetch: vi.fn() }),
+  useBuildScenes: mutation,
+  useCreateScene: mutation,
+  useDeleteScene: mutation,
+  useDeleteSceneCustomPackage: mutation,
+  useDeleteSceneMaster: mutation,
+  useDeleteScenePano: mutation,
+  useGenerateScene3gsPlyAsync: mutation,
+  useGenerateSceneMasterAsync: mutation,
+  useGenerateScenePanoAsync: mutation,
+  useGenerateSceneReverseAsync: mutation,
+  useClearSceneDirectorWorld: mutation,
+  useSaveSceneDirectorWorld: mutation,
+  useSceneDirectorStageManifest: emptyQuery,
+  useScenePanoManifest: emptyQuery,
+  useUpdateScene: mutation,
+  useUploadSceneCustomPackage: mutation,
+  useUploadSceneMaster: mutation,
+  useUploadScenePano: mutation,
+}));
+
+vi.mock("@/lib/queries/generation-credit-cost", () => ({
+  useGenerationCreditCost: () => ({ data: { ok: true, data: { display: "12", cost: 12 } } }),
+}));
+
+vi.mock("@/lib/queries/character-image-selection", () => ({
+  useAssetImageSourceSelection: () => ({ data: undefined, isLoading: false, isFetching: false }),
+  useUpdateAssetImageSourceSelection: mutation,
+}));
+
+vi.mock("@/lib/queries/asset-references", () => ({
+  useAssetReferenceIndex: () => ({ countFor: () => 0, referencesFor: () => [] }),
+}));
+
+vi.mock("@/hooks/use-task-controller", () => ({
+  useTaskController: () => ({
+    started: false,
+    stream: { status: "idle", progress: 0, currentTask: "", result: null, error: null },
+    logs: [],
+    start: vi.fn(),
+    stop: vi.fn(),
+    stopping: false,
+  }),
+}));
+
+vi.mock("@/hooks/use-asset-focus", () => ({ useAssetFocus: () => ({ current: null }) }));
+vi.mock("@/hooks/use-assets-deep-link", () => ({
+  useAssetsDeepLink: () => ({}),
+  useNavigateToAsset: () => vi.fn(),
+}));
+vi.mock("@/features/freezone/openPresetProjection", () => ({
+  openPresetProjectionInMyCanvas: vi.fn(),
+}));
+
+const i18n = i18next.createInstance();
+
+beforeAll(async () => {
+  await i18n.use(initReactI18next).init({
+    lng: "en",
+    fallbackLng: "en",
+    interpolation: { escapeValue: false },
+    resources: {
+      en: {
+        translation: {
+          common: { refresh: "Refresh", loading: "Loading" },
+          assets: {
+            common: { edit: "Edit", delete: "Delete" },
+            scenes: {
+              newScene: "New scene",
+              build: "Build scenes",
+              emptyTitle: "No scenes yet",
+              emptyDescription: "Build the scene catalogue.",
+              emptyDescriptionPerEpisode:
+                "Scenes are created automatically while planning each episode.",
+            },
+          },
+        },
+      },
+    },
+  });
+});
+
+function renderPanel(sceneBuildSupported: boolean | undefined) {
+  projectState.sceneBuildSupported = sceneBuildSupported;
+  return render(
+    <I18nextProvider i18n={i18n}>
+      <AssetHeaderActionsSlotProvider>
+        <AssetHeaderActionsTarget />
+        <ScenesPanel project="alice/demo" />
+      </AssetHeaderActionsSlotProvider>
+    </I18nextProvider>,
+  );
+}
+
+describe("scenes panel build action", () => {
+  it("hides the build button when the project cannot use it", () => {
+    // Narrated structured projects build no catalogue; the button would report
+    // success, produce nothing, and — because the reservation is taken at
+    // enqueue — still be charged for.
+    renderPanel(false);
+    expect(screen.queryByText("Build scenes")).toBeNull();
+    expect(
+      screen.getByText("Scenes are created automatically while planning each episode."),
+    ).toBeTruthy();
+  });
+
+  it("keeps the build button for projects a build works for", () => {
+    renderPanel(true);
+    expect(screen.getByText("Build scenes")).toBeTruthy();
+    expect(screen.getByText("Build the scene catalogue.")).toBeTruthy();
+  });
+
+  it("keeps the build button when the field is absent", () => {
+    // Older responses do not carry the flag; treating undefined as false would
+    // hide the button for every project the moment the API lagged the client.
+    renderPanel(undefined);
+    expect(screen.getByText("Build scenes")).toBeTruthy();
+  });
+});

--- a/frontend/src/components/assets/scenes-panel.tsx
+++ b/frontend/src/components/assets/scenes-panel.tsx
@@ -104,6 +104,7 @@ import {
   useUploadScenePano,
   type ScenePayload,
 } from "@/lib/queries/scenes";
+import { useProject } from "@/lib/queries/projects";
 import { queryKeys } from "@/lib/query-keys";
 import type { ErrorResponse } from "@/types/api";
 import type {
@@ -1188,6 +1189,12 @@ export function ScenesPanel({
   focusId?: string | null;
 }) {
   const { t } = useTranslation();
+  // Narrated projects have no scene headings to build a catalogue from; their
+  // scenes are created per episode during planning. The page stays — those
+  // scenes are still global assets — only the project-level build is hidden.
+  const projectConfigRes = useProject(project);
+  const sceneBuildSupported =
+    projectConfigRes.data?.data?.scene_build_supported !== false;
   const scenes = useScenes(project);
   const createScene = useCreateScene(project);
   const [dialogOpen, setDialogOpen] = useState(false);
@@ -1405,25 +1412,27 @@ export function ScenesPanel({
           <Plus className="size-3.5" />
           {t("assets.scenes.newScene")}
         </Button>
-        <Button
-          size="sm"
-          onClick={handleBuildScenes}
-          disabled={buildDisabled}
-          className="h-8 gap-1.5 rounded-[8px] bg-primary px-3 text-xs font-normal text-primary-foreground shadow-none hover:bg-primary/85 active:bg-primary/75"
-        >
-          {isBuildingScenes ? (
-            <Loader2 className="size-3.5 animate-spin" />
-          ) : (
-            <Sparkles className="size-3.5" />
-          )}
-          {t("assets.scenes.build")}
-          <CreditCostInline
-            display={buildScenesCostDisplay}
-            promotion={buildScenesCost.data?.data.promotion}
-            className="text-black"
-            iconClassName="text-black drop-shadow-none [&_path]:fill-current"
-          />
-        </Button>
+        {sceneBuildSupported ? (
+          <Button
+            size="sm"
+            onClick={handleBuildScenes}
+            disabled={buildDisabled}
+            className="h-8 gap-1.5 rounded-[8px] bg-primary px-3 text-xs font-normal text-primary-foreground shadow-none hover:bg-primary/85 active:bg-primary/75"
+          >
+            {isBuildingScenes ? (
+              <Loader2 className="size-3.5 animate-spin" />
+            ) : (
+              <Sparkles className="size-3.5" />
+            )}
+            {t("assets.scenes.build")}
+            <CreditCostInline
+              display={buildScenesCostDisplay}
+              promotion={buildScenesCost.data?.data.promotion}
+              className="text-black"
+              iconClassName="text-black drop-shadow-none [&_path]:fill-current"
+            />
+          </Button>
+        ) : null}
       </AssetHeaderActions>
       {scenes.isLoading ? (
         <div className="flex min-h-0 flex-1 items-center justify-center text-sm text-muted-foreground">
@@ -1455,7 +1464,9 @@ export function ScenesPanel({
               {t("assets.scenes.emptyTitle")}
             </h3>
             <p className="max-w-[15rem] text-xs leading-5 text-muted-foreground">
-              {t("assets.scenes.emptyDescription")}
+              {sceneBuildSupported
+                ? t("assets.scenes.emptyDescription")
+                : t("assets.scenes.emptyDescriptionPerEpisode")}
             </p>
           </div>
           <Button

--- a/frontend/src/types/project.ts
+++ b/frontend/src/types/project.ts
@@ -21,6 +21,11 @@ export interface ProjectConfig {
   sketch_image_selection?: string;
   render_image_selection?: string;
   sketch_aspect_padding?: boolean;
+  // Server-computed: whether a project-level scene build can produce anything.
+  // Narrated structured projects have no scene headings to build a catalogue
+  // from, so their scenes are created per episode during planning instead.
+  // Absent on older responses, which is why callers treat undefined as true.
+  readonly scene_build_supported?: boolean;
 }
 
 export type Project = string;

--- a/license-inventory.csv
+++ b/license-inventory.csv
@@ -282,6 +282,7 @@ frontend/src/__tests__/components/assets/prop-asset-card.test.tsx,Elastic-2.0,20
 frontend/src/__tests__/components/assets/props-panel.ce.test.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/__tests__/components/assets/scene-asset-card.test.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/__tests__/components/assets/scene-environment-prompt.test.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
+frontend/src/__tests__/components/assets/scenes-panel-build-visibility.test.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/__tests__/components/confirm-dialog-host.test.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/__tests__/components/credit-cost-inline.ce.test.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/__tests__/components/credit-promotion-coverage.test.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation

--- a/src/novelvideo/api/routes/projects.py
+++ b/src/novelvideo/api/routes/projects.py
@@ -31,6 +31,7 @@ from novelvideo.config import ensure_project_dirs_at_paths
 from novelvideo.knowledge_pipeline import KNOWLEDGE_PIPELINE_KEY, KNOWLEDGE_PIPELINE_STRUCTURED
 from novelvideo.novel_source import has_imported_novel
 from novelvideo.ports import get_project_access, get_project_registry
+from novelvideo.scene_prerequisites import scene_build_applies
 from novelvideo.ports.project import ProjectRecord
 from novelvideo.project_config import (
     default_aspect_ratio_for_spine_template,
@@ -508,6 +509,13 @@ async def get_project(project: str, user: dict = Depends(get_api_user)):
             "home_node_id": ctx.home_node_id,
             "status": record.status if record is not None else "active",
             "purged_at": record.purged_at if record is not None else None,
+            # The question the UI actually asks, answered here rather than
+            # rebuilt from spine_template and the knowledge pipeline on the
+            # client — which would put the rule in two places and leak the
+            # track name into the API surface.
+            "scene_build_supported": scene_build_applies(
+                str(ctx.state_dir), str(config.get("spine_template") or "drama")
+            ),
         }
     )
     return {"ok": True, "data": data}

--- a/src/novelvideo/api/routes/scenes.py
+++ b/src/novelvideo/api/routes/scenes.py
@@ -42,9 +42,12 @@ from novelvideo.ports import get_task_backend
 from novelvideo.project_config import load_project_config_file
 from novelvideo.project_context import ProjectContext, resolve_project_context
 from novelvideo.sqlite_store import SQLiteStore
+from novelvideo.project_config import load_project_config_file_from_state_dir
 from novelvideo.scene_prerequisites import (
+    SceneBuildNotApplicableError,
     ScenePlanningRunningError,
     running_scene_planner,
+    scene_build_applies,
     scene_prerequisite_response,
 )
 from novelvideo.task_identity import project_task_state_key
@@ -1047,6 +1050,15 @@ async def build_scenes(project: str, user: dict = Depends(get_api_user)):
     if ctx is not None:
         if not has_imported_novel(project_dir):
             return novel_import_required_response()
+        # Answered before the queue, not inside it. Enqueueing reserves a
+        # feature credit, and the runner's no-op result then confirms the
+        # charge — so a narrated project could pay for a build that made no
+        # model call and produced no scene.
+        config = load_project_config_file_from_state_dir(ctx.state_dir)
+        if not scene_build_applies(
+            str(ctx.state_dir), str(config.get("spine_template") or "drama")
+        ):
+            return scene_prerequisite_response(SceneBuildNotApplicableError())
         # The other half of the exclusion. Both write the scenes table, so a
         # build landing on top of a running planner leaves a catalogue whose
         # contents depend on which writer got there first.

--- a/src/novelvideo/scene_prerequisites.py
+++ b/src/novelvideo/scene_prerequisites.py
@@ -35,6 +35,9 @@ from typing import Any
 SCENE_CATALOG_BUILDING_CODE = "SCENE_CATALOG_BUILDING"
 SCENE_CATALOG_BUILDING_MESSAGE = "场景正在构建，请完成后再规划场景"
 
+SCENE_BUILD_NOT_APPLICABLE_CODE = "SCENE_BUILD_NOT_APPLICABLE"
+SCENE_BUILD_NOT_APPLICABLE_MESSAGE = "解说剧场景将在分集规划时按需生成，无需提前构建"
+
 SCENE_PLANNING_RUNNING_CODE = "SCENE_PLANNING_RUNNING"
 # Project-wide: the planner holding the build back may be another episode's.
 SCENE_PLANNING_RUNNING_MESSAGE = "有分集场景正在规划，请完成后再构建场景"
@@ -55,6 +58,43 @@ class SceneCatalogBuildingError(ScenePlanningPrerequisiteError):
 
     def __init__(self) -> None:
         super().__init__(SCENE_CATALOG_BUILDING_MESSAGE)
+
+
+class SceneBuildNotApplicableError(ScenePlanningPrerequisiteError):
+    """Raised when a project's format has nothing to build a catalogue from.
+
+    A screenplay names every location in its scene headings, so a full-text pass
+    produces a reusable catalogue. Narrated prose has no equivalent marker — the
+    same room is "公司", "那家公司", "郑氏集团的办公室" — so a full-text sweep
+    would be guessing, and the build defers to per-episode planning, where the
+    question is scoped to one chapter.
+
+    The runner already returns that as a no-op result. This exists because a
+    no-op is not free: enqueueing reserves a feature credit before the runner is
+    ever reached, and a successful no-op confirms the charge. The user pays for
+    a build that made no model call and produced no scene. So the answer has to
+    come before the queue, not from inside it.
+    """
+
+    error_code = SCENE_BUILD_NOT_APPLICABLE_CODE
+
+    def __init__(self) -> None:
+        super().__init__(SCENE_BUILD_NOT_APPLICABLE_MESSAGE)
+
+
+def scene_build_applies(state_dir: str, spine_template: str) -> bool:
+    """Whether a project-level scene build can produce anything.
+
+    Only structured narrated projects are excluded. Legacy projects keep the
+    Cognee path whatever their template, because their build does reach a model
+    and does produce scenes — changing that would change what existing projects
+    do.
+    """
+    from novelvideo.knowledge_pipeline import is_structured_pipeline
+
+    if not is_structured_pipeline(state_dir):
+        return True
+    return str(spine_template or "").strip() != "narrated"
 
 
 class ScenePlanningRunningError(ScenePlanningPrerequisiteError):

--- a/tests/test_episode_asset_runner.py
+++ b/tests/test_episode_asset_runner.py
@@ -234,19 +234,131 @@ def test_scene_build_applies_only_where_it_can_produce_something():
         assert scene_build_applies(str(legacy), "narrated")
 
 
-def test_the_build_route_answers_before_the_queue():
-    """A no-op is not free: enqueueing reserves a feature credit, and the
-    runner's successful no-op then confirms the charge — so a narrated project
-    could pay for a build that made no model call and produced no scene. The
-    check has to sit before enqueue, not inside the runner.
+@pytest.mark.asyncio
+async def test_a_narrated_build_never_reaches_the_queue(tmp_path, monkeypatch):
+    """The money path, driven rather than asserted about.
+
+    A no-op is not free: EE resolves the billing key from task_type when the
+    payload carries no explicit billing, reserves a feature credit at enqueue,
+    and the runner's successful no-op then confirms the charge. So what has to
+    be true is that enqueue is never called — not that a source file mentions
+    the check before the call.
     """
-    import inspect
+    import json
 
-    from novelvideo.api.routes import scenes
+    from novelvideo.api.routes import scenes as scenes_routes
+    from novelvideo.knowledge_pipeline import (
+        KNOWLEDGE_PIPELINE_KEY,
+        KNOWLEDGE_PIPELINE_STRUCTURED,
+    )
+    from novelvideo.scene_prerequisites import SCENE_BUILD_NOT_APPLICABLE_CODE
 
-    source = inspect.getsource(scenes.build_scenes)
-    assert "scene_build_applies" in source
-    assert source.index("scene_build_applies") < source.index("enqueue_project_task")
+    state_dir = tmp_path / "alice" / "demo"
+    state_dir.mkdir(parents=True)
+    (state_dir / "project_config.json").write_text(
+        json.dumps(
+            {
+                KNOWLEDGE_PIPELINE_KEY: KNOWLEDGE_PIPELINE_STRUCTURED,
+                "spine_template": "narrated",
+            },
+            ensure_ascii=False,
+        ),
+        encoding="utf-8",
+    )
+    (state_dir / "novel.txt").write_text("第一章 归来\n\n正文。\n", encoding="utf-8")
+
+    ctx = SimpleNamespace(
+        project_id="p1",
+        owner_username="alice",
+        project_name="demo",
+        output_dir=state_dir,
+        state_dir=state_dir,
+    )
+
+    enqueued: list = []
+
+    class RecordingBackend:
+        async def enqueue_project_task(self, *args, **kwargs):
+            enqueued.append(kwargs)
+            raise AssertionError("a narrated build must not reach the queue")
+
+    async def _resolve(project, user, **_kwargs):
+        return (ctx, "alice", "demo", state_dir, str(state_dir), object())
+
+    monkeypatch.setattr(scenes_routes, "_resolve_scene_project", _resolve)
+    monkeypatch.setattr(scenes_routes, "get_task_backend", lambda: RecordingBackend())
+    monkeypatch.setattr(
+        scenes_routes,
+        "get_task_manager",
+        lambda: SimpleNamespace(list_tasks_for_project=lambda _ctx: []),
+    )
+
+    response = await scenes_routes.build_scenes("demo", {"username": "alice"})
+
+    assert enqueued == []
+    assert response["ok"] is False
+    assert response["code"] == SCENE_BUILD_NOT_APPLICABLE_CODE
+
+
+@pytest.mark.asyncio
+async def test_a_drama_build_still_reaches_the_queue(tmp_path, monkeypatch):
+    """The guard must not turn away the projects a build does work for."""
+    import json
+
+    from novelvideo.api.routes import scenes as scenes_routes
+    from novelvideo.knowledge_pipeline import (
+        KNOWLEDGE_PIPELINE_KEY,
+        KNOWLEDGE_PIPELINE_STRUCTURED,
+    )
+
+    state_dir = tmp_path / "alice" / "demo"
+    state_dir.mkdir(parents=True)
+    (state_dir / "project_config.json").write_text(
+        json.dumps(
+            {
+                KNOWLEDGE_PIPELINE_KEY: KNOWLEDGE_PIPELINE_STRUCTURED,
+                "spine_template": "drama",
+            },
+            ensure_ascii=False,
+        ),
+        encoding="utf-8",
+    )
+    (state_dir / "novel.txt").write_text("第1场 客厅 日 内\n", encoding="utf-8")
+
+    ctx = SimpleNamespace(
+        project_id="p1",
+        owner_username="alice",
+        project_name="demo",
+        output_dir=state_dir,
+        state_dir=state_dir,
+    )
+    enqueued: list = []
+
+    class RecordingBackend:
+        async def enqueue_project_task(self, *args, **kwargs):
+            enqueued.append(kwargs)
+            return SimpleNamespace(
+                task_state=SimpleNamespace(task_id="t1"),
+                backend="inline",
+                queue="default",
+            )
+
+    async def _resolve(project, user, **_kwargs):
+        return (ctx, "alice", "demo", state_dir, str(state_dir), object())
+
+    monkeypatch.setattr(scenes_routes, "_resolve_scene_project", _resolve)
+    monkeypatch.setattr(scenes_routes, "get_task_backend", lambda: RecordingBackend())
+    monkeypatch.setattr(
+        scenes_routes,
+        "get_task_manager",
+        lambda: SimpleNamespace(list_tasks_for_project=lambda _ctx: []),
+    )
+
+    response = await scenes_routes.build_scenes("demo", {"username": "alice"})
+
+    assert len(enqueued) == 1
+    assert enqueued[0]["task_type"] == "build_scenes"
+    assert response["ok"] is True
 
 
 def test_the_runner_still_defers_for_narrated():

--- a/tests/test_episode_asset_runner.py
+++ b/tests/test_episode_asset_runner.py
@@ -193,3 +193,67 @@ def test_any_episodes_planner_blocks_the_build():
     assert running_scene_planner([_planner_task("running")])
     assert "本集" not in SCENE_PLANNING_RUNNING_MESSAGE
     assert str(ScenePlanningRunningError()) == SCENE_PLANNING_RUNNING_MESSAGE
+
+
+# ── a build a narrated project cannot use must not reach the queue ──────────
+
+
+def test_scene_build_applies_only_where_it_can_produce_something():
+    """Narrated structured projects have nothing to build a catalogue from.
+
+    Legacy keeps the Cognee path whatever the template: its build does reach a
+    model and does produce scenes, so excluding it would change what existing
+    projects do.
+    """
+    import json
+    import tempfile
+    from pathlib import Path
+
+    from novelvideo.knowledge_pipeline import (
+        KNOWLEDGE_PIPELINE_KEY,
+        KNOWLEDGE_PIPELINE_STRUCTURED,
+    )
+    from novelvideo.scene_prerequisites import scene_build_applies
+
+    with tempfile.TemporaryDirectory() as tmp:
+        structured = Path(tmp) / "structured"
+        structured.mkdir()
+        (structured / "project_config.json").write_text(
+            json.dumps({KNOWLEDGE_PIPELINE_KEY: KNOWLEDGE_PIPELINE_STRUCTURED}),
+            encoding="utf-8",
+        )
+        legacy = Path(tmp) / "legacy"
+        legacy.mkdir()
+        (legacy / "project_config.json").write_text(
+            json.dumps({"user": "eric"}), encoding="utf-8"
+        )
+
+        assert scene_build_applies(str(structured), "drama")
+        assert not scene_build_applies(str(structured), "narrated")
+        assert scene_build_applies(str(legacy), "drama")
+        assert scene_build_applies(str(legacy), "narrated")
+
+
+def test_the_build_route_answers_before_the_queue():
+    """A no-op is not free: enqueueing reserves a feature credit, and the
+    runner's successful no-op then confirms the charge — so a narrated project
+    could pay for a build that made no model call and produced no scene. The
+    check has to sit before enqueue, not inside the runner.
+    """
+    import inspect
+
+    from novelvideo.api.routes import scenes
+
+    source = inspect.getsource(scenes.build_scenes)
+    assert "scene_build_applies" in source
+    assert source.index("scene_build_applies") < source.index("enqueue_project_task")
+
+
+def test_the_runner_still_defers_for_narrated():
+    """Kept as the backstop for tasks queued before the route learned to say no."""
+    import inspect
+
+    from novelvideo import structured_builders
+
+    source = inspect.getsource(structured_builders.build_scenes_structured)
+    assert "episode_on_demand" in source

--- a/tests/test_project_spine_template.py
+++ b/tests/test_project_spine_template.py
@@ -467,3 +467,67 @@ async def test_start_ingest_accepts_repairable_premium_drama(monkeypatch, tmp_pa
 
     assert response["ok"] is False
     assert "project context" in response["error"]
+
+
+@pytest.mark.asyncio
+async def test_project_config_reports_whether_a_scene_build_applies(
+    monkeypatch, tmp_path
+):
+    """The UI asks one question; answer it here rather than on the client.
+
+    Rebuilding the rule from spine_template plus the knowledge pipeline in the
+    frontend would put it in two places and leak the track name into the API.
+    """
+    import json
+
+    from novelvideo.api.routes import projects
+    from novelvideo.knowledge_pipeline import (
+        KNOWLEDGE_PIPELINE_KEY,
+        KNOWLEDGE_PIPELINE_STRUCTURED,
+    )
+
+    state_dir = tmp_path / "alice" / "demo"
+    state_dir.mkdir(parents=True)
+
+    async def _read(config: dict) -> bool:
+        (state_dir / "project_config.json").write_text(
+            json.dumps(config, ensure_ascii=False), encoding="utf-8"
+        )
+        ctx = SimpleNamespace(
+            project_id="project_123",
+            owner_username="alice",
+            project_name="demo",
+            effective_role="owner",
+            home_node_id="node",
+            output_dir=tmp_path,
+            state_dir=state_dir,
+            runtime_dir=tmp_path / "runtime",
+        )
+
+        async def _resolve(**_kwargs):
+            return ctx
+
+        monkeypatch.setattr(projects, "resolve_project_context", _resolve)
+        monkeypatch.setattr(projects, "require_project_home_node", lambda *a, **k: None)
+        monkeypatch.setattr(
+            projects,
+            "load_project_config_from_state_dir",
+            lambda _state_dir, **_kwargs: dict(config),
+        )
+
+        async def _registry_get(_project_id):
+            return None
+
+        monkeypatch.setattr(
+            projects,
+            "get_project_registry",
+            lambda: SimpleNamespace(get_project=_registry_get),
+        )
+        response = await projects.get_project("demo", {"username": "alice"})
+        return response["data"]["scene_build_supported"]
+
+    structured = {KNOWLEDGE_PIPELINE_KEY: KNOWLEDGE_PIPELINE_STRUCTURED}
+    assert await _read({**structured, "spine_template": "drama"}) is True
+    assert await _read({**structured, "spine_template": "narrated"}) is False
+    # Legacy keeps its build whatever the template.
+    assert await _read({"spine_template": "narrated"}) is True


### PR DESCRIPTION
## The bug

`structured_v1` + narrated projects have no scene headings to build a catalogue from, so `build_scenes_structured` returns immediately:

```python
if template != "drama":
    return {"scenes": 0, "added_scenes": 0, "mode": "episode_on_demand", ...}
```

No model call, no scene. Their scenes are created per episode during planning instead.

But the button was still shown, and clicking it reported success. **That is not just misleading UI — it charges.** EE resolves the billing key from `task_type` when the payload carries no explicit `billing`:

```python
spec = feature_billing_spec(explicit_feature_key or task_type)
```

`build_scenes` is registered as `mainline.build_scenes` with `require_positive_cost=True`. The reservation happens at enqueue; the runner's successful no-op then reaches `_confirm_feature_credit_reservation` with `business_outcome: "delivered"`.

So: **click → reserve credit → zero model calls → task succeeds → charge confirmed.**

I originally concluded the opposite from CE alone (no `billing` field in the payload ⇒ no charge). That was wrong: the absence of the field is exactly what triggers the `task_type` default. Verified against the EE source.

## Why the runner cannot fix it

The reservation is taken before the runner is ever invoked. A no-op result is indistinguishable from delivered work at that point. The answer has to come before the queue.

## The change

- **Route** refuses with `SCENE_BUILD_NOT_APPLICABLE` ahead of `enqueue_project_task`, which is ahead of the reservation.
- **Project config** reports `scene_build_supported`. The UI asks one question rather than rebuilding the rule from `spine_template` plus the knowledge pipeline — that would put the rule in two places and leak the track name into the API surface.
- **Panel** hides the build button, and the empty state explains that scenes are created while planning episodes.
- **Runner** keeps `episode_on_demand` as the backstop for tasks queued before the route learned to say no.

The scenes **page stays**. Narrated scenes are still global assets — reused across episodes, with images, variants and manual edits. Only the project-level build is hidden.

## Legacy

Untouched whatever the template. A legacy build does reach a model and does produce scenes, so excluding it would change what existing projects do.

| | build_characters | project-level build_scenes | per-episode planning |
|---|---|---|---|
| structured drama | shown | shown | selects from the catalogue |
| structured narrated | shown | **hidden / refused** | identifies scenes, writes them to the global table |
| legacy (either) | unchanged | unchanged, via Cognee | unchanged |

## Tests

- **The charge path, driven rather than asserted about**: the route is called against a recording backend. Narrated must leave `enqueue_project_task` uncalled and return `SCENE_BUILD_NOT_APPLICABLE`; drama must still get through. Both fail against the route with the guard disabled.
- `scene_build_applies` across all four track/template combinations
- the runner still defers, as the backstop
- the config endpoint reports the flag for structured drama / structured narrated / legacy narrated
- frontend visibility, including the default: an **absent** flag keeps the button, because treating `undefined` as false would hide it for every project the moment the API lagged the client

`ruff` clean. Python **3822 passed**, 16 skipped. Frontend **2593 passed**. `tsc -b` clean.

## Review follow-ups in the second commit

`ProjectConfig` did not declare `scene_build_supported`, so `tsc -b` — what `npm run build` runs — failed with TS2339. My check missed it twice: I ran `tsc --noEmit` against the root tsconfig, which has only `paths` and therefore checks nothing, and then filtered the output for the file I expected to see.

The first version of the "answers before the queue" test compared the order of two strings in the route's source. That proves a source file mentions a check, not that enqueue is never reached — and enqueue is where the reservation is taken, so it is the only thing that matters here.

Credit for finding this: the review that pushed back on my CE-only conclusion and walked the EE path.
