### PR TITLE
feat(codex): harden project-scoped runtime

### DIFF
--- a/.hermes/plugins/dramaclaw/__init__.py
+++ b/.hermes/plugins/dramaclaw/__init__.py
@@ -298,6 +298,7 @@ def _available() -> bool:
         os.environ.get("DRAMACLAW_API_URL")
         and (
             os.environ.get("DRAMACLAW_AGENT_TOKEN")
+            or os.environ.get("DRAMACLAW_AGENT_TOKEN_FILE")
             or _local_agent_trust_enabled()
             or _ce_owner_mode()
         )
@@ -312,10 +313,22 @@ def _base_url() -> str:
 
 
 def _token() -> str:
-    value = os.environ.get("DRAMACLAW_AGENT_TOKEN", "").strip()
+    value = _current_agent_token()
     if not value:
         raise ValueError("DRAMACLAW_AGENT_TOKEN is not set")
     return value
+
+
+def _current_agent_token() -> str:
+    """Read a turn token lazily so resumed Codex MCP processes stay safe."""
+
+    token_file = os.environ.get("DRAMACLAW_AGENT_TOKEN_FILE", "").strip()
+    if token_file:
+        try:
+            return Path(token_file).read_text(encoding="utf-8").strip()
+        except OSError:
+            return ""
+    return os.environ.get("DRAMACLAW_AGENT_TOKEN", "").strip()
 
 
 def _ce_owner_mode() -> bool:
@@ -358,7 +371,7 @@ def _request_headers(user_agent: str) -> dict[str, str]:
         "Accept": "application/json",
         "User-Agent": user_agent,
     }
-    token = os.environ.get("DRAMACLAW_AGENT_TOKEN", "").strip()
+    token = _current_agent_token()
     if token:
         headers["Authorization"] = f"Bearer {token}"
     elif _ce_owner_mode():

--- a/docs/zh/guides/community-skill-recipe-ecosystem-design.md
+++ b/docs/zh/guides/community-skill-recipe-ecosystem-design.md
@@ -194,7 +194,7 @@ Freezone Memory 覆盖问题已经修复：`_ensure_freezone_identity_context()`
 
 当前只剩一个版本收口问题：`.hermes-version` 已经是 `0.19.0`，但 `hermes_pool.py` 的缺文件 fallback 仍是 `0.18.0`。正式发布前应让 `.hermes-version` 成为唯一版本来源，避免非 Docker 安装出现漂移。
 
-`preferences.md` 是旧的用户偏好兼容层。Freezone 2.0 不继续扩展它，也不围绕它建设新的 Memory 产品；虾画助手优先使用 Hermes Memory。主线虾导是否继续兼容 `preferences.md` 可以单独处理。
+旧的用户级 `preferences.md` 兼容层已经移除。创作偏好和项目事实都应留在项目作用域，由项目内的 Agent Memory 与会话承载，避免电影、广告、电商等不同项目之间互相污染。
 
 ### 2.2 Skill Studio 已经能让用户创建 Skill
 

--- a/docs/zh/guides/community-skill-recipe-ecosystem-design.md
+++ b/docs/zh/guides/community-skill-recipe-ecosystem-design.md
@@ -196,6 +196,10 @@ Freezone Memory 覆盖问题已经修复：`_ensure_freezone_identity_context()`
 
 旧的用户级 `preferences.md` 兼容层已经移除。创作偏好和项目事实都应留在项目作用域，由项目内的 Agent Memory 与会话承载，避免电影、广告、电商等不同项目之间互相污染。
 
+对用户可见的变化是：`state/<user>/preferences.md` 旧格式不再受支持，运行时不会创建、读取、注入或迁移其中的内容，也不会自动跨项目继承偏好。用户若希望某项偏好生效，需要在相关项目中重新说明或写入项目记忆。
+
+Codex 的 thread rollout 位于 Home Node 的共享 `CODEX_HOME`，不随项目目录一起自然删除。因此生命周期操作采用 fail-closed：删除画布前必须成功归档该画布的 Codex thread，永久清理项目前必须成功删除对应 rollout；App Server 不可用且确实存在待处理 thread 时，删除请求会失败并保留画布/项目，待运行时恢复后重试。没有 Codex thread 的项目不受影响。
+
 ### 2.2 Skill Studio 已经能让用户创建 Skill
 
 当前 Skill Studio 与设置页合起来已支持：

--- a/docs/zh/guides/community-skill-recipe-ecosystem-design.md
+++ b/docs/zh/guides/community-skill-recipe-ecosystem-design.md
@@ -200,6 +200,8 @@ Freezone Memory 覆盖问题已经修复：`_ensure_freezone_identity_context()`
 
 Codex 的 thread rollout 位于 Home Node 的共享 `CODEX_HOME`，不随项目目录一起自然删除。因此生命周期操作采用 fail-closed：删除画布前必须成功归档该画布的 Codex thread，永久清理项目前必须成功删除对应 rollout；App Server 不可用且确实存在待处理 thread 时，删除请求会失败并保留画布/项目，待运行时恢复后重试。没有 Codex thread 的项目不受影响。
 
+一个 Home Node 只运行一个共享 Codex App Server，不为 Director 与 Freezone 重复常驻运行时。两种 Profile 通过独立 workspace、独立 thread/session key、thread-local MCP 环境、短期 token 和带 `project + canvas + profile` 的 active-turn key 隔离；共享 `CODEX_HOME` 中的原生 Memory、Plugin 与 Multi-agent 均关闭，避免节点级状态跨 Profile 泄漏。
+
 ### 2.2 Skill Studio 已经能让用户创建 Skill
 
 当前 Skill Studio 与设置页合起来已支持：

--- a/src/novelvideo/api/routes/chat.py
+++ b/src/novelvideo/api/routes/chat.py
@@ -108,10 +108,6 @@ async def cancel_chat_turn(user: dict = Depends(get_api_user)) -> dict[str, Any]
             cancelled = await hermes_pool.close_user(username)
     except Exception:
         cancelled = False
-    try:
-        chat_service.force_release_chat_run_lock(username, "")
-    except Exception:
-        pass
     return {"ok": True, "data": {"cancelled": cancelled}}
 
 
@@ -470,6 +466,7 @@ async def list_freezone_canvas_agents(
         str(user["username"]),
         project_id=project_ctx.project_name if project_ctx is not None else project_id,
         canvas_id=canvas_id,
+        project_state_dir=project_ctx.state_dir if project_ctx is not None else None,
     )
     return {"ok": True, "data": {"agents": agents}}
 
@@ -490,7 +487,15 @@ def _chat_store_scope_for_project_context(
 ) -> ChatScope:
     if not _is_freezone_scope(scope) or project_ctx is None:
         return scope
-    return replace(scope, id=project_ctx.project_name)
+    return replace(
+        scope,
+        id=project_ctx.project_name,
+        state_dir=(
+            str(project_ctx.state_dir)
+            if getattr(project_ctx, "state_dir", None) is not None
+            else None
+        ),
+    )
 
 
 def _canvas_bridge_profile_for_scope(scope: ChatScope) -> str:
@@ -1754,6 +1759,7 @@ async def _chat_heartbeat(
     scope: ChatScope,
     turn_id: str,
     send_lock: asyncio.Lock,
+    disconnected: asyncio.Event | None = None,
     interval_seconds: float = 10.0,
 ) -> None:
     while True:
@@ -1764,7 +1770,25 @@ async def _chat_heartbeat(
             send_lock,
         )
         if not sent:
+            if disconnected is not None:
+                disconnected.set()
             return
+
+
+async def _interrupt_agent_on_disconnect(
+    disconnected: asyncio.Event,
+    username: str,
+) -> None:
+    await disconnected.wait()
+    try:
+        if chat_service.get_chat_backend_name() == "codex":
+            await chat_service.interrupt_active_codex_turns(username)
+        else:
+            from novelvideo.chat.hermes_pool import pool as hermes_pool
+
+            await hermes_pool.close_user(username)
+    except Exception:
+        logger.warning("failed to interrupt disconnected chat turn", exc_info=True)
 
 
 async def _sync_running_agent_scope(username: str, scope: ChatScope) -> None:
@@ -2452,8 +2476,18 @@ async def _stream_project_turn(
             project_state_dir=project_state_dir,
         )
     send_lock = asyncio.Lock()
