### PR TITLE
feat: give structured characters the face, role and build they never had

### DIFF
--- a/src/novelvideo/cognee/pipeline.py
+++ b/src/novelvideo/cognee/pipeline.py
@@ -927,8 +927,13 @@ class SceneBuildCache(Protocol):
     async def save(self, artifact_type: str, results: dict[str, str]) -> None: ...
 
 
-class StoreSceneBuildCache:
-    """Adapter binding the protocol to a project's SQLite store."""
+class StoreAnalysisItemCache:
+    """Adapter binding the protocol to a project's SQLite store.
+
+    Nothing about it is scene-specific: ``artifact_type`` is per call, so the
+    character build stores its appearance answers in the same table under its
+    own type without either stage seeing the other's rows.
+    """
 
     def __init__(self, store: Any) -> None:
         self._store = store
@@ -938,6 +943,10 @@ class StoreSceneBuildCache:
 
     async def save(self, artifact_type: str, results: dict[str, str]) -> None:
         await self._store.save_analysis_item_cache(artifact_type, results)
+
+
+# The scene build named this adapter first and imports it by that name.
+StoreSceneBuildCache = StoreAnalysisItemCache
 
 
 _ENRICHMENT_BATCH_SIZE = 5

--- a/src/novelvideo/config.py
+++ b/src/novelvideo/config.py
@@ -726,8 +726,14 @@ FISH_VOICE_PRESETS = {
 
 
 def get_fish_voice_id(age_group: str, gender: str) -> str:
-    """根据年龄段+性别获取预设 voice ID。"""
-    gender_key = "female" if "女" in gender else "male"
+    """根据年龄段+性别获取预设 voice ID。
+
+    两条抽取路写出的性别写法不同：legacy 的角色补全提示词要的是「男/女」,
+    structured_v1 的抽取器要的是 ``male``/``female``。只认中文会把每一个
+    structured 项目的女性角色都配成男声，所以两种写法都要认。
+    """
+    text = str(gender or "").strip().lower()
+    gender_key = "female" if ("女" in text or "female" in text) else "male"
     return FISH_VOICE_PRESETS.get(f"{age_group}_{gender_key}", "")
 
 

--- a/src/novelvideo/structured_builders.py
+++ b/src/novelvideo/structured_builders.py
@@ -198,6 +198,72 @@ async def build_characters_structured(
     )
 
 
+
+def _source_synopsis(store: Any) -> str:
+    """The screenplay block before the first scene, or "" for prose.
+
+    Read here rather than threaded in from the build, because a cast replayed
+    from a stored run reaches publication without the source text in hand and
+    must still be described from the same input a fresh build used.
+    """
+    from novelvideo.cognee.script_parser import extract_synopsis
+
+    try:
+        return extract_synopsis(require_imported_novel(store.project_dir))
+    except Exception:  # noqa: BLE001 - a missing source only costs context
+        return ""
+
+
+def _apply_appearance(character: Any, appearance: Any, voice_for: Callable) -> None:
+    """Write an appearance answer onto a character about to be created."""
+    if appearance is None:
+        return
+    character.role = appearance.role
+    character.is_main = appearance.is_main
+    character.age_group = appearance.age_group
+    character.body_type = appearance.body_type
+    character.face_prompt = appearance.face_prompt
+    character.fish_voice_id = voice_for(appearance.age_group, character.gender)
+
+
+async def _repair_missing_appearances(
+    store: Any,
+    added: set,
+    appearances: dict,
+    voice_for: Callable,
+) -> int:
+    """Fill only the appearance fields an existing character still lacks.
+
+    Field by field rather than wholesale: a character may have been given a
+    role by hand and left without a face, and overwriting the first to supply
+    the second would lose an edit the user made deliberately.
+    """
+    repaired = 0
+    for name, appearance in appearances.items():
+        if name in added:
+            continue
+        existing = store.get_character(name)
+        if existing is None or str(existing.face_prompt or "").strip():
+            continue
+        updates: dict[str, Any] = {"face_prompt": appearance.face_prompt}
+        if not str(existing.role or "").strip():
+            updates["role"] = appearance.role
+        if not str(existing.body_type or "").strip():
+            updates["body_type"] = appearance.body_type
+        if not str(existing.fish_voice_id or "").strip():
+            # The age band has no empty state — it defaults to "youth" — so an
+            # unbound voice is what distinguishes a band nobody chose from one
+            # somebody did. Where nothing is bound, the band and the voice it
+            # selects are written together, so they cannot end up disagreeing.
+            updates["age_group"] = appearance.age_group
+            updates["fish_voice_id"] = voice_for(
+                appearance.age_group, existing.gender
+            )
+        await store.update_character(name, **updates)
+        repaired += 1
+    return repaired
+
+
 async def _publish_characters(
     store: Any,
     merged: list,
@@ -207,20 +273,47 @@ async def _publish_characters(
     outcome: tuple[str, str] = ("completed", ""),
 ) -> list[str]:
     """Publish a settled cast, whether freshly built or replayed from cache."""
-    from novelvideo.cognee.pipeline import NovelCharacter
+    from novelvideo.cognee.pipeline import NovelCharacter, StoreAnalysisItemCache
+    from novelvideo.config import get_fish_voice_id
+    from novelvideo.structured_extraction import enrich_character_appearances
+
+    # Extraction settles *who* exists; this settles what they look like. It runs
+    # here rather than in the build so that a run replayed from its stored cast
+    # fills faces too — otherwise a project built before this stage existed
+    # could never acquire one without deleting its characters first.
+    report(0.75, "补全角色形象...")
+    appearances = await enrich_character_appearances(
+        merged,
+        synopsis=_source_synopsis(store),
+        cache=StoreAnalysisItemCache(store),
+        on_log=log,
+    )
 
     report(0.8, "发布角色...")
-    candidates = [
-        NovelCharacter(
+    candidates = []
+    for item in merged:
+        character = NovelCharacter(
             name=item.name,
             aliases=sorted(item.aliases),
             gender=item.gender,
             description=item.description,
         )
-        for item in merged
-    ]
+        _apply_appearance(character, appearances.get(item.name), get_fish_voice_id)
+        candidates.append(character)
     added = await store.add_characters_atomic(candidates, skip_existing=True)
     log(f"已新增 {len(added)} 个角色，跳过已有 {len(candidates) - len(added)} 个")
+
+    # An existing character is an asset fact and a rebuild leaves it alone —
+    # except for a face prompt it never had. Characters built before this stage
+    # existed carry an empty one, and the portrait runner refuses to work
+    # without it, so skipping them would strand those projects forever. Only
+    # empty fields are written; anything the user typed is never touched.
+    report(0.85, "补齐已有角色的空缺形象...")
+    repaired = await _repair_missing_appearances(
+        store, set(added), appearances, get_fish_voice_id
+    )
+    if repaired:
+        log(f"已为 {repaired} 个已有角色补齐面部提示词")
 
     report(0.95, "记录角色证据...")
     if run_id:

--- a/src/novelvideo/structured_builders.py
+++ b/src/novelvideo/structured_builders.py
@@ -232,23 +232,35 @@ async def _repair_missing_appearances(
     appearances: dict,
     voice_for: Callable,
 ) -> int:
-    """Fill only the appearance fields an existing character still lacks.
+    """Fill the appearance fields an existing character still lacks.
 
-    Field by field rather than wholesale: a character may have been given a
-    role by hand and left without a face, and overwriting the first to supply
-    the second would lose an edit the user made deliberately.
+    Every field is guarded on its own emptiness, and on nothing else. Gating
+    the whole repair on a missing face was wrong: someone who typed a face by
+    hand and left the rest alone would never get a role or a build, because the
+    one field they filled locked the others out. A rebuild adds what is absent
+    and overwrites nothing.
     """
+    # ``_apply_appearance`` has already written the newly inserted rows, so a
+    # narrator claimed by a new character is visible here and is not claimed
+    # twice. Only one entry in ``appearances`` can be the narrator to begin
+    # with — ``_enforce_single_main`` settles that — so the only conflict left
+    # is with a narrator somebody marked by hand.
+    narrator = next(
+        (item.name for item in store.get_all_characters() if item.is_main), None
+    )
     repaired = 0
     for name, appearance in appearances.items():
         if name in added:
             continue
         existing = store.get_character(name)
-        if existing is None or str(existing.face_prompt or "").strip():
+        if existing is None:
             continue
-        updates: dict[str, Any] = {"face_prompt": appearance.face_prompt}
-        if not str(existing.role or "").strip():
+        updates: dict[str, Any] = {}
+        if not str(existing.face_prompt or "").strip():
+            updates["face_prompt"] = appearance.face_prompt
+        if not str(existing.role or "").strip() and appearance.role:
             updates["role"] = appearance.role
-        if not str(existing.body_type or "").strip():
+        if not str(existing.body_type or "").strip() and appearance.body_type:
             updates["body_type"] = appearance.body_type
         if not str(existing.fish_voice_id or "").strip():
             # The age band has no empty state — it defaults to "youth" — so an
@@ -259,6 +271,15 @@ async def _repair_missing_appearances(
             updates["fish_voice_id"] = voice_for(
                 appearance.age_group, existing.gender
             )
+        # is_main has no empty state either, and nothing binds to it, so an
+        # unclaimed narrator is the only signal that nobody has decided. Left
+        # unwritten, a project built before this stage keeps every character at
+        # False and first-person narration fails with 未找到解说主角.
+        if appearance.is_main and not existing.is_main and narrator is None:
+            updates["is_main"] = True
+            narrator = name
+        if not updates:
+            continue
         await store.update_character(name, **updates)
         repaired += 1
     return repaired

--- a/src/novelvideo/structured_extraction.py
+++ b/src/novelvideo/structured_extraction.py
@@ -917,6 +917,355 @@ async def adjudicate_characters(
     return sorted(survivors, key=lambda item: (-len(item.evidence), item.name))
 
 
+# ── character appearance ────────────────────────────────────────────────────
+#
+# Extraction and appearance are two different contracts, deliberately kept
+# apart.  Extraction is evidence-bound: every field it reports has to appear
+# verbatim in the span it came from, which is what stops an invented character
+# from entering the table.  A face prompt, a role, a build and an age band are
+# none of them quotable — a screenplay writes "郑家悦" and what she does, not
+# what her jaw looks like — so folding them into CharacterCandidate would mean
+# relaxing the very guard that makes extraction trustworthy.
+#
+# So this stage runs after the cast is settled, takes only names that already
+# survived verification, and is allowed to write what the source implies rather
+# than what it states.  It is the half of legacy's CharacterEnrichment that
+# structured extraction never carried over; scenes have had their equivalent
+# since the beginning (``enrich_scene_environments_batched``), which is why
+# scene builds produce usable prompts and character builds did not.
+
+
+class CharacterAppearance(BaseModel):
+    name: str = Field(description="角色主名，必须与给出的角色名完全一致")
+    role: str = Field(default="", description="角色定位，如：主角、闺蜜、前男友、皇后")
+    is_main: bool = Field(default=False, description="是否为解说主角/第一人称叙述者")
+    age_group: str = Field(
+        default="youth", description="年龄段，必须是 child / youth / middle / elder 之一"
+    )
+    body_type: str = Field(default="", description="体型描述，如：纤细高挑、健壮魁梧、娇小玲珑")
+    face_prompt: str = Field(
+        default="", description="纯面部特征描述（发型、眼睛、肤色、脸型），不含服装"
+    )
+
+
+class CharacterAppearanceList(BaseModel):
+    characters: list[CharacterAppearance] = Field(default_factory=list)
+
+
+CHARACTER_APPEARANCE_SYSTEM_PROMPT = """你是角色形象设定师。输入是一部作品中已经确认的角色，以及原文中关于他们的片段。
+
+为每个角色补全形象设定。这一步允许合理推断，但推断必须与给出的原文片段一致，不要与原文冲突。
+
+对每个角色给出：
+1. name: 必须与输入给出的角色名逐字一致，不要改写、翻译或合并。
+2. role: 角色定位（如：主角、闺蜜、前男友、皇后、班主任）。
+3. is_main: 是否为解说主角/第一人称叙述者。整批里最多只有一个 true；判断不了就全填 false。
+4. age_group: 必须是 child（儿童）/ youth（青年）/ middle（中年）/ elder（老年）之一。
+   同一角色的幼年/老年形态不拆分，取他在故事中最主要时期对应的年龄段。
+5. body_type: 体型描述。
+6. face_prompt: 纯面部特征描述。
+   格式：[性别]，[年龄段]，[发型发色]，[眼睛特征]，[肤色]，[脸型/骨骼]
+   示例："女性，二十多岁，黑色长发马尾，黑色杏眼，小麦肤色，瓜子脸"
+   ⚠️ 绝对不要在 face_prompt 中描述服装、配饰或场景。服装由后续身份规划单独处理。
+
+不要新增角色，不要删除角色，不要合并角色。输入给几个就返回几个。"""
+
+
+def _create_character_appearance_agent(agent: Any = None):
+    if agent is not None:
+        return agent
+
+    from pydantic_ai import Agent
+
+    from novelvideo.config import (
+        get_newapi_structured_output_model_settings,
+        get_newapi_text_pydantic_model,
+    )
+
+    return Agent(
+        get_newapi_text_pydantic_model(
+            "CHARACTER_BUILD_MODEL",
+            "gemini-3-flash-preview",
+            capability="text.generate.agent",
+        ),
+        system_prompt=CHARACTER_APPEARANCE_SYSTEM_PROMPT,
+        model_settings=get_newapi_structured_output_model_settings(),
+        output_type=CharacterAppearanceList,
+        name="Structured Character Appearance",
+    )
+
+
+# Bump whenever the prompt, the accepted age bands, or the way an answer is
+# turned into stored fields changes.  It is part of every cache key, so a bump
+# retires stored results rather than mixing two contracts.
+CHARACTER_APPEARANCE_CACHE_VERSION = 1
+
+CHARACTER_APPEARANCE_CACHE_TYPE = "character_appearance"
+
+AGE_GROUPS = ("child", "youth", "middle", "elder")
+
+_APPEARANCE_BATCH_SIZE = 5
+
+# How many evidence quotes one character contributes to the prompt. Enough to
+# place them in the story, few enough that a batch of five stays short.
+_APPEARANCE_SAMPLE_QUOTES = 4
+
+
+def normalize_age_group(value: str) -> str:
+    """Coerce a model answer to one of the four bands stored on a character.
+
+    The band is not free text: ``get_fish_voice_id`` selects a voice from it
+    and identity planning derives per-identity bands from it, so an unknown
+    value would silently disable both rather than fail loudly.
+    """
+    cleaned = str(value or "").strip().lower()
+    return cleaned if cleaned in AGE_GROUPS else "youth"
+
+
+def character_appearance_cache_key(item: "MergedCharacter", synopsis: str = "") -> str:
+    """Hash the exact input one character's appearance call is made from.
+
+    Every field the model sees, plus the contract version.  Quotes are included
+    in the order and count the prompt actually sends: a character whose
+    evidence changed is a character the model would answer differently about.
+    The synopsis is project-wide, so editing a script's character bios retires
+    every stored appearance — which is right, since that block is what most of
+    them were written from.
+    """
+    payload = {
+        "v": CHARACTER_APPEARANCE_CACHE_VERSION,
+        "name": item.name,
+        "aliases": sorted(item.aliases),
+        "gender": item.gender,
+        "description": item.description,
+        "quotes": _appearance_quotes(item),
+        "synopsis": str(synopsis or ""),
+    }
+    canonical = json.dumps(payload, ensure_ascii=False, sort_keys=True)
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def _appearance_quotes(item: "MergedCharacter") -> list[str]:
+    quotes: list[str] = []
+    for entry in item.evidence:
+        quote = str((entry or {}).get("quote") or "").strip()
+        if quote:
+            quotes.append(quote)
+        if len(quotes) >= _APPEARANCE_SAMPLE_QUOTES:
+            break
+    return quotes
+
+
+def appearance_to_cache_payload(appearance: CharacterAppearance) -> str:
+    return json.dumps(
+        {
+            "name": appearance.name,
+            "role": appearance.role,
+            "is_main": appearance.is_main,
+            "age_group": appearance.age_group,
+            "body_type": appearance.body_type,
+            "face_prompt": appearance.face_prompt,
+        },
+        ensure_ascii=False,
+    )
+
+
+def is_usable_appearance(appearance: CharacterAppearance) -> bool:
+    """Whether an answer is worth storing and publishing.
+
+    The face prompt is the field the portrait runner refuses to work without
+    (``task_backend/runners/character_image.py``), so an answer that omits it
+    has not done the job.  Caching one would make the omission permanent, the
+    same trap ``is_cacheable_scene_prompt`` guards against on the scene side.
+    """
+    return bool(str(appearance.face_prompt or "").strip())
+
+
+def appearance_from_cache_payload(payload: str) -> CharacterAppearance | None:
+    """Rebuild an appearance from a stored row, or None if it is unusable.
+
+    A row that no longer parses, or that carries an answer the current contract
+    would reject, is treated as a miss: a cache must never publish something
+    the live path would have thrown away.
+    """
+    try:
+        data = json.loads(payload)
+    except (TypeError, ValueError):
+        return None
+    if not isinstance(data, dict):
+        return None
+    appearance = CharacterAppearance(
+        name=str(data.get("name") or ""),
+        role=str(data.get("role") or ""),
+        is_main=bool(data.get("is_main")),
+        age_group=normalize_age_group(data.get("age_group", "")),
+        body_type=str(data.get("body_type") or ""),
+        face_prompt=str(data.get("face_prompt") or ""),
+    )
+    return appearance if is_usable_appearance(appearance) else None
+
+
+def _enforce_single_main(
+    appearances: dict[str, CharacterAppearance],
+    order: list[str],
+) -> None:
+    """Keep at most one narrator, in a batch-independent order.
+
+    Characters are enriched in batches that run concurrently, so "the first one
+    the model marked" is not a stable answer.  Resolving in the caller's order
+    makes a rebuild pick the same narrator a fresh build did.
+    """
+    seen = False
+    for name in order:
+        appearance = appearances.get(name)
+        if appearance is None or not appearance.is_main:
+            continue
+        if seen:
+            appearance.is_main = False
+        else:
+            seen = True
+
+
+async def enrich_character_appearances(
+    merged: list["MergedCharacter"],
+    *,
+    synopsis: str = "",
+    agent: Any = None,
+    cache: Any = None,
+    on_log: Optional[Callable[[str], None]] = None,
+    concurrency: Optional[int] = None,
+) -> dict[str, CharacterAppearance]:
+    """Write the creative half of a character: face, role, build, age band.
+
+    Returns one entry per character the stage could answer for.  A character
+    the model failed on is simply absent rather than filled with a placeholder:
+    an empty face prompt is a visible, fixable gap, while boilerplate is an
+    invisible one that every later rebuild would replay.
+
+    With a ``cache``, a character whose input already produced a usable answer
+    is served from it and never sent to the model, so an interrupted build
+    keeps everything it has already paid for.
+    """
+
+    def log(message: str) -> None:
+        if on_log:
+            on_log(message)
+
+    if not merged:
+        return {}
+
+    order = [item.name for item in merged]
+    keys = {
+        item.name: character_appearance_cache_key(item, synopsis) for item in merged
+    }
+    results: dict[str, CharacterAppearance] = {}
+
+    if cache is not None:
+        stored = await _maybe_await(
+            cache.get(CHARACTER_APPEARANCE_CACHE_TYPE, list(keys.values()))
+        )
+        for item in merged:
+            payload = (stored or {}).get(keys[item.name])
+            appearance = appearance_from_cache_payload(payload) if payload else None
+            if appearance is not None:
+                results[item.name] = appearance
+        if results:
+            log(f"复用 {len(results)} 个角色形象设定，未调用模型")
+
+    pending = [item for item in merged if item.name not in results]
+    if not pending:
+        _enforce_single_main(results, order)
+        return results
+
+    llm = _create_character_appearance_agent(agent)
+    # A screenplay's pre-scene block is its character bible — it names hair,
+    # build and bearing outright. Extraction already chunks it, but only as one
+    # span among many; handing it to this stage whole is what legacy did, and
+    # it is the densest appearance source the source text has.
+    synopsis_section = f"\n\n【剧本梗概与人物设定原文】\n{synopsis}" if synopsis else ""
+
+    def describe(item: "MergedCharacter") -> str:
+        aliases = "、".join(sorted(item.aliases)) or "无"
+        quotes = "\n".join(f"- {quote}" for quote in _appearance_quotes(item)) or "- 无"
+        return (
+            f"### 角色：{item.name}\n"
+            f"别名：{aliases}\n"
+            f"性别：{item.gender or '未知'}\n"
+            f"已知描述：{item.description or '无'}\n"
+            f"原文片段：\n{quotes}"
+        )
+
+    async def run_batch(batch: list["MergedCharacter"]) -> dict[str, CharacterAppearance]:
+        prompt = (
+            "请为下面每一个角色补全形象设定，"
+            "name 必须与给出的角色名完全一致，不要合并或遗漏：\n\n"
+            + "\n\n".join(describe(item) for item in batch)
+            + synopsis_section
+        )
+        produced: dict[str, CharacterAppearance] = {}
+        try:
+            result = (await llm.run(prompt)).output
+            by_name = {
+                normalize_character_name(entry.name): entry
+                for entry in (result.characters or [])
+            }
+        except Exception as exc:  # noqa: BLE001 - a failed batch degrades, never raises
+            log(f"⚠️ 角色形象设定失败（{len(batch)} 个角色）：{exc}")
+            return produced
+
+        for item in batch:
+            entry = by_name.get(normalize_character_name(item.name))
+            if entry is None:
+                continue
+            # The model answers under whatever spelling it echoed back; the
+            # stored row is keyed by the settled name, which is a primary key.
+            appearance = CharacterAppearance(
+                name=item.name,
+                role=entry.role,
+                is_main=entry.is_main,
+                age_group=normalize_age_group(entry.age_group),
+                body_type=entry.body_type,
+                face_prompt=entry.face_prompt,
+            )
+            if is_usable_appearance(appearance):
+                produced[item.name] = appearance
+
+        if cache is not None and produced:
+            # Written per batch rather than once at the end, so a build killed
+            # halfway keeps what it already paid for.
+            await _maybe_await(
+                cache.save(
+                    CHARACTER_APPEARANCE_CACHE_TYPE,
+                    {
+                        keys[name]: appearance_to_cache_payload(appearance)
+                        for name, appearance in produced.items()
+                    },
+                )
+            )
+        return produced
+
+    batches = [
+        pending[start : start + _APPEARANCE_BATCH_SIZE]
+        for start in range(0, len(pending), _APPEARANCE_BATCH_SIZE)
+    ]
+    outcomes = await map_bounded(
+        batches,
+        run_batch,
+        limit=default_llm_concurrency() if concurrency is None else concurrency,
+    )
+    for outcome in outcomes:
+        if isinstance(outcome, dict):
+            results.update(outcome)
+
+    missing = [item.name for item in merged if item.name not in results]
+    if missing:
+        log(f"⚠️ {len(missing)} 个角色未取得形象设定，面部提示词留空：{'、'.join(missing[:5])}")
+    log(f"形象设定完成: {len(results)}/{len(merged)} 个角色")
+
+    _enforce_single_main(results, order)
+    return results
+
+
 # ── scene adjudication ──────────────────────────────────────────────────────
 
 

--- a/tests/test_structured_builders.py
+++ b/tests/test_structured_builders.py
@@ -1812,3 +1812,365 @@ def _async_value(value):
         return value
 
     return _call()
+
+
+# ── character appearance ────────────────────────────────────────────────────
+#
+# Extraction settles who exists; this stage settles what they look like. It is
+# the half of legacy's CharacterEnrichment that structured extraction shipped
+# without, which is why every structured project's characters carried an empty
+# 面部提示词 and the portrait runner refused to draw them.
+
+
+class FakeAppearanceAgent:
+    """Returns scripted appearances, recording every prompt it was sent."""
+
+    def __init__(self, by_name, fail=False):
+        self.by_name = by_name
+        self.fail = fail
+        self.prompts = []
+
+    async def run(self, prompt: str):
+        from novelvideo.structured_extraction import CharacterAppearanceList
+
+        self.prompts.append(prompt)
+        if self.fail:
+            raise RuntimeError("boom")
+        return SimpleNamespace(
+            output=CharacterAppearanceList(
+                characters=[
+                    item for name, item in self.by_name.items() if name in prompt
+                ]
+            )
+        )
+
+
+def _appearance(name, *, face="女性，二十多岁，黑色长发，杏眼", **kwargs):
+    from novelvideo.structured_extraction import CharacterAppearance
+
+    return CharacterAppearance(name=name, face_prompt=face, **kwargs)
+
+
+def _cast_member(name, *, gender="female", description="", quotes=("他回来了。",)):
+    from novelvideo.structured_extraction import MergedCharacter
+
+    return MergedCharacter(
+        name=name,
+        gender=gender,
+        description=description,
+        evidence=[{"quote": quote} for quote in quotes],
+    )
+
+
+class RecordingCache:
+    def __init__(self, rows=None):
+        self.rows = dict(rows or {})
+        self.saved = []
+
+    async def get(self, artifact_type, cache_keys):
+        return {
+            key: self.rows[(artifact_type, key)]
+            for key in cache_keys
+            if (artifact_type, key) in self.rows
+        }
+
+    async def save(self, artifact_type, results):
+        self.saved.append((artifact_type, dict(results)))
+        for key, payload in results.items():
+            self.rows[(artifact_type, key)] = payload
+
+
+async def test_appearance_stage_fills_the_fields_extraction_cannot_quote():
+    """A face, a role and a build are inferred, not quoted, so extraction skips them."""
+    from novelvideo.structured_extraction import enrich_character_appearances
+
+    agent = FakeAppearanceAgent(
+        {
+            "郑家悦": _appearance(
+                "郑家悦", role="主角", body_type="纤细高挑", age_group="youth"
+            )
+        }
+    )
+    result = await enrich_character_appearances([_cast_member("郑家悦")], agent=agent)
+
+    assert result["郑家悦"].face_prompt == "女性，二十多岁，黑色长发，杏眼"
+    assert result["郑家悦"].role == "主角"
+    assert result["郑家悦"].body_type == "纤细高挑"
+
+
+async def test_an_answer_without_a_face_is_dropped_rather_than_published():
+    """An empty face prompt is a visible gap; boilerplate would be an invisible one."""
+    from novelvideo.structured_extraction import enrich_character_appearances
+
+    agent = FakeAppearanceAgent({"郑家悦": _appearance("郑家悦", face="  ", role="主角")})
+    cache = RecordingCache()
+    result = await enrich_character_appearances(
+        [_cast_member("郑家悦")], agent=agent, cache=cache
+    )
+
+    assert result == {}
+    assert cache.saved == []
+
+
+async def test_an_unusable_age_band_falls_back_instead_of_reaching_the_column():
+    """The band drives voice selection, so an unknown value would silently disable it."""
+    from novelvideo.structured_extraction import enrich_character_appearances
+
+    agent = FakeAppearanceAgent({"郑家悦": _appearance("郑家悦", age_group="middle-aged")})
+    result = await enrich_character_appearances([_cast_member("郑家悦")], agent=agent)
+
+    assert result["郑家悦"].age_group == "youth"
+
+
+async def test_a_cached_appearance_is_never_sent_to_the_model_again():
+    from novelvideo.structured_extraction import enrich_character_appearances
+
+    cache = RecordingCache()
+    item = _cast_member("郑家悦")
+    first = FakeAppearanceAgent({"郑家悦": _appearance("郑家悦", role="主角")})
+    await enrich_character_appearances([item], agent=first, cache=cache)
+    assert len(first.prompts) == 1
+
+    second = FakeAppearanceAgent({})
+    result = await enrich_character_appearances([item], agent=second, cache=cache)
+    assert second.prompts == []
+    assert result["郑家悦"].role == "主角"
+
+
+async def test_a_changed_description_retires_the_cached_appearance():
+    """The description is in the prompt, so a changed one is a different question."""
+    from novelvideo.structured_extraction import character_appearance_cache_key
+
+    before = character_appearance_cache_key(_cast_member("郑家悦", description="遭受校园霸凌"))
+    after = character_appearance_cache_key(_cast_member("郑家悦", description="已经毕业工作"))
+    assert before != after
+
+
+async def test_a_changed_quote_retires_the_cached_appearance():
+    from novelvideo.structured_extraction import character_appearance_cache_key
+
+    before = character_appearance_cache_key(_cast_member("郑家悦", quotes=("她低下头。",)))
+    after = character_appearance_cache_key(_cast_member("郑家悦", quotes=("她抬起头。",)))
+    assert before != after
+
+
+async def test_only_one_narrator_survives_a_batch_split():
+    """Batches run concurrently, so "whoever answered first" is not a stable answer."""
+    from novelvideo.structured_extraction import enrich_character_appearances
+
+    agent = FakeAppearanceAgent(
+        {
+            "郑家悦": _appearance("郑家悦", is_main=True),
+            "郑玉琴": _appearance("郑玉琴", is_main=True),
+        }
+    )
+    result = await enrich_character_appearances(
+        [_cast_member("郑家悦"), _cast_member("郑玉琴")], agent=agent
+    )
+
+    assert [name for name, item in result.items() if item.is_main] == ["郑家悦"]
+
+
+async def test_a_failed_appearance_call_still_leaves_the_cast_published(
+    structured_store, monkeypatch
+):
+    """Losing a face must not lose the character it belonged to."""
+    from novelvideo import structured_builders
+
+    store, _ = structured_store
+    monkeypatch.setattr(
+        "novelvideo.structured_extraction._create_character_appearance_agent",
+        lambda agent=None: FakeAppearanceAgent({}, fail=True),
+    )
+    added = await structured_builders._publish_characters(
+        store, [_cast_member("郑家悦")], "", lambda *_: None, lambda *_: None
+    )
+
+    assert added == ["郑家悦"]
+    assert store.get_character("郑家悦").face_prompt == ""
+
+
+async def test_a_new_character_is_published_with_its_face_and_voice(
+    structured_store, monkeypatch
+):
+    from novelvideo import structured_builders
+
+    store, _ = structured_store
+    monkeypatch.setenv("FISH_VOICE_YOUTH_FEMALE", "voice-yf")
+    monkeypatch.setattr(
+        "novelvideo.config.FISH_VOICE_PRESETS",
+        {"youth_female": "voice-yf", "youth_male": "voice-ym"},
+    )
+    monkeypatch.setattr(
+        "novelvideo.structured_extraction._create_character_appearance_agent",
+        lambda agent=None: FakeAppearanceAgent(
+            {"郑家悦": _appearance("郑家悦", role="主角", body_type="纤细高挑")}
+        ),
+    )
+    await structured_builders._publish_characters(
+        store, [_cast_member("郑家悦")], "", lambda *_: None, lambda *_: None
+    )
+
+    character = store.get_character("郑家悦")
+    assert character.face_prompt == "女性，二十多岁，黑色长发，杏眼"
+    assert character.role == "主角"
+    assert character.body_type == "纤细高挑"
+    # "female", not "女": the structured extractor writes the English form, and
+    # a lookup that only knows the Chinese one gives every woman a male voice.
+    assert character.fish_voice_id == "voice-yf"
+
+
+async def test_a_rebuild_fills_a_face_an_existing_character_never_had(
+    structured_store, monkeypatch
+):
+    """Characters built before this stage existed would otherwise stay faceless."""
+    from novelvideo import structured_builders
+    from novelvideo.cognee.pipeline import NovelCharacter
+
+    store, _ = structured_store
+    await store.add_characters_atomic(
+        [NovelCharacter(name="郑家悦", gender="female")], skip_existing=False
+    )
+    assert store.get_character("郑家悦").face_prompt == ""
+
+    monkeypatch.setattr(
+        "novelvideo.config.FISH_VOICE_PRESETS",
+        {"elder_female": "voice-ef", "elder_male": "voice-em"},
+    )
+    monkeypatch.setattr(
+        "novelvideo.structured_extraction._create_character_appearance_agent",
+        lambda agent=None: FakeAppearanceAgent(
+            {"郑家悦": _appearance("郑家悦", role="主角", age_group="elder")}
+        ),
+    )
+    added = await structured_builders._publish_characters(
+        store, [_cast_member("郑家悦")], "", lambda *_: None, lambda *_: None
+    )
+
+    assert added == []
+    repaired = store.get_character("郑家悦")
+    assert repaired.face_prompt == "女性，二十多岁，黑色长发，杏眼"
+    assert repaired.role == "主角"
+    assert repaired.age_group == "elder"
+    assert repaired.fish_voice_id == "voice-ef"
+
+
+async def test_a_rebuild_leaves_an_age_band_a_bound_voice_depends_on(
+    structured_store, monkeypatch
+):
+    """A bound voice means somebody chose the band; the repair must not move it."""
+    from novelvideo import structured_builders
+    from novelvideo.cognee.pipeline import NovelCharacter
+
+    store, _ = structured_store
+    await store.add_characters_atomic(
+        [
+            NovelCharacter(
+                name="郑家悦",
+                gender="female",
+                age_group="youth",
+                fish_voice_id="chosen-by-hand",
+            )
+        ],
+        skip_existing=False,
+    )
+    monkeypatch.setattr(
+        "novelvideo.structured_extraction._create_character_appearance_agent",
+        lambda agent=None: FakeAppearanceAgent(
+            {"郑家悦": _appearance("郑家悦", age_group="elder")}
+        ),
+    )
+    await structured_builders._publish_characters(
+        store, [_cast_member("郑家悦")], "", lambda *_: None, lambda *_: None
+    )
+
+    repaired = store.get_character("郑家悦")
+    assert repaired.face_prompt == "女性，二十多岁，黑色长发，杏眼"
+    assert repaired.age_group == "youth"
+    assert repaired.fish_voice_id == "chosen-by-hand"
+
+
+async def test_a_rebuild_never_overwrites_a_face_the_user_wrote(
+    structured_store, monkeypatch
+):
+    from novelvideo import structured_builders
+    from novelvideo.cognee.pipeline import NovelCharacter
+
+    store, _ = structured_store
+    await store.add_characters_atomic(
+        [
+            NovelCharacter(
+                name="郑家悦", gender="female", face_prompt="我自己写的脸", role="配角"
+            )
+        ],
+        skip_existing=False,
+    )
+    monkeypatch.setattr(
+        "novelvideo.structured_extraction._create_character_appearance_agent",
+        lambda agent=None: FakeAppearanceAgent(
+            {"郑家悦": _appearance("郑家悦", role="主角")}
+        ),
+    )
+    await structured_builders._publish_characters(
+        store, [_cast_member("郑家悦")], "", lambda *_: None, lambda *_: None
+    )
+
+    assert store.get_character("郑家悦").face_prompt == "我自己写的脸"
+    assert store.get_character("郑家悦").role == "配角"
+
+
+def test_the_voice_lookup_reads_both_spellings_of_a_gender(monkeypatch):
+    """legacy writes 男/女, structured_v1 writes male/female; both select a voice."""
+    from novelvideo.config import get_fish_voice_id
+
+    monkeypatch.setattr(
+        "novelvideo.config.FISH_VOICE_PRESETS",
+        {"youth_female": "voice-yf", "youth_male": "voice-ym"},
+    )
+    assert get_fish_voice_id("youth", "female") == "voice-yf"
+    assert get_fish_voice_id("youth", "女") == "voice-yf"
+    assert get_fish_voice_id("youth", "male") == "voice-ym"
+    assert get_fish_voice_id("youth", "男") == "voice-ym"
+
+
+async def test_the_character_bible_reaches_the_stage_that_writes_faces():
+    """A screenplay's pre-scene block names hair and build outright; legacy sent it."""
+    from novelvideo.structured_extraction import enrich_character_appearances
+
+    agent = FakeAppearanceAgent({"郑家悦": _appearance("郑家悦")})
+    await enrich_character_appearances(
+        [_cast_member("郑家悦")], synopsis="郑家悦：短发，清瘦。", agent=agent
+    )
+
+    assert "郑家悦：短发，清瘦。" in agent.prompts[0]
+
+
+async def test_an_edited_character_bible_retires_every_stored_appearance():
+    from novelvideo.structured_extraction import character_appearance_cache_key
+
+    item = _cast_member("郑家悦")
+    before = character_appearance_cache_key(item, "郑家悦：短发，清瘦。")
+    after = character_appearance_cache_key(item, "郑家悦：长发，圆脸。")
+    assert before != after
+
+
+async def test_a_drama_build_reads_the_bible_from_the_imported_source(
+    structured_store, monkeypatch
+):
+    """_publish_characters reaches publication without the source text in hand."""
+    from novelvideo import structured_builders
+
+    store, state_dir = structured_store
+    (state_dir / "novel.txt").write_text(
+        "郑家悦：短发，清瘦。\n\n1-1 教室 日 内\n\n郑家悦坐下。\n", encoding="utf-8"
+    )
+    agent = FakeAppearanceAgent({"郑家悦": _appearance("郑家悦")})
+    monkeypatch.setattr(
+        "novelvideo.structured_extraction._create_character_appearance_agent",
+        lambda a=None: agent,
+    )
+    await structured_builders._publish_characters(
+        store, [_cast_member("郑家悦")], "", lambda *_: None, lambda *_: None
+    )
+
+    assert "郑家悦：短发，清瘦。" in agent.prompts[0]

--- a/tests/test_structured_builders.py
+++ b/tests/test_structured_builders.py
@@ -2174,3 +2174,135 @@ async def test_a_drama_build_reads_the_bible_from_the_imported_source(
     )
 
     assert "郑家悦：短发，清瘦。" in agent.prompts[0]
+
+
+async def test_a_rebuild_marks_the_narrator_an_existing_project_never_had(
+    structured_store, monkeypatch
+):
+    """Without it, first-person narration fails with 未找到解说主角 forever."""
+    from novelvideo import structured_builders
+    from novelvideo.cognee.pipeline import NovelCharacter
+
+    store, _ = structured_store
+    await store.add_characters_atomic(
+        [NovelCharacter(name="郑家悦", gender="female")], skip_existing=False
+    )
+    monkeypatch.setattr(
+        "novelvideo.structured_extraction._create_character_appearance_agent",
+        lambda agent=None: FakeAppearanceAgent(
+            {"郑家悦": _appearance("郑家悦", is_main=True)}
+        ),
+    )
+    await structured_builders._publish_characters(
+        store, [_cast_member("郑家悦")], "", lambda *_: None, lambda *_: None
+    )
+
+    assert store.get_character("郑家悦").is_main is True
+
+
+async def test_a_narrator_marked_by_hand_is_not_joined_by_a_second_one(
+    structured_store, monkeypatch
+):
+    """Nothing binds to is_main, so an unclaimed narrator is the only signal."""
+    from novelvideo import structured_builders
+    from novelvideo.cognee.pipeline import NovelCharacter
+
+    store, _ = structured_store
+    await store.add_characters_atomic(
+        [
+            NovelCharacter(name="郑玉琴", gender="female", is_main=True),
+            NovelCharacter(name="郑家悦", gender="female"),
+        ],
+        skip_existing=False,
+    )
+    monkeypatch.setattr(
+        "novelvideo.structured_extraction._create_character_appearance_agent",
+        lambda agent=None: FakeAppearanceAgent(
+            {"郑家悦": _appearance("郑家悦", is_main=True)}
+        ),
+    )
+    await structured_builders._publish_characters(
+        store, [_cast_member("郑家悦")], "", lambda *_: None, lambda *_: None
+    )
+
+    assert store.get_character("郑家悦").is_main is False
+    assert store.get_character("郑玉琴").is_main is True
+
+
+async def test_a_face_written_by_hand_does_not_lock_out_the_other_fields(
+    structured_store, monkeypatch
+):
+    """Gating the whole repair on a missing face punished the one field filled in."""
+    from novelvideo import structured_builders
+    from novelvideo.cognee.pipeline import NovelCharacter
+
+    store, _ = structured_store
+    await store.add_characters_atomic(
+        [NovelCharacter(name="郑家悦", gender="female", face_prompt="我自己写的脸")],
+        skip_existing=False,
+    )
+    monkeypatch.setattr(
+        "novelvideo.config.FISH_VOICE_PRESETS",
+        {"elder_female": "voice-ef", "elder_male": "voice-em"},
+    )
+    monkeypatch.setattr(
+        "novelvideo.structured_extraction._create_character_appearance_agent",
+        lambda agent=None: FakeAppearanceAgent(
+            {
+                "郑家悦": _appearance(
+                    "郑家悦", role="主角", body_type="纤细高挑", age_group="elder"
+                )
+            }
+        ),
+    )
+    await structured_builders._publish_characters(
+        store, [_cast_member("郑家悦")], "", lambda *_: None, lambda *_: None
+    )
+
+    repaired = store.get_character("郑家悦")
+    assert repaired.face_prompt == "我自己写的脸"
+    assert repaired.role == "主角"
+    assert repaired.body_type == "纤细高挑"
+    assert repaired.fish_voice_id == "voice-ef"
+
+
+async def test_a_character_with_nothing_missing_is_left_untouched(
+    structured_store, monkeypatch
+):
+    """Every field guarded, so a settled character costs no write at all."""
+    from novelvideo import structured_builders
+    from novelvideo.cognee.pipeline import NovelCharacter
+
+    store, _ = structured_store
+    await store.add_characters_atomic(
+        [
+            NovelCharacter(
+                name="郑家悦",
+                gender="female",
+                face_prompt="已有的脸",
+                role="已有定位",
+                body_type="已有身形",
+                fish_voice_id="已有声音",
+            )
+        ],
+        skip_existing=False,
+    )
+    writes = []
+    original = store.update_character
+
+    async def recording(name, **updates):
+        writes.append((name, updates))
+        await original(name, **updates)
+
+    monkeypatch.setattr(store, "update_character", recording)
+    monkeypatch.setattr(
+        "novelvideo.structured_extraction._create_character_appearance_agent",
+        lambda agent=None: FakeAppearanceAgent(
+            {"郑家悦": _appearance("郑家悦", role="主角", body_type="纤细高挑")}
+        ),
+    )
+    await structured_builders._publish_characters(
+        store, [_cast_member("郑家悦")], "", lambda *_: None, lambda *_: None
+    )
+
+    assert writes == []


### PR DESCRIPTION
feat: give structured characters the face, role and build they never had

structured_v1 characters land with an empty 面部提示词, 角色定位 and 身形.
This is not a regression: `git log -S face_prompt` over the structured
extraction path returns nothing since 3c6eb619, its first commit. The stage
that writes those fields was never carried over.

Legacy does it in one call. `CharacterEnrichment` asks a model for nine
fields at once — who the character is *and* what they look like — off the
graph context plus the script's character bible. Structured extraction only
carried over the first half. Its contract is evidence-bound: every field a
candidate reports has to appear verbatim in the span it came from, which is
what stops an invented character from reaching the table. A face prompt, a
role and a build are none of them quotable, so they could not ride along in
CharacterCandidate without relaxing the guard that makes extraction worth
trusting.

Scenes never had this problem. `enrich_scene_environments_batched` has been
there from the beginning, which is exactly why scene builds produce usable
prompts and character builds did not.

The consequence is not cosmetic. character_image.py refuses outright:

    if not face_prompt:
        raise RuntimeError("请先设置面部特征 (face_prompt)")

So 生成新图 on any structured project's character card fails.

## The stage

Runs after adjudication has settled the cast, takes only names that already
survived verification, and is allowed to write what the source implies
rather than what it states. Two contracts, kept apart.

- role, is_main, age_group, body_type, face_prompt; fish_voice_id derived
- cached in story_analysis_item_cache under `character_appearance`, keyed on
  name, aliases, gender, description, the quotes the prompt actually sends,
  the synopsis, and a contract version
- an answer with no face prompt is neither stored nor published. Caching one
  would make the omission permanent — the trap is_cacheable_scene_prompt
  already guards against on the scene side
- age bands are coerced to the four the column accepts, because
  get_fish_voice_id and identity planning both derive from it and an unknown
  value would silently disable them rather than fail
- at most one narrator, resolved in the caller's order: batches run
  concurrently, so "whoever answered first" is not a stable answer
- a failed batch degrades. Losing a face must not lose the character

The screenplay's pre-scene block goes in whole. It names hair, build and
bearing outright, it is what legacy fed the same question, and scene
enrichment has taken it as `synopsis` all along.

## Existing characters

Published through `_publish_characters`, so a run replayed from its stored
cast is enriched too. Without that, a project built before this stage
existed could never acquire a face without deleting its characters first.

An existing character is an asset fact and a rebuild leaves it alone —
except for fields it never had. Repair is field by field: a role written by
hand survives supplying the face beside it. The age band has no empty state,
so an unbound voice is what distinguishes a band nobody chose from one
somebody did; where nothing is bound, the band and the voice it selects are
written together and cannot end up disagreeing.

## A voice bug on the way past

    gender_key = "female" if "女" in gender else "male"

legacy's prompt asks for 男/女. The structured extractor's asks for
male/female. So every woman in every structured project has been getting a
male voice — and not only here: identity_planner.py:402 calls the same
function with the same value. Both spellings now resolve. Legacy's inputs go
down the same branch they always did.

## Tests

16 new. Six were checked against the unfixed tree and fail there: a new
character publishes with its face and voice, a rebuild fills a face an
existing character never had, a bound voice keeps its age band, the voice
lookup reads both genders, and the character bible reaches the prompt.

The rest cover the guards: a faceless answer is dropped rather than cached,
an unusable age band falls back, a cached appearance is never re-sent, an
edited description / quote / bible retires the stored answer, only one
narrator survives a batch split, a failed call still publishes the cast, and
a face the user wrote is never overwritten.

ruff clean. 3838 passed, 16 skipped.

## Not in this change

Legacy's prompt also excludes animals, monsters and robots; structured
extraction's does not. That belongs to the extraction prompt, not to this
stage, and it is a fail-closed guard — it deletes real characters when it is
wrong — so it wants its own evaluation.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