+    disconnected = asyncio.Event()
     heartbeat_task = asyncio.create_task(
-        _chat_heartbeat(websocket, scope=scope, turn_id=turn_id, send_lock=send_lock)
+        _chat_heartbeat(
+            websocket,
+            scope=scope,
+            turn_id=turn_id,
+            send_lock=send_lock,
+            disconnected=disconnected,
+        )
+    )
+    disconnect_task = asyncio.create_task(
+        _interrupt_agent_on_disconnect(disconnected, username)
     )
     bridge_result_receive_task = asyncio.create_task(
         _receive_bridge_results_during_turn(websocket=websocket, user=user, username=username)
@@ -2730,6 +2764,7 @@ async def _stream_project_turn(
             )
     finally:
         heartbeat_task.cancel()
+        disconnect_task.cancel()
         bridge_result_receive_task.cancel()
         pending_canvas_task.cancel()
         pending_canvas_context_task.cancel()
@@ -2737,6 +2772,8 @@ async def _stream_project_turn(
         pending_clarification_task.cancel()
         with contextlib.suppress(asyncio.CancelledError):
             await heartbeat_task
+        with contextlib.suppress(asyncio.CancelledError):
+            await disconnect_task
         with contextlib.suppress(asyncio.CancelledError):
             await bridge_result_receive_task
         with contextlib.suppress(asyncio.CancelledError):
@@ -2780,8 +2817,18 @@ async def _stream_home_turn_codex(
         turn_id=turn_id,
     )
     send_lock = asyncio.Lock()
+    disconnected = asyncio.Event()
     heartbeat_task = asyncio.create_task(
-        _chat_heartbeat(websocket, scope=scope, turn_id=turn_id, send_lock=send_lock)
+        _chat_heartbeat(
+            websocket,
+            scope=scope,
+            turn_id=turn_id,
+            send_lock=send_lock,
+            disconnected=disconnected,
+        )
+    )
+    disconnect_task = asyncio.create_task(
+        _interrupt_agent_on_disconnect(disconnected, username)
     )
     done_sent = False
     assistant_sent_text = ""
@@ -2950,8 +2997,11 @@ async def _stream_home_turn_codex(
             )
     finally:
         heartbeat_task.cancel()
+        disconnect_task.cancel()
         with contextlib.suppress(asyncio.CancelledError):
             await heartbeat_task
+        with contextlib.suppress(asyncio.CancelledError):
+            await disconnect_task
         if not done_sent:
             await _send_json_best_effort(
                 websocket,
@@ -3051,8 +3101,18 @@ async def _stream_home_turn(
     tool_name = ""
     persisted = False
     send_lock = asyncio.Lock()
+    disconnected = asyncio.Event()
     heartbeat_task = asyncio.create_task(
-        _chat_heartbeat(websocket, scope=scope, turn_id=turn_id, send_lock=send_lock)
+        _chat_heartbeat(
+            websocket,
+            scope=scope,
+            turn_id=turn_id,
+            send_lock=send_lock,
+            disconnected=disconnected,
+        )
+    )
+    disconnect_task = asyncio.create_task(
+        _interrupt_agent_on_disconnect(disconnected, username)
     )
     done_sent = False
 
@@ -3343,8 +3403,11 @@ async def _stream_home_turn(
         )
     finally:
         heartbeat_task.cancel()
+        disconnect_task.cancel()
         with contextlib.suppress(asyncio.CancelledError):
             await heartbeat_task
+        with contextlib.suppress(asyncio.CancelledError):
+            await disconnect_task
         persist_partial_reply()
         if not done_sent:
             await _send_json_best_effort(

--- a/src/novelvideo/api/routes/chat.py
+++ b/src/novelvideo/api/routes/chat.py
@@ -431,7 +431,9 @@ async def resolve_agent_permission(
         raise HTTPException(status_code=400, detail="option_id is required")
     from novelvideo.chat.hermes_pool import pool as hermes_pool
 
-    agent_profile = _freezone_agent_profile(scope) if _is_freezone_scope(scope) else "main"
+    agent_profile = (
+        _freezone_agent_profile(scope) if _is_freezone_scope(scope) else "main"
+    )
     resolved = await hermes_pool.resolve_permission(
         str(user["username"]),
         agent_profile,
@@ -1777,16 +1779,42 @@ async def _chat_heartbeat(
 
 async def _interrupt_agent_on_disconnect(
     disconnected: asyncio.Event,
+    *,
+    runtime_backend: str,
     username: str,
+    project: str,
+    agent_profile: str,
+    runtime_ids: dict[str, str | None],
 ) -> None:
     await disconnected.wait()
+    # A socket can disappear while the runtime is still starting. Give the
+    # matching turn a short window to publish its IDs, but never fall back to
+    # a username-wide shutdown.
+    for _attempt in range(100):
+        thread_id = str(runtime_ids.get("thread_id") or "").strip()
+        turn_id = str(runtime_ids.get("turn_id") or "").strip()
+        if thread_id and (runtime_backend == "hermes" or turn_id):
+            break
+        await asyncio.sleep(0.05)
+    else:
+        return
     try:
-        if chat_service.get_chat_backend_name() == "codex":
-            await chat_service.interrupt_active_codex_turns(username)
-        else:
+        if runtime_backend == "hermes":
             from novelvideo.chat.hermes_pool import pool as hermes_pool
 
-            await hermes_pool.close_user(username)
+            await hermes_pool.close_user_thread(
+                username,
+                agent_profile,
+                thread_id,
+            )
+        else:
+            await chat_service.interrupt_chat_turn(
+                username,
+                project,
+                thread_id,
+                turn_id,
+                backend=runtime_backend,
+            )
     except Exception:
         logger.warning("failed to interrupt disconnected chat turn", exc_info=True)
 
@@ -2477,6 +2505,9 @@ async def _stream_project_turn(
         )
     send_lock = asyncio.Lock()
     disconnected = asyncio.Event()
+    runtime_backend = chat_service.get_chat_backend_name()
+    runtime_ids: dict[str, str | None] = {"thread_id": None, "turn_id": None}
+    agent_profile = _freezone_agent_profile(scope) if _is_freezone_scope(scope) else "main"
     heartbeat_task = asyncio.create_task(
         _chat_heartbeat(
             websocket,
@@ -2487,7 +2518,14 @@ async def _stream_project_turn(
         )
     )
     disconnect_task = asyncio.create_task(
-        _interrupt_agent_on_disconnect(disconnected, username)
+        _interrupt_agent_on_disconnect(
+            disconnected,
+            runtime_backend=runtime_backend,
+            username=username,
+            project=project,
+            agent_profile=agent_profile,
+            runtime_ids=runtime_ids,
+        )
     )
     bridge_result_receive_task = asyncio.create_task(
         _receive_bridge_results_during_turn(websocket=websocket, user=user, username=username)
@@ -2554,6 +2592,8 @@ async def _stream_project_turn(
         nonlocal assistant_sent_text, done_sent
         event_type = event.get("type")
         if event_type == "thread_started":
+            runtime_ids["thread_id"] = str(event.get("thread_id") or "").strip() or None
+            runtime_ids["turn_id"] = str(event.get("turn_id") or "").strip() or None
             await _send_json_best_effort(
                 websocket,
                 {
@@ -2761,6 +2801,7 @@ async def _stream_project_turn(
                 store_scope=storage_scope,
                 turn_id=turn_id,
                 route_prompt=display_text,
+                backend=runtime_backend,
             )
     finally:
         heartbeat_task.cancel()
@@ -2818,6 +2859,7 @@ async def _stream_home_turn_codex(
     )
     send_lock = asyncio.Lock()
     disconnected = asyncio.Event()
+    runtime_ids: dict[str, str | None] = {"thread_id": None, "turn_id": None}
     heartbeat_task = asyncio.create_task(
         _chat_heartbeat(
             websocket,
@@ -2828,7 +2870,14 @@ async def _stream_home_turn_codex(
         )
     )
     disconnect_task = asyncio.create_task(
-        _interrupt_agent_on_disconnect(disconnected, username)
+        _interrupt_agent_on_disconnect(
+            disconnected,
+            runtime_backend="codex",
+            username=username,
+            project="",
+            agent_profile="main",
+            runtime_ids=runtime_ids,
+        )
     )
     done_sent = False
     assistant_sent_text = ""
@@ -2837,6 +2886,8 @@ async def _stream_home_turn_codex(
         nonlocal assistant_sent_text, done_sent
         event_type = str(event.get("type") or "")
         if event_type == "thread_started":
+            runtime_ids["thread_id"] = str(event.get("thread_id") or "").strip() or None
+            runtime_ids["turn_id"] = str(event.get("turn_id") or "").strip() or None
             await _send_json_best_effort(
                 websocket,
                 {
@@ -2980,6 +3031,7 @@ async def _stream_home_turn_codex(
                 egress_project_id=HOME_SCOPE_EGRESS_PROJECT_ID,
                 store_scope=scope,
                 turn_id=turn_id,
+                backend="codex",
             )
         after_projects = set(list_user_projects(username))
         for project in sorted(after_projects - before_projects):
@@ -3102,6 +3154,10 @@ async def _stream_home_turn(
     persisted = False
     send_lock = asyncio.Lock()
     disconnected = asyncio.Event()
+    runtime_ids: dict[str, str | None] = {
+        "thread_id": str(getattr(thread, "id", "") or "").strip() or None,
+        "turn_id": None,
+    }
     heartbeat_task = asyncio.create_task(
         _chat_heartbeat(
             websocket,
@@ -3112,7 +3168,14 @@ async def _stream_home_turn(
         )
     )
     disconnect_task = asyncio.create_task(
-        _interrupt_agent_on_disconnect(disconnected, username)
+        _interrupt_agent_on_disconnect(
+            disconnected,
+            runtime_backend="hermes",
+            username=username,
+            project="",
+            agent_profile="main",
+            runtime_ids=runtime_ids,
+        )
     )
     done_sent = False
 
@@ -3203,6 +3266,10 @@ async def _stream_home_turn(
     try:
         async for event in hermes_events_with_session_retry():
             if event.type == "thread_started":
+                runtime_ids["thread_id"] = (
+                    str(event.thread_id or "").strip() or None
+                )
+                runtime_ids["turn_id"] = str(event.turn_id or "").strip() or None
                 await _send_json_best_effort(
                     websocket,
                     {

--- a/src/novelvideo/api/routes/freezone.py
+++ b/src/novelvideo/api/routes/freezone.py
@@ -28,6 +28,7 @@ from fastapi import (
 from fastapi.responses import FileResponse
 
 from novelvideo.api.auth import get_api_user
+from novelvideo.chat import service as chat_service
 from novelvideo.api.deps import (
     make_cognee_store_for_context,
     make_sqlite_store,
@@ -13152,12 +13153,18 @@ async def put_canvas(
 async def delete_canvas(project: str, canvas_id: str, user: dict = Depends(get_api_user)):
     if not CANVAS_ID_RE.match(canvas_id):
         raise HTTPException(400, "invalid canvas_id")
-    ctx, _username, _project_name, project_dir, _output_dir = await _resolve_freezone_project(
+    ctx, username, project_name, project_dir, _output_dir = await _resolve_freezone_project(
         project,
         user,
         require_home_node=False,
     )
     canvas_project_dir = _canvas_state_project_dir(ctx, project_dir)
+    await chat_service.archive_codex_canvas_threads(
+        username,
+        project_name,
+        canvas_id,
+        project_state_dir=ctx.state_dir,
+    )
     try:
         deleted_canvas = canvas_store.soft_delete_canvas(
             canvas_project_dir,

--- a/src/novelvideo/api/routes/projects.py
+++ b/src/novelvideo/api/routes/projects.py
@@ -29,6 +29,7 @@ from novelvideo.api.schemas import (
     ProjectUpdate,
 )
 from novelvideo.config import ensure_project_dirs_at_paths
+from novelvideo.chat import service as chat_service
 from novelvideo.embedding_models import (
     PROJECT_EMBEDDING_DIMENSION_KEY,
     PROJECT_EMBEDDING_MODEL_KEY,
@@ -952,6 +953,13 @@ async def purge_project(
         )
     if record.purged_at:
         raise HTTPException(status_code=400, detail="Project has already been purged.")
+    # Codex rollouts live under the home-node CODEX_HOME, outside the project
+    # directories quarantined below. Delete them before releasing the project.
+    await chat_service.delete_codex_project_threads(
+        str(user["username"]),
+        ctx.project_name,
+        project_state_dir=ctx.state_dir,
+    )
     try:
         quarantined_dirs = _quarantine_project_dirs(
             record,

--- a/src/novelvideo/chat/backend_sdk.py
+++ b/src/novelvideo/chat/backend_sdk.py
@@ -103,6 +103,50 @@ def interrupt_live_codex_turn(thread_id: str, turn_id: str) -> bool:
     return True
 
 
+def control_codex_runtime(
+    *,
+    codex_bin: Path,
+    cwd: Path,
+    env: dict[str, str],
+    config_overrides: tuple[str, ...],
+    operation: Literal["interrupt", "archive", "delete"],
+    thread_id: str,
+    turn_id: str | None = None,
+) -> bool:
+    """Send lifecycle RPCs through the shared home-node App Server.
+
+    Unlike the in-process turn-handle fast path, this works when the HTTP
+    request lands on a different Gunicorn worker from the streaming request.
+    """
+
+    from openai_codex import CodexConfig
+    from novelvideo.chat.codex_app_server import shared_codex
+
+    config = CodexConfig(
+        codex_bin=str(codex_bin),
+        cwd=str(cwd),
+        env=env,
+        config_overrides=config_overrides,
+    )
+    with shared_codex(config) as codex:
+        client = codex._client
+        if operation == "interrupt":
+            if not turn_id:
+                return False
+            client.turn_interrupt(thread_id, turn_id)
+        elif operation == "archive":
+            client.thread_archive(thread_id)
+        else:
+            from openai_codex.generated.v2_all import ThreadDeleteResponse
+
+            client.request(
+                "thread/delete",
+                {"threadId": thread_id},
+                response_model=ThreadDeleteResponse,
+            )
+    return True
+
+
 def consume_interrupted_codex_turn(thread_id: str, turn_id: str) -> bool:
     key = (str(thread_id or "").strip(), str(turn_id or "").strip())
     if not key[0] or not key[1]:
@@ -1201,7 +1245,6 @@ class CodexThread:
                 ModelReroutedNotification,
                 PlanDeltaNotification,
                 ReasoningSummaryTextDeltaNotification,
-                ReasoningTextDeltaNotification,
                 ItemStartedNotification,
                 TerminalInteractionNotification,
                 ThreadTokenUsageUpdatedNotification,
@@ -1327,19 +1370,6 @@ class CodexThread:
                                     turn_id=turn.id,
                                     text=payload.delta,
                                     name="reasoning_summary",
-                                    raw=raw,
-                                ),
-                            )
-                            continue
-                        if isinstance(payload, ReasoningTextDeltaNotification) and payload.turn_id == turn.id and payload.delta:
-                            emit(
-                                "event",
-                                ChatBackendEvent(
-                                    type="thought_delta",
-                                    thread_id=self.id,
-                                    turn_id=turn.id,
-                                    text=payload.delta,
-                                    name="reasoning",
                                     raw=raw,
                                 ),
                             )
@@ -1632,6 +1662,16 @@ class CodexThread:
                 if event.type == "complete":
                     break
         finally:
+            current_task = asyncio.current_task()
+            if (
+                current_task is not None
+                and current_task.cancelling()
+                and self.id
+                and current_turn_id
+            ):
+                await asyncio.to_thread(
+                    interrupt_live_codex_turn, self.id, current_turn_id
+                )
             await worker_task
 
     async def run(self, prompt: str) -> ChatRunResult:

--- a/src/novelvideo/chat/codex_app_server.py
+++ b/src/novelvideo/chat/codex_app_server.py
@@ -8,7 +8,6 @@ WebSocket connection over its private Unix socket.
 
 from __future__ import annotations
 
-import atexit
 import hashlib
 import json
 import os
@@ -311,7 +310,6 @@ class _SharedCodexRuntime:
 
 
 _RUNTIME = _SharedCodexRuntime()
-atexit.register(_RUNTIME.stop)
 
 
 def stop_shared_codex_runtime() -> None:

--- a/src/novelvideo/chat/dramaclaw_mcp.py
+++ b/src/novelvideo/chat/dramaclaw_mcp.py
@@ -114,6 +114,11 @@ def _scope_kind() -> str:
 def _available_tools() -> dict[str, tuple[dict[str, Any], Any]]:
     if _scope_kind() == "home":
         return {name: TOOLS[name] for name in sorted(HOME_TOOL_NAMES) if name in TOOLS}
+    if os.environ.get("DRAMACLAW_TOOL_MODE", "").strip() == "freezone_canvas":
+        denied = frozenset(
+            getattr(PLUGIN, "FREEZONE_DENIED_MAINLINE_WRITE_TOOLS", ())
+        )
+        return {name: item for name, item in TOOLS.items() if name not in denied}
     return dict(TOOLS)
 
 

--- a/src/novelvideo/chat/hermes_pool.py
+++ b/src/novelvideo/chat/hermes_pool.py
@@ -1198,6 +1198,27 @@ class HermesPool:
             await self._close_slot(slot)
             return True
 
+    async def close_user_thread(
+        self,
+        username: str,
+        agent_profile: str,
+        thread_id: str,
+    ) -> bool:
+        """Close only the exact Hermes session that owned a disconnected turn."""
+
+        profile = (agent_profile or "main").strip() or "main"
+        expected_thread_id = str(thread_id or "").strip()
+        if not expected_thread_id:
+            return False
+        async with self._lock:
+            key = self._slot_key(username, profile)
+            slot = self._slots.get(key)
+            if slot is None or str(slot.thread.id or "").strip() != expected_thread_id:
+                return False
+            self._slots.pop(key, None)
+            await self._close_slot(slot)
+            return True
+
     async def resolve_permission(
         self,
         username: str,

--- a/src/novelvideo/chat/hermes_workspace.py
+++ b/src/novelvideo/chat/hermes_workspace.py
@@ -687,14 +687,17 @@ def _ensure_freezone_identity_context(home: Path) -> None:
     """Keep the Freezone assistant identity separate from the director profile."""
     soul_file = home / "SOUL.md"
     try:
-        soul_file.write_text(_FREEZONE_SOUL_MD, encoding="utf-8")
+        if not soul_file.exists():
+            soul_file.write_text(_FREEZONE_SOUL_MD, encoding="utf-8")
     except OSError:
         _log.warning("failed to ensure freezone hermes SOUL.md at %s", soul_file)
 
     memories_dir = home / "memories"
     try:
         memories_dir.mkdir(exist_ok=True)
-        (memories_dir / "MEMORY.md").write_text(_FREEZONE_MEMORY_MD, encoding="utf-8")
+        memory_file = memories_dir / "MEMORY.md"
+        if not memory_file.exists():
+            memory_file.write_text(_FREEZONE_MEMORY_MD, encoding="utf-8")
     except OSError:
         _log.warning(
             "failed to ensure freezone hermes MEMORY.md under %s", memories_dir

--- a/src/novelvideo/chat/service.py
+++ b/src/novelvideo/chat/service.py
@@ -4646,11 +4646,16 @@ def _build_codex_thread(
 
 
 async def interrupt_chat_turn(
-    username: str, project: str, thread_id: str, turn_id: str
+    username: str,
+    project: str,
+    thread_id: str,
+    turn_id: str,
+    *,
+    backend: str | None = None,
 ) -> bool:
     thread_id = str(thread_id or "").strip()
     turn_id = str(turn_id or "").strip()
-    backend = _chat_backend()
+    backend = str(backend or "").strip() or _chat_backend()
     if backend == "claude":
         if not thread_id:
             return False
@@ -4733,6 +4738,7 @@ async def stream_assistant_reply(
     egress_context=None,
     requester_user_id: str | None = None,
     egress_project_id: str | None = None,
+    backend: str | None = None,
 ) -> dict[str, Any]:
     tool_mode = _tool_mode_for_surface(
         surface,
@@ -4763,7 +4769,7 @@ async def stream_assistant_reply(
             _script_creation_model_reply_prompt(prompt, tool_mode=tool_mode)
             or prompt
         )
-        backend = _chat_backend()
+        backend = str(backend or "").strip() or _chat_backend()
         if backend == "codex":
             return await _stream_assistant_reply_codex(
                 username,

--- a/src/novelvideo/chat/service.py
+++ b/src/novelvideo/chat/service.py
@@ -17,7 +17,7 @@ import threading
 import uuid
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 from urllib.parse import quote, unquote, urlparse
 from urllib.request import Request, urlopen
 
@@ -28,6 +28,7 @@ from novelvideo.chat.backend_sdk import (
     _codex_item_completed_trace,
     _codex_item_started_trace,
     _codex_unwrap_item,
+    control_codex_runtime,
     interrupt_live_claude_client,
     interrupt_live_codex_turn,
 )
@@ -3862,6 +3863,138 @@ def _set_codex_thread_id(
         )
 
 
+def _active_codex_turns_path(username: str) -> Path:
+    return _user_state_dir(username) / "active_codex_turns.json"
+
+
+def _load_active_codex_turns(username: str) -> dict[str, dict[str, str]]:
+    path = _active_codex_turns_path(username)
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+    if not isinstance(payload, dict):
+        return {}
+    return {
+        str(key): {str(k): str(v) for k, v in value.items()}
+        for key, value in payload.items()
+        if isinstance(value, dict)
+    }
+
+
+def _set_active_codex_turn(
+    username: str,
+    scope_key: str,
+    value: tuple[str, str] | None,
+) -> None:
+    from novelvideo.utils.state_index_files import index_file_lock, write_json_atomic
+
+    path = _active_codex_turns_path(username)
+    with index_file_lock(path):
+        payload = _load_active_codex_turns(username)
+        if value is None:
+            payload.pop(scope_key, None)
+        else:
+            payload[scope_key] = {"thread_id": value[0], "turn_id": value[1]}
+        write_json_atomic(path, payload)
+
+
+def _control_codex_thread(
+    operation: Literal["interrupt", "archive", "delete"],
+    thread_id: str,
+    turn_id: str | None = None,
+) -> bool:
+    codex_bin = _codex_bin_path()
+    if codex_bin is None:
+        return False
+    from novelvideo.chat.hermes_workspace import effective_gateway_credentials
+
+    _key, base_url = effective_gateway_credentials()
+    normalized_base_url = str(base_url or "").strip().rstrip("/")
+    if not normalized_base_url:
+        return False
+    codex_home = _codex_node_home()
+    env = os.environ.copy()
+    env["CODEX_HOME"] = str(codex_home)
+    env[_CODEX_GATEWAY_BASE_URL_ENV] = normalized_base_url
+    return control_codex_runtime(
+        codex_bin=codex_bin,
+        cwd=codex_home,
+        env=env,
+        config_overrides=_codex_gateway_config_overrides(normalized_base_url),
+        operation=operation,
+        thread_id=thread_id,
+        turn_id=turn_id,
+    )
+
+
+async def archive_codex_canvas_threads(
+    username: str,
+    project: str,
+    canvas_id: str,
+    *,
+    project_state_dir: str | Path | None = None,
+) -> int:
+    """Archive and forget every Codex agent thread attached to one canvas."""
+
+    state = _load_codex_session_state(
+        username, project, project_state_dir=project_state_dir
+    )
+    matches: dict[str, str] = {}
+    for key, value in state.items():
+        try:
+            scope_parts = json.loads(key)
+        except json.JSONDecodeError:
+            continue
+        if (
+            isinstance(scope_parts, list)
+            and len(scope_parts) == 4
+            and str(scope_parts[0]).startswith("freezone")
+            and scope_parts[3] == canvas_id
+        ):
+            matches[key] = value
+    for thread_id in sorted(set(matches.values())):
+        archived = await asyncio.to_thread(
+            _control_codex_thread, "archive", thread_id
+        )
+        if not archived:
+            raise RuntimeError(f"Codex thread could not be archived: {thread_id}")
+    if matches:
+        state_path = _codex_session_state_path(
+            username, project, project_state_dir=project_state_dir
+        )
+        from novelvideo.utils.state_index_files import index_file_lock
+
+        with index_file_lock(state_path):
+            latest = _load_codex_session_state(
+                username, project, project_state_dir=project_state_dir
+            )
+            for key, thread_id in matches.items():
+                if latest.get(key) == thread_id:
+                    latest.pop(key, None)
+            _save_codex_session_state(
+                username, project, latest, project_state_dir=project_state_dir
+            )
+    return len(set(matches.values()))
+
+
+async def delete_codex_project_threads(
+    username: str,
+    project: str,
+    *,
+    project_state_dir: str | Path | None = None,
+) -> int:
+    state = _load_codex_session_state(
+        username, project, project_state_dir=project_state_dir
+    )
+    threads = sorted(set(state.values()))
+    for thread_id in threads:
+        deleted = await asyncio.to_thread(_control_codex_thread, "delete", thread_id)
+        if not deleted:
+            raise RuntimeError(f"Codex thread could not be deleted: {thread_id}")
+    return len(threads)
+
+
 def _load_api_url() -> str:
     explicit = os.environ.get("DRAMACLAW_API_URL", "").strip()
     if explicit:
@@ -3896,6 +4029,7 @@ PAGE_AGENT_SCOPES = [
     "assets:read",
 ]
 PAGE_AGENT_SESSION_TTL_SECONDS = 24 * 3600
+CODEX_AGENT_SESSION_TTL_SECONDS = 2 * 3600
 
 
 async def _create_page_agent_session_token(
@@ -3903,11 +4037,12 @@ async def _create_page_agent_session_token(
     project: str,
     *,
     agent_kind: str,
+    ttl_seconds: int = PAGE_AGENT_SESSION_TTL_SECONDS,
 ) -> str:
     token = await get_auth_session_port().create_agent_session(
         username=username,
         scopes=PAGE_AGENT_SCOPES,
-        ttl_seconds=PAGE_AGENT_SESSION_TTL_SECONDS,
+        ttl_seconds=ttl_seconds,
         agent_kind=agent_kind,
         worker_id=f"page-agent:{agent_kind}:{username}",
         current_scope_kind="project" if project else "home",
@@ -4067,7 +4202,10 @@ def _build_codex_env(
     *,
     egress_context=None,
     authorization=None,
+    tool_mode: str = "default",
+    canvas_id: str | None = None,
     project_state_dir: str | Path | None = None,
+    agent_token_file: str | Path | None = None,
 ) -> dict[str, str]:
     env = os.environ.copy()
     agent_scope = "project" if project else "user"
@@ -4080,8 +4218,16 @@ def _build_codex_env(
         env["SUPERTALE_PROJECT_ID"] = project
     env["DRAMACLAW_API_URL"] = _load_api_url()
     env["SUPERTALE_API_URL"] = _load_api_url()
-    env["DRAMACLAW_AGENT_TOKEN"] = agent_token
-    env["SUPERTALE_AGENT_TOKEN"] = agent_token
+    env.pop("DRAMACLAW_AGENT_TOKEN", None)
+    env.pop("SUPERTALE_AGENT_TOKEN", None)
+    if agent_token_file is not None:
+        env["DRAMACLAW_AGENT_TOKEN_FILE"] = str(agent_token_file)
+    env["DRAMACLAW_TOOL_MODE"] = str(tool_mode or "default").strip() or "default"
+    normalized_canvas_id = str(canvas_id or "").strip()
+    if normalized_canvas_id:
+        env["DRAMACLAW_CANVAS_ID"] = normalized_canvas_id
+    else:
+        env.pop("DRAMACLAW_CANVAS_ID", None)
     _workspace, codex_home = ensure_user_codex_workspace(
         username, project, agent_token, project_state_dir=project_state_dir
     )
@@ -4353,8 +4499,10 @@ def _dramaclaw_mcp_servers() -> dict[str, dict[str, Any]]:
             "args": ["-m", "novelvideo.chat.dramaclaw_mcp"],
             "env_vars": [
                 "DRAMACLAW_API_URL",
-                "DRAMACLAW_AGENT_TOKEN",
+                "DRAMACLAW_AGENT_TOKEN_FILE",
+                "DRAMACLAW_CANVAS_ID",
                 "DRAMACLAW_PROJECT_ID",
+                "DRAMACLAW_TOOL_MODE",
                 "DRAMACLAW_USERNAME",
             ],
         }
@@ -4446,8 +4594,10 @@ def _build_codex_thread(
     authorization=None,
     control_capability: str | None = None,
     agent_profile: str = "main",
+    tool_mode: str = "default",
     canvas_id: str | None = None,
     project_state_dir: str | Path | None = None,
+    agent_token_file: str | Path | None = None,
 ) -> AgentRuntimeThreadPort:
     workspace, _codex_home = ensure_user_codex_workspace(
         username,
@@ -4461,7 +4611,10 @@ def _build_codex_thread(
         agent_token,
         egress_context=egress_context,
         authorization=authorization,
+        tool_mode=tool_mode,
+        canvas_id=canvas_id,
         project_state_dir=project_state_dir,
+        agent_token_file=agent_token_file,
     )
     gateway_api_key, gateway_base_url = _codex_turn_gateway_credentials(authorization)
     node_config_overrides = _codex_gateway_config_overrides(gateway_base_url)
@@ -4511,8 +4664,13 @@ async def interrupt_chat_turn(
         if not thread_id or not turn_id:
             return False
         try:
-            return await asyncio.to_thread(
+            interrupted = await asyncio.to_thread(
                 interrupt_live_codex_turn, thread_id, turn_id
+            )
+            if interrupted:
+                return True
+            return await asyncio.to_thread(
+                _control_codex_thread, "interrupt", thread_id, turn_id
             )
         except Exception as exc:
             if "app-server closed stdout" in str(exc):
@@ -4533,9 +4691,25 @@ async def interrupt_active_codex_turns(username: str) -> bool:
             for (turn_username, _project), value in _ACTIVE_CODEX_TURNS.items()
             if turn_username == normalized
         ]
+    turns.extend(
+        (entry.get("thread_id", ""), entry.get("turn_id", ""))
+        for entry in _load_active_codex_turns(normalized).values()
+    )
+    turns = list({turn for turn in turns if turn[0] and turn[1]})
+
+    async def interrupt_pair(thread_id: str, turn_id: str) -> bool:
+        local = await asyncio.to_thread(
+            interrupt_live_codex_turn, thread_id, turn_id
+        )
+        if local:
+            return True
+        return await asyncio.to_thread(
+            _control_codex_thread, "interrupt", thread_id, turn_id
+        )
+
     results = await asyncio.gather(
         *(
-            asyncio.to_thread(interrupt_live_codex_turn, thread_id, turn_id)
+            interrupt_pair(thread_id, turn_id)
             for thread_id, turn_id in turns
         ),
         return_exceptions=True,
@@ -4602,8 +4776,10 @@ async def stream_assistant_reply(
                 requester_user_id=requester_user_id,
                 egress_project_id=egress_project_id,
                 tool_mode=tool_mode,
+                surface_context=surface_context,
                 store_scope=store_scope,
                 turn_id=turn_id,
+                route_prompt=route_prompt,
             )
         if backend == "hermes":
             return await _stream_assistant_reply_hermes(
@@ -5557,8 +5733,10 @@ async def _stream_assistant_reply_codex(
     requester_user_id: str | None = None,
     egress_project_id: str | None = None,
     tool_mode: str = "default",
+    surface_context: dict[str, Any] | None = None,
     store_scope: Any | None = None,
     turn_id: str | None = None,
+    route_prompt: str | None = None,
 ) -> dict[str, Any]:
     assistant_text = ""
     tool_text = ""
@@ -5594,12 +5772,29 @@ async def _stream_assistant_reply_codex(
     )
     active_turn_key = (username, codex_scope_key)
     active_turn_value: tuple[str, str] | None = None
+    agent_token: str | None = None
+    token_file: Path | None = None
     try:
         agent_token = await _create_page_agent_session_token(
             username,
             project,
             agent_kind="codex",
+            ttl_seconds=CODEX_AGENT_SESSION_TTL_SECONDS,
         )
+        token_root = (
+            Path(project_state_dir)
+            if project_state_dir is not None
+            else _project_state_dir(username, project)
+            if project
+            else _user_state_dir(username)
+        ) / "agents" / "codex" / "turn_tokens"
+        token_root.mkdir(parents=True, exist_ok=True)
+        token_name = hashlib.sha256(codex_scope_key.encode("utf-8")).hexdigest()
+        token_file = token_root / f"{token_name}.token"
+        temporary_token_file = token_file.with_suffix(f".{uuid.uuid4().hex}.tmp")
+        temporary_token_file.write_text(agent_token, encoding="utf-8")
+        temporary_token_file.chmod(0o600)
+        temporary_token_file.replace(token_file)
         thread = _build_codex_thread(
             username,
             project,
@@ -5608,14 +5803,33 @@ async def _stream_assistant_reply_codex(
             authorization=authorization,
             control_capability=control_capability,
             agent_profile=agent_profile,
+            tool_mode=tool_mode,
             canvas_id=canvas_id,
             project_state_dir=project_state_dir,
+            agent_token_file=token_file,
         )
     except Exception:
         if turn_operation is not None:
             await turn_operation.finish(turn_disposition)
+        if token_file is not None:
+            try:
+                token_file.unlink(missing_ok=True)
+            except OSError:
+                logger.warning("failed to remove failed Codex token file", exc_info=True)
+        if agent_token:
+            try:
+                await get_auth_session_port().revoke_agent_session(agent_token)
+            except Exception:
+                logger.warning("failed to revoke failed Codex launch token", exc_info=True)
         raise
-    agent_prompt = _prompt_with_user_context(username, project, prompt)
+    agent_prompt = _prompt_with_user_context(
+        username,
+        project,
+        prompt,
+        tool_mode=tool_mode,
+        surface_context=surface_context,
+        route_prompt=route_prompt,
+    )
     try:
         async for event in thread.stream(agent_prompt):
             if event.type == "egress_submitted":
@@ -5641,6 +5855,9 @@ async def _stream_assistant_reply_codex(
                     active_turn_value = (codex_thread_id, codex_turn_id)
                     with _ACTIVE_CODEX_TURNS_LOCK:
                         _ACTIVE_CODEX_TURNS[active_turn_key] = active_turn_value
+                    _set_active_codex_turn(
+                        username, codex_scope_key, active_turn_value
+                    )
                 await on_event(
                     {
                         "type": "thread_started",
@@ -5750,8 +5967,19 @@ async def _stream_assistant_reply_codex(
             with _ACTIVE_CODEX_TURNS_LOCK:
                 if _ACTIVE_CODEX_TURNS.get(active_turn_key) == active_turn_value:
                     _ACTIVE_CODEX_TURNS.pop(active_turn_key, None)
+            _set_active_codex_turn(username, codex_scope_key, None)
         if turn_operation is not None:
             await turn_operation.finish(turn_disposition)
+        if token_file is not None:
+            try:
+                token_file.unlink(missing_ok=True)
+            except OSError:
+                logger.warning("failed to remove Codex turn token file", exc_info=True)
+        if agent_token:
+            try:
+                await get_auth_session_port().revoke_agent_session(agent_token)
+            except Exception:
+                logger.warning("failed to revoke Codex turn token", exc_info=True)
 
     assistant_text = assistant_text.strip() or "已执行，但没有返回正文。"
     assistant_text = _normalize_json_render_reply(assistant_text)

--- a/src/novelvideo/chat/service.py
+++ b/src/novelvideo/chat/service.py
@@ -268,29 +268,6 @@ def _json_render_error_log_path() -> Path:
     return _repo_root() / "jr_error.log"
 
 
-def _user_preferences_path(username: str) -> Path:
-    return _state_root() / username / "preferences.md"
-
-
-def load_user_preferences(username: str) -> str:
-    """Load/create the user-level long-term preference file.
-
-    This is the Lovart-style long-term memory layer: project chat history stays
-    project-scoped, while stable taste/workflow preferences live per user.
-    """
-
-    path = _user_preferences_path(username)
-    path.parent.mkdir(parents=True, exist_ok=True)
-    if not path.exists():
-        path.write_text(
-            "# User Preferences\n\n"
-            "Record stable cross-project preferences here, such as visual taste, "
-            "brand/style defaults, pacing habits, and recurring workflow choices.\n",
-            encoding="utf-8",
-        )
-    return path.read_text(encoding="utf-8").strip()
-
-
 _FREEZONE_CANVAS_ASSISTANT_INSTRUCTIONS = """[FREEZONE_CANVAS_ASSISTANT]
 This chat turn is running inside the Xi画/Freezone canvas.
 
@@ -644,7 +621,6 @@ def _prompt_with_user_context(
     surface_context: dict[str, Any] | None = None,
     route_prompt: str | None = None,
 ) -> str:
-    preferences = load_user_preferences(username)
     user_message, execution_context = _route_prompt_with_execution_context(
         prompt,
         route_prompt,
@@ -685,10 +661,7 @@ def _prompt_with_user_context(
         "[DRAMACLAW_USER_CONTEXT]\n"
         f"username: {username}\n"
         f"scope: {scope}\n"
-        "Project-scoped facts must stay in the project scope. "
-        "Only stable user preferences should be reused across projects.\n\n"
-        "[USER_PREFERENCES]\n"
-        f"{preferences}\n\n"
+        "Project-scoped facts and learned preferences must stay in the project scope.\n\n"
         f"{rendering_instructions}"
         f"{continuation_instructions}"
         f"{surface_instructions}\n\n"

--- a/src/novelvideo/chat/service.py
+++ b/src/novelvideo/chat/service.py
@@ -3899,6 +3899,38 @@ def _set_active_codex_turn(
         write_json_atomic(path, payload)
 
 
+def _write_codex_turn_token(
+    token_root: Path,
+    *,
+    scope_key: str,
+    business_turn_id: str,
+    token: str,
+) -> Path:
+    """Atomically create one credential file owned by exactly one Codex turn."""
+
+    token_root.mkdir(parents=True, exist_ok=True)
+    scope_digest = hashlib.sha256(scope_key.encode("utf-8")).hexdigest()
+    normalized_turn_id = str(business_turn_id or "").strip() or "turn"
+    turn_slug = re.sub(r"[^A-Za-z0-9._-]+", "-", normalized_turn_id).strip(
+        "-._"
+    )
+    turn_digest = hashlib.sha256(normalized_turn_id.encode("utf-8")).hexdigest()[:12]
+    unique_suffix = uuid.uuid4().hex
+    token_file = token_root / (
+        f"{scope_digest}.{(turn_slug or 'turn')[:40]}.{turn_digest}.{unique_suffix}.token"
+    )
+    temporary_token_file = token_root / f".{token_file.name}.{uuid.uuid4().hex}.tmp"
+    try:
+        temporary_token_file.touch(mode=0o600, exist_ok=False)
+        temporary_token_file.write_text(token, encoding="utf-8")
+        temporary_token_file.chmod(0o600)
+        temporary_token_file.replace(token_file)
+    except Exception:
+        temporary_token_file.unlink(missing_ok=True)
+        raise
+    return token_file
+
+
 def _control_codex_thread(
     operation: Literal["interrupt", "archive", "delete"],
     thread_id: str,
@@ -5809,13 +5841,12 @@ async def _stream_assistant_reply_codex(
             if project
             else _user_state_dir(username)
         ) / "agents" / "codex" / "turn_tokens"
-        token_root.mkdir(parents=True, exist_ok=True)
-        token_name = hashlib.sha256(codex_scope_key.encode("utf-8")).hexdigest()
-        token_file = token_root / f"{token_name}.token"
-        temporary_token_file = token_file.with_suffix(f".{uuid.uuid4().hex}.tmp")
-        temporary_token_file.write_text(agent_token, encoding="utf-8")
-        temporary_token_file.chmod(0o600)
-        temporary_token_file.replace(token_file)
+        token_file = _write_codex_turn_token(
+            token_root,
+            scope_key=codex_scope_key,
+            business_turn_id=business_turn_id,
+            token=agent_token,
+        )
         thread = _build_codex_thread(
             username,
             project,

--- a/src/novelvideo/chat/service.py
+++ b/src/novelvideo/chat/service.py
@@ -4103,6 +4103,7 @@ def ensure_user_codex_workspace(
     project: str,
     agent_token: str = "",
     *,
+    agent_profile: str = "main",
     project_state_dir: str | Path | None = None,
 ) -> tuple[Path, Path]:
     if project:
@@ -4112,7 +4113,11 @@ def ensure_user_codex_workspace(
             else _project_state_dir(username, project)
         )
         agent_root = state_dir / "agents" / "codex"
-        workspace = agent_root / "workspace"
+        profile = str(agent_profile or "main").strip() or "main"
+        profile_slug = re.sub(r"[^A-Za-z0-9._-]+", "-", profile).strip("-._")
+        profile_digest = hashlib.sha256(profile.encode("utf-8")).hexdigest()[:12]
+        profile_dir = f"{(profile_slug or 'profile')[:40]}-{profile_digest}"
+        workspace = agent_root / "workspaces" / profile_dir
     else:
         workspace = _user_agent_workspace(username)
     codex_dir = _codex_node_home()
@@ -4202,6 +4207,7 @@ def _build_codex_env(
     *,
     egress_context=None,
     authorization=None,
+    agent_profile: str = "main",
     tool_mode: str = "default",
     canvas_id: str | None = None,
     project_state_dir: str | Path | None = None,
@@ -4213,6 +4219,8 @@ def _build_codex_env(
     env["DRAMACLAW_AGENT_SCOPE"] = agent_scope
     env["SUPERTALE_USERNAME"] = username
     env["SUPERTALE_AGENT_SCOPE"] = agent_scope
+    profile = str(agent_profile or "main").strip() or "main"
+    env["DRAMACLAW_AGENT_PROFILE"] = profile
     if project:
         env["DRAMACLAW_PROJECT_ID"] = project
         env["SUPERTALE_PROJECT_ID"] = project
@@ -4229,7 +4237,11 @@ def _build_codex_env(
     else:
         env.pop("DRAMACLAW_CANVAS_ID", None)
     _workspace, codex_home = ensure_user_codex_workspace(
-        username, project, agent_token, project_state_dir=project_state_dir
+        username,
+        project,
+        agent_token,
+        agent_profile=profile,
+        project_state_dir=project_state_dir,
     )
     env["CODEX_HOME"] = str(codex_home)
     from novelvideo.task_backend.subprocesses import build_model_child_env
@@ -4501,6 +4513,7 @@ def _dramaclaw_mcp_servers() -> dict[str, dict[str, Any]]:
                 "DRAMACLAW_API_URL",
                 "DRAMACLAW_AGENT_TOKEN_FILE",
                 "DRAMACLAW_CANVAS_ID",
+                "DRAMACLAW_AGENT_PROFILE",
                 "DRAMACLAW_PROJECT_ID",
                 "DRAMACLAW_TOOL_MODE",
                 "DRAMACLAW_USERNAME",
@@ -4603,6 +4616,7 @@ def _build_codex_thread(
         username,
         project,
         agent_token,
+        agent_profile=agent_profile,
         project_state_dir=project_state_dir,
     )
     env = _build_codex_env(
@@ -4611,6 +4625,7 @@ def _build_codex_thread(
         agent_token,
         egress_context=egress_context,
         authorization=authorization,
+        agent_profile=agent_profile,
         tool_mode=tool_mode,
         canvas_id=canvas_id,
         project_state_dir=project_state_dir,

--- a/src/novelvideo/chat/service.py
+++ b/src/novelvideo/chat/service.py
@@ -5860,29 +5860,14 @@ async def _stream_assistant_reply_codex(
             project_state_dir=project_state_dir,
             agent_token_file=token_file,
         )
-    except Exception:
-        if turn_operation is not None:
-            await turn_operation.finish(turn_disposition)
-        if token_file is not None:
-            try:
-                token_file.unlink(missing_ok=True)
-            except OSError:
-                logger.warning("failed to remove failed Codex token file", exc_info=True)
-        if agent_token:
-            try:
-                await get_auth_session_port().revoke_agent_session(agent_token)
-            except Exception:
-                logger.warning("failed to revoke failed Codex launch token", exc_info=True)
-        raise
-    agent_prompt = _prompt_with_user_context(
-        username,
-        project,
-        prompt,
-        tool_mode=tool_mode,
-        surface_context=surface_context,
-        route_prompt=route_prompt,
-    )
-    try:
+        agent_prompt = _prompt_with_user_context(
+            username,
+            project,
+            prompt,
+            tool_mode=tool_mode,
+            surface_context=surface_context,
+            route_prompt=route_prompt,
+        )
         async for event in thread.stream(agent_prompt):
             if event.type == "egress_submitted":
                 if turn_operation is not None:
@@ -6019,9 +6004,13 @@ async def _stream_assistant_reply_codex(
             with _ACTIVE_CODEX_TURNS_LOCK:
                 if _ACTIVE_CODEX_TURNS.get(active_turn_key) == active_turn_value:
                     _ACTIVE_CODEX_TURNS.pop(active_turn_key, None)
-            _set_active_codex_turn(username, codex_scope_key, None)
-        if turn_operation is not None:
-            await turn_operation.finish(turn_disposition)
+            try:
+                _set_active_codex_turn(username, codex_scope_key, None)
+            except OSError:
+                logger.warning(
+                    "failed to remove persisted active Codex turn",
+                    exc_info=True,
+                )
         if token_file is not None:
             try:
                 token_file.unlink(missing_ok=True)
@@ -6032,6 +6021,8 @@ async def _stream_assistant_reply_codex(
                 await get_auth_session_port().revoke_agent_session(agent_token)
             except Exception:
                 logger.warning("failed to revoke Codex turn token", exc_info=True)
+        if turn_operation is not None:
+            await turn_operation.finish(turn_disposition)
 
     assistant_text = assistant_text.strip() or "已执行，但没有返回正文。"
     assistant_text = _normalize_json_render_reply(assistant_text)

--- a/src/novelvideo/chat/store.py
+++ b/src/novelvideo/chat/store.py
@@ -156,7 +156,12 @@ class ChatStore:
         return _state_root() / username / f"_{scope.kind}" / str(scope.id) / "chat.db"
 
     def _legacy_freezone_canvas_db_for(self, username: str, scope: ChatScope) -> Path | None:
-        if scope.kind != "project" or scope.surface != "freezone" or not scope.canvas_id:
+        if (
+            scope.state_dir
+            or scope.kind != "project"
+            or scope.surface != "freezone"
+            or not scope.canvas_id
+        ):
             return None
         if scope.agent_id not in {None, "", "main"}:
             return None
@@ -170,37 +175,8 @@ class ChatStore:
             / "chat.db"
         )
 
-    def _pre_authoritative_freezone_db_for(
-        self, username: str, scope: ChatScope
-    ) -> Path | None:
-        if (
-            not scope.state_dir
-            or scope.kind != "project"
-            or scope.surface != "freezone"
-            or not scope.canvas_id
-        ):
-            return None
-        return (
-            _state_root()
-            / username
-            / str(scope.id)
-            / "_chat"
-            / "freezone"
-            / str(scope.canvas_id)
-            / "agents"
-            / (scope.agent_id or "main")
-            / "chat.db"
-        )
-
     def read_db_for(self, username: str, scope: ChatScope) -> Path:
         db_path = self.db_for(username, scope)
-        pre_authoritative = self._pre_authoritative_freezone_db_for(username, scope)
-        if (
-            pre_authoritative is not None
-            and not db_path.exists()
-            and pre_authoritative.exists()
-        ):
-            return pre_authoritative
         legacy_db_path = self._legacy_freezone_canvas_db_for(username, scope)
         if legacy_db_path is not None and not db_path.exists() and legacy_db_path.exists():
             return legacy_db_path
@@ -322,25 +298,17 @@ class ChatStore:
                 for path in agents_dir.glob("*/chat.db")
                 if path.parent.name
             )
-        if project_state_dir is not None:
-            previous_agents_dir = self._freezone_canvas_agents_dir(
+        legacy_db = (
+            self._freezone_canvas_legacy_db(
                 username,
                 project_id=project_id,
                 canvas_id=canvas_id,
             )
-            if previous_agents_dir != agents_dir and previous_agents_dir.exists():
-                candidates.extend(
-                    (path.parent.name, path)
-                    for path in previous_agents_dir.glob("*/chat.db")
-                    if path.parent.name
-                )
-        legacy_db = self._freezone_canvas_legacy_db(
-            username,
-            project_id=project_id,
-            canvas_id=canvas_id,
+            if project_state_dir is None
+            else None
         )
         main_db = agents_dir / "main" / "chat.db"
-        if legacy_db.exists() and not main_db.exists():
+        if legacy_db is not None and legacy_db.exists() and not main_db.exists():
             candidates.append(("main", legacy_db))
 
         summaries: list[dict[str, Any]] = []
@@ -367,30 +335,7 @@ class ChatStore:
         return (int(summary.get("lastActiveAt") or 0), agent_rank, agent_id)
 
     def connect(self, username: str, scope: ChatScope, *, db_path: Path | None = None) -> sqlite3.Connection:
-        if db_path is None:
-            db_path = self.db_for(username, scope)
-            legacy_db = self._pre_authoritative_freezone_db_for(username, scope)
-            if legacy_db is None or not legacy_db.exists():
-                legacy_db = self._legacy_freezone_canvas_db_for(username, scope)
-            if (
-                scope.state_dir
-                and legacy_db is not None
-                and legacy_db != db_path
-                and legacy_db.exists()
-                and not db_path.exists()
-            ):
-                from novelvideo.utils.state_index_files import index_file_lock
-
-                with index_file_lock(db_path):
-                    if not db_path.exists():
-                        db_path.parent.mkdir(parents=True, exist_ok=True)
-                        source = sqlite3.connect(legacy_db)
-                        destination = sqlite3.connect(db_path)
-                        try:
-                            source.backup(destination)
-                        finally:
-                            destination.close()
-                            source.close()
+        db_path = db_path or self.db_for(username, scope)
         db_path.parent.mkdir(parents=True, exist_ok=True)
         conn = sqlite3.connect(db_path)
         conn.row_factory = sqlite3.Row

--- a/src/novelvideo/chat/store.py
+++ b/src/novelvideo/chat/store.py
@@ -72,6 +72,9 @@ class ChatScope:
     surface: str | None = None
     canvas_id: str | None = None
     agent_id: str | None = None
+    # Server-resolved project state root. This is deliberately omitted from
+    # ``to_dict`` so filesystem topology never becomes a browser contract.
+    state_dir: str | None = None
 
     @classmethod
     def from_payload(cls, payload: dict[str, Any] | None) -> "ChatScope":
@@ -123,19 +126,23 @@ class ChatScope:
 
 
 class ChatStore:
+    @staticmethod
+    def _project_root(username: str, scope: ChatScope) -> Path:
+        if scope.state_dir:
+            return Path(scope.state_dir)
+        return _state_root() / username / str(scope.id)
+
     def db_for(self, username: str, scope: ChatScope) -> Path:
         if scope.kind == "home":
             return _state_root() / username / "_home" / "chat.db"
         if scope.kind == "project":
             if (scope.surface or "director") == "director" and not scope.canvas_id:
-                return _state_root() / username / str(scope.id) / "chat.db"
+                return self._project_root(username, scope) / "chat.db"
             surface = scope.surface or "director"
             if surface == "freezone" and scope.canvas_id:
                 agent_id = scope.agent_id or "main"
                 return (
-                    _state_root()
-                    / username
-                    / str(scope.id)
+                    self._project_root(username, scope)
                     / "_chat"
                     / surface
                     / str(scope.canvas_id)
@@ -143,7 +150,7 @@ class ChatStore:
                     / agent_id
                     / "chat.db"
                 )
-            return _state_root() / username / str(scope.id) / "_chat" / surface / "chat.db"
+            return self._project_root(username, scope) / "_chat" / surface / "chat.db"
         if scope.kind == "freezone":
             return _state_root() / username / "_freezone" / str(scope.id) / "chat.db"
         return _state_root() / username / f"_{scope.kind}" / str(scope.id) / "chat.db"
@@ -163,8 +170,37 @@ class ChatStore:
             / "chat.db"
         )
 
+    def _pre_authoritative_freezone_db_for(
+        self, username: str, scope: ChatScope
+    ) -> Path | None:
+        if (
+            not scope.state_dir
+            or scope.kind != "project"
+            or scope.surface != "freezone"
+            or not scope.canvas_id
+        ):
+            return None
+        return (
+            _state_root()
+            / username
+            / str(scope.id)
+            / "_chat"
+            / "freezone"
+            / str(scope.canvas_id)
+            / "agents"
+            / (scope.agent_id or "main")
+            / "chat.db"
+        )
+
     def read_db_for(self, username: str, scope: ChatScope) -> Path:
         db_path = self.db_for(username, scope)
+        pre_authoritative = self._pre_authoritative_freezone_db_for(username, scope)
+        if (
+            pre_authoritative is not None
+            and not db_path.exists()
+            and pre_authoritative.exists()
+        ):
+            return pre_authoritative
         legacy_db_path = self._legacy_freezone_canvas_db_for(username, scope)
         if legacy_db_path is not None and not db_path.exists() and legacy_db_path.exists():
             return legacy_db_path
@@ -176,11 +212,15 @@ class ChatStore:
         *,
         project_id: str,
         canvas_id: str,
+        project_state_dir: str | Path | None = None,
     ) -> Path:
+        project_root = (
+            Path(project_state_dir)
+            if project_state_dir is not None
+            else _state_root() / username / str(project_id)
+        )
         return (
-            _state_root()
-            / username
-            / str(project_id)
+            project_root
             / "_chat"
             / "freezone"
             / str(canvas_id)
@@ -267,11 +307,13 @@ class ChatStore:
         project_id: str,
         canvas_id: str,
         limit: int = 20,
+        project_state_dir: str | Path | None = None,
     ) -> list[dict[str, Any]]:
         agents_dir = self._freezone_canvas_agents_dir(
             username,
             project_id=project_id,
             canvas_id=canvas_id,
+            project_state_dir=project_state_dir,
         )
         candidates: list[tuple[str, Path]] = []
         if agents_dir.exists():
@@ -280,6 +322,18 @@ class ChatStore:
                 for path in agents_dir.glob("*/chat.db")
                 if path.parent.name
             )
+        if project_state_dir is not None:
+            previous_agents_dir = self._freezone_canvas_agents_dir(
+                username,
+                project_id=project_id,
+                canvas_id=canvas_id,
+            )
+            if previous_agents_dir != agents_dir and previous_agents_dir.exists():
+                candidates.extend(
+                    (path.parent.name, path)
+                    for path in previous_agents_dir.glob("*/chat.db")
+                    if path.parent.name
+                )
         legacy_db = self._freezone_canvas_legacy_db(
             username,
             project_id=project_id,
@@ -313,7 +367,30 @@ class ChatStore:
         return (int(summary.get("lastActiveAt") or 0), agent_rank, agent_id)
 
     def connect(self, username: str, scope: ChatScope, *, db_path: Path | None = None) -> sqlite3.Connection:
-        db_path = db_path or self.db_for(username, scope)
+        if db_path is None:
+            db_path = self.db_for(username, scope)
+            legacy_db = self._pre_authoritative_freezone_db_for(username, scope)
+            if legacy_db is None or not legacy_db.exists():
+                legacy_db = self._legacy_freezone_canvas_db_for(username, scope)
+            if (
+                scope.state_dir
+                and legacy_db is not None
+                and legacy_db != db_path
+                and legacy_db.exists()
+                and not db_path.exists()
+            ):
+                from novelvideo.utils.state_index_files import index_file_lock
+
+                with index_file_lock(db_path):
+                    if not db_path.exists():
+                        db_path.parent.mkdir(parents=True, exist_ok=True)
+                        source = sqlite3.connect(legacy_db)
+                        destination = sqlite3.connect(db_path)
+                        try:
+                            source.backup(destination)
+                        finally:
+                            destination.close()
+                            source.close()
         db_path.parent.mkdir(parents=True, exist_ok=True)
         conn = sqlite3.connect(db_path)
         conn.row_factory = sqlite3.Row

--- a/tests/test_chat_service_user_agent_scope.py
+++ b/tests/test_chat_service_user_agent_scope.py
@@ -837,8 +837,19 @@ async def test_codex_canvas_archive_removes_only_matching_scope(monkeypatch, tmp
     canvas_b = chat_service._codex_scope_key(
         "project-a", agent_profile="freezone:main", canvas_id="canvas-b"
     )
+    canvas_a_agent_2 = chat_service._codex_scope_key(
+        "project-a", agent_profile="freezone:agent-2", canvas_id="canvas-a"
+    )
+    mainline = chat_service._codex_scope_key("project-a")
     sessions.write_text(
-        json.dumps({canvas_a: "thread-a", canvas_b: "thread-b"}),
+        json.dumps(
+            {
+                canvas_a: "thread-a",
+                canvas_a_agent_2: "thread-agent-2",
+                canvas_b: "thread-b",
+                mainline: "thread-mainline",
+            }
+        ),
         encoding="utf-8",
     )
     calls = []
@@ -855,10 +866,14 @@ async def test_codex_canvas_archive_removes_only_matching_scope(monkeypatch, tmp
         "admin", "project-a", "canvas-a", project_state_dir=project_state
     )
 
-    assert count == 1
-    assert calls == [("archive", "thread-a", None)]
+    assert count == 2
+    assert calls == [
+        ("archive", "thread-a", None),
+        ("archive", "thread-agent-2", None),
+    ]
     assert json.loads(sessions.read_text(encoding="utf-8")) == {
-        canvas_b: "thread-b"
+        canvas_b: "thread-b",
+        mainline: "thread-mainline",
     }
 
 
@@ -868,7 +883,21 @@ async def test_codex_project_delete_covers_unique_threads(monkeypatch, tmp_path)
     sessions = project_state / "agents" / "codex" / "sessions.json"
     sessions.parent.mkdir(parents=True)
     sessions.write_text(
-        json.dumps({"one": "thread-a", "two": "thread-a", "three": "thread-b"}),
+        json.dumps(
+            {
+                chat_service._codex_scope_key("project-a"): "thread-mainline",
+                chat_service._codex_scope_key(
+                    "project-a",
+                    agent_profile="freezone:main",
+                    canvas_id="canvas-a",
+                ): "thread-freezone",
+                chat_service._codex_scope_key(
+                    "project-a",
+                    agent_profile="freezone:agent-2",
+                    canvas_id="canvas-a",
+                ): "thread-freezone",
+            }
+        ),
         encoding="utf-8",
     )
     calls = []
@@ -887,8 +916,8 @@ async def test_codex_project_delete_covers_unique_threads(monkeypatch, tmp_path)
 
     assert count == 2
     assert calls == [
-        ("delete", "thread-a", None),
-        ("delete", "thread-b", None),
+        ("delete", "thread-freezone", None),
+        ("delete", "thread-mainline", None),
     ]
 
 
@@ -1076,15 +1105,26 @@ def test_user_agent_workspace_is_not_project_workspace(monkeypatch, tmp_path):
     codex_workspace, codex_home = chat_service.ensure_user_codex_workspace(
         "admin", "project-a"
     )
+    freezone_workspace, freezone_home = chat_service.ensure_user_codex_workspace(
+        "admin",
+        "project-a",
+        agent_profile="freezone:main",
+    )
 
     workspace = chat_service._user_agent_workspace("admin")
     assert workspace == tmp_path / "state" / "admin" / ".chat_agents"
     assert (workspace / ".claude" / "settings.local.json").exists()
     assert (workspace / ".claude" / "skills").is_dir()
     project_agent_root = tmp_path / "state" / "admin" / "project-a" / "agents" / "codex"
-    assert codex_workspace == project_agent_root / "workspace"
+    assert codex_workspace.parent == project_agent_root / "workspaces"
+    assert codex_workspace.name.startswith("main-")
+    assert freezone_workspace.parent == project_agent_root / "workspaces"
+    assert freezone_workspace.name.startswith("freezone-main-")
+    assert freezone_workspace != codex_workspace
     assert codex_home == tmp_path / "state" / ".codex-app-server"
+    assert freezone_home == codex_home
     assert (codex_workspace / ".agents" / "skills").is_dir()
+    assert (freezone_workspace / ".agents" / "skills").is_dir()
     assert codex_home.is_dir()
 
     project_workspace = Path(tmp_path / "output" / "admin" / "project-a")
@@ -1101,6 +1141,7 @@ def test_dramaclaw_mcp_server_config_is_agent_neutral():
         "DRAMACLAW_API_URL",
         "DRAMACLAW_AGENT_TOKEN_FILE",
         "DRAMACLAW_CANVAS_ID",
+        "DRAMACLAW_AGENT_PROFILE",
         "DRAMACLAW_PROJECT_ID",
         "DRAMACLAW_TOOL_MODE",
         "DRAMACLAW_USERNAME",
@@ -1128,7 +1169,8 @@ def test_codex_client_carries_dramaclaw_mcp_servers(tmp_path):
     assert 'mcp_servers.dramaclaw.args=["-m","novelvideo.chat.dramaclaw_mcp"]' in overrides
     assert (
         'mcp_servers.dramaclaw.env_vars=["DRAMACLAW_API_URL",'
-        '"DRAMACLAW_AGENT_TOKEN_FILE","DRAMACLAW_CANVAS_ID","DRAMACLAW_PROJECT_ID",'
+        '"DRAMACLAW_AGENT_TOKEN_FILE","DRAMACLAW_CANVAS_ID",'
+        '"DRAMACLAW_AGENT_PROFILE","DRAMACLAW_PROJECT_ID",'
         '"DRAMACLAW_TOOL_MODE","DRAMACLAW_USERNAME"]'
         in overrides
     )
@@ -1138,7 +1180,12 @@ def test_codex_client_carries_dramaclaw_mcp_servers(tmp_path):
     client = backend_sdk.CodexClient(
         codex_bin=Path("/usr/local/bin/codex"),
         cwd=tmp_path,
-        env={"DRAMACLAW_AGENT_TOKEN_FILE": "/tmp/turn.token"},
+        env={
+            "DRAMACLAW_AGENT_TOKEN_FILE": "/tmp/turn.token",
+            "DRAMACLAW_AGENT_PROFILE": "freezone:agent-2",
+            "DRAMACLAW_CANVAS_ID": "canvas-a",
+            "DRAMACLAW_TOOL_MODE": "freezone_canvas",
+        },
         model="DC-codex-agent-LLM",
         model_provider="dramaclaw_gateway",
         developer_instructions="Use DramaClaw MCP only.",
@@ -1149,7 +1196,10 @@ def test_codex_client_carries_dramaclaw_mcp_servers(tmp_path):
 
     assert thread._config_overrides == overrides
     assert thread._thread_config["mcp_servers.dramaclaw.env"] == {
-        "DRAMACLAW_AGENT_TOKEN_FILE": "/tmp/turn.token"
+        "DRAMACLAW_AGENT_TOKEN_FILE": "/tmp/turn.token",
+        "DRAMACLAW_AGENT_PROFILE": "freezone:agent-2",
+        "DRAMACLAW_CANVAS_ID": "canvas-a",
+        "DRAMACLAW_TOOL_MODE": "freezone_canvas",
     }
     assert "mcp_servers.dramaclaw.env_vars" not in thread._thread_config
     assert thread._model == "DC-codex-agent-LLM"
@@ -1264,6 +1314,7 @@ def test_codex_env_uses_effective_gateway_and_isolates_codex_home(
     assert env["CODEX_HOME"] == str(tmp_path / "state" / ".codex-app-server")
     assert env["DRAMACLAW_AGENT_SCOPE"] == "project"
     assert env["SUPERTALE_AGENT_SCOPE"] == "project"
+    assert env["DRAMACLAW_AGENT_PROFILE"] == "main"
     assert env["DRAMACLAW_TOOL_MODE"] == "default"
     assert "DRAMACLAW_AGENT_TOKEN" not in env
     assert env["DRAMACLAW_AGENT_TOKEN_FILE"] == str(project_state / "turn.token")
@@ -1279,12 +1330,14 @@ def test_codex_env_uses_effective_gateway_and_isolates_codex_home(
         "admin",
         "project-a",
         "agent-token",
+        agent_profile="freezone:agent-2",
         tool_mode="freezone_canvas",
         canvas_id="canvas-a",
         project_state_dir=project_state,
     )
     assert freezone_env["DRAMACLAW_TOOL_MODE"] == "freezone_canvas"
     assert freezone_env["DRAMACLAW_CANVAS_ID"] == "canvas-a"
+    assert freezone_env["DRAMACLAW_AGENT_PROFILE"] == "freezone:agent-2"
 
 
 def test_codex_turn_gateway_credentials_reject_foreign_origin(monkeypatch):
@@ -1500,6 +1553,33 @@ async def test_cancel_reads_active_codex_turns_from_other_worker(monkeypatch, tm
 
     assert await chat_service.interrupt_active_codex_turns("alice") is True
     assert calls == [("interrupt", "thread-a", "turn-a")]
+
+
+def test_active_codex_turn_registry_keeps_mainline_and_freezone_scopes_separate(
+    monkeypatch, tmp_path
+):
+    monkeypatch.setenv("NOVELVIDEO_STATE_DIR", str(tmp_path / "state"))
+    mainline = chat_service._codex_scope_key("project-a")
+    freezone = chat_service._codex_scope_key(
+        "project-a",
+        agent_profile="freezone:agent-2",
+        canvas_id="canvas-a",
+    )
+
+    chat_service._set_active_codex_turn(
+        "alice", mainline, ("thread-mainline", "turn-mainline")
+    )
+    chat_service._set_active_codex_turn(
+        "alice", freezone, ("thread-freezone", "turn-freezone")
+    )
+    chat_service._set_active_codex_turn("alice", freezone, None)
+
+    assert chat_service._load_active_codex_turns("alice") == {
+        mainline: {
+            "thread_id": "thread-mainline",
+            "turn_id": "turn-mainline",
+        }
+    }
 
 
 @pytest.mark.asyncio

--- a/tests/test_chat_service_user_agent_scope.py
+++ b/tests/test_chat_service_user_agent_scope.py
@@ -1098,6 +1098,74 @@ async def test_codex_stream_passes_conversation_scope_to_thread_builder(
 
 
 @pytest.mark.asyncio
+async def test_codex_prompt_construction_failure_cleans_turn_credentials(
+    monkeypatch,
+    tmp_path,
+):
+    project_state = tmp_path / "state" / "admin" / "project-a"
+    captured: dict[str, Path] = {}
+    revoked: list[str] = []
+    finished: list[str] = []
+
+    class FakeAuthPort:
+        async def revoke_agent_session(self, token):
+            revoked.append(token)
+
+    class FakeTurnOperation:
+        async def finish(self, disposition):
+            finished.append(disposition)
+
+    async def fake_authorize(**_kwargs):
+        return SimpleNamespace()
+
+    async def fake_create_token(*_args, **_kwargs):
+        return "agent-token"
+
+    def fake_build_thread(*_args, **kwargs):
+        token_file = Path(kwargs["agent_token_file"])
+        assert token_file.read_text(encoding="utf-8") == "agent-token"
+        captured["token_file"] = token_file
+        return SimpleNamespace()
+
+    def fail_prompt(*_args, **_kwargs):
+        raise RuntimeError("prompt construction failed")
+
+    monkeypatch.setattr(chat_service, "authorize_hermes_launch", fake_authorize)
+    monkeypatch.setattr(
+        chat_service,
+        "_turn_operation_finalizer",
+        lambda _authorization: FakeTurnOperation(),
+    )
+    monkeypatch.setattr(
+        chat_service,
+        "_create_page_agent_session_token",
+        fake_create_token,
+    )
+    monkeypatch.setattr(chat_service, "_build_codex_thread", fake_build_thread)
+    monkeypatch.setattr(chat_service, "_prompt_with_user_context", fail_prompt)
+    monkeypatch.setattr(chat_service, "get_auth_session_port", lambda: FakeAuthPort())
+    monkeypatch.setattr(hermes_sdk, "_issue_turn_capability", lambda **_kwargs: None)
+
+    async def collect_event(_event):
+        raise AssertionError("prompt failure must happen before streaming")
+
+    with pytest.raises(RuntimeError, match="prompt construction failed"):
+        await chat_service._stream_assistant_reply_codex(
+            "admin",
+            "project-a",
+            "hello",
+            collect_event,
+            project_state_dir=project_state,
+            turn_id="business-turn",
+        )
+
+    assert not captured["token_file"].exists()
+    assert revoked == ["agent-token"]
+    assert finished == ["failed"]
+    assert list((project_state / "agents" / "codex" / "turn_tokens").iterdir()) == []
+
+
+@pytest.mark.asyncio
 async def test_codex_turn_token_files_are_unique_and_cleanup_is_turn_local(
     tmp_path,
 ):

--- a/tests/test_chat_service_user_agent_scope.py
+++ b/tests/test_chat_service_user_agent_scope.py
@@ -1671,6 +1671,9 @@ def test_prompt_injects_json_render_contract(monkeypatch, tmp_path):
     assert "发送前自检" in prompt
     assert "角色列表、剧集规划、项目进度、任务状态、脚本/beat 摘要、表格、长篇正文、普通结构化说明默认使用 markdown" in prompt
     assert "不要为纯文本、进度、脚本、表格、角色/剧集清单调用媒体展示工具" in prompt
+    assert "[USER_PREFERENCES]" not in prompt
+    assert "reused across projects" not in prompt
+    assert not (tmp_path / "state" / "admin" / "preferences.md").exists()
     assert prompt.rstrip().endswith("查看肖像图片，用 json-render 显示")
 
 

--- a/tests/test_chat_service_user_agent_scope.py
+++ b/tests/test_chat_service_user_agent_scope.py
@@ -827,6 +827,72 @@ def test_codex_main_thread_key_stays_backward_compatible():
 
 
 @pytest.mark.anyio
+async def test_codex_canvas_archive_removes_only_matching_scope(monkeypatch, tmp_path):
+    project_state = tmp_path / "project-state"
+    sessions = project_state / "agents" / "codex" / "sessions.json"
+    sessions.parent.mkdir(parents=True)
+    canvas_a = chat_service._codex_scope_key(
+        "project-a", agent_profile="freezone:main", canvas_id="canvas-a"
+    )
+    canvas_b = chat_service._codex_scope_key(
+        "project-a", agent_profile="freezone:main", canvas_id="canvas-b"
+    )
+    sessions.write_text(
+        json.dumps({canvas_a: "thread-a", canvas_b: "thread-b"}),
+        encoding="utf-8",
+    )
+    calls = []
+    monkeypatch.setattr(
+        chat_service,
+        "_control_codex_thread",
+        lambda operation, thread_id, turn_id=None: calls.append(
+            (operation, thread_id, turn_id)
+        )
+        or True,
+    )
+
+    count = await chat_service.archive_codex_canvas_threads(
+        "admin", "project-a", "canvas-a", project_state_dir=project_state
+    )
+
+    assert count == 1
+    assert calls == [("archive", "thread-a", None)]
+    assert json.loads(sessions.read_text(encoding="utf-8")) == {
+        canvas_b: "thread-b"
+    }
+
+
+@pytest.mark.anyio
+async def test_codex_project_delete_covers_unique_threads(monkeypatch, tmp_path):
+    project_state = tmp_path / "project-state"
+    sessions = project_state / "agents" / "codex" / "sessions.json"
+    sessions.parent.mkdir(parents=True)
+    sessions.write_text(
+        json.dumps({"one": "thread-a", "two": "thread-a", "three": "thread-b"}),
+        encoding="utf-8",
+    )
+    calls = []
+    monkeypatch.setattr(
+        chat_service,
+        "_control_codex_thread",
+        lambda operation, thread_id, turn_id=None: calls.append(
+            (operation, thread_id, turn_id)
+        )
+        or True,
+    )
+
+    count = await chat_service.delete_codex_project_threads(
+        "admin", "project-a", project_state_dir=project_state
+    )
+
+    assert count == 2
+    assert calls == [
+        ("delete", "thread-a", None),
+        ("delete", "thread-b", None),
+    ]
+
+
+@pytest.mark.anyio
 @pytest.mark.parametrize(
     ("tool_mode", "store_scope", "expected_profile", "expected_canvas"),
     [
@@ -855,6 +921,11 @@ async def test_codex_stream_passes_conversation_scope_to_thread_builder(
 ):
     monkeypatch.setenv("NOVELVIDEO_STATE_DIR", str(tmp_path / "state"))
     captured: dict[str, object] = {}
+    revoked: list[str] = []
+
+    class FakeAuthPort:
+        async def revoke_agent_session(self, token):
+            revoked.append(token)
 
     async def fake_create_token(*args, **kwargs):  # noqa: ARG001
         return "agent-token"
@@ -923,6 +994,9 @@ async def test_codex_stream_passes_conversation_scope_to_thread_builder(
 
     def fake_build_thread(*args, **kwargs):
         captured.update(kwargs)
+        token_file = Path(kwargs["agent_token_file"])
+        assert token_file.read_text(encoding="utf-8") == "agent-token"
+        assert token_file.stat().st_mode & 0o777 == 0o600
         return FakeThread()
 
     monkeypatch.setattr(
@@ -931,6 +1005,7 @@ async def test_codex_stream_passes_conversation_scope_to_thread_builder(
         fake_create_token,
     )
     monkeypatch.setattr(chat_service, "_build_codex_thread", fake_build_thread)
+    monkeypatch.setattr(chat_service, "get_auth_session_port", lambda: FakeAuthPort())
     monkeypatch.setattr(hermes_sdk, "_issue_turn_capability", lambda **kwargs: None)
 
     events = []
@@ -945,12 +1020,23 @@ async def test_codex_stream_passes_conversation_scope_to_thread_builder(
         collect_event,
         project_state_dir=tmp_path / "state" / "admin" / "project-a",
         tool_mode=tool_mode,
+        surface_context={"freezone_canvas_id": "canvas-a"},
         store_scope=store_scope,
         turn_id="business-turn",
+        route_prompt="hello",
     )
 
     assert captured["agent_profile"] == expected_profile
+    assert captured["tool_mode"] == tool_mode
     assert captured["canvas_id"] == expected_canvas
+    assert not Path(captured["agent_token_file"]).exists()
+    assert revoked == ["agent-token"]
+    if tool_mode == "freezone_canvas":
+        assert "[FREEZONE_CANVAS_ASSISTANT]" in captured["prompt"]
+        assert "[FREEZONE_CANVAS_CONTEXT]" in captured["prompt"]
+        assert "canvas_id: canvas-a" in captured["prompt"]
+    else:
+        assert "[FREEZONE_CANVAS_ASSISTANT]" not in captured["prompt"]
     assert [event["type"] for event in events] == [
         "thread_started",
         "turn_started",
@@ -1013,8 +1099,10 @@ def test_dramaclaw_mcp_server_config_is_agent_neutral():
     assert servers["dramaclaw"]["args"] == ["-m", "novelvideo.chat.dramaclaw_mcp"]
     assert servers["dramaclaw"]["env_vars"] == [
         "DRAMACLAW_API_URL",
-        "DRAMACLAW_AGENT_TOKEN",
+        "DRAMACLAW_AGENT_TOKEN_FILE",
+        "DRAMACLAW_CANVAS_ID",
         "DRAMACLAW_PROJECT_ID",
+        "DRAMACLAW_TOOL_MODE",
         "DRAMACLAW_USERNAME",
     ]
 
@@ -1040,7 +1128,8 @@ def test_codex_client_carries_dramaclaw_mcp_servers(tmp_path):
     assert 'mcp_servers.dramaclaw.args=["-m","novelvideo.chat.dramaclaw_mcp"]' in overrides
     assert (
         'mcp_servers.dramaclaw.env_vars=["DRAMACLAW_API_URL",'
-        '"DRAMACLAW_AGENT_TOKEN","DRAMACLAW_PROJECT_ID","DRAMACLAW_USERNAME"]'
+        '"DRAMACLAW_AGENT_TOKEN_FILE","DRAMACLAW_CANVAS_ID","DRAMACLAW_PROJECT_ID",'
+        '"DRAMACLAW_TOOL_MODE","DRAMACLAW_USERNAME"]'
         in overrides
     )
     assert "mcp_servers.dramaclaw.required=true" in overrides
@@ -1049,7 +1138,7 @@ def test_codex_client_carries_dramaclaw_mcp_servers(tmp_path):
     client = backend_sdk.CodexClient(
         codex_bin=Path("/usr/local/bin/codex"),
         cwd=tmp_path,
-        env={"DRAMACLAW_AGENT_TOKEN": "token"},
+        env={"DRAMACLAW_AGENT_TOKEN_FILE": "/tmp/turn.token"},
         model="DC-codex-agent-LLM",
         model_provider="dramaclaw_gateway",
         developer_instructions="Use DramaClaw MCP only.",
@@ -1060,11 +1149,38 @@ def test_codex_client_carries_dramaclaw_mcp_servers(tmp_path):
 
     assert thread._config_overrides == overrides
     assert thread._thread_config["mcp_servers.dramaclaw.env"] == {
-        "DRAMACLAW_AGENT_TOKEN": "token"
+        "DRAMACLAW_AGENT_TOKEN_FILE": "/tmp/turn.token"
     }
     assert "mcp_servers.dramaclaw.env_vars" not in thread._thread_config
     assert thread._model == "DC-codex-agent-LLM"
     assert thread._model_provider == "dramaclaw_gateway"
+
+
+def test_codex_client_carries_freezone_scope_into_mcp_process(tmp_path):
+    overrides = chat_service._codex_mcp_config_overrides(
+        chat_service._dramaclaw_mcp_servers()
+    )
+    client = backend_sdk.CodexClient(
+        codex_bin=Path("/usr/local/bin/codex"),
+        cwd=tmp_path,
+        env={
+            "DRAMACLAW_AGENT_TOKEN_FILE": "/tmp/turn.token",
+            "DRAMACLAW_CANVAS_ID": "canvas-a",
+            "DRAMACLAW_TOOL_MODE": "freezone_canvas",
+        },
+        model="DC-codex-agent-LLM",
+        model_provider="dramaclaw_gateway",
+        developer_instructions="Use DramaClaw MCP only.",
+        config_overrides=overrides,
+    )
+
+    thread = client.thread_start()
+
+    assert thread._thread_config["mcp_servers.dramaclaw.env"] == {
+        "DRAMACLAW_AGENT_TOKEN_FILE": "/tmp/turn.token",
+        "DRAMACLAW_CANVAS_ID": "canvas-a",
+        "DRAMACLAW_TOOL_MODE": "freezone_canvas",
+    }
 
 
 def test_codex_client_keeps_gateway_credentials_in_turn_metadata(tmp_path):
@@ -1074,7 +1190,7 @@ def test_codex_client_keeps_gateway_credentials_in_turn_metadata(tmp_path):
     client = backend_sdk.CodexClient(
         codex_bin=Path("/usr/local/bin/codex"),
         cwd=tmp_path,
-        env={"DRAMACLAW_AGENT_TOKEN": "agent-turn-secret"},
+        env={"DRAMACLAW_AGENT_TOKEN_FILE": "/tmp/turn.token"},
         model="DC-codex-agent-LLM",
         model_provider="dramaclaw_gateway",
         developer_instructions="Use DramaClaw MCP only.",
@@ -1090,7 +1206,7 @@ def test_codex_client_keeps_gateway_credentials_in_turn_metadata(tmp_path):
 
     thread = client.thread_start()
     assert thread._thread_config["mcp_servers.dramaclaw.env"] == {
-        "DRAMACLAW_AGENT_TOKEN": "agent-turn-secret"
+        "DRAMACLAW_AGENT_TOKEN_FILE": "/tmp/turn.token"
     }
     assert thread._turn_metadata == {
         "dramaclaw_gateway_api_key": "turn-secret",
@@ -1142,17 +1258,33 @@ def test_codex_env_uses_effective_gateway_and_isolates_codex_home(
         "project-a",
         "agent-token",
         project_state_dir=project_state,
+        agent_token_file=project_state / "turn.token",
     )
 
     assert env["CODEX_HOME"] == str(tmp_path / "state" / ".codex-app-server")
     assert env["DRAMACLAW_AGENT_SCOPE"] == "project"
     assert env["SUPERTALE_AGENT_SCOPE"] == "project"
+    assert env["DRAMACLAW_TOOL_MODE"] == "default"
+    assert "DRAMACLAW_AGENT_TOKEN" not in env
+    assert env["DRAMACLAW_AGENT_TOKEN_FILE"] == str(project_state / "turn.token")
+    assert "DRAMACLAW_CANVAS_ID" not in env
     assert "DRAMACLAW_CODEX_GATEWAY_API_KEY" not in env
     assert "NEWAPI_API_KEY" not in env
     assert "OPENAI_API_KEY" not in env
     assert env["DRAMACLAW_CODEX_GATEWAY_BASE_URL"] == (
         "https://gateway.example/v1"
     )
+
+    freezone_env = chat_service._build_codex_env(
+        "admin",
+        "project-a",
+        "agent-token",
+        tool_mode="freezone_canvas",
+        canvas_id="canvas-a",
+        project_state_dir=project_state,
+    )
+    assert freezone_env["DRAMACLAW_TOOL_MODE"] == "freezone_canvas"
+    assert freezone_env["DRAMACLAW_CANVAS_ID"] == "canvas-a"
 
 
 def test_codex_turn_gateway_credentials_reject_foreign_origin(monkeypatch):
@@ -1347,6 +1479,27 @@ async def test_cancel_interrupts_only_the_users_active_codex_turns(monkeypatch):
     finally:
         with chat_service._ACTIVE_CODEX_TURNS_LOCK:
             chat_service._ACTIVE_CODEX_TURNS.clear()
+
+
+@pytest.mark.asyncio
+async def test_cancel_reads_active_codex_turns_from_other_worker(monkeypatch, tmp_path):
+    monkeypatch.setenv("NOVELVIDEO_STATE_DIR", str(tmp_path / "state"))
+    chat_service._set_active_codex_turn(
+        "alice", "project:project-a", ("thread-a", "turn-a")
+    )
+    calls = []
+    monkeypatch.setattr(chat_service, "interrupt_live_codex_turn", lambda *_: False)
+    monkeypatch.setattr(
+        chat_service,
+        "_control_codex_thread",
+        lambda operation, thread_id, turn_id=None: calls.append(
+            (operation, thread_id, turn_id)
+        )
+        or True,
+    )
+
+    assert await chat_service.interrupt_active_codex_turns("alice") is True
+    assert calls == [("interrupt", "thread-a", "turn-a")]
 
 
 def test_chat_run_lock_is_user_scoped(monkeypatch, tmp_path):
@@ -2297,6 +2450,46 @@ async def test_freezone_history_reads_project_name_storage_scope(monkeypatch, tm
         / "canvas-a"
         / "agents"
         / "agent-2"
+        / "chat.db"
+    ).exists()
+
+
+def test_freezone_chat_store_uses_authoritative_project_state_and_migrates_legacy(
+    monkeypatch, tmp_path
+):
+    state_root = tmp_path / "state"
+    authoritative = tmp_path / "mounted-project-state"
+    monkeypatch.setenv("NOVELVIDEO_STATE_DIR", str(state_root))
+    legacy_scope = ChatScope(
+        kind="project",
+        id="project-a",
+        surface="freezone",
+        canvas_id="canvas-a",
+        agent_id="main",
+    )
+    chat_store.append_message("admin", legacy_scope, "user", "legacy history")
+    authoritative_scope = ChatScope(
+        kind="project",
+        id="project-a",
+        surface="freezone",
+        canvas_id="canvas-a",
+        agent_id="main",
+        state_dir=str(authoritative),
+    )
+
+    chat_store.append_message("admin", authoritative_scope, "assistant", "new reply")
+
+    assert [
+        item["content"]
+        for item in chat_store.list_messages("admin", authoritative_scope)
+    ] == ["legacy history", "new reply"]
+    assert (
+        authoritative
+        / "_chat"
+        / "freezone"
+        / "canvas-a"
+        / "agents"
+        / "main"
         / "chat.db"
     ).exists()
 

--- a/tests/test_chat_service_user_agent_scope.py
+++ b/tests/test_chat_service_user_agent_scope.py
@@ -1502,6 +1502,85 @@ async def test_cancel_reads_active_codex_turns_from_other_worker(monkeypatch, tm
     assert calls == [("interrupt", "thread-a", "turn-a")]
 
 
+@pytest.mark.asyncio
+async def test_disconnect_interrupts_only_its_exact_codex_turn(monkeypatch):
+    disconnected = asyncio.Event()
+    disconnected.set()
+    calls = []
+
+    async def interrupt(username, project, thread_id, turn_id, *, backend=None):
+        calls.append((username, project, thread_id, turn_id, backend))
+        return True
+
+    monkeypatch.setattr(chat_service, "interrupt_chat_turn", interrupt)
+    monkeypatch.setattr(
+        chat_service,
+        "get_chat_backend_name",
+        lambda: (_ for _ in ()).throw(AssertionError("backend must be captured")),
+    )
+
+    await chat_routes._interrupt_agent_on_disconnect(
+        disconnected,
+        runtime_backend="codex",
+        username="alice",
+        project="project-a",
+        agent_profile="freezone:main",
+        runtime_ids={"thread_id": "thread-a", "turn_id": "turn-a"},
+    )
+
+    assert calls == [
+        ("alice", "project-a", "thread-a", "turn-a", "codex")
+    ]
+
+
+@pytest.mark.asyncio
+async def test_disconnect_closes_only_matching_hermes_thread(monkeypatch):
+    from novelvideo.chat import hermes_pool
+
+    disconnected = asyncio.Event()
+    disconnected.set()
+    calls = []
+
+    class FakePool:
+        async def close_user_thread(self, username, profile, thread_id):
+            calls.append((username, profile, thread_id))
+            return True
+
+        async def close_user(self, _username):
+            raise AssertionError("disconnect must not close every user worker")
+
+    monkeypatch.setattr(hermes_pool, "pool", FakePool())
+
+    await chat_routes._interrupt_agent_on_disconnect(
+        disconnected,
+        runtime_backend="hermes",
+        username="alice",
+        project="project-a",
+        agent_profile="freezone:agent-2",
+        runtime_ids={"thread_id": "session-a", "turn_id": "turn-a"},
+    )
+
+    assert calls == [("alice", "freezone:agent-2", "session-a")]
+
+
+@pytest.mark.asyncio
+async def test_interrupt_chat_turn_uses_captured_backend(monkeypatch):
+    monkeypatch.setattr(
+        chat_service,
+        "_chat_backend",
+        lambda: (_ for _ in ()).throw(AssertionError("must not re-read backend")),
+    )
+    monkeypatch.setattr(chat_service, "interrupt_live_codex_turn", lambda *_: True)
+
+    assert await chat_service.interrupt_chat_turn(
+        "alice",
+        "project-a",
+        "thread-a",
+        "turn-a",
+        backend="codex",
+    )
+
+
 def test_chat_run_lock_is_user_scoped(monkeypatch, tmp_path):
     monkeypatch.setenv("NOVELVIDEO_STATE_DIR", str(tmp_path / "state"))
     monkeypatch.setenv("NOVELVIDEO_OUTPUT_DIR", str(tmp_path / "output"))
@@ -2454,7 +2533,7 @@ async def test_freezone_history_reads_project_name_storage_scope(monkeypatch, tm
     ).exists()
 
 
-def test_freezone_chat_store_uses_authoritative_project_state_and_migrates_legacy(
+def test_freezone_chat_store_uses_only_authoritative_project_state(
     monkeypatch, tmp_path
 ):
     state_root = tmp_path / "state"
@@ -2482,7 +2561,7 @@ def test_freezone_chat_store_uses_authoritative_project_state_and_migrates_legac
     assert [
         item["content"]
         for item in chat_store.list_messages("admin", authoritative_scope)
-    ] == ["legacy history", "new reply"]
+    ] == ["new reply"]
     assert (
         authoritative
         / "_chat"

--- a/tests/test_chat_service_user_agent_scope.py
+++ b/tests/test_chat_service_user_agent_scope.py
@@ -1097,6 +1097,47 @@ async def test_codex_stream_passes_conversation_scope_to_thread_builder(
     assert events[-1]["type"] == "done"
 
 
+@pytest.mark.asyncio
+async def test_codex_turn_token_files_are_unique_and_cleanup_is_turn_local(
+    tmp_path,
+):
+    token_root = tmp_path / "turn_tokens"
+    scope_key = chat_service._codex_scope_key(
+        "project-a",
+        agent_profile="freezone:agent-2",
+        canvas_id="canvas-a",
+    )
+
+    first, second = await asyncio.gather(
+        asyncio.to_thread(
+            chat_service._write_codex_turn_token,
+            token_root,
+            scope_key=scope_key,
+            business_turn_id="retry-turn",
+            token="token-first",
+        ),
+        asyncio.to_thread(
+            chat_service._write_codex_turn_token,
+            token_root,
+            scope_key=scope_key,
+            business_turn_id="retry-turn",
+            token="token-second",
+        ),
+    )
+
+    assert first != second
+    assert first.read_text(encoding="utf-8") == "token-first"
+    assert second.read_text(encoding="utf-8") == "token-second"
+    assert first.stat().st_mode & 0o777 == 0o600
+    assert second.stat().st_mode & 0o777 == 0o600
+
+    first.unlink()
+    assert not first.exists()
+    assert second.read_text(encoding="utf-8") == "token-second"
+    second.unlink()
+    assert list(token_root.iterdir()) == []
+
+
 def test_user_agent_workspace_is_not_project_workspace(monkeypatch, tmp_path):
     monkeypatch.setenv("NOVELVIDEO_STATE_DIR", str(tmp_path / "state"))
     monkeypatch.setenv("NOVELVIDEO_OUTPUT_DIR", str(tmp_path / "output"))

--- a/tests/test_codex_app_server.py
+++ b/tests/test_codex_app_server.py
@@ -10,12 +10,55 @@ from novelvideo.chat.backend_sdk import (
     CodexThread,
     _start_codex_turn,
     _start_or_resume_codex_thread,
+    control_codex_runtime,
 )
 
 
 def test_runtime_rejects_sdk_bundled_binary():
     with pytest.raises(RuntimeError, match="DramaClaw-patched Codex runtime"):
         codex_app_server._resolve_codex_bin(SimpleNamespace(codex_bin=None))
+
+
+def test_control_rpc_uses_shared_app_server_for_lifecycle(monkeypatch, tmp_path):
+    calls = []
+
+    class FakeClient:
+        def turn_interrupt(self, thread_id, turn_id):
+            calls.append(("interrupt", thread_id, turn_id))
+
+        def thread_archive(self, thread_id):
+            calls.append(("archive", thread_id))
+
+        def request(self, method, payload, *, response_model):
+            calls.append((method, payload, response_model.__name__))
+
+    @contextmanager
+    def fake_shared_codex(_config):
+        yield SimpleNamespace(_client=FakeClient())
+
+    monkeypatch.setattr(codex_app_server, "shared_codex", fake_shared_codex)
+    common = {
+        "codex_bin": tmp_path / "codex",
+        "cwd": tmp_path,
+        "env": {},
+        "config_overrides": (),
+        "thread_id": "thread-a",
+    }
+
+    assert control_codex_runtime(
+        **common, operation="interrupt", turn_id="turn-a"
+    )
+    assert control_codex_runtime(**common, operation="archive")
+    assert control_codex_runtime(**common, operation="delete")
+    assert calls == [
+        ("interrupt", "thread-a", "turn-a"),
+        ("archive", "thread-a"),
+        (
+            "thread/delete",
+            {"threadId": "thread-a"},
+            "ThreadDeleteResponse",
+        ),
+    ]
 
 
 def test_legacy_log_sanitizer_removes_turn_secrets_from_sqlite(tmp_path):
@@ -292,6 +335,18 @@ async def test_codex_stream_maps_structured_runtime_events(monkeypatch, tmp_path
                     "itemId": "reasoning-1",
                     "summaryIndex": 0,
                     "delta": "Checking available projects",
+                }
+            ),
+        ),
+        Notification(
+            method="item/reasoning/textDelta",
+            payload=v2.ReasoningTextDeltaNotification.model_validate(
+                {
+                    "threadId": "thread-1",
+                    "turnId": "turn-1",
+                    "itemId": "reasoning-1",
+                    "contentIndex": 0,
+                    "delta": "private chain of thought",
                 }
             ),
         ),

--- a/tests/test_dramaclaw_mcp_progressive.py
+++ b/tests/test_dramaclaw_mcp_progressive.py
@@ -7,6 +7,21 @@ import pytest
 from novelvideo.chat import dramaclaw_mcp
 
 
+def test_plugin_reads_turn_token_file_lazily(monkeypatch, tmp_path):
+    token_file = tmp_path / "turn.token"
+    token_file.write_text("first-token", encoding="utf-8")
+    monkeypatch.setenv("DRAMACLAW_AGENT_TOKEN_FILE", str(token_file))
+    monkeypatch.delenv("DRAMACLAW_AGENT_TOKEN", raising=False)
+
+    assert dramaclaw_mcp.PLUGIN._request_headers("test")["Authorization"] == (
+        "Bearer first-token"
+    )
+    token_file.write_text("second-token", encoding="utf-8")
+    assert dramaclaw_mcp.PLUGIN._request_headers("test")["Authorization"] == (
+        "Bearer second-token"
+    )
+
+
 @pytest.mark.asyncio
 async def test_list_tools_exposes_only_progressive_bridge(monkeypatch):
     monkeypatch.setenv("DRAMACLAW_PROJECT_ID", "project-a")
@@ -28,12 +43,42 @@ def test_home_scope_only_discovers_project_collection_tools(monkeypatch):
 
 def test_project_scope_can_discover_production_tools(monkeypatch):
     monkeypatch.setenv("DRAMACLAW_PROJECT_ID", "project-a")
+    monkeypatch.delenv("DRAMACLAW_TOOL_MODE", raising=False)
 
     available = dramaclaw_mcp._available_tools()
     matches = dramaclaw_mcp._search_tools("首帧生成", 6)
 
     assert set(available) == set(dramaclaw_mcp.TOOLS)
     assert "dramaclaw_render_first_frames" in {match["name"] for match in matches}
+
+
+def test_freezone_scope_hides_mainline_write_tools(monkeypatch):
+    monkeypatch.setenv("DRAMACLAW_PROJECT_ID", "project-a")
+    monkeypatch.setenv("DRAMACLAW_TOOL_MODE", "freezone_canvas")
+
+    available = dramaclaw_mcp._available_tools()
+    denied = dramaclaw_mcp.PLUGIN.FREEZONE_DENIED_MAINLINE_WRITE_TOOLS
+
+    assert set(available).isdisjoint(denied)
+    assert "dramaclaw_save_freezone_canvas" in available
+
+
+@pytest.mark.asyncio
+async def test_freezone_scope_rejects_direct_mainline_write_call(monkeypatch):
+    monkeypatch.setenv("DRAMACLAW_PROJECT_ID", "project-a")
+    monkeypatch.setenv("DRAMACLAW_TOOL_MODE", "freezone_canvas")
+
+    result = await dramaclaw_mcp.call_tool(
+        dramaclaw_mcp.TOOL_CALL_NAME,
+        {
+            "tool_name": "dramaclaw_render_first_frames",
+            "arguments": {"episode": 1},
+        },
+    )
+    payload = json.loads(result[0].text)
+
+    assert payload["ok"] is False
+    assert payload["error"] == "tool_not_available_in_scope"
 
 
 @pytest.mark.asyncio

--- a/tests/test_freezone_image_backend.py
+++ b/tests/test_freezone_image_backend.py
@@ -2608,6 +2608,17 @@ async def test_delete_canvas_soft_deletes_and_hides_tombstone_from_list(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     _project_dir, _output_dir = _patch_freezone_project(monkeypatch, tmp_path)
+    archived = []
+
+    async def archive_threads(username, project, canvas_id, **kwargs):
+        archived.append((username, project, canvas_id, kwargs["project_state_dir"]))
+        return 1
+
+    monkeypatch.setattr(
+        freezone_routes.chat_service,
+        "archive_codex_canvas_threads",
+        archive_threads,
+    )
     state_dir = _canvas_state_dir(tmp_path)
     canvas_file = state_dir / "freezone" / "canvases" / "experiment.json"
     canvas_file.parent.mkdir(parents=True)
@@ -2630,6 +2641,7 @@ async def test_delete_canvas_soft_deletes_and_hides_tombstone_from_list(
     )
 
     assert deleted["data"]["deleted"] is True
+    assert archived == [("admin", "58", "experiment", state_dir)]
     assert not canvas_file.exists()
     tombstone = canvas_file.with_name("experiment.deleted.json")
     assert tombstone.exists()

--- a/tests/test_hermes_pool_session_resume.py
+++ b/tests/test_hermes_pool_session_resume.py
@@ -50,6 +50,24 @@ class _FakeThread:
         return self.closed
 
 
+@pytest.mark.asyncio
+async def test_close_user_thread_requires_exact_session_id(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    pool, _calls, fake_auth, _gateway = _patch_fake_hermes_pool(
+        tmp_path, monkeypatch
+    )
+    thread = await pool.get_for_user(
+        "alice", scope_kind="project", project_id="project_a"
+    )
+
+    assert await pool.close_user_thread("alice", "main", "other-session") is False
+    assert thread.closed is False
+    assert await pool.close_user_thread("alice", "main", thread.id) is True
+    assert thread.closed is True
+    assert fake_auth.revoked == ["token-1"]
+
+
 def test_hermes_session_pointer_is_durable_in_runtime_home(tmp_path: Path) -> None:
     from novelvideo.chat.hermes_pool import HermesPool
 

--- a/tests/test_hermes_workspace.py
+++ b/tests/test_hermes_workspace.py
@@ -214,6 +214,27 @@ def test_freezone_profile_uses_isolated_workspace(
     assert (hw.freezone_python_hook_dir(home) / "sitecustomize.py").is_file()
 
 
+def test_freezone_workspace_preserves_learned_identity_and_memory(
+    isolated_workspace, repo_skills, repo_plugins
+):
+    home = hw.ensure_user_hermes_workspace("admin", profile="freezone")
+    soul_file = home / "SOUL.md"
+    memory_file = home / "memories" / "MEMORY.md"
+    soul_file.write_text(
+        soul_file.read_text(encoding="utf-8") + "\n用户偏好简洁沟通。\n",
+        encoding="utf-8",
+    )
+    memory_file.write_text(
+        memory_file.read_text(encoding="utf-8") + "\n项目使用暖色电影感。\n",
+        encoding="utf-8",
+    )
+
+    hw.ensure_user_hermes_workspace("admin", profile="freezone")
+
+    assert "用户偏好简洁沟通" in soul_file.read_text(encoding="utf-8")
+    assert "项目使用暖色电影感" in memory_file.read_text(encoding="utf-8")
+
+
 def test_freezone_sitecustomize_disables_only_skill_manage(
     isolated_workspace,
     repo_skills,

--- a/tests/test_project_lifecycle_storage.py
+++ b/tests/test_project_lifecycle_storage.py
@@ -141,14 +141,23 @@ async def test_purge_detaches_files_before_releasing_project_name(monkeypatch, t
     async def emit_audit(**_kwargs):
         calls.append("audit")
 
+    async def delete_codex_threads(*_args, **_kwargs):
+        calls.append("codex")
+        return 1
+
     monkeypatch.setattr(projects, "resolve_project_context", resolve_context)
     monkeypatch.setattr(projects, "get_project_registry", lambda: Registry())
     monkeypatch.setattr(projects, "emit_project_audit", emit_audit)
+    monkeypatch.setattr(
+        projects.chat_service,
+        "delete_codex_project_threads",
+        delete_codex_threads,
+    )
 
     result = await projects.purge_project("01PROJECT", user={"username": "alice"})
 
     assert result["ok"] is True
-    assert calls == ["purged", "home", "audit"]
+    assert calls == ["codex", "purged", "home", "audit"]
     for raw_path in (record.output_dir, record.state_dir, record.runtime_dir):
         path = projects.Path(raw_path)
         assert not path.exists()


### PR DESCRIPTION
## What changed

- Keep Hermes and Codex native memory/project state inside the project state directory; remove the legacy cross-project `preferences.md` injection.
- Give Codex Freezone turns the same surface prompt and hard MCP write boundary as Hermes.
- Replace reusable MCP bearer tokens with short-lived per-turn tokens delivered through a project-scoped `0600` token file; revoke and remove them after completion, failure, or cancellation.
- Make Codex cancellation work across Gunicorn workers through the shared App Server and a disk-backed active-turn registry.
- Stop API-worker `atexit` handlers from owning and terminating the shared home-node App Server.
- Archive canvas Codex threads on canvas deletion and permanently delete project rollouts before project purge.
- Bind WebSocket disconnect cleanup to the captured backend and exact thread/turn; never cancel another project or canvas by username.
- Isolate Mainline and Freezone Codex profiles with separate workspaces, session scope keys, thread-local MCP environments, turn-token paths, and active-turn keys.
- Stop forwarding raw reasoning text; only reasoning summaries reach the UI.
- Resolve Freezone ChatStore paths exclusively from the authoritative project `state_dir` when supplied.
- Preserve learned Hermes Freezone `SOUL.md` and `MEMORY.md` content across workspace refreshes.

## Runtime boundaries

- One Home Node runs one shared Codex App Server and one `CODEX_HOME`; Mainline and Freezone do not duplicate resident runtimes.
- Codex profile isolation is enforced below the App Server boundary: distinct workspace and thread/session identity plus thread-local MCP identity and permissions. Node-global memory, plugins, multi-agent, shell, and image tools remain disabled.
- Codex continues to use its native read-only sandbox; Hermes continues to use the existing external sandbox wrapper.
- NewAPI model credentials and BrainClaw control capabilities remain turn-scoped and separate from the DramaClaw MCP authorization token.
- Multi-agent-per-canvas behavior is intentionally unchanged in this PR.

## Validation

- `uv run pytest -q tests/test_chat_service_user_agent_scope.py tests/test_codex_app_server.py tests/test_project_lifecycle_storage.py tests/test_freezone_image_backend.py::test_delete_canvas_soft_deletes_and_hides_tombstone_from_list tests/test_freezone_image_backend.py::test_delete_default_canvas_soft_deletes_without_recreating` — 176 passed.
- `uv run pytest tests/test_chat_service_user_agent_scope.py tests/test_hermes_pool_session_resume.py -q` — 166 passed.
- `uv run ruff check` on all changed Python files and tests — passed.
- `git diff --check` — passed.

## Impact

- No database schema migration.
- Development-stage state is intentionally clean-cut: when an authoritative project `state_dir` is supplied, legacy chat databases are neither copied nor used as a read fallback.
- Legacy `state/<user>/preferences.md` is unsupported: the runtime does not create, read, inject, or migrate it. Existing files may remain physically present but have no runtime effect.
- Project/canvas deletion now fails closed when an existing Codex rollout cannot be archived or deleted.
