### PR TITLE
perf(assets): 虾塘引用索引改走聚合接口，消掉按集扇出的 beats 请求

### DIFF
--- a/frontend/src/__tests__/components/assets/asset-tabs-beats-contract.test.tsx
+++ b/frontend/src/__tests__/components/assets/asset-tabs-beats-contract.test.tsx
@@ -1,0 +1,155 @@
+// SPDX-License-Identifier: Elastic-2.0
+// Copyright (c) 2026 ClaymoreLab
+/**
+ * The assets workbench must never read the beats table.
+ *
+ * Usage counts used to come from walking every episode's beats: opening a tab
+ * fired one `/episodes/{n}/beats` per episode, and each of those is the
+ * expensive route — it hydrates a store, probes the filesystem for four asset
+ * URLs per beat, and forks ffprobe for every audio clip. The counts now arrive
+ * from the single project-wide `/assets/references` aggregate instead.
+ *
+ * This is a network-level assertion on purpose. The fan-out was never visible
+ * in a rendered-output test; it lived in which hooks the panels happened to
+ * call, which is exactly the kind of thing a UI refactor reintroduces silently.
+ */
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, waitFor } from "@testing-library/react";
+import i18next from "i18next";
+import { I18nextProvider, initReactI18next } from "react-i18next";
+import { http, HttpResponse } from "msw";
+import ky from "ky";
+import type { ReactNode } from "react";
+import { beforeAll, describe, expect, it, vi } from "vitest";
+
+import { server } from "@/__mocks__/msw/server";
+
+vi.mock("@/lib/api", () => ({
+  api: ky.create({ baseUrl: "http://localhost:3000/" }),
+  uploadApi: ky.create({ baseUrl: "http://localhost:3000/" }),
+}));
+
+// Routing is stubbed to the bare minimum: this file asserts on what the network
+// sees, not on navigation.
+vi.mock("@tanstack/react-router", () => ({
+  Link: ({ children, ...rest }: { children: ReactNode }) => (
+    <a {...(rest as object)}>{children}</a>
+  ),
+  useNavigate: () => vi.fn(),
+  useSearch: () => ({}),
+  useParams: () => ({}),
+}));
+
+vi.mock("@/hooks/use-task-controller", () => ({
+  useTaskController: () => ({
+    started: false,
+    stream: {
+      status: "idle",
+      progress: 0,
+      currentTask: "",
+      result: null,
+      error: null,
+    },
+    logs: [],
+    start: vi.fn(),
+    stop: vi.fn(),
+    stopping: false,
+  }),
+}));
+
+import { PropsPanel } from "@/components/assets/props-panel";
+import { ScenesPanel } from "@/components/assets/scenes-panel";
+
+const i18n = i18next.createInstance();
+
+beforeAll(async () => {
+  await i18n.use(initReactI18next).init({ lng: "en", fallbackLng: "en", resources: {} });
+});
+
+/**
+ * Record the API path of every request the render makes.
+ *
+ * The catch-all is registered first so the per-test handlers below still win,
+ * and it answers rather than falling through: an unhandled request would escape
+ * to the real network and turn a missing handler into a confusing timeout
+ * instead of a recorded path.
+ */
+function recordRequests(): string[] {
+  const seen: string[] = [];
+  server.use(
+    http.get("http://localhost:3000/api/v1/*", ({ request }) => {
+      seen.push(new URL(request.url).pathname);
+      return HttpResponse.json({ ok: true, data: [] });
+    }),
+  );
+  return seen;
+}
+
+function renderWithProviders(ui: ReactNode) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <I18nextProvider i18n={i18n}>
+      <QueryClientProvider client={qc}>{ui}</QueryClientProvider>
+    </I18nextProvider>,
+  );
+}
+
+describe("asset tabs do not read the beats table", () => {
+  it("opens the scenes tab without requesting any episode's beats", async () => {
+    const seen = recordRequests();
+    server.use(
+      http.get("http://localhost:3000/api/v1/projects/demo/scenes", () =>
+        HttpResponse.json({
+          ok: true,
+          data: [{ name: "Hall", description: "", image_url: "" }],
+        }),
+      ),
+    );
+
+    renderWithProviders(<ScenesPanel project="demo" />);
+
+    await waitFor(() => expect(seen.length).toBeGreaterThan(0));
+    expect(seen.filter((path) => path.includes("/beats"))).toEqual([]);
+  });
+
+  it("opens the props tab without requesting any episode's beats", async () => {
+    const seen = recordRequests();
+    server.use(
+      http.get("http://localhost:3000/api/v1/projects/demo/props", () =>
+        HttpResponse.json({
+          ok: true,
+          data: [{ name: "Sword", description: "", image_url: "" }],
+        }),
+      ),
+    );
+
+    renderWithProviders(<PropsPanel project="demo" />);
+
+    await waitFor(() => expect(seen.length).toBeGreaterThan(0));
+    expect(seen.filter((path) => path.includes("/beats"))).toEqual([]);
+  });
+
+  it("asks the aggregate reference endpoint at most once per panel", async () => {
+    const seen = recordRequests();
+    server.use(
+      http.get("http://localhost:3000/api/v1/projects/demo/scenes", () =>
+        HttpResponse.json({
+          ok: true,
+          data: [
+            { name: "Hall", description: "", image_url: "" },
+            { name: "Alley", description: "", image_url: "" },
+          ],
+        }),
+      ),
+    );
+
+    renderWithProviders(<ScenesPanel project="demo" />);
+
+    await waitFor(() => expect(seen.length).toBeGreaterThan(0));
+    // One project-wide call covers every card's usage badge; the old shape was
+    // one call per asset, which is the same fan-out wearing a different URL.
+    expect(
+      seen.filter((path) => path.endsWith("/assets/references")).length,
+    ).toBeLessThanOrEqual(1);
+  });
+});

--- a/frontend/src/__tests__/components/assets/props-panel.ce.test.tsx
+++ b/frontend/src/__tests__/components/assets/props-panel.ce.test.tsx
@@ -77,9 +77,11 @@ vi.mock("@/lib/queries/props", () => ({
 }));
 
 vi.mock("@/lib/queries/asset-references", () => ({
-  useAssetReferenceIndex: () => ({
-    countFor: () => 0,
+  useAssetReferenceCounts: () => ({ countFor: () => 0, isLoading: false }),
+  useAssetReferences: () => ({
     referencesFor: () => [],
+    coOccurrenceForScene: () => ({ identities: [], props: [] }),
+    isLoading: false,
   }),
 }));
 

--- a/frontend/src/__tests__/features/canvas/video-model-capabilities.test.ts
+++ b/frontend/src/__tests__/features/canvas/video-model-capabilities.test.ts
@@ -20,11 +20,13 @@ import {
   resolveVideoKeyframeUrls,
   videoEmptyStateCtaModes,
   videoModeForcesAutomaticAspectRatio,
+  videoModeRequiresMedia,
   videoModeRequiresPrompt,
   videoModelDefaultGenerateAudio,
   videoModelSupportsGenerateAudio,
   videoModelReferenceDisabledReason,
   videoMultiImageAutoSwitchMode,
+  videoNoUpstreamResetMode,
   videoReferenceAutoSwitchAction,
   type VideoReferenceAutoSwitchAction,
   videoSubmitMediaRejectionReason,
@@ -1182,5 +1184,90 @@ describe("videoModeRequiresPrompt — submit validation by mode", () => {
     ] as VideoGenMode[]) {
       expect(videoModeRequiresPrompt(mode)).toBe(false);
     }
+  });
+});
+
+describe("videoModeRequiresMedia — 该模式是否必须有上游素材", () => {
+  it("文生视频是唯一不需要素材的模式", () => {
+    expect(videoModeRequiresMedia("textToVideo")).toBe(false);
+  });
+
+  it("全能参考同样需要素材（omni 端点没素材就发不出去）", () => {
+    // 与 videoModeRequiresPrompt 是**并列**关系而非二选一：全能参考两条都要。
+    // 只看提示词的话，素材撤空后按钮仍然可点，点了却被 handleSubmit 的
+    // references.length === 0 静默拦下 —— 用户看到的就是「点了没反应」。
+    expect(videoModeRequiresMedia("allReference")).toBe(true);
+    expect(videoModeRequiresPrompt("allReference")).toBe(true);
+  });
+
+  it("其余生成模式都要素材", () => {
+    for (const mode of [
+      "firstFrame",
+      "imageToVideo",
+      "imageReference",
+      "firstLastFrame",
+      "videoEdit",
+    ] as VideoGenMode[]) {
+      expect(videoModeRequiresMedia(mode)).toBe(true);
+    }
+  });
+});
+
+describe("videoNoUpstreamResetMode — 素材撤空后退回文生视频", () => {
+  const EMPTY = { images: 0, videos: 0, audios: 0 };
+
+  it("上游清空后，任何素材模式都退回文生视频", () => {
+    for (const mode of [
+      "allReference",
+      "imageReference",
+      "firstFrame",
+      "imageToVideo",
+      "firstLastFrame",
+      "videoEdit",
+    ] as VideoGenMode[]) {
+      expect(videoNoUpstreamResetMode(mode, EMPTY)).toBe("textToVideo");
+    }
+  });
+
+  it("已经是文生视频就不动（避免每帧都发一次 patch）", () => {
+    expect(videoNoUpstreamResetMode("textToVideo", EMPTY)).toBeNull();
+  });
+
+  it.each([
+    ["图片", { images: 1, videos: 0, audios: 0 }],
+    ["视频", { images: 0, videos: 1, audios: 0 }],
+    ["音频", { images: 0, videos: 0, audios: 1 }],
+  ] as const)("上游还有%s素材时不动", (_label, counts) => {
+    expect(videoNoUpstreamResetMode("allReference", counts)).toBeNull();
+  });
+});
+
+describe("VideoNode 接线：素材撤空 → 文生视频", () => {
+  const source = readFileSync("src/features/canvas/nodes/VideoNode.tsx", "utf8");
+
+  it("反向复位 effect 按节点类型口径判定，不用已解析 URL 口径", () => {
+    // upstreamCounts（已解析 URL）会把空态 CTA 刚铺好、还没出图的图片节点算成 0 张，
+    // 用它当场就会把三个 CTA 顶回文生视频。
+    expect(source).toContain(
+      "videoNoUpstreamResetMode(genMode, upstreamTypeCounts)",
+    );
+  });
+
+  it("复位不进撤销栈", () => {
+    // 这是「用户删素材」的衍生结果而非独立改动；记进 past 会让 ⌘Z 被本 effect 立刻
+    // 撤销回去、redo 栈还被清空，等于把「回到连线之前」这条路堵死。
+    expect(source).toContain(
+      "updateNodeData(id, { genMode: target }, { recordHistory: false });",
+    );
+  });
+
+  it("提交闸门把提示词与素材拆成两条并列判定", () => {
+    expect(source).toContain(
+      "(videoModeRequiresPrompt(genMode) && !hasPromptText) ||\n      (videoModeRequiresMedia(genMode) && !hasRequiredMediaForMode);",
+    );
+    // 旧的三元写法：要提示词的模式就不再看素材 —— 全能参考因此漏网。
+    expect(source).not.toContain(
+      "videoModeRequiresPrompt(genMode)\n        ? !hasPromptText\n        : !hasRequiredMediaForMode",
+    );
   });
 });

--- a/frontend/src/__tests__/lib/queries/asset-references.test.tsx
+++ b/frontend/src/__tests__/lib/queries/asset-references.test.tsx
@@ -3,10 +3,9 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { renderHook, waitFor } from "@testing-library/react";
 import { http, HttpResponse } from "msw";
-import { setupServer } from "msw/node";
 import ky from "ky";
 import type { ReactNode } from "react";
-import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 vi.mock("@/lib/api", () => ({
   api: ky.create({ baseUrl: "http://localhost:3000/" }),
@@ -17,12 +16,11 @@ import {
   useAssetReferences,
   type AssetRef,
 } from "@/lib/queries/asset-references";
-
-const server = setupServer();
-
-beforeAll(() => server.listen());
-afterEach(() => server.resetHandlers());
-afterAll(() => server.close());
+// The shared server from `__tests__/setup.ts`, not a second `setupServer()`.
+// Two listening MSW instances both dispatch every request, which silently
+// doubles any handler-side call counter — and counting requests is the whole
+// point of the dedup assertions below.
+import { server } from "@/__mocks__/msw/server";
 
 // The client is created per-test and held outside the component, not built in
 // the wrapper body: these tests re-render, and a fresh QueryClient per render
@@ -117,10 +115,6 @@ describe("useAssetReferences id round-trip", () => {
     expect(result.current.referencesFor("scene", "hall / lobby")).toHaveLength(1);
   });
 
-  // Dedup is asserted on the query cache and the distinct URL set, not on a
-  // handler call counter: this file runs its own `setupServer` alongside the
-  // global one in `__tests__/setup.ts`, so both interceptors dispatch each
-  // request and any raw counter reads double.
   it("reuses one cache entry for the same set regardless of order or duplicates", async () => {
     const urls: string[] = [];
     server.use(
@@ -167,7 +161,7 @@ describe("useAssetReferences id round-trip", () => {
 
     await waitFor(() => expect(result.current.isLoading).toBe(false));
 
-    expect(new Set(urls).size).toBe(1);
+    expect(urls).toHaveLength(1);
     expect(qc.getQueryCache().getAll()).toHaveLength(1);
   });
 

--- a/frontend/src/__tests__/lib/queries/asset-references.test.tsx
+++ b/frontend/src/__tests__/lib/queries/asset-references.test.tsx
@@ -1,0 +1,197 @@
+// SPDX-License-Identifier: Elastic-2.0
+// Copyright (c) 2026 ClaymoreLab
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import { http, HttpResponse } from "msw";
+import { setupServer } from "msw/node";
+import ky from "ky";
+import type { ReactNode } from "react";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/api", () => ({
+  api: ky.create({ baseUrl: "http://localhost:3000/" }),
+  uploadApi: ky.create({ baseUrl: "http://localhost:3000/" }),
+}));
+
+import {
+  useAssetReferences,
+  type AssetRef,
+} from "@/lib/queries/asset-references";
+
+const server = setupServer();
+
+beforeAll(() => server.listen());
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+// The client is created per-test and held outside the component, not built in
+// the wrapper body: these tests re-render, and a fresh QueryClient per render
+// would drop the cache and re-issue every request — which is exactly what the
+// dedup assertion below is measuring.
+function makeWrapper() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
+  };
+}
+
+/** Capture the `ids` the hook actually asks the backend for, and echo them back. */
+function captureIds(): { get: () => string[] } {
+  let seen: string[] = [];
+  server.use(
+    http.get(
+      "http://localhost:3000/api/v1/projects/demo/assets/references",
+      ({ request }) => {
+        seen = new URL(request.url).searchParams.getAll("ids");
+        return HttpResponse.json({
+          ok: true,
+          data: {
+            counts: {},
+            // Echo one beat per requested key, so `referencesFor` resolving to a
+            // non-empty list proves the key survived the request round-trip.
+            references: Object.fromEntries(
+              seen.map((key, i) => [key, [{ episode: 1, beat_number: i + 1 }]]),
+            ),
+            scene_co_occurrence: {},
+          },
+        });
+      },
+    ),
+  );
+  return { get: () => seen };
+}
+
+describe("useAssetReferences id round-trip", () => {
+  // Asset ids are user-authored names. A space-separated cache signature used to
+  // be split back apart on whitespace, so `prop:red wine glass` left as one id
+  // and came back as three that match nothing — an empty beat list, no error.
+  it("keeps ids containing spaces intact", async () => {
+    const captured = captureIds();
+    const refs: AssetRef[] = [
+      { type: "prop", id: "red wine glass" },
+      { type: "scene", id: "New York Office" },
+    ];
+
+    const { result } = renderHook(() => useAssetReferences("demo", refs), {
+      wrapper: makeWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(captured.get()).toEqual([
+      "prop:red wine glass",
+      "scene:New York Office",
+    ]);
+    expect(result.current.referencesFor("prop", "red wine glass")).toHaveLength(1);
+    expect(result.current.referencesFor("scene", "New York Office")).toHaveLength(1);
+  });
+
+  it("keeps ids containing separators and url-significant characters intact", async () => {
+    const captured = captureIds();
+    const refs: AssetRef[] = [
+      { type: "identity", id: "a:b" },
+      { type: "prop", id: "100% cotton" },
+      { type: "prop", id: "tag#1" },
+      { type: "scene", id: "hall / lobby" },
+    ];
+
+    const { result } = renderHook(() => useAssetReferences("demo", refs), {
+      wrapper: makeWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(captured.get().sort()).toEqual(
+      [
+        "identity:a:b",
+        "prop:100% cotton",
+        "prop:tag#1",
+        "scene:hall / lobby",
+      ].sort(),
+    );
+    // `identity:a:b` is the one that survives a naive `split(":")` too — assert
+    // the hook hands it back under the full id, not the truncated `a`.
+    expect(result.current.referencesFor("identity", "a:b")).toHaveLength(1);
+    expect(result.current.referencesFor("identity", "a")).toHaveLength(0);
+    expect(result.current.referencesFor("prop", "100% cotton")).toHaveLength(1);
+    expect(result.current.referencesFor("scene", "hall / lobby")).toHaveLength(1);
+  });
+
+  // Dedup is asserted on the query cache and the distinct URL set, not on a
+  // handler call counter: this file runs its own `setupServer` alongside the
+  // global one in `__tests__/setup.ts`, so both interceptors dispatch each
+  // request and any raw counter reads double.
+  it("reuses one cache entry for the same set regardless of order or duplicates", async () => {
+    const urls: string[] = [];
+    server.use(
+      http.get(
+        "http://localhost:3000/api/v1/projects/demo/assets/references",
+        ({ request }) => {
+          urls.push(request.url);
+          return HttpResponse.json({
+            ok: true,
+            data: { counts: {}, references: {}, scene_co_occurrence: {} },
+          });
+        },
+      ),
+    );
+
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    function Wrapper({ children }: { children: ReactNode }) {
+      return <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
+    }
+
+    const { result, rerender } = renderHook(
+      ({ refs }: { refs: AssetRef[] }) => useAssetReferences("demo", refs),
+      {
+        wrapper: Wrapper,
+        initialProps: {
+          refs: [
+            { type: "prop", id: "red wine glass" },
+            { type: "identity", id: "lin" },
+          ] as AssetRef[],
+        },
+      },
+    );
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    // Same set, new array identity, reversed, with a duplicate.
+    rerender({
+      refs: [
+        { type: "identity", id: "lin" },
+        { type: "prop", id: "red wine glass" },
+        { type: "identity", id: "lin" },
+      ] as AssetRef[],
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(new Set(urls).size).toBe(1);
+    expect(qc.getQueryCache().getAll()).toHaveLength(1);
+  });
+
+  it("issues no request when nothing is on screen", async () => {
+    let calls = 0;
+    server.use(
+      http.get(
+        "http://localhost:3000/api/v1/projects/demo/assets/references",
+        () => {
+          calls += 1;
+          return HttpResponse.json({
+            ok: true,
+            data: { counts: {}, references: {}, scene_co_occurrence: {} },
+          });
+        },
+      ),
+    );
+
+    const { result } = renderHook(() => useAssetReferences("demo", []), {
+      wrapper: makeWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(calls).toBe(0);
+    expect(result.current.referencesFor("prop", "anything")).toEqual([]);
+  });
+});

--- a/frontend/src/__tests__/lib/queries/identity-owner-index.test.tsx
+++ b/frontend/src/__tests__/lib/queries/identity-owner-index.test.tsx
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: Elastic-2.0
+// Copyright (c) 2026 ClaymoreLab
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import { http, HttpResponse } from "msw";
+import { setupServer } from "msw/node";
+import ky from "ky";
+import type { ReactNode } from "react";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/api", () => ({
+  api: ky.create({ baseUrl: "http://localhost:3000/" }),
+  uploadApi: ky.create({ baseUrl: "http://localhost:3000/" }),
+}));
+
+import { useIdentityOwnerIndex } from "@/lib/queries/characters";
+
+const server = setupServer();
+
+beforeAll(() => server.listen());
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+function wrapper({ children }: { children: ReactNode }) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
+}
+
+describe("useIdentityOwnerIndex", () => {
+  // This hook used to fan out `/characters/{name}/identities` for every
+  // character in the project, unconditionally on mount — 100 characters meant
+  // 100 requests on every visit to the assets page, to build a lookup table
+  // that is only read when an `?type=identity&id=` deep link is present.
+  it("resolves owners from the character list without per-character requests", async () => {
+    const identityPaths: string[] = [];
+    server.use(
+      http.get("http://localhost:3000/api/v1/projects/demo/characters", () =>
+        HttpResponse.json({
+          ok: true,
+          data: [
+            { name: "林昭", identity_ids: ["林昭_青年", "林昭_少年"] },
+            { name: "苏清晏", identity_ids: ["苏清晏_少女"] },
+            { name: "路人", identity_ids: [] },
+          ],
+        }),
+      ),
+      http.get(
+        "http://localhost:3000/api/v1/projects/demo/characters/:name/identities",
+        ({ request }) => {
+          identityPaths.push(new URL(request.url).pathname);
+          return HttpResponse.json({ ok: true, data: [] });
+        },
+      ),
+    );
+
+    const { result } = renderHook(() => useIdentityOwnerIndex("demo"), {
+      wrapper,
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.ownerOf("林昭_少年")).toBe("林昭");
+    expect(result.current.ownerOf("苏清晏_少女")).toBe("苏清晏");
+    expect(result.current.ownerOf("不存在的身份")).toBeNull();
+    // The whole point: the owner index costs the character list and nothing else.
+    expect(identityPaths).toEqual([]);
+  });
+
+  it("reports no owner while the character list is still loading", async () => {
+    server.use(
+      http.get("http://localhost:3000/api/v1/projects/demo/characters", () =>
+        HttpResponse.json({ ok: true, data: [] }),
+      ),
+    );
+
+    const { result } = renderHook(() => useIdentityOwnerIndex("demo"), {
+      wrapper,
+    });
+
+    expect(result.current.ownerOf("林昭_青年")).toBeNull();
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.ownerOf("林昭_青年")).toBeNull();
+  });
+
+  // Older backends predate `identity_ids`; a missing field must degrade to
+  // "deep link unresolved", not to a crash on `undefined.length`.
+  it("tolerates a character list without identity_ids", async () => {
+    server.use(
+      http.get("http://localhost:3000/api/v1/projects/demo/characters", () =>
+        HttpResponse.json({ ok: true, data: [{ name: "林昭" }] }),
+      ),
+    );
+
+    const { result } = renderHook(() => useIdentityOwnerIndex("demo"), {
+      wrapper,
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.ownerOf("林昭_青年")).toBeNull();
+  });
+});

--- a/frontend/src/__tests__/lib/queries/identity-owner-index.test.tsx
+++ b/frontend/src/__tests__/lib/queries/identity-owner-index.test.tsx
@@ -1,29 +1,42 @@
 // SPDX-License-Identifier: Elastic-2.0
 // Copyright (c) 2026 ClaymoreLab
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { renderHook, waitFor } from "@testing-library/react";
+import { act, renderHook, waitFor } from "@testing-library/react";
 import { http, HttpResponse } from "msw";
-import { setupServer } from "msw/node";
 import ky from "ky";
 import type { ReactNode } from "react";
-import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 vi.mock("@/lib/api", () => ({
   api: ky.create({ baseUrl: "http://localhost:3000/" }),
   uploadApi: ky.create({ baseUrl: "http://localhost:3000/" }),
 }));
 
-import { useIdentityOwnerIndex } from "@/lib/queries/characters";
-
-const server = setupServer();
-
-beforeAll(() => server.listen());
-afterEach(() => server.resetHandlers());
-afterAll(() => server.close());
+import {
+  useCreateIdentity,
+  useDeleteIdentity,
+  useIdentityOwnerIndex,
+} from "@/lib/queries/characters";
+// Shared server, not a second `setupServer()` — two listening instances dispatch
+// every request twice, which doubles the request counters these tests assert on.
+import { server } from "@/__mocks__/msw/server";
 
 function wrapper({ children }: { children: ReactNode }) {
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
   return <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
+}
+
+// A wrapper that holds ONE client across re-renders. The plain `wrapper` above
+// builds a fresh QueryClient in its body, so every re-render starts from an
+// empty cache — fine for a single read, useless for a mutation test, where the
+// entire question is whether invalidation reaches a cache that is still there.
+function makeStableWrapper() {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
+  };
 }
 
 describe("useIdentityOwnerIndex", () => {
@@ -97,5 +110,96 @@ describe("useIdentityOwnerIndex", () => {
 
     await waitFor(() => expect(result.current.isLoading).toBe(false));
     expect(result.current.ownerOf("林昭_青年")).toBeNull();
+  });
+});
+
+// The owner map is what `?type=identity&id=` deep links resolve against, and it
+// is built from `identity_ids` on the CHARACTER list — a different query key
+// from the identities list the mutation obviously touches. Invalidating only
+// `queryKeys.identities` therefore leaves the map holding a membership set that
+// no longer matches, and the staleness lasts as long as the page stays mounted:
+// a link to an identity the user just created resolves to no owner at all.
+describe("owner index freshness across identity mutations", () => {
+  function serveCharacters(identityIds: () => string[]) {
+    server.use(
+      http.get("http://localhost:3000/api/v1/projects/demo/characters", () =>
+        HttpResponse.json({
+          ok: true,
+          data: [{ name: "lin", identity_ids: identityIds() }],
+        }),
+      ),
+    );
+  }
+
+  it("resolves the owner of a just-created identity without a remount", async () => {
+    let owned = ["lin_young"];
+    serveCharacters(() => owned);
+    server.use(
+      http.post(
+        "http://localhost:3000/api/v1/projects/demo/characters/lin/identities",
+        () => {
+          owned = ["lin_young", "lin_old"];
+          return HttpResponse.json({
+            ok: true,
+            data: { identity_id: "lin_old" },
+          });
+        },
+      ),
+    );
+
+    const { result } = renderHook(
+      () => ({
+        index: useIdentityOwnerIndex("demo"),
+        create: useCreateIdentity("demo", "lin"),
+      }),
+      { wrapper: makeStableWrapper() },
+    );
+
+    await waitFor(() => expect(result.current.index.isLoading).toBe(false));
+    expect(result.current.index.ownerOf("lin_old")).toBeNull();
+
+    await act(async () => {
+      await result.current.create.mutateAsync({ identity_name: "old" });
+    });
+
+    await waitFor(() =>
+      expect(result.current.index.ownerOf("lin_old")).toBe("lin"),
+    );
+  });
+
+  it("drops the owner of a deleted identity without a remount", async () => {
+    let owned = ["lin_young", "lin_old"];
+    serveCharacters(() => owned);
+    server.use(
+      http.delete(
+        "http://localhost:3000/api/v1/projects/demo/characters/lin/identities/lin_old",
+        () => {
+          owned = ["lin_young"];
+          return HttpResponse.json({ ok: true, data: null });
+        },
+      ),
+    );
+
+    const { result } = renderHook(
+      () => ({
+        index: useIdentityOwnerIndex("demo"),
+        remove: useDeleteIdentity("demo", "lin"),
+      }),
+      { wrapper: makeStableWrapper() },
+    );
+
+    await waitFor(() => expect(result.current.index.isLoading).toBe(false));
+    expect(result.current.index.ownerOf("lin_old")).toBe("lin");
+
+    await act(async () => {
+      await result.current.remove.mutateAsync("lin_old");
+    });
+
+    await waitFor(() =>
+      expect(result.current.index.ownerOf("lin_old")).toBeNull(),
+    );
+    // The surviving identity must still resolve — a blanket cache reset would
+    // pass the assertion above for the wrong reason.
+    expect(result.current.index.ownerOf("lin_young")).toBe("lin");
   });
 });

--- a/frontend/src/__tests__/routes/characters.ce.test.tsx
+++ b/frontend/src/__tests__/routes/characters.ce.test.tsx
@@ -116,9 +116,11 @@ vi.mock("@/lib/queries/generation-credit-cost", () => ({
 }));
 
 vi.mock("@/lib/queries/asset-references", () => ({
-  useAssetReferenceIndex: () => ({
-    countFor: () => 0,
+  useAssetReferenceCounts: () => ({ countFor: () => 0, isLoading: false }),
+  useAssetReferences: () => ({
     referencesFor: () => [],
+    coOccurrenceForScene: () => ({ identities: [], props: [] }),
+    isLoading: false,
   }),
 }));
 

--- a/frontend/src/components/assets/props-panel.tsx
+++ b/frontend/src/components/assets/props-panel.tsx
@@ -18,7 +18,8 @@ import {
   type AssetSortKey,
 } from "@/components/assets/asset-search-box";
 import {
-  useAssetReferenceIndex,
+  useAssetReferenceCounts,
+  useAssetReferences,
   type BeatReference,
 } from "@/lib/queries/asset-references";
 import { useGenerationCreditCost } from "@/lib/queries/generation-credit-cost";
@@ -343,7 +344,17 @@ export function PropsPanel({
   const [editing, setEditing] = useState<PropAsset | null>(null);
   const updateProp = useUpdateProp(project, editing?.name ?? "");
   const deleteProp = useDeleteProp(project);
-  const refIndex = useAssetReferenceIndex(project);
+  // Counts feed every card's badge and the usage sort, so they cover the whole
+  // project. The beat list is only rendered inside the edit dialog, so it is
+  // fetched for that one prop instead of for all of them.
+  const refCounts = useAssetReferenceCounts(project);
+  const refDetail = useAssetReferences(
+    project,
+    useMemo(
+      () => (editing ? [{ type: "prop" as const, id: editing.name }] : []),
+      [editing],
+    ),
+  );
   const imageSourceQuery = useAssetImageSourceSelection(project, "prop");
   const imageSourceSelection = imageSourceQuery.data?.data.image_source_selection ?? "";
   const allItems = props.data?.data ?? [];
@@ -362,9 +373,9 @@ export function PropsPanel({
       filtered,
       sortKey,
       (prop) => prop.name,
-      (prop) => refIndex.countFor("prop", prop.name),
+      (prop) => refCounts.countFor("prop", prop.name),
     );
-  }, [allItems, searchQuery, sortKey, refIndex]);
+  }, [allItems, searchQuery, sortKey, refCounts]);
   const gridRef = useAssetFocus(focusId, !props.isLoading && items.length > 0);
 
   async function handleSave(data: PropPayload) {
@@ -494,7 +505,7 @@ export function PropsPanel({
                   project={project}
                   prop={prop}
                   imageSourceSelection={imageSourceSelection}
-                  referenceCount={refIndex.countFor("prop", prop.name)}
+                  referenceCount={refCounts.countFor("prop", prop.name)}
                   onEdit={() => {
                     setEditing(prop);
                     setDialogOpen(true);
@@ -510,7 +521,9 @@ export function PropsPanel({
         open={dialogOpen}
         initial={editing}
         project={project}
-        references={editing ? refIndex.referencesFor("prop", editing.name) : []}
+        references={
+          editing ? refDetail.referencesFor("prop", editing.name) : []
+        }
         onOpenChange={(open) => {
           setDialogOpen(open);
           if (!open) setEditing(null);

--- a/frontend/src/components/assets/scene-asset-card.tsx
+++ b/frontend/src/components/assets/scene-asset-card.tsx
@@ -101,6 +101,8 @@ function AssetImageSlot({
                 src={resolved}
                 alt=""
                 aria-hidden="true"
+                loading="lazy"
+                decoding="async"
                 className="absolute inset-0 h-full w-full scale-110 object-cover opacity-50 blur-md"
               />
             )}

--- a/frontend/src/components/assets/scenes-panel.tsx
+++ b/frontend/src/components/assets/scenes-panel.tsx
@@ -1106,6 +1106,8 @@ function SceneGroupListItem({
             src={previewUrl}
             alt=""
             aria-hidden="true"
+            loading="lazy"
+            decoding="async"
             className="h-full w-full object-cover"
           />
         ) : (

--- a/frontend/src/components/assets/scenes-panel.tsx
+++ b/frontend/src/components/assets/scenes-panel.tsx
@@ -28,7 +28,8 @@ import {
   type AssetSortKey,
 } from "@/components/assets/asset-search-box";
 import {
-  useAssetReferenceIndex,
+  useAssetReferenceCounts,
+  useAssetReferences,
   type BeatReference,
   type SceneCoOccurrence,
 } from "@/lib/queries/asset-references";
@@ -1170,7 +1171,17 @@ export function ScenesPanel({
     (buildScenesCost.error instanceof BillingRuleNotConfiguredError
       ? t("common.billingRuleNotConfiguredShort")
       : null);
-  const refIndex = useAssetReferenceIndex(project);
+  // Counts feed every card's badge and the usage sort, so they cover the whole
+  // project. The beat list is only rendered inside the edit dialog, so it is
+  // fetched for that one scene instead of for all of them.
+  const refCounts = useAssetReferenceCounts(project);
+  const refDetail = useAssetReferences(
+    project,
+    useMemo(
+      () => (editing ? [{ type: "scene" as const, id: editing.name }] : []),
+      [editing],
+    ),
+  );
 
   const allItems = scenes.data?.data ?? [];
   const [searchQuery, setSearchQuery] = useState("");
@@ -1218,11 +1229,11 @@ export function ScenesPanel({
       (group) => group.baseName,
       (group) =>
         group.scenes.reduce(
-          (sum, scene) => sum + refIndex.countFor("scene", scene.name),
+          (sum, scene) => sum + refCounts.countFor("scene", scene.name),
           0,
         ),
     );
-  }, [allSceneGroups, searchQuery, sortKey, refIndex]);
+  }, [allSceneGroups, searchQuery, sortKey, refCounts]);
   useEffect(() => {
     if (scenes.isLoading) {
       return;
@@ -1461,7 +1472,7 @@ export function ScenesPanel({
                       group={group}
                       selected={selectedBaseName === group.baseName}
                       referenceCount={group.scenes.reduce(
-                        (sum, scene) => sum + refIndex.countFor("scene", scene.name),
+                        (sum, scene) => sum + refCounts.countFor("scene", scene.name),
                         0,
                       )}
                       onSelect={() => rememberSelectedBaseName(group.baseName)}
@@ -1542,7 +1553,7 @@ export function ScenesPanel({
                         project={project}
                         scene={scene}
                         imageSourceSelection={imageSourceSelection}
-                        referenceCount={refIndex.countFor("scene", scene.name)}
+                        referenceCount={refCounts.countFor("scene", scene.name)}
                         onEdit={() => {
                           setEditing(scene);
                           setDraftSeed(null);
@@ -1564,11 +1575,11 @@ export function ScenesPanel({
         draftSeed={draftSeed}
         project={project}
         references={
-          editing ? refIndex.referencesFor("scene", editing.name) : []
+          editing ? refDetail.referencesFor("scene", editing.name) : []
         }
         coOccurrence={
           editing
-            ? refIndex.coOccurrenceForScene(editing.name)
+            ? refDetail.coOccurrenceForScene(editing.name)
             : { identities: [], props: [] }
         }
         onOpenChange={(open) => {

--- a/frontend/src/features/canvas/nodes/VideoNode.tsx
+++ b/frontend/src/features/canvas/nodes/VideoNode.tsx
@@ -77,11 +77,13 @@ import {
   resolveVideoKeyframeUrls,
   videoEmptyStateCtaModes,
   videoModeForcesAutomaticAspectRatio,
+  videoModeRequiresMedia,
   videoModeRequiresPrompt,
   videoModelDefaultGenerateAudio,
   videoModelReferenceDisabledReason,
   videoModelSupportsGenerateAudio,
   videoMultiImageAutoSwitchMode,
+  videoNoUpstreamResetMode,
   videoReferenceAutoSwitchAction,
   videoSubmitMediaRejectionReason,
   videoUpstreamImageDefaultMode,
@@ -1672,6 +1674,34 @@ export const VideoNode = memo(
       updateNodeData,
     ]);
 
+    // 上面几条模式推导都是**单向**的：素材接进来就把模式推到能消费它的那一个，却没有
+    // 任何一条负责在素材撤空后把模式推回去。于是「连一张图 → 又把图撤掉」之后节点卡在
+    // 全能参考上：界面看不出异常，提交却会被 handleSubmit 的 references.length === 0
+    // 静默拦下，用户看到的就是「打了字、点发送没反应」。这里补上反向的那一档 ——
+    // 没有任何上游素材 = 文生视频，与 HappyHorse 统一状态机的「无上游 → 文生视频」同规则。
+    //
+    // 用 upstreamTypeCounts（按节点类型）而非 upstreamCounts（已解析 URL）：空态 CTA
+    // 先铺一个还没出图的图片/上传节点、再切模式，按 URL 口径那一瞬间是 0 张，会被这条
+    // 当场顶回文生视频。理由同 videoNoUpstreamResetMode 的注释。
+    //
+    // recordHistory: false —— 这是用户「删掉素材」那一步的**衍生结果**，不是一次独立的
+    // 用户改动。若照常压 past，⌘Z 只会撤掉模式回到「无素材 + 全能参考」，本 effect 立刻
+    // 又把它改回来并清空 redo 栈，撤销看着毫无反应、也再回不到连线之前（成因见上面
+    // 模型自动救场那条 effect 的注释）。不记历史则 ⌘Z 直接回到「有图 + 全能参考」，正向 effect
+    // 看到素材还在便不再改写。
+    useEffect(() => {
+      if (isHappyHorseModel) return;
+      const target = videoNoUpstreamResetMode(genMode, upstreamTypeCounts);
+      if (!target) return;
+      updateNodeData(id, { genMode: target }, { recordHistory: false });
+    }, [
+      genMode,
+      isHappyHorseModel,
+      upstreamTypeCounts,
+      id,
+      updateNodeData,
+    ]);
+
     useEffect(
       () => () => {
         clearTransientPreview();
@@ -1894,11 +1924,13 @@ export const VideoNode = memo(
       updateNodeData,
     ]);
 
-    // 提交可用性按模式区分（对齐后端各端点校验）：
-    // - 文生 / 全能参考：后端强校验 prompt，必须有提示词（自写或上游 text）；
-    // - 首帧 / 图生视频 / 图片参考 / 首尾帧 / 视频编辑：后端不校验 prompt，允许空提示词，
-    //   只要素材齐备即可提交（图片类要 ≥1 张上游图；视频编辑要 ≥1 个上游视频）。
-    //   这修掉「删掉默认提示词后传了首帧仍无法直接生成」的问题。
+    // 提交可用性按模式区分（对齐后端各端点校验），提示词与素材两条**分别**判定：
+    // - 提示词：文生 / 全能参考 后端强校验 prompt，必须有（自写或上游 text）；首帧 /
+    //   图生视频 / 图片参考 / 首尾帧 / 视频编辑允许空提示词 —— 这修掉「删掉默认提示词后
+    //   传了首帧仍无法直接生成」的问题。
+    // - 素材：除文生视频外都要有（图片类要 ≥1 张上游图；视频编辑要 ≥1 个上游视频；
+    //   全能参考图/视频/音频任意一类 ≥1）—— 对齐 handleSubmit 各分支的空素材早退。
+    // 全能参考是唯一两条都要的模式，所以这里不能写成「要提示词的就只看提示词」。
     const hasPromptText =
       prompt.trim().length > 0 || upstreamTextJoined.length > 0;
     const hasRequiredMediaForMode =
@@ -1958,9 +1990,11 @@ export const VideoNode = memo(
       !selectedVideoModel ||
       selectedModelReferenceError !== null ||
       mediaRejectionReason != null ||
-      (videoModeRequiresPrompt(genMode)
-        ? !hasPromptText
-        : !hasRequiredMediaForMode);
+      // 提示词与素材是**两条并列**的要求，不是二选一：全能参考两条都要（后端强校验
+      // prompt，omni 端点又没素材可发）。写成三元的时候，全能参考只看提示词，素材撤空后
+      // 按钮仍是可点态，点下去被 handleSubmit 的 references.length === 0 静默拦掉。
+      (videoModeRequiresPrompt(genMode) && !hasPromptText) ||
+      (videoModeRequiresMedia(genMode) && !hasRequiredMediaForMode);
 
     const handleSubmit = useCallback(async () => {
       if (submitDisabled) return;

--- a/frontend/src/features/canvas/nodes/shared/videoModelCapabilities.ts
+++ b/frontend/src/features/canvas/nodes/shared/videoModelCapabilities.ts
@@ -254,6 +254,43 @@ export function videoModeRequiresPrompt(mode: VideoGenMode): boolean {
 }
 
 /**
+ * 该 genMode 是否**必须有上游素材**才能提交：只有文生视频不需要，其余模式的提交
+ * 分支都会在素材为空时直接 return（见 VideoNode 的 handleSubmit）。
+ *
+ * 和 `videoModeRequiresPrompt` 是**并列**关系，不是二选一 —— 全能参考两条都要：
+ * 后端 omni 端点强校验 prompt，而 references 为空又根本没得可发。曾经写成「要提示词
+ * 的模式就只看提示词」，于是「接过图 → 又把图撤走 → 只打字」这条路上按钮看着可点、
+ * 点下去却被 handleSubmit 的 `references.length === 0` 静默拦掉，表现为「点了没反应」。
+ * 正常情况下 `videoNoUpstreamResetMode` 会先把模式退回文生视频，这条是兜底：上游节点
+ * 还连着、里面的图却被清空时（typeCounts>0 而 counts==0）退回不触发，仍要拦住提交。
+ */
+export function videoModeRequiresMedia(mode: VideoGenMode): boolean {
+  return mode !== "textToVideo";
+}
+
+/**
+ * 上游素材被全部撤走后该退回哪个模式：`"textToVideo"` = 退回文生视频，null = 不动。
+ *
+ * 视频节点的模式推导原本是**单向**的：接入图片/视频/音频时有一堆 effect 把模式推进
+ * 到能消费该素材的模式，却没有任何一条在素材撤空后把它推回来。于是「连一张图 → 又把
+ * 图删掉」之后节点卡在全能参考上，界面上看不出异常，提交却必然被静默拦下。
+ * HappyHorse 那条统一状态机早就有「无上游 → 文生视频」这一档，这里把同一条规则补给
+ * 其余模型。
+ *
+ * 素材计数要传**按节点类型**的口径（`upstreamTypeCounts`，空的图片节点也算），不能用
+ * 「已解析 URL」的口径：空态 CTA（全能参考 / 图片参考 / 首尾帧）正是先铺一个还没出图
+ * 的图片/上传节点、再把模式切过去，按 URL 口径这一瞬间素材数是 0，会被这条规则当场
+ * 顶回文生视频，等于把三个 CTA 全废掉。
+ */
+export function videoNoUpstreamResetMode(
+  mode: VideoGenMode,
+  counts: { images: number; videos: number; audios: number },
+): VideoGenMode | null {
+  if (counts.images > 0 || counts.videos > 0 || counts.audios > 0) return null;
+  return mode === "textToVideo" ? null : "textToVideo";
+}
+
+/**
  * 该模型的 i2v 端点是否放行多图（>1）。后端只在「非 2.0 且非 HappyHorse」时对
  * `len(source_paths) > 1` 直接 400（freezone.py），所以这两族之外的模型（Seedance
  * 1.x 等）一次只能吃一张图 —— 对它们来说换模式救不了，得换模型。

--- a/frontend/src/lib/queries/asset-references.ts
+++ b/frontend/src/lib/queries/asset-references.ts
@@ -89,9 +89,10 @@ function refKey(type: AssetRefType, id: string): string {
  * The per-asset detail key nests under the counts key, so this one prefix
  * invalidation covers both hooks.
  *
- * Missing a call site here degrades to stale usage counts, not wrong data: both
- * queries inherit the default 30s staleTime and the assets page is its own
- * route, so returning to it refetches. Prefer adding the call anyway.
+ * Do not treat the 30s staleTime as a safety net: staleTime only marks an entry
+ * stale, it never schedules a refetch. A page that stays mounted keeps showing
+ * the old counts indefinitely. Only a remount (or an explicit invalidation)
+ * refetches — so every mutation that moves a beat/asset relation must call this.
  */
 export function invalidateAssetReferences(
   qc: QueryClient,
@@ -136,16 +137,18 @@ export function useAssetReferences(
   project: string,
   refs: AssetRef[],
 ): AssetReferences {
-  const signature = [
-    ...new Set(refs.filter((r) => r.id).map((r) => refKey(r.type, r.id))),
-  ]
-    .sort()
-    .join(" ");
-
-  const keys = useMemo(
-    () => (signature ? signature.split(" ") : []),
-    [signature],
+  // JSON, not `.join(" ")`. Asset ids are user-authored names and legitimately
+  // contain spaces (`prop:red wine glass`, `scene:New York Office`), so any
+  // unescaped separator round-trips into different ids than went in — silently,
+  // as an empty beat list rather than an error. JSON.stringify of the sorted
+  // array is both a stable cache signature and an exact inverse.
+  const signature = JSON.stringify(
+    [
+      ...new Set(refs.filter((r) => r.id).map((r) => refKey(r.type, r.id))),
+    ].sort(),
   );
+
+  const keys = useMemo(() => JSON.parse(signature) as string[], [signature]);
 
   const { data, isLoading } = useQuery({
     queryKey: queryKeys.assetReferenceDetail(project, signature),

--- a/frontend/src/lib/queries/asset-references.ts
+++ b/frontend/src/lib/queries/asset-references.ts
@@ -12,21 +12,37 @@ import type { OkResponse } from "@/types/api";
 /**
  * Cross-asset reference index ("which beats use this asset").
  *
- * Served by `GET /projects/{p}/assets/references` in one request: the backend
- * makes a single pass over the beats table and returns only the reverse index.
- * This used to be derived on the client by fetching every episode's beats and
- * scanning them here — one request per episode, each carrying the full beat
- * payload (sketch/frame/video URLs plus an ffprobe per audio clip) so the FE
- * could read three fields per beat. That cost grew with episode count and is
- * why opening the assets page fired dozens of `beats` requests.
+ * Both hooks here are served by `GET /projects/{p}/assets/references`, which
+ * makes a single pass over the beats table. This used to be derived on the
+ * client by fetching every episode's beats and scanning them here — one request
+ * per episode, each carrying the full beat payload (sketch/frame/video URLs
+ * plus an ffprobe per audio clip) so the FE could read three fields per beat.
+ * That cost grew with episode count and is why opening the assets page fired
+ * dozens of `beats` requests.
+ *
+ * The split into two hooks is deliberate, because the two things the workbench
+ * needs scale differently:
+ *
+ *   - `useAssetReferenceCounts` — every card in every grid shows a usage badge,
+ *     and the panels sort/sum by it, so counts must cover the whole project.
+ *     One integer per asset keeps that bounded by asset count.
+ *   - `useAssetReferences` — the beat list for specific assets, requested only
+ *     for what is actually on screen. Fetching every asset's list up front is
+ *     what makes the payload grow with total references, the one dimension that
+ *     grows without bound as episodes pile up.
  *
  * Reference keys are `"{type}:{id}"`. Id semantics follow the persisted beat
  * contract: identity → `identity_id`, scene → `scene_ref.scene_id`, prop →
- * prop name. Matching now happens server-side, at the source of those ids, so
- * a backend rename can no longer silently zero out every usage count.
+ * prop name. Matching happens server-side, at the source of those ids, so a
+ * backend rename can no longer silently zero out every usage count.
  */
 
 export type AssetRefType = "identity" | "scene" | "prop";
+
+export interface AssetRef {
+  type: AssetRefType;
+  id: string;
+}
 
 export interface BeatReference {
   episode: number;
@@ -39,18 +55,22 @@ export interface SceneCoOccurrence {
   props: string[];
 }
 
-export interface AssetReferenceIndex {
-  /** Lookup references for one asset. Empty array when none / still loading. */
-  referencesFor: (type: AssetRefType, id: string) => BeatReference[];
-  /** Convenience: usage count for one asset. */
+export interface AssetReferenceCounts {
+  /** Usage count for one asset. 0 when unreferenced / still loading. */
   countFor: (type: AssetRefType, id: string) => number;
+  isLoading: boolean;
+}
+
+export interface AssetReferences {
+  /** Beat list for one of the requested assets. Empty when not requested. */
+  referencesFor: (type: AssetRefType, id: string) => BeatReference[];
   /** Identities/props co-appearing in beats where this scene is used. */
   coOccurrenceForScene: (sceneId: string) => SceneCoOccurrence;
-  /** True while the index is still loading. */
   isLoading: boolean;
 }
 
 interface AssetReferencesPayload {
+  counts: Record<string, number>;
   references: Record<string, { episode: number; beat_number: number }[]>;
   scene_co_occurrence: Record<string, { identities: string[]; props: string[] }>;
 }
@@ -62,12 +82,15 @@ function refKey(type: AssetRefType, id: string): string {
 /**
  * Drop the index after a mutation changes which assets a beat references —
  * beat text/scene edits, manual-shot insert/delete, identity detection, colour
- * binding. Call it alongside the `queryKeys.beats` invalidation those
- * mutations already do; the index lives under its own project-wide key, so
- * invalidating a single episode's beats no longer reaches it.
+ * binding. Call it alongside the `queryKeys.beats` invalidation those mutations
+ * already do; the index lives under its own project-wide key, so invalidating a
+ * single episode's beats no longer reaches it.
  *
- * Missing a call site here degrades to stale usage counts, not wrong data: the
- * index inherits the default 30s staleTime and the assets page is its own
+ * The per-asset detail key nests under the counts key, so this one prefix
+ * invalidation covers both hooks.
+ *
+ * Missing a call site here degrades to stale usage counts, not wrong data: both
+ * queries inherit the default 30s staleTime and the assets page is its own
  * route, so returning to it refetches. Prefer adding the call anyway.
  */
 export function invalidateAssetReferences(
@@ -80,7 +103,8 @@ export function invalidateAssetReferences(
 const EMPTY: BeatReference[] = [];
 const EMPTY_CO: SceneCoOccurrence = { identities: [], props: [] };
 
-export function useAssetReferenceIndex(project: string): AssetReferenceIndex {
+/** Whole-project usage counts — one integer per asset. */
+export function useAssetReferenceCounts(project: string): AssetReferenceCounts {
   const { data, isLoading } = useQuery({
     queryKey: queryKeys.assetReferences(project),
     queryFn: ({ signal }) =>
@@ -90,13 +114,64 @@ export function useAssetReferenceIndex(project: string): AssetReferenceIndex {
     enabled: !!project,
   });
 
+  const counts = data?.data?.counts;
+
+  return useMemo(
+    () => ({
+      countFor: (type, id) => counts?.[refKey(type, id)] ?? 0,
+      isLoading,
+    }),
+    [counts, isLoading],
+  );
+}
+
+/**
+ * Beat lists for a specific set of assets — pass only what is rendered.
+ *
+ * `refs` may be rebuilt on every render; it is reduced to a sorted, deduped
+ * signature so an unchanged set is one cache entry regardless of array identity
+ * or ordering. An empty set issues no request.
+ */
+export function useAssetReferences(
+  project: string,
+  refs: AssetRef[],
+): AssetReferences {
+  const signature = [
+    ...new Set(refs.filter((r) => r.id).map((r) => refKey(r.type, r.id))),
+  ]
+    .sort()
+    .join(" ");
+
+  const keys = useMemo(
+    () => (signature ? signature.split(" ") : []),
+    [signature],
+  );
+
+  const { data, isLoading } = useQuery({
+    queryKey: queryKeys.assetReferenceDetail(project, signature),
+    queryFn: ({ signal }) => {
+      const searchParams = new URLSearchParams();
+      for (const key of keys) searchParams.append("ids", key);
+      return api
+        .get(p`api/v1/projects/${project}/assets/references`, {
+          signal,
+          searchParams,
+        })
+        .json<OkResponse<AssetReferencesPayload>>();
+    },
+    enabled: !!project && keys.length > 0,
+  });
+
   const { map, sceneCo } = useMemo(() => {
     const acc = new Map<string, BeatReference[]>();
     const co = new Map<string, SceneCoOccurrence>();
-    for (const [key, refs] of Object.entries(data?.data?.references ?? {})) {
+    for (const [key, list] of Object.entries(data?.data?.references ?? {})) {
       acc.set(
         key,
-        refs.map((ref) => ({ episode: ref.episode, beatNumber: ref.beat_number })),
+        list.map((ref) => ({
+          episode: ref.episode,
+          beatNumber: ref.beat_number,
+        })),
       );
     }
     for (const [sceneId, bucket] of Object.entries(
@@ -113,10 +188,9 @@ export function useAssetReferenceIndex(project: string): AssetReferenceIndex {
   return useMemo(
     () => ({
       referencesFor: (type, id) => map.get(refKey(type, id)) ?? EMPTY,
-      countFor: (type, id) => map.get(refKey(type, id))?.length ?? 0,
       coOccurrenceForScene: (sceneId) => sceneCo.get(sceneId) ?? EMPTY_CO,
-      isLoading,
+      isLoading: keys.length > 0 && isLoading,
     }),
-    [map, sceneCo, isLoading],
+    [map, sceneCo, isLoading, keys.length],
   );
 }

--- a/frontend/src/lib/queries/asset-references.ts
+++ b/frontend/src/lib/queries/asset-references.ts
@@ -1,38 +1,29 @@
 // SPDX-License-Identifier: Elastic-2.0
 // Copyright (c) 2026 ClaymoreLab
 import { useMemo } from "react";
-import { useQueries, useQuery } from "@tanstack/react-query";
-import type { QueryFunctionContext } from "@tanstack/react-query";
+import { useQuery } from "@tanstack/react-query";
+import type { QueryClient } from "@tanstack/react-query";
 
 import { api } from "@/lib/api";
 import { p } from "@/lib/api-path";
 import { queryKeys } from "@/lib/query-keys";
 import type { OkResponse } from "@/types/api";
-import type { Beat, Episode } from "@/types/episode";
 
 /**
- * Client-side cross-asset reference index.
+ * Cross-asset reference index ("which beats use this asset").
  *
- * The backend does not (yet) expose `GET /assets/{type}/{id}/references`, so we
- * derive "which beats use this asset" on the FE from data already present on
- * each beat:
- *   - identities → `beat.detected_identities` (matched by `identity_id`)
- *   - props      → `beat.detected_props` (sketch color-bound) UNION the
- *                  `[[prop]]` markers inside `beat.visual_description`
- *                  (matched by prop `name`)
- *   - scenes     → `beat.scene_ref.scene_id`  (matched by scene `name`)
+ * Served by `GET /projects/{p}/assets/references` in one request: the backend
+ * makes a single pass over the beats table and returns only the reverse index.
+ * This used to be derived on the client by fetching every episode's beats and
+ * scanning them here — one request per episode, each carrying the full beat
+ * payload (sketch/frame/video URLs plus an ffprobe per audio clip) so the FE
+ * could read three fields per beat. That cost grew with episode count and is
+ * why opening the assets page fired dozens of `beats` requests.
  *
- * Props have two carriers: a prop is "in" a beat when it is either color-bound
- * on the sketch (`detected_props`) OR marked inline in the visual description
- * as `[[name]]` — the sketch workbench renders both, so the reverse index must
- * count both, otherwise a prop referenced only via the text marker (never
- * color-bound) would show zero beats.
- *
- * Matching caveat: identity matching is exact (`detected_identities` carries
- * `identity_id`). Prop/scene ids are assumed to equal the asset `name`; if the
- * backend later diverges (slug vs name), swap the key builders below. Once the
- * backend ships a references endpoint, replace the aggregation here and keep
- * the public shape.
+ * Reference keys are `"{type}:{id}"`. Id semantics follow the persisted beat
+ * contract: identity → `identity_id`, scene → `scene_ref.scene_id`, prop →
+ * prop name. Matching now happens server-side, at the source of those ids, so
+ * a backend rename can no longer silently zero out every usage count.
  */
 
 export type AssetRefType = "identity" | "scene" | "prop";
@@ -55,119 +46,75 @@ export interface AssetReferenceIndex {
   countFor: (type: AssetRefType, id: string) => number;
   /** Identities/props co-appearing in beats where this scene is used. */
   coOccurrenceForScene: (sceneId: string) => SceneCoOccurrence;
-  /** True while any episode's beats are still loading. */
+  /** True while the index is still loading. */
   isLoading: boolean;
+}
+
+interface AssetReferencesPayload {
+  references: Record<string, { episode: number; beat_number: number }[]>;
+  scene_co_occurrence: Record<string, { identities: string[]; props: string[] }>;
 }
 
 function refKey(type: AssetRefType, id: string): string {
   return `${type}:${id}`;
 }
 
+/**
+ * Drop the index after a mutation changes which assets a beat references —
+ * beat text/scene edits, manual-shot insert/delete, identity detection, colour
+ * binding. Call it alongside the `queryKeys.beats` invalidation those
+ * mutations already do; the index lives under its own project-wide key, so
+ * invalidating a single episode's beats no longer reaches it.
+ *
+ * Missing a call site here degrades to stale usage counts, not wrong data: the
+ * index inherits the default 30s staleTime and the assets page is its own
+ * route, so returning to it refetches. Prefer adding the call anyway.
+ */
+export function invalidateAssetReferences(
+  qc: QueryClient,
+  project: string,
+): void {
+  qc.invalidateQueries({ queryKey: queryKeys.assetReferences(project) });
+}
+
 const EMPTY: BeatReference[] = [];
 const EMPTY_CO: SceneCoOccurrence = { identities: [], props: [] };
 
-/** Inline `[[prop]]` markers inside a beat's visual description. */
-function extractMarkedProps(visualDescription: string): string[] {
-  const out: string[] = [];
-  for (const m of visualDescription.matchAll(/\[\[([^\]]+)\]\]/g)) {
-    const id = (m[1] ?? "").trim();
-    if (id) out.push(id);
-  }
-  return out;
-}
-
 export function useAssetReferenceIndex(project: string): AssetReferenceIndex {
-  const episodesRes = useQuery({
-    queryKey: queryKeys.episodes(project),
+  const { data, isLoading } = useQuery({
+    queryKey: queryKeys.assetReferences(project),
     queryFn: ({ signal }) =>
       api
-        .get(p`api/v1/projects/${project}/episodes`, { signal })
-        .json<OkResponse<Episode[]>>(),
+        .get(p`api/v1/projects/${project}/assets/references`, { signal })
+        .json<OkResponse<AssetReferencesPayload>>(),
     enabled: !!project,
   });
 
-  const episodeNumbers = useMemo(
-    () => (episodesRes.data?.data ?? []).map((e) => e.number),
-    [episodesRes.data?.data],
-  );
-
-  const beatQueries = useQueries({
-    queries: episodeNumbers.map((episode) => ({
-      queryKey: queryKeys.beats(project, episode),
-      queryFn: ({ signal }: QueryFunctionContext) =>
-        api
-          .get(p`api/v1/projects/${project}/episodes/${episode}/beats`, {
-            signal,
-          })
-          .json<OkResponse<Beat[]>>(),
-      enabled: !!project && episode > 0,
-    })),
-  });
-
-  const isLoading =
-    episodesRes.isLoading || beatQueries.some((q) => q.isLoading);
-
-  // Stable, fixed-shape dependency: the deps array length must not vary across
-  // renders, so collapse all per-episode query freshness into one signature.
-  const dataSignature = beatQueries
-    .map((q) => q.dataUpdatedAt)
-    .join(",");
-  const beatsByEpisode = beatQueries.map((q) => q.data?.data);
-
   const { map, sceneCo } = useMemo(() => {
     const acc = new Map<string, BeatReference[]>();
-    const co = new Map<string, { identities: Set<string>; props: Set<string> }>();
-    const push = (key: string, ref: BeatReference) => {
-      const prev = acc.get(key);
-      if (prev) prev.push(ref);
-      else acc.set(key, [ref]);
-    };
-    beatsByEpisode.forEach((beats, i) => {
-      const episode = episodeNumbers[i];
-      if (!beats) return;
-      for (const beat of beats) {
-        const ref: BeatReference = { episode, beatNumber: beat.beat_number };
-        const beatIdentities = beat.detected_identities ?? [];
-        const beatProps = [
-          ...new Set([
-            ...(beat.detected_props ?? []),
-            ...extractMarkedProps(beat.visual_description ?? ""),
-          ]),
-        ];
-        for (const id of beatIdentities) {
-          push(refKey("identity", id), ref);
-        }
-        for (const id of beatProps) {
-          push(refKey("prop", id), ref);
-        }
-        const sceneId = beat.scene_ref?.scene_id;
-        if (sceneId) {
-          push(refKey("scene", sceneId), ref);
-          let bucket = co.get(sceneId);
-          if (!bucket) {
-            bucket = { identities: new Set(), props: new Set() };
-            co.set(sceneId, bucket);
-          }
-          for (const id of beatIdentities) bucket.identities.add(id);
-          for (const id of beatProps) bucket.props.add(id);
-        }
-      }
-    });
+    const co = new Map<string, SceneCoOccurrence>();
+    for (const [key, refs] of Object.entries(data?.data?.references ?? {})) {
+      acc.set(
+        key,
+        refs.map((ref) => ({ episode: ref.episode, beatNumber: ref.beat_number })),
+      );
+    }
+    for (const [sceneId, bucket] of Object.entries(
+      data?.data?.scene_co_occurrence ?? {},
+    )) {
+      co.set(sceneId, {
+        identities: bucket.identities ?? [],
+        props: bucket.props ?? [],
+      });
+    }
     return { map: acc, sceneCo: co };
-  }, [episodeNumbers, dataSignature]);
+  }, [data]);
 
   return useMemo(
     () => ({
       referencesFor: (type, id) => map.get(refKey(type, id)) ?? EMPTY,
       countFor: (type, id) => map.get(refKey(type, id))?.length ?? 0,
-      coOccurrenceForScene: (sceneId) => {
-        const bucket = sceneCo.get(sceneId);
-        if (!bucket) return EMPTY_CO;
-        return {
-          identities: [...bucket.identities].sort((a, b) => a.localeCompare(b)),
-          props: [...bucket.props].sort((a, b) => a.localeCompare(b)),
-        };
-      },
+      coOccurrenceForScene: (sceneId) => sceneCo.get(sceneId) ?? EMPTY_CO,
       isLoading,
     }),
     [map, sceneCo, isLoading],

--- a/frontend/src/lib/queries/characters.ts
+++ b/frontend/src/lib/queries/characters.ts
@@ -1,13 +1,7 @@
 // SPDX-License-Identifier: Elastic-2.0
 // Copyright (c) 2026 ClaymoreLab
 import { useMemo } from "react";
-import {
-  useQueries,
-  useQuery,
-  useMutation,
-  useQueryClient,
-} from "@tanstack/react-query";
-import type { QueryFunctionContext } from "@tanstack/react-query";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { jsonWithBackendError } from "@/lib/api-errors";
 import { api, uploadApi } from "@/lib/api";
 import { p } from "@/lib/api-path";
@@ -383,10 +377,16 @@ export function useCharacterIdentities(project: string, name: string) {
 }
 
 /**
- * Maps `identity_id` → owning character name by fanning out the per-character
- * identity lists. Used to resolve a `?type=identity&id=` deep link to the
- * character that owns it (the identity list is otherwise lazy-loaded per
- * selected character). React Query dedupes these with the per-card fetches.
+ * Maps `identity_id` → owning character name, to resolve a `?type=identity&id=`
+ * deep link to the character that owns it.
+ *
+ * Built from `identity_ids` on the character list — one request, the same one
+ * the page already makes. This used to fan out `/characters/{name}/identities`
+ * for every character in the project, unconditionally on mount: a project with
+ * 100 characters fired 100 requests on every visit to the assets page, whether
+ * or not a deep link was present, to build a lookup table that is usually never
+ * read. Identity *details* are still lazy per selected character; only the ids
+ * ride along with the list.
  */
 export function useIdentityOwnerIndex(project: string) {
   const charactersRes = useQuery({
@@ -398,42 +398,21 @@ export function useIdentityOwnerIndex(project: string) {
     enabled: !!project,
   });
 
-  const names = useMemo(
-    () => (charactersRes.data?.data ?? []).map((c) => c.name),
-    [charactersRes.data?.data],
-  );
-
-  const identityQueries = useQueries({
-    queries: names.map((name) => ({
-      queryKey: queryKeys.identities(project, name),
-      queryFn: ({ signal }: QueryFunctionContext) =>
-        api
-          .get(p`api/v1/projects/${project}/characters/${name}/identities`, {
-            signal,
-          })
-          .json<OkResponse<Identity[]>>(),
-      enabled: !!project && !!name,
-    })),
-  });
-
-  const dataSignature = identityQueries.map((q) => q.dataUpdatedAt).join(",");
-  const identitiesByCharacter = identityQueries.map((q) => q.data?.data);
+  const characters = charactersRes.data?.data;
 
   const ownerById = useMemo(() => {
     const acc = new Map<string, string>();
-    identitiesByCharacter.forEach((identities, i) => {
-      const name = names[i];
-      if (!identities) return;
-      for (const identity of identities) {
-        acc.set(identity.identity_id, name);
+    for (const character of characters ?? []) {
+      for (const identityId of character.identity_ids ?? []) {
+        acc.set(identityId, character.name);
       }
-    });
+    }
     return acc;
-  }, [names, dataSignature]);
+  }, [characters]);
 
   return {
     ownerOf: (identityId: string) => ownerById.get(identityId) ?? null,
-    isLoading: charactersRes.isLoading || identityQueries.some((q) => q.isLoading),
+    isLoading: charactersRes.isLoading,
   };
 }
 

--- a/frontend/src/lib/queries/characters.ts
+++ b/frontend/src/lib/queries/characters.ts
@@ -416,12 +416,33 @@ export function useIdentityOwnerIndex(project: string) {
   };
 }
 
+/**
+ * Identity create/delete changes which ids a character owns, and that set is
+ * also projected into the character list payload as `identity_ids` — which is
+ * what `useIdentityOwnerIndex` resolves `?type=identity&id=` deep links
+ * against. Invalidating only the identities key leaves that map holding a set
+ * that no longer matches, so a link to a just-created identity resolves to no
+ * owner while the page stays mounted.
+ *
+ * Mutations that edit an existing identity in place (rename, appearance, image
+ * generation) do not go through here: they never add or remove an id, so the
+ * character list stays correct and refetching it would be waste.
+ */
+function invalidateIdentityMembership(
+  qc: ReturnType<typeof useQueryClient>,
+  project: string,
+  name: string,
+): void {
+  qc.invalidateQueries({ queryKey: queryKeys.identities(project, name) });
+  qc.invalidateQueries({ queryKey: queryKeys.characters(project) });
+}
+
 export function useCreateIdentity(project: string, name: string) {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: (data: { identity_name: string; age_group?: string; appearance_details?: string }) =>
       api.post(p`api/v1/projects/${project}/characters/${name}/identities`, { json: data }).json<OkResponse<Identity>>(),
-    onSuccess: () => qc.invalidateQueries({ queryKey: queryKeys.identities(project, name) }),
+    onSuccess: () => invalidateIdentityMembership(qc, project, name),
   });
 }
 
@@ -451,7 +472,7 @@ export function useDeleteIdentity(project: string, name: string) {
   return useMutation({
     mutationFn: (identityId: string) =>
       api.delete(p`api/v1/projects/${project}/characters/${name}/identities/${identityId}`).json<OkResponse<unknown>>(),
-    onSuccess: () => qc.invalidateQueries({ queryKey: queryKeys.identities(project, name) }),
+    onSuccess: () => invalidateIdentityMembership(qc, project, name),
   });
 }
 

--- a/frontend/src/lib/queries/episodes.ts
+++ b/frontend/src/lib/queries/episodes.ts
@@ -10,6 +10,7 @@ import { api } from "@/lib/api";
 import { p } from "@/lib/api-path";
 import { jsonWithBackendError } from "@/lib/api-errors";
 import { queryKeys } from "@/lib/query-keys";
+import { invalidateAssetReferences } from "@/lib/queries/asset-references";
 import type { ApiResponse, ErrorResponse, OkResponse, TaskResponse } from "@/types/api";
 import type {
   Episode,
@@ -356,6 +357,8 @@ export function useInsertManualShot(project: string, episode: number) {
       queryClient.invalidateQueries({
         queryKey: queryKeys.script(project, episode),
       });
+      // A new beat can reference assets, which shifts every usage count.
+      invalidateAssetReferences(queryClient, project);
     },
   });
 }
@@ -382,6 +385,8 @@ export function useDeleteManualShot(project: string, episode: number) {
       queryClient.invalidateQueries({
         queryKey: queryKeys.script(project, episode),
       });
+      // Removing a beat removes every reference it carried.
+      invalidateAssetReferences(queryClient, project);
     },
   });
 }

--- a/frontend/src/lib/queries/episodes.ts
+++ b/frontend/src/lib/queries/episodes.ts
@@ -359,6 +359,8 @@ export function useInsertManualShot(project: string, episode: number) {
       });
       // A new beat can reference assets, which shifts every usage count.
       invalidateAssetReferences(queryClient, project);
+      // ...and it moves this episode's beat_count, which the list badge reads.
+      queryClient.invalidateQueries({ queryKey: queryKeys.episodes(project) });
     },
   });
 }
@@ -387,6 +389,8 @@ export function useDeleteManualShot(project: string, episode: number) {
       });
       // Removing a beat removes every reference it carried.
       invalidateAssetReferences(queryClient, project);
+      // ...and it moves this episode's beat_count, which the list badge reads.
+      queryClient.invalidateQueries({ queryKey: queryKeys.episodes(project) });
     },
   });
 }

--- a/frontend/src/lib/queries/scripts.ts
+++ b/frontend/src/lib/queries/scripts.ts
@@ -5,6 +5,7 @@ import { api } from "@/lib/api";
 import { jsonWithBackendError } from "@/lib/api-errors";
 import { p } from "@/lib/api-path";
 import { queryKeys } from "@/lib/query-keys";
+import { invalidateAssetReferences } from "@/lib/queries/asset-references";
 import type { ErrorResponse, OkResponse, TaskResponse } from "@/types/api";
 import type { Script, BeatUpdate } from "@/types/script";
 import type { Beat } from "@/types/episode";
@@ -95,6 +96,9 @@ export function useUpdateBeat(project: string, episode: number) {
       // Script view derives its text from the aggregated script payload; a
       // beat edit can change that, so keep it in sync lazily.
       qc.invalidateQueries({ queryKey: queryKeys.script(project, episode) });
+      // A beat edit can add/remove [[prop]] markers or repoint scene_ref, so
+      // the assets page's usage counts are no longer trustworthy.
+      invalidateAssetReferences(qc, project);
     },
   });
 }
@@ -110,6 +114,7 @@ export function useSaveScript(project: string, episode: number) {
         .json<OkResponse<{ episode: number; beats_count: number }>>(),
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: queryKeys.script(project, episode) });
+      invalidateAssetReferences(qc, project);
     },
   });
 }

--- a/frontend/src/lib/queries/sketches.ts
+++ b/frontend/src/lib/queries/sketches.ts
@@ -9,6 +9,7 @@ import { api, uploadApi } from "@/lib/api";
 import { jsonWithBackendError } from "@/lib/api-errors";
 import { p } from "@/lib/api-path";
 import { queryKeys } from "@/lib/query-keys";
+import { invalidateAssetReferences } from "@/lib/queries/asset-references";
 import type { ApiResponse, ErrorResponse, OkResponse, TaskResponse } from "@/types/api";
 import type { Beat } from "@/types/episode";
 
@@ -492,6 +493,9 @@ export function useAssignColors(project: string, episode: number) {
       qc.invalidateQueries({
         queryKey: queryKeys.episodeDetail(project, episode),
       });
+      // Colour binding is what writes detected_identities / detected_props,
+      // i.e. exactly the fields the asset usage counts are built from.
+      invalidateAssetReferences(qc, project);
     },
   });
 }
@@ -526,6 +530,7 @@ export function useDetectIdentities(project: string, episode: number) {
       if (!res.ok) return;
       qc.invalidateQueries({ queryKey: queryKeys.beats(project, episode) });
       qc.invalidateQueries({ queryKey: queryKeys.script(project, episode) });
+      invalidateAssetReferences(qc, project);
     },
   });
 }

--- a/frontend/src/lib/query-keys.ts
+++ b/frontend/src/lib/query-keys.ts
@@ -33,6 +33,7 @@ export const queryKeys = {
     ["projects", p, "characters", name, "asset-history", url] as const,
   identities: (p: string, name: string) =>
     ["projects", p, "characters", name, "identities"] as const,
+  assetReferences: (p: string) => ["projects", p, "asset-references"] as const,
   scenes: (p: string) => ["projects", p, "scenes"] as const,
   scenePlatePreview: (
     p: string,

--- a/frontend/src/lib/query-keys.ts
+++ b/frontend/src/lib/query-keys.ts
@@ -34,6 +34,10 @@ export const queryKeys = {
   identities: (p: string, name: string) =>
     ["projects", p, "characters", name, "identities"] as const,
   assetReferences: (p: string) => ["projects", p, "asset-references"] as const,
+  // Nested under assetReferences so one prefix invalidation drops both the
+  // project-wide counts and every per-asset detail slice.
+  assetReferenceDetail: (p: string, signature: string) =>
+    ["projects", p, "asset-references", "detail", signature] as const,
   scenes: (p: string) => ["projects", p, "scenes"] as const,
   scenePlatePreview: (
     p: string,

--- a/frontend/src/routes/_app/projects.$project/characters.lazy.tsx
+++ b/frontend/src/routes/_app/projects.$project/characters.lazy.tsx
@@ -85,7 +85,8 @@ import { UsageCountBadge } from "@/components/assets/usage-count-badge";
 import { CopyAssetLinkButton } from "@/components/assets/copy-asset-link-button";
 import { AssetBeatReferences } from "@/components/assets/asset-beat-references";
 import {
-  useAssetReferenceIndex,
+  useAssetReferenceCounts,
+  useAssetReferences,
   type AssetRefType,
   type BeatReference,
 } from "@/lib/queries/asset-references";
@@ -2371,10 +2372,25 @@ function IdentitiesGridSection({
     project,
     character.name,
   );
-  const refIndex = useAssetReferenceIndex(project);
   const deepLink = useAssetsDeepLink();
   const createIdentity = useCreateIdentity(project, character.name);
   const identities = identitiesRes?.data ?? [];
+  // Unlike the scene/prop panels, every identity card renders its beat list
+  // inline rather than behind a dialog — so the detail slice has to cover all
+  // of them. It stays one small request: these are the selected character's
+  // identities, not the project's.
+  const refCounts = useAssetReferenceCounts(project);
+  const refDetail = useAssetReferences(
+    project,
+    useMemo(
+      () =>
+        identities.map((id) => ({
+          type: "identity" as const,
+          id: id.identity_id,
+        })),
+      [identities],
+    ),
+  );
   const gridRef = useAssetFocus(
     deepLink.type === "identity" ? deepLink.id : null,
     identities.length > 0,
@@ -2470,8 +2486,14 @@ function IdentitiesGridSection({
                 imageModel={imageModel}
                 ageLabel={ageLabel}
                 roleLabel={roleLabel}
-                referenceCount={refIndex.countFor("identity", id.identity_id)}
-                references={refIndex.referencesFor("identity", id.identity_id)}
+                referenceCount={refCounts.countFor(
+                  "identity",
+                  id.identity_id,
+                )}
+                references={refDetail.referencesFor(
+                  "identity",
+                  id.identity_id,
+                )}
                 onAttempt={onAttempt}
               />
             </div>

--- a/frontend/src/routes/_app/projects.$project/episodes.$episode/script.lazy.tsx
+++ b/frontend/src/routes/_app/projects.$project/episodes.$episode/script.lazy.tsx
@@ -133,6 +133,8 @@ function ScriptTabContent() {
     invalidateKeys: [
       queryKeys.script(project, epNum),
       queryKeys.beats(project, epNum),
+      // 拆镜改变 beat_count，分集列表的镜头数角标读它。
+      queryKeys.episodes(project),
       queryKeys.pipelineStatus(project),
     ],
     showCompleteToast: false,

--- a/frontend/src/routes/_app/projects.$project/episodes.tsx
+++ b/frontend/src/routes/_app/projects.$project/episodes.tsx
@@ -556,10 +556,11 @@ function EpisodeListItem({
   propPromotion?: CreditPromotionDisplay | null;
 }) {
   const { t } = useTranslation();
-  // 镜头数量 = 该集 beats 数。复用既有的 beats 查询（无需后端新增字段）；react-query
-  // 会缓存，进入该集详情时本就要拉这份数据。未就绪时不显示，避免闪烁。
-  const { data: beatsRes } = useEpisodeBeats(project, episode.number);
-  const shotCount = beatsRes?.data.length;
+  // 镜头数直接读列表接口带出的 beat_count。这里曾经是 useEpisodeBeats(episode.number)
+  // ——每张卡片自己拉一次该集的完整 beats 载荷，只为取 .length。列表有几集就发几个
+  // 请求，每个都要解析项目上下文、开库、给每个 beat 拼 sketch/frame/video URL 并对
+  // 每条音频 fork 一次 ffprobe。改成后端一次 GROUP BY 带出来，这一页的扇出归零。
+  const shotCount = episode.beat_count;
   const planIdentities = usePlanIdentities(project);
   const identityTask = useStageTask({
     taskType: "identity_planner",

--- a/frontend/src/routes/_app/projects.$project/episodes.tsx
+++ b/frontend/src/routes/_app/projects.$project/episodes.tsx
@@ -30,7 +30,6 @@ import { useCharacters } from "@/lib/queries/characters";
 import {
   derivePipelineEpisodeStatuses,
   isPlanEpisodeAssetsResult,
-  useEpisodeBeats,
   useEpisodeDetail,
   useEpisodes,
   usePipelineStatus,
@@ -285,9 +284,14 @@ function TopBar({
   const { t } = useTranslation();
   const episodeNumber = selectedEpisode?.number ?? 0;
   const { data: episodeDetailRes } = useEpisodeDetail(project, episodeNumber);
-  const { data: beatsRes } = useEpisodeBeats(project, episodeNumber);
   const episodeDetail = episodeDetailRes?.data ?? selectedEpisode;
-  const beatCount = beatsRes?.data.length ?? 0;
+  // Same `beat_count` the cards read, from the list response — this header used
+  // to pull the auto-selected episode's whole beats payload just to take
+  // `.length`. Auto-selection is not a signal the user is heading into that
+  // episode, so nothing was being usefully prefetched: it was one more full
+  // beats request (sketch/frame/video URLs, an ffprobe per audio clip) on every
+  // visit to this page, for one integer already present in the list.
+  const beatCount = selectedEpisode?.beat_count ?? 0;
   const sourceLineCount = countContentLines(
     episodeDetail?.beat_source_text || episodeDetail?.raw_content,
   );

--- a/frontend/src/task-center/provider.tsx
+++ b/frontend/src/task-center/provider.tsx
@@ -62,6 +62,8 @@ function invalidateCompletedAssetQueries(
       queryClient.invalidateQueries({
         queryKey: queryKeys.beats(projectId, task.episode),
       });
+      // 拆镜是 beat_count 从 0 变成 N 的那一步，分集列表的镜头数角标读它。
+      queryClient.invalidateQueries({ queryKey: queryKeys.episodes(projectId) });
       queryClient.invalidateQueries({
         queryKey: queryKeys.pipelineStatus(projectId),
       });

--- a/frontend/src/task-center/provider.tsx
+++ b/frontend/src/task-center/provider.tsx
@@ -9,6 +9,7 @@ import { useTranslation } from "react-i18next";
 import { useAuthStore } from "@/stores/auth-store";
 import { useAppStore } from "@/stores/app-store";
 import { queryKeys } from "@/lib/query-keys";
+import { invalidateAssetReferences } from "@/lib/queries/asset-references";
 import { api, handleSessionExpired } from "@/lib/api";
 import { createEventBus } from "./event-bus";
 import { EventBusContext } from "./event-bus-context";
@@ -64,6 +65,10 @@ function invalidateCompletedAssetQueries(
       });
       // 拆镜是 beat_count 从 0 变成 N 的那一步，分集列表的镜头数角标读它。
       queryClient.invalidateQueries({ queryKey: queryKeys.episodes(projectId) });
+      // 拆镜整集重写 beats，身份/场景/道具的引用关系随之改变。资产索引挂在项目级
+      // key 上，逐集失效 beats 够不着它；而 staleTime 只标记陈旧、不会自动重取，
+      // 停在资产页不动的用户会一直看着旧的使用次数。
+      invalidateAssetReferences(queryClient, projectId);
       queryClient.invalidateQueries({
         queryKey: queryKeys.pipelineStatus(projectId),
       });

--- a/frontend/src/types/character.ts
+++ b/frontend/src/types/character.ts
@@ -77,6 +77,12 @@ export interface Character {
   portrait_url?: string | null;
   history_url?: string;
   restore_url?: string;
+  /**
+   * 该角色名下所有身份的 id，由角色列表接口一次带出（身份详情仍走
+   * `/characters/{name}/identities` 按需拉）。用于把 `?type=identity&id=` 深链
+   * 解析到拥有它的角色，不必逐个角色去拉身份列表。
+   */
+  identity_ids?: string[];
 }
 
 export interface Identity {

--- a/frontend/src/types/episode.ts
+++ b/frontend/src/types/episode.ts
@@ -35,6 +35,8 @@ export interface Episode {
   identity_default_map?: Record<string, string>;
   scene_menu?: EpisodeSceneMenuItem[];
   prop_menu?: EpisodePropMenuItem[];
+  /** 该集已拆出的镜头数，由列表接口一次分组查询带出。未拆镜为 0。 */
+  beat_count?: number;
 }
 
 export interface Chapter {

--- a/license-inventory.csv
+++ b/license-inventory.csv
@@ -1794,6 +1794,7 @@ tests/test_api_seedance2_prompt_route.py,Elastic-2.0,2026 SuperTale contributors
 tests/test_api_sketch_ai_detection.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_api_sketch_pose_editor.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_api_sketch_regenerate.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
+tests/test_api_store_scope_lifecycle.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_api_style_analysis_billing.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_api_styles.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_asset_compiler_prop_planning.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation

--- a/license-inventory.csv
+++ b/license-inventory.csv
@@ -511,6 +511,7 @@ frontend/src/__tests__/lib/product-surfaces.test.ts,Elastic-2.0,2026 SuperTale c
 frontend/src/__tests__/lib/project-cover.test.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/__tests__/lib/project-permissions.test.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/__tests__/lib/project-route.test.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
+frontend/src/__tests__/lib/queries/asset-references.test.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/__tests__/lib/queries/assets.test.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/__tests__/lib/queries/audio.test.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/__tests__/lib/queries/character-generation-model.test.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
@@ -523,6 +524,7 @@ frontend/src/__tests__/lib/queries/episodes.test.tsx,Elastic-2.0,2026 SuperTale 
 frontend/src/__tests__/lib/queries/freezone-beat-context.test.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/__tests__/lib/queries/generation-credit-cost.ce.test.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/__tests__/lib/queries/generation-credit-cost.test.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
+frontend/src/__tests__/lib/queries/identity-owner-index.test.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/__tests__/lib/queries/ingest.test.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/__tests__/lib/queries/model-gateway.test.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/__tests__/lib/queries/narrator-voice.test.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
@@ -593,10 +595,10 @@ frontend/src/__tests__/stores/canvas-store-undo-history.test.ts,Elastic-2.0,2026
 frontend/src/__tests__/stores/canvas-store-video-reference-limits.test.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/__tests__/stores/canvas-store-viewport-bookmarks.test.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/__tests__/stores/episode-workbench-store.test.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
-frontend/src/__tests__/stores/settings-store-feature-model-config.test.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/__tests__/stores/region-store.test.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/__tests__/stores/save-status-store.test.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/__tests__/stores/seen-pool-store.test.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
+frontend/src/__tests__/stores/settings-store-feature-model-config.test.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/__tests__/stores/store-resets.test.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/__tests__/task-center/backward-compat.test.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/__tests__/task-center/derivations.test.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
@@ -1881,6 +1883,7 @@ tests/test_literal_script_writing_audio_type.py,Elastic-2.0,2026 SuperTale contr
 tests/test_m10_final_gate.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_manual_shots.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_mcp_ce_owner.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
+tests/test_media_io_probe_concurrency.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_media_model_request_schema.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_media_relay.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_media_thumbnails.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation

--- a/license-inventory.csv
+++ b/license-inventory.csv
@@ -269,6 +269,7 @@ frontend/src/__tests__/api/style-templates-shape.test.ts,Elastic-2.0,2026 SuperT
 frontend/src/__tests__/api/task-poll-timeout.test.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/__tests__/components/account/avatar-upload-dialog.test.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/__tests__/components/assets/asset-panels-rename.test.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
+frontend/src/__tests__/components/assets/asset-tabs-beats-contract.test.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/__tests__/components/assets/character-image-source-select.test.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/__tests__/components/assets/character-search.test.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/__tests__/components/assets/character-stats-strip.test.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation

--- a/src/novelvideo/api/deps.py
+++ b/src/novelvideo/api/deps.py
@@ -195,8 +195,20 @@ async def make_sqlite_store(username: str, project: str) -> "SQLiteStore":
     return store
 
 
-async def make_sqlite_store_for_context(ctx: ProjectContext) -> "SQLiteStore":
-    """Create a SQLiteStore from the resolved project owner/home paths."""
+async def make_sqlite_store_for_context(
+    ctx: ProjectContext,
+    *,
+    load_graph_state: bool = True,
+) -> "SQLiteStore":
+    """Create a SQLiteStore from the resolved project owner/home paths.
+
+    ``load_graph_state()`` hydrates the in-memory character/episode/prop caches
+    with three full-table reads. Callers that only touch ``beats`` (and never
+    ``get_character`` / ``get_episode`` / ``get_cached_prop`` / ``resolve_name``)
+    should pass ``load_graph_state=False`` — otherwise those three reads cost
+    more than the query they precede. Default stays ``True`` so existing callers
+    keep the hydrated behaviour they rely on.
+    """
     from novelvideo.sqlite_store import SQLiteStore
 
     require_project_home_node(ctx, operation="open project SQLite store")
@@ -207,7 +219,8 @@ async def make_sqlite_store_for_context(ctx: ProjectContext) -> "SQLiteStore":
         state_dir=str(ctx.state_dir),
     )
     await store.initialize()
-    await store.load_graph_state()
+    if load_graph_state:
+        await store.load_graph_state()
     return store
 
 

--- a/src/novelvideo/api/deps.py
+++ b/src/novelvideo/api/deps.py
@@ -4,11 +4,12 @@
 项目级 API 必须先解析为 ProjectContext；username/project 只保留给路径显示与脚本工具。
 """
 
+import contextlib
 import re
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, AsyncIterator
+from typing import TYPE_CHECKING, Any, AsyncIterator
 
 from fastapi import Depends, HTTPException
 
@@ -166,6 +167,33 @@ def get_runtime_dir(username: str, project: str) -> str:
     return str(Path(RUNTIME_DIR) / username / project)
 
 
+async def _close_on_init_failure(store: "Any", *steps: "Any") -> "Any":
+    """Run a freshly constructed store's init steps, closing it if one raises.
+
+    ``SQLiteStore.initialize()`` opens the aiosqlite connection and starts its
+    background thread; ``load_graph_state()`` runs after that and can fail on a
+    corrupt or half-migrated database. Between those two points the store is
+    live but has never been handed to anyone — the ``*_scope`` wrappers below
+    only take ownership of what the factory *returns*, so their ``finally`` never
+    sees a store whose init blew up. Raising without closing here therefore
+    leaks the connection and its thread for the rest of the process, silently.
+
+    Errors from ``close()`` are swallowed on purpose: the init failure is the
+    one worth reporting, and a close that fails on a store that never finished
+    opening tells the caller nothing useful.
+    """
+    try:
+        for step in steps:
+            await step()
+    except BaseException:
+        close = getattr(store, "close", None)
+        if close is not None:
+            with contextlib.suppress(Exception):
+                await close()
+        raise
+    return store
+
+
 async def make_cognee_store(username: str, project: str) -> "CogneeStore":
     """按请求创建 CogneeStore 实例。
 
@@ -178,8 +206,7 @@ async def make_cognee_store(username: str, project: str) -> "CogneeStore":
     output_dir = get_output_dir(username, project)
     state_dir = get_state_dir(username, project)
     store = CogneeStore(project_name, output_dir=output_dir, state_dir=state_dir)
-    await store.initialize()
-    return store
+    return await _close_on_init_failure(store, store.initialize)
 
 
 async def make_sqlite_store(username: str, project: str) -> "SQLiteStore":
@@ -190,9 +217,7 @@ async def make_sqlite_store(username: str, project: str) -> "SQLiteStore":
     output_dir = get_output_dir(username, project)
     state_dir = get_state_dir(username, project)
     store = SQLiteStore(project_name, output_dir=output_dir, state_dir=state_dir)
-    await store.initialize()
-    await store.load_graph_state()
-    return store
+    return await _close_on_init_failure(store, store.initialize, store.load_graph_state)
 
 
 async def make_sqlite_store_for_context(
@@ -218,10 +243,10 @@ async def make_sqlite_store_for_context(
         output_dir=str(ctx.output_dir),
         state_dir=str(ctx.state_dir),
     )
-    await store.initialize()
+    steps = [store.initialize]
     if load_graph_state:
-        await store.load_graph_state()
-    return store
+        steps.append(store.load_graph_state)
+    return await _close_on_init_failure(store, *steps)
 
 
 async def make_cognee_store_for_context(ctx: ProjectContext) -> "CogneeStore":
@@ -234,8 +259,7 @@ async def make_cognee_store_for_context(ctx: ProjectContext) -> "CogneeStore":
         output_dir=str(ctx.output_dir),
         state_dir=str(ctx.state_dir),
     )
-    await store.initialize()
-    return store
+    return await _close_on_init_failure(store, store.initialize)
 
 
 async def _make_cognee_store_scope(username: str, project: str) -> AsyncIterator["CogneeStore"]:

--- a/src/novelvideo/api/deps.py
+++ b/src/novelvideo/api/deps.py
@@ -258,8 +258,31 @@ async def _make_sqlite_store_scope(username: str, project: str) -> AsyncIterator
             await close()
 
 
+async def _make_sqlite_store_for_context_scope(
+    ctx: ProjectContext,
+    *,
+    load_graph_state: bool = True,
+) -> AsyncIterator["SQLiteStore"]:
+    store = await make_sqlite_store_for_context(ctx, load_graph_state=load_graph_state)
+    try:
+        yield store
+    finally:
+        close = getattr(store, "close", None)
+        if close:
+            await close()
+
+
 sqlite_store_scope = asynccontextmanager(_make_sqlite_store_scope)
 cognee_store_scope = asynccontextmanager(_make_cognee_store_scope)
+
+#: ``async with`` 作用域版的 :func:`make_sqlite_store_for_context`。
+#:
+#: 裸 factory 把关闭的责任丢给每个调用点，路由里于是散落着一遍遍手抄的
+#: ``try/finally`` + ``getattr(store, "close", None)``——抄漏一处就是一条泄漏的
+#: SQLite 连接，而且是静默的。已解析出 ``ProjectContext`` 的读取路径应该用这个，
+#: 它同时透传 ``load_graph_state``：只读 beats 的路径传 ``False``，省掉三次整表
+#: 读出来的角色/分集/道具缓存水合。
+sqlite_store_for_context_scope = asynccontextmanager(_make_sqlite_store_for_context_scope)
 
 
 async def get_sqlite_store(

--- a/src/novelvideo/api/routes/assets.py
+++ b/src/novelvideo/api/routes/assets.py
@@ -55,15 +55,19 @@ def _beat_asset_refs(beat) -> tuple[list[str], list[str], str]:
     return identities, props, beat_scene_id(beat)
 
 
-async def _load_visual_beats(ctx):
-    """Read every beat, with graph-state hydration skipped.
+async def _load_beat_asset_refs(ctx):
+    """Read the reference columns of every beat, and nothing else.
 
-    ``list_visual_beats()`` touches only the beats table, so the three
-    full-table reads inside ``load_graph_state()`` would be pure overhead.
+    Two things are deliberately skipped. ``load_graph_state=False``: this scan
+    only touches the beats table, so the three full-table reads that hydrate the
+    character/episode/prop caches would be pure overhead. And
+    ``list_beat_asset_refs`` over ``list_visual_beats``: the scan reads six
+    columns per beat, while the latter selects every column and constructs a
+    validated ``NovelVisualBeat`` for each row.
     """
     store = await make_sqlite_store_for_context(ctx, load_graph_state=False)
     try:
-        return await store.list_visual_beats()
+        return await store.list_beat_asset_refs()
     finally:
         close = getattr(store, "close", None)
         if close:
@@ -96,7 +100,7 @@ async def get_project_asset_references(
     scene → ``scene_ref.scene_id``, prop → prop name.
     """
     resolved = await resolve_project_scope(project, user, required_role="viewer")
-    beats = await _load_visual_beats(resolved.ctx)
+    beats = await _load_beat_asset_refs(resolved.ctx)
 
     wanted = {key for key in (str(item or "").strip() for item in ids) if key}
     wanted_scenes = {
@@ -171,7 +175,7 @@ async def get_asset_references(
     if not target_id:
         return {"ok": False, "error": "Asset id is required"}
 
-    beats = await _load_visual_beats(resolved.ctx)
+    beats = await _load_beat_asset_refs(resolved.ctx)
     references: list[dict[str, int]] = []
     co_identities: set[str] = set()
     co_props: set[str] = set()

--- a/src/novelvideo/api/routes/assets.py
+++ b/src/novelvideo/api/routes/assets.py
@@ -8,7 +8,12 @@ from fastapi import APIRouter, Depends
 
 from novelvideo.api.auth import get_api_user
 from novelvideo.api.deps import make_sqlite_store_for_context, resolve_project_scope
-from novelvideo.models import beat_scene_id, real_detected_identities, real_detected_props
+from novelvideo.models import (
+    beat_scene_id,
+    extract_prop_ids_from_markers,
+    real_detected_identities,
+    real_detected_props,
+)
 
 router = APIRouter()
 
@@ -28,6 +33,96 @@ def _json_list(value: object) -> list[str]:
         except (TypeError, ValueError, json.JSONDecodeError):
             raw = []
     return [str(item or "").strip() for item in raw if str(item or "").strip()]
+
+
+def _beat_asset_refs(beat) -> tuple[list[str], list[str], str]:
+    """Assets referenced by one beat, as ``(identities, props, scene_id)``.
+
+    Props have two carriers and both count: a prop is "in" a beat when it is
+    color-bound on the sketch (``detected_props``) OR marked inline in the
+    visual description as ``[[name]]``. A prop that is only ever marked inline
+    would otherwise report zero references.
+    """
+    identities = real_detected_identities(
+        _json_list(getattr(beat, "detected_identities_json", "[]"))
+    )
+    props = real_detected_props(_json_list(getattr(beat, "detected_props_json", "[]")))
+    for prop_id in extract_prop_ids_from_markers(
+        str(getattr(beat, "visual_description", "") or "")
+    ):
+        if prop_id not in props:
+            props.append(prop_id)
+    return identities, props, beat_scene_id(beat)
+
+
+async def _load_visual_beats(ctx):
+    store = await make_sqlite_store_for_context(ctx)
+    try:
+        return await store.list_visual_beats()
+    finally:
+        close = getattr(store, "close", None)
+        if close:
+            await close()
+
+
+@router.get("/projects/{project}/assets/references")
+async def get_project_asset_references(
+    project: str,
+    user: dict = Depends(get_api_user),
+):
+    """Whole-project reverse index: which beats reference each asset.
+
+    The assets workbench needs a usage count on every card at once. Fetching it
+    per asset would be one request per card, and deriving it on the client means
+    pulling every episode's full beat payload (sketch/frame/video URLs, audio
+    durations) just to read three fields per beat. Both are answered here by a
+    single pass over ``list_visual_beats()`` — one SQL read, no filesystem work.
+
+    Reference keys are ``"{type}:{id}"`` so the client can look one up without
+    walking the map. Id semantics match the persisted beat contract:
+    identity → ``identity_id``, scene → ``scene_ref.scene_id``, prop → prop name.
+    """
+    resolved = await resolve_project_scope(project, user, required_role="viewer")
+    beats = await _load_visual_beats(resolved.ctx)
+
+    references: dict[str, list[dict[str, int]]] = {}
+    scene_co: dict[str, dict[str, set[str]]] = {}
+
+    def _push(key: str, ref: dict[str, int]) -> None:
+        references.setdefault(key, []).append(ref)
+
+    for beat in beats:
+        ref = {
+            "episode": int(getattr(beat, "episode_number", 0) or 0),
+            "beat_number": int(getattr(beat, "beat_number", 0) or 0),
+        }
+        identities, props, scene_id = _beat_asset_refs(beat)
+
+        for identity_id in identities:
+            _push(f"identity:{identity_id}", ref)
+        for prop_id in props:
+            _push(f"prop:{prop_id}", ref)
+        if not scene_id:
+            continue
+
+        _push(f"scene:{scene_id}", ref)
+        bucket = scene_co.setdefault(scene_id, {"identities": set(), "props": set()})
+        bucket["identities"].update(identities)
+        bucket["props"].update(props)
+
+    return {
+        "ok": True,
+        "data": {
+            "references": references,
+            "scene_co_occurrence": {
+                scene_id: {
+                    "identities": sorted(bucket["identities"]),
+                    "props": sorted(bucket["props"]),
+                }
+                for scene_id, bucket in scene_co.items()
+            },
+        },
+    }
 
 
 @router.get("/projects/{project}/assets/{asset_type}/{asset_id}/references")
@@ -52,13 +147,7 @@ async def get_asset_references(
     if not target_id:
         return {"ok": False, "error": "Asset id is required"}
 
-    store = await make_sqlite_store_for_context(resolved.ctx)
-    try:
-        beats = await store.list_visual_beats()
-    finally:
-        close = getattr(store, "close", None)
-        if close:
-            await close()
+    beats = await _load_visual_beats(resolved.ctx)
     references: list[dict[str, int]] = []
     co_identities: set[str] = set()
     co_props: set[str] = set()
@@ -66,13 +155,7 @@ async def get_asset_references(
     for beat in beats:
         episode = int(getattr(beat, "episode_number", 0) or 0)
         beat_number = int(getattr(beat, "beat_number", 0) or 0)
-        scene_id = beat_scene_id(beat)
-        detected_identities = real_detected_identities(
-            _json_list(getattr(beat, "detected_identities_json", "[]"))
-        )
-        detected_props = real_detected_props(
-            _json_list(getattr(beat, "detected_props_json", "[]"))
-        )
+        detected_identities, detected_props, scene_id = _beat_asset_refs(beat)
 
         matched = False
         if normalized_type == "identity":

--- a/src/novelvideo/api/routes/assets.py
+++ b/src/novelvideo/api/routes/assets.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Query
 
 from novelvideo.api.auth import get_api_user
 from novelvideo.api.deps import make_sqlite_store_for_context, resolve_project_scope
@@ -56,7 +56,12 @@ def _beat_asset_refs(beat) -> tuple[list[str], list[str], str]:
 
 
 async def _load_visual_beats(ctx):
-    store = await make_sqlite_store_for_context(ctx)
+    """Read every beat, with graph-state hydration skipped.
+
+    ``list_visual_beats()`` touches only the beats table, so the three
+    full-table reads inside ``load_graph_state()`` would be pure overhead.
+    """
+    store = await make_sqlite_store_for_context(ctx, load_graph_state=False)
     try:
         return await store.list_visual_beats()
     finally:
@@ -68,28 +73,44 @@ async def _load_visual_beats(ctx):
 @router.get("/projects/{project}/assets/references")
 async def get_project_asset_references(
     project: str,
+    ids: list[str] = Query(default=[]),
     user: dict = Depends(get_api_user),
 ):
     """Whole-project reverse index: which beats reference each asset.
 
-    The assets workbench needs a usage count on every card at once. Fetching it
-    per asset would be one request per card, and deriving it on the client means
-    pulling every episode's full beat payload (sketch/frame/video URLs, audio
-    durations) just to read three fields per beat. Both are answered here by a
-    single pass over ``list_visual_beats()`` — one SQL read, no filesystem work.
+    Two shapes, one scan, because the assets workbench needs two different
+    things and paying for the second everywhere is what made this slow:
 
-    Reference keys are ``"{type}:{id}"`` so the client can look one up without
-    walking the map. Id semantics match the persisted beat contract:
-    identity → ``identity_id``, scene → ``scene_ref.scene_id``, prop → prop name.
+    - ``counts`` is always returned — one integer per asset. Every card in every
+      grid shows a usage badge, and the panels sort/sum by it, so this has to
+      cover the whole project. It stays small: one int per asset, not one entry
+      per reference.
+    - ``references`` (and ``scene_co_occurrence``) are returned only for the
+      assets named in ``ids``, i.e. the ones whose beat list is actually on
+      screen. Passing every id back would make the response grow with total
+      references — the dimension that grows without bound as episodes pile up.
+
+    Callers pass ``?ids=identity:foo&ids=scene:bar``; keys are ``"{type}:{id}"``
+    throughout so a client can look one up without walking the map. Id semantics
+    match the persisted beat contract: identity → ``identity_id``,
+    scene → ``scene_ref.scene_id``, prop → prop name.
     """
     resolved = await resolve_project_scope(project, user, required_role="viewer")
     beats = await _load_visual_beats(resolved.ctx)
 
+    wanted = {key for key in (str(item or "").strip() for item in ids) if key}
+    wanted_scenes = {
+        key.split(":", 1)[1] for key in wanted if key.startswith("scene:") and ":" in key
+    }
+
+    counts: dict[str, int] = {}
     references: dict[str, list[dict[str, int]]] = {}
     scene_co: dict[str, dict[str, set[str]]] = {}
 
-    def _push(key: str, ref: dict[str, int]) -> None:
-        references.setdefault(key, []).append(ref)
+    def _record(key: str, ref: dict[str, int]) -> None:
+        counts[key] = counts.get(key, 0) + 1
+        if key in wanted:
+            references.setdefault(key, []).append(ref)
 
     for beat in beats:
         ref = {
@@ -99,13 +120,15 @@ async def get_project_asset_references(
         identities, props, scene_id = _beat_asset_refs(beat)
 
         for identity_id in identities:
-            _push(f"identity:{identity_id}", ref)
+            _record(f"identity:{identity_id}", ref)
         for prop_id in props:
-            _push(f"prop:{prop_id}", ref)
+            _record(f"prop:{prop_id}", ref)
         if not scene_id:
             continue
 
-        _push(f"scene:{scene_id}", ref)
+        _record(f"scene:{scene_id}", ref)
+        if scene_id not in wanted_scenes:
+            continue
         bucket = scene_co.setdefault(scene_id, {"identities": set(), "props": set()})
         bucket["identities"].update(identities)
         bucket["props"].update(props)
@@ -113,6 +136,7 @@ async def get_project_asset_references(
     return {
         "ok": True,
         "data": {
+            "counts": counts,
             "references": references,
             "scene_co_occurrence": {
                 scene_id: {

--- a/src/novelvideo/api/routes/assets.py
+++ b/src/novelvideo/api/routes/assets.py
@@ -7,7 +7,7 @@ import json
 from fastapi import APIRouter, Depends, Query
 
 from novelvideo.api.auth import get_api_user
-from novelvideo.api.deps import make_sqlite_store_for_context, resolve_project_scope
+from novelvideo.api.deps import resolve_project_scope, sqlite_store_for_context_scope
 from novelvideo.models import (
     beat_scene_id,
     extract_prop_ids_from_markers,
@@ -65,13 +65,8 @@ async def _load_beat_asset_refs(ctx):
     columns per beat, while the latter selects every column and constructs a
     validated ``NovelVisualBeat`` for each row.
     """
-    store = await make_sqlite_store_for_context(ctx, load_graph_state=False)
-    try:
+    async with sqlite_store_for_context_scope(ctx, load_graph_state=False) as store:
         return await store.list_beat_asset_refs()
-    finally:
-        close = getattr(store, "close", None)
-        if close:
-            await close()
 
 
 @router.get("/projects/{project}/assets/references")

--- a/src/novelvideo/api/routes/characters.py
+++ b/src/novelvideo/api/routes/characters.py
@@ -4,8 +4,10 @@ import io
 import logging
 import re
 import shutil
+from contextlib import asynccontextmanager
 from datetime import datetime
 from pathlib import Path
+from typing import AsyncIterator
 from urllib.parse import quote, urlencode
 
 from fastapi import APIRouter, Depends, UploadFile, File
@@ -21,6 +23,8 @@ from novelvideo.api.deps import (
     make_sqlite_store_for_context,
     make_static_url_for_context,
     resolve_project_scope,
+    sqlite_store_for_context_scope,
+    sqlite_store_scope,
 )
 from novelvideo.project_context import ProjectContext
 from novelvideo.novel_source import has_imported_novel, novel_import_required_response
@@ -119,6 +123,40 @@ async def _resolve_character_project(
         resolved.output_dir,
         store,
     )
+
+
+@asynccontextmanager
+async def _character_project_scope(
+    project: str,
+    user: dict,
+    *,
+    required_role: str = "editor",
+) -> "AsyncIterator[tuple[ProjectContext | None, str, str, Path, str, SQLiteStore]]":
+    """``_resolve_character_project`` 的作用域版：出了 ``async with`` 一定关连接。
+
+    裸版本把 store 直接返回给路由，而路由从头到尾没有一处 ``close()``——正常返回、
+    "角色不存在" 这类提前返回、以及中途抛错，三条路都不关。每个 SQLiteStore 背后是
+    一条 aiosqlite 连接加一个后台线程，指望 GC 回收既不及时也不保证。角色页一进去
+    就打列表、选中角色再打 identities，这两条正是资产页的常规加载路径，泄漏是按请
+    求数累积的。
+
+    元组形状与裸版本一致，改造路由只需要把赋值换成 ``async with``。
+    """
+    resolved = await resolve_project_scope(project, user, required_role=required_role)
+    store_scope = (
+        sqlite_store_for_context_scope(resolved.ctx)
+        if resolved.ctx
+        else sqlite_store_scope(resolved.username, resolved.project_name)
+    )
+    async with store_scope as store:
+        yield (
+            resolved.ctx,
+            resolved.username,
+            resolved.project_name,
+            resolved.project_dir,
+            resolved.output_dir,
+            store,
+        )
 
 
 def _character_image_selection_payload(username: str, project: str) -> dict:
@@ -578,15 +616,14 @@ async def list_characters(
     user: dict = Depends(get_api_user),
 ):
     """获取项目角色列表。"""
-    ctx, _username, _project_name, project_dir, _output_dir, store = (
-        await _resolve_character_project(project, user, required_role="viewer")
-    )
-
-    if may_run_asset_repair(ctx):
-        await _heal_path_unsafe_character_names(store, project_dir)
-    characters = await _repair_duplicate_main_characters(
-        store, store.get_all_characters()
-    )
+    async with _character_project_scope(
+        project, user, required_role="viewer"
+    ) as (ctx, _username, _project_name, project_dir, _output_dir, store):
+        if may_run_asset_repair(ctx):
+            await _heal_path_unsafe_character_names(store, project_dir)
+        characters = await _repair_duplicate_main_characters(
+            store, store.get_all_characters()
+        )
 
     data = []
     asset_project = getattr(ctx, "project_id", "") or project
@@ -846,11 +883,12 @@ async def get_character_identities(
     user: dict = Depends(get_api_user),
 ):
     """获取角色全部身份及图片。"""
-    ctx, _username, _project_name, project_dir, _output_dir, store = (
-        await _resolve_character_project(project, user, required_role="viewer")
-    )
-
-    characters = store.get_all_characters()
+    # store 只用来取角色，取完就关：后面拼载荷读的是已经在内存里的模型对象和
+    # 文件系统，不再需要连接。"角色不存在" 的提前返回因此也发生在关闭之后。
+    async with _character_project_scope(
+        project, user, required_role="viewer"
+    ) as (ctx, _username, _project_name, project_dir, _output_dir, store):
+        characters = store.get_all_characters()
 
     target = None
     for c in characters:

--- a/src/novelvideo/api/routes/characters.py
+++ b/src/novelvideo/api/routes/characters.py
@@ -610,6 +610,16 @@ async def list_characters(
                 getattr(c, "updated_at", ""),
                 tree_updated_at(project_dir / "assets" / "characters" / c.name),
             ),
+            # 只出 id，不出身份详情。资产页要把 ``?type=identity&id=`` 深链解析到
+            # 拥有它的角色，此前是遍历每个角色各调一次 ``/characters/{name}/identities``
+            # ——角色有多少个就发多少个请求，只为建一张 id→角色名 的表。身份已经随
+            # ``get_all_characters()`` 在内存里了，这里带出来不多一次查询；而带的是
+            # 一串 id，载荷不会随身份的图片/描述增长。
+            "identity_ids": [
+                str(getattr(ident, "identity_id", "") or "")
+                for ident in (getattr(c, "identities", None) or [])
+                if str(getattr(ident, "identity_id", "") or "")
+            ],
         }
         item.update(
             _character_asset_links(

--- a/src/novelvideo/api/routes/episodes.py
+++ b/src/novelvideo/api/routes/episodes.py
@@ -387,13 +387,14 @@ async def get_beats(project: str, episode_num: int, user: dict = Depends(get_api
             beat["audio_url"] = ""
 
     if audio_duration_jobs:
-        import asyncio
+        from novelvideo.utils.media_io import get_audio_durations_async
 
-        from novelvideo.utils.media_io import get_audio_duration_async
-
-        durations = await asyncio.gather(
-            *(get_audio_duration_async(path) for _, path in audio_duration_jobs),
-            return_exceptions=True,
+        # 有界并发。这里此前是对整集的音频一次性 gather——一集多少个有声镜头就同时
+        # fork 多少个 ffprobe，而且用的是默认线程池，抽干期间进程里其他阻塞调用一起
+        # 排队。真正的修法是把时长在生成时写进库、读的时候直接出（TTS 本来就量过），
+        # 这里先把扇出封顶。
+        durations = await get_audio_durations_async(
+            [path for _, path in audio_duration_jobs]
         )
         for (beat, _), value in zip(audio_duration_jobs, durations):
             if isinstance(value, (int, float)) and value > 0:

--- a/src/novelvideo/api/routes/episodes.py
+++ b/src/novelvideo/api/routes/episodes.py
@@ -1,6 +1,9 @@
 """分集列表 & 规划 & 身份端点。"""
 
+import asyncio
 import logging
+import os
+from pathlib import Path
 from typing import Literal
 
 from fastapi import APIRouter, Depends
@@ -14,6 +17,8 @@ from novelvideo.api.deps import (
     make_sqlite_store_for_context,
     make_static_url_for_context,
     resolve_project_scope,
+    sqlite_store_for_context_scope,
+    sqlite_store_scope,
 )
 from novelvideo.api.schemas import EpisodePlanRequest, EpisodeUpdate, InsertManualShotRequest
 from novelvideo.novel_source import (
@@ -29,6 +34,14 @@ logger = logging.getLogger("novelvideo.api.episodes")
 
 router = APIRouter()
 AssetCompiler = None
+
+
+def _dir_entry_names(directory: "Path") -> set[str]:
+    """目录里的文件名集合；目录不存在/不可读时当空。"""
+    try:
+        return set(os.listdir(directory))
+    except OSError:
+        return set()
 
 _EPISODE_ASSET_PLANNER_TASKS = {
     "scene": ("episode_scene_planner", "场景"),
@@ -316,17 +329,13 @@ async def get_beats(project: str, episode_num: int, user: dict = Depends(get_api
     # 从图谱读取 beats（统一数据源）。
     # get_beats_as_dicts 只读 beats 表，不碰 store 的角色/集/道具内存缓存，
     # 所以跳过 load_graph_state()——那是三次全表读，比这里的查询本身还贵。
-    store = (
-        await make_sqlite_store_for_context(resolved.ctx, load_graph_state=False)
+    store_scope = (
+        sqlite_store_for_context_scope(resolved.ctx, load_graph_state=False)
         if resolved.ctx
-        else await make_sqlite_store(resolved.username, resolved.project_name)
+        else sqlite_store_scope(resolved.username, resolved.project_name)
     )
-    try:
+    async with store_scope as store:
         beats = await store.get_beats_as_dicts(episode_num)
-    finally:
-        close = getattr(store, "close", None)
-        if close:
-            await close()
 
     # 为每个 beat 附加 sketch_url / frame_url / video_url / audio_url.
     # Asset files are named by beat_number. Do not use enumerate index here:
@@ -335,56 +344,76 @@ async def get_beats(project: str, episode_num: int, user: dict = Depends(get_api
     frames_dir = project_dir / "frames" / f"ep{episode_num:03d}"
     videos_dir = project_dir / "videos" / "beats" / f"ep{episode_num:03d}"
     audio_dir = project_dir / "audio" / f"ep{episode_num:03d}"
-    # 收集已存在的音频，循环后并发探测时长，供前端时长控件做默认值/下限（视频时长须 >= 音频）。
-    audio_duration_jobs: list[tuple[dict, str]] = []
-    for beat in beats:
-        beat["audio_duration_seconds"] = None
-        beat_num = int(beat.get("beat_number", 0) or 0)
-        if beat_num <= 0:
-            beat["sketch_url"] = ""
-            beat["frame_url"] = ""
-            beat["video_url"] = ""
-            beat["audio_url"] = ""
-            continue
-        # sketch
-        sketch_file = f"beat_{beat_num:02d}.png"
-        if (sketches_dir / sketch_file).exists():
-            rel = f"sketches/ep{episode_num:03d}/{sketch_file}"
-            beat["sketch_url"] = make_static_url_for_context(
-                resolved.ctx,
-                rel,
-                local_path=sketches_dir / sketch_file,
-            )
-        else:
-            beat["sketch_url"] = ""
-        # frame
-        frame_file = f"beat_{beat_num:02d}.png"
-        if (frames_dir / frame_file).exists():
-            rel = f"frames/ep{episode_num:03d}/{frame_file}"
-            beat["frame_url"] = make_static_url_for_context(
-                resolved.ctx, rel, local_path=frames_dir / frame_file
-            )
-        else:
-            beat["frame_url"] = ""
-        # video
-        video_file = f"beat_{beat_num:02d}.mp4"
-        if (videos_dir / video_file).exists():
-            rel = f"videos/beats/ep{episode_num:03d}/{video_file}"
-            beat["video_url"] = make_static_url_for_context(
-                resolved.ctx, rel, local_path=videos_dir / video_file
-            )
-        else:
-            beat["video_url"] = ""
-        # audio
-        audio_file = f"beat_{beat_num:02d}.mp3"
-        if (audio_dir / audio_file).exists():
-            rel = f"audio/ep{episode_num:03d}/{audio_file}"
-            beat["audio_url"] = make_static_url_for_context(
-                resolved.ctx, rel, local_path=audio_dir / audio_file
-            )
-            audio_duration_jobs.append((beat, str(audio_dir / audio_file)))
-        else:
-            beat["audio_url"] = ""
+    # 整段文件存在性探测 + URL 组装一次性搬进线程，事件循环上不留同步 syscall。
+    # 原先是逐 beat 做的：4 次 Path.exists() 找文件，命中后 project_static_url 再各
+    # 做一次 exists()+stat()——静态 URL 尾巴上的 ?v=mtime 要靠 stat 拿。一集 20 个
+    # beat 就是约 160 次 exists 加 80 次 stat，全在 async handler 里同步执行。本地
+    # SSD 上无感；OSSFS/网络盘上每次都是一个网络往返，一旦卡顿，单个 /beats 请求就
+    # 能把 Uvicorn worker 的心跳按住，同进程的其他请求跟着一起等。
+    #
+    # 现在：每个目录列一次（4 次 listdir 取代 4N 次 exists），剩下的 stat 仍是每个
+    # 命中文件一次，但整段都发生在线程里，事件循环随时可以调度别的请求。
+    def _attach_asset_urls() -> list[tuple[dict, str]]:
+        sketch_names = _dir_entry_names(sketches_dir)
+        frame_names = _dir_entry_names(frames_dir)
+        video_names = _dir_entry_names(videos_dir)
+        audio_names = _dir_entry_names(audio_dir)
+
+        # 收集已存在的音频交回给调用方并发探测时长，供前端时长控件做默认值/下限
+        # （视频时长须 >= 音频）。探测不在这个线程里做：它要 fork ffprobe，得走
+        # media_io 里那道有界并发闸门。
+        jobs: list[tuple[dict, str]] = []
+        for beat in beats:
+            beat["audio_duration_seconds"] = None
+            beat_num = int(beat.get("beat_number", 0) or 0)
+            if beat_num <= 0:
+                beat["sketch_url"] = ""
+                beat["frame_url"] = ""
+                beat["video_url"] = ""
+                beat["audio_url"] = ""
+                continue
+            # sketch
+            sketch_file = f"beat_{beat_num:02d}.png"
+            if sketch_file in sketch_names:
+                rel = f"sketches/ep{episode_num:03d}/{sketch_file}"
+                beat["sketch_url"] = make_static_url_for_context(
+                    resolved.ctx,
+                    rel,
+                    local_path=sketches_dir / sketch_file,
+                )
+            else:
+                beat["sketch_url"] = ""
+            # frame
+            frame_file = f"beat_{beat_num:02d}.png"
+            if frame_file in frame_names:
+                rel = f"frames/ep{episode_num:03d}/{frame_file}"
+                beat["frame_url"] = make_static_url_for_context(
+                    resolved.ctx, rel, local_path=frames_dir / frame_file
+                )
+            else:
+                beat["frame_url"] = ""
+            # video
+            video_file = f"beat_{beat_num:02d}.mp4"
+            if video_file in video_names:
+                rel = f"videos/beats/ep{episode_num:03d}/{video_file}"
+                beat["video_url"] = make_static_url_for_context(
+                    resolved.ctx, rel, local_path=videos_dir / video_file
+                )
+            else:
+                beat["video_url"] = ""
+            # audio
+            audio_file = f"beat_{beat_num:02d}.mp3"
+            if audio_file in audio_names:
+                rel = f"audio/ep{episode_num:03d}/{audio_file}"
+                beat["audio_url"] = make_static_url_for_context(
+                    resolved.ctx, rel, local_path=audio_dir / audio_file
+                )
+                jobs.append((beat, str(audio_dir / audio_file)))
+            else:
+                beat["audio_url"] = ""
+        return jobs
+
+    audio_duration_jobs = await asyncio.to_thread(_attach_asset_urls)
 
     if audio_duration_jobs:
         from novelvideo.utils.media_io import get_audio_durations_async

--- a/src/novelvideo/api/routes/episodes.py
+++ b/src/novelvideo/api/routes/episodes.py
@@ -224,18 +224,23 @@ async def list_episodes(project: str, user: dict = Depends(get_api_user)):
         else await make_sqlite_store(resolved.username, resolved.project_name)
     )
     episodes = store.get_all_episodes()
+    # 每张分集卡片都要显示镜头数。一次分组查询带上，前端就不必逐集去拉完整
+    # beats 载荷再数长度——那是「有几集发几个请求」，且每个请求都远比这个整数贵。
+    beat_counts = await store.count_beats_by_episode()
 
     data = []
     for ep in episodes:
+        number = ep.number if hasattr(ep, "number") else 0
         data.append(
             {
-                "number": ep.number if hasattr(ep, "number") else 0,
+                "number": number,
                 "title": ep.title if hasattr(ep, "title") else "",
                 "summary": (getattr(ep, "content_summary", "") or getattr(ep, "summary", "") or ""),
                 "identity_ids": list(getattr(ep, "identity_ids", []) or []),
                 "key_events": list(getattr(ep, "key_events", []) or []),
                 "scene_menu": _dump_episode_items(getattr(ep, "scene_menu", []) or []),
                 "prop_menu": _dump_episode_items(getattr(ep, "prop_menu", []) or []),
+                "beat_count": beat_counts.get(number, 0),
             }
         )
 

--- a/src/novelvideo/api/routes/episodes.py
+++ b/src/novelvideo/api/routes/episodes.py
@@ -308,13 +308,20 @@ async def get_beats(project: str, episode_num: int, user: dict = Depends(get_api
     resolved = await resolve_project_scope(project, user, required_role="viewer")
     project_dir = resolved.project_dir
 
-    # 从图谱读取 beats（统一数据源）
+    # 从图谱读取 beats（统一数据源）。
+    # get_beats_as_dicts 只读 beats 表，不碰 store 的角色/集/道具内存缓存，
+    # 所以跳过 load_graph_state()——那是三次全表读，比这里的查询本身还贵。
     store = (
-        await make_sqlite_store_for_context(resolved.ctx)
+        await make_sqlite_store_for_context(resolved.ctx, load_graph_state=False)
         if resolved.ctx
         else await make_sqlite_store(resolved.username, resolved.project_name)
     )
-    beats = await store.get_beats_as_dicts(episode_num)
+    try:
+        beats = await store.get_beats_as_dicts(episode_num)
+    finally:
+        close = getattr(store, "close", None)
+        if close:
+            await close()
 
     # 为每个 beat 附加 sketch_url / frame_url / video_url / audio_url.
     # Asset files are named by beat_number. Do not use enumerate index here:

--- a/src/novelvideo/api/routes/generation.py
+++ b/src/novelvideo/api/routes/generation.py
@@ -850,13 +850,23 @@ def _merge_seedance2_request_config(
 
 
 async def _api_audio_duration_seconds(output_dir: str | Path, episode: int, beat_num: int):
+    """Duration of one beat's audio, or ``None`` if there isn't one to report.
+
+    ``None`` already means "no duration for this beat" here (the file may simply
+    not have been generated yet), so a probe that fails or times out reports the
+    same thing rather than failing the whole beat list. On network storage an
+    unreadable file is a routine condition, not a request-level error.
+    """
     from novelvideo.utils.media_io import get_audio_duration_async
     from novelvideo.utils.path_resolver import PathResolver
 
     audio_path = PathResolver(output_dir, episode).audio(beat_num)
     if not audio_path.exists():
         return None
-    return await get_audio_duration_async(str(audio_path))
+    try:
+        return await get_audio_duration_async(str(audio_path))
+    except Exception:
+        return None
 
 
 async def _prepare_seedance2_api_beat(

--- a/src/novelvideo/api/routes/scripts.py
+++ b/src/novelvideo/api/routes/scripts.py
@@ -49,13 +49,23 @@ def _requester_user_id_for_billing(resolved: Any, user: dict) -> str:
 
 
 async def _audio_duration_seconds(output_dir: str | Path, episode: int, beat_num: int):
+    """Duration of one beat's audio, or ``None`` if there isn't one to report.
+
+    ``None`` already means "no duration for this beat" here (the file may simply
+    not have been generated yet), so a probe that fails or times out reports the
+    same thing rather than failing the whole beat list. On network storage an
+    unreadable file is a routine condition, not a request-level error.
+    """
     from novelvideo.utils.media_io import get_audio_duration_async
     from novelvideo.utils.path_resolver import PathResolver
 
     audio_path = PathResolver(str(output_dir), episode).audio(beat_num)
     if not audio_path.exists():
         return None
-    return await get_audio_duration_async(str(audio_path))
+    try:
+        return await get_audio_duration_async(str(audio_path))
+    except Exception:
+        return None
 
 
 def _first_existing_path(*paths: Path) -> str:

--- a/src/novelvideo/cognee/store.py
+++ b/src/novelvideo/cognee/store.py
@@ -50,6 +50,7 @@ from novelvideo.utils.path_resolver import (  # noqa: F401
 )
 
 from novelvideo.models import (
+    BeatAssetRefRow,
     CharacterIdentity,
     NovelCharacter,
     NovelEpisode,
@@ -2316,6 +2317,10 @@ class CogneeStore:
     async def list_visual_beats(self) -> List[NovelVisualBeat]:
         """列出所有视觉节拍。"""
         return await self.sqlite_store.list_visual_beats()
+
+    async def list_beat_asset_refs(self) -> List[BeatAssetRefRow]:
+        """每个 beat 的资产引用字段（只取六列，不构造 Beat 对象）。"""
+        return await self.sqlite_store.list_beat_asset_refs()
 
     async def get_character_from_graph(self, name: str) -> Optional[NovelCharacter]:
         """从 SQLite 获取角色（兼容旧接口名）。"""

--- a/src/novelvideo/cognee/store.py
+++ b/src/novelvideo/cognee/store.py
@@ -2325,6 +2325,10 @@ class CogneeStore:
         """从 SQLite 获取剧集（兼容旧接口名）。"""
         return await self.sqlite_store.get_episode_from_graph(number)
 
+    async def count_beats_by_episode(self) -> Dict[int, int]:
+        """每集的 Beat 数（一次分组查询，不构造 Beat 对象）。"""
+        return await self.sqlite_store.count_beats_by_episode()
+
     async def get_beats_for_episode(self, number: int) -> List[NovelVisualBeat]:
         """获取指定剧集的所有 Beat。"""
         return await self.sqlite_store.get_beats_for_episode(number)

--- a/src/novelvideo/models.py
+++ b/src/novelvideo/models.py
@@ -5,6 +5,7 @@
 
 import json
 import re
+from dataclasses import dataclass
 from datetime import datetime
 from enum import Enum
 from typing import Any, Dict, List, Optional
@@ -202,6 +203,48 @@ def build_scene_ref(
     scene_id = (scene_id or "").strip()
     variant_id = (variant_id or "").strip()
     return SceneRef(scene_id=scene_id, variant_id=variant_id) if scene_id else None
+
+
+def parse_scene_ref_json(raw: str | None) -> SceneRef | None:
+    """Decode a persisted ``scene_ref_json`` column. Empty/corrupt → ``None``."""
+    if not raw:
+        return None
+    try:
+        return _coerce_scene_ref(json.loads(raw))
+    except (TypeError, ValueError, json.JSONDecodeError):
+        return None
+
+
+@dataclass(frozen=True, slots=True)
+class BeatAssetRefRow:
+    """One beat reduced to the columns the asset-reference scan actually reads.
+
+    That scan walks every beat in the project to answer "which beats use this
+    asset". Materialising a full :class:`NovelVisualBeat` per row to read six
+    fields is the expensive half: ~20 columns off ``SELECT *`` plus a pydantic
+    validator that re-serialises ``scene_ref_json`` and back-fills narration and
+    visual_description defaults — work whose only output is discarded.
+
+    Attribute names match :class:`NovelVisualBeat` (including the ``scene_ref``
+    property), so ``beat_scene_id`` and the scan's field readers treat both
+    shapes identically.
+    """
+
+    episode_number: int
+    beat_number: int
+    visual_description: str
+    detected_identities_json: str
+    detected_props_json: str
+    scene_ref_json: str
+
+    @property
+    def scene_ref(self) -> SceneRef | None:
+        return parse_scene_ref_json(self.scene_ref_json)
+
+    @property
+    def scene_id(self) -> str:
+        scene_ref = self.scene_ref
+        return scene_ref.scene_id if scene_ref else ""
 
 
 def beat_scene_ref(value: Any) -> SceneRef | None:
@@ -1441,12 +1484,7 @@ class NovelVisualBeat(BaseModel):
 
     @property
     def scene_ref(self) -> SceneRef | None:
-        if not self.scene_ref_json:
-            return None
-        try:
-            return _coerce_scene_ref(json.loads(self.scene_ref_json))
-        except (TypeError, ValueError, json.JSONDecodeError):
-            return None
+        return parse_scene_ref_json(self.scene_ref_json)
 
     @property
     def scene_id(self) -> str:

--- a/src/novelvideo/sqlite_store.py
+++ b/src/novelvideo/sqlite_store.py
@@ -20,6 +20,7 @@ import aiosqlite
 from rich.console import Console
 
 from novelvideo.models import (
+    BeatAssetRefRow,
     CharacterIdentity,
     NovelCharacter,
     NovelEpisode,
@@ -1874,6 +1875,33 @@ class SQLiteStore:
         async with db.execute("SELECT * FROM beats ORDER BY episode_number, beat_number") as cursor:
             rows = await cursor.fetchall()
         return [self._row_to_visual_beat(row) for row in rows]
+
+    async def list_beat_asset_refs(self) -> List[BeatAssetRefRow]:
+        """每个 beat 的资产引用字段，只取用得上的六列。
+
+        资产反向索引要扫全项目的 beats。走 ``list_visual_beats()`` 的话，每行都是
+        ``SELECT *`` 出约 20 列、再构造一个完整 ``NovelVisualBeat``——那个 pydantic
+        validator 还会把 ``scene_ref_json`` 反序列化再序列化回去、给 narration 和
+        visual_description 填默认值。这些结果扫描一个都不读。
+        """
+        db = await self._ensure_db()
+        async with db.execute(
+            "SELECT episode_number, beat_number, visual_description, "
+            "detected_identities_json, detected_props_json, scene_ref_json "
+            "FROM beats ORDER BY episode_number, beat_number"
+        ) as cursor:
+            rows = await cursor.fetchall()
+        return [
+            BeatAssetRefRow(
+                episode_number=int(row["episode_number"] or 0),
+                beat_number=int(row["beat_number"] or 0),
+                visual_description=row["visual_description"] or "",
+                detected_identities_json=row["detected_identities_json"] or "[]",
+                detected_props_json=row["detected_props_json"] or "[]",
+                scene_ref_json=row["scene_ref_json"] or "",
+            )
+            for row in rows
+        ]
 
     async def count_beats_by_episode(self) -> Dict[int, int]:
         """每集的 beat 数，一次分组查询。

--- a/src/novelvideo/sqlite_store.py
+++ b/src/novelvideo/sqlite_store.py
@@ -1875,6 +1875,21 @@ class SQLiteStore:
             rows = await cursor.fetchall()
         return [self._row_to_visual_beat(row) for row in rows]
 
+    async def count_beats_by_episode(self) -> Dict[int, int]:
+        """每集的 beat 数，一次分组查询。
+
+        分集列表要在每张卡片上显示镜头数。前端此前是逐集调
+        ``GET /episodes/{n}/beats`` 再取 ``len()``——有几集就发几个请求，每个都要
+        解析项目上下文、开库、构造完整 beat 载荷（含 sketch/frame/video URL 与
+        每条音频一次 ffprobe），只为了拿一个整数。
+        """
+        db = await self._ensure_db()
+        async with db.execute(
+            "SELECT episode_number, COUNT(*) AS n FROM beats GROUP BY episode_number"
+        ) as cursor:
+            rows = await cursor.fetchall()
+        return {int(row["episode_number"]): int(row["n"]) for row in rows}
+
     async def get_beats_for_episode(self, number: int) -> List[NovelVisualBeat]:
         db = await self._ensure_db()
         async with db.execute(

--- a/src/novelvideo/utils/media_io.py
+++ b/src/novelvideo/utils/media_io.py
@@ -10,8 +10,26 @@ from pathlib import Path
 from novelvideo.utils.async_ops import call_blocking
 
 
-def get_audio_duration(audio_path: str) -> float:
-    """Return audio duration in seconds using ffprobe."""
+# ffprobe only reads the format header, which is milliseconds of work on a
+# healthy file — this ceiling exists for the unhealthy one. On network-backed
+# storage (OSSFS) a read can stall indefinitely, and without a timeout the probe
+# stalls with it: the worker thread never returns, so the concurrency gate below
+# fills up with processes that will never exit and every later probe queues
+# behind them. Ten seconds is ~1000x the honest cost of the call.
+_PROBE_TIMEOUT_SECONDS = 10.0
+
+
+def get_audio_duration(audio_path: str, *, timeout: float | None = _PROBE_TIMEOUT_SECONDS) -> float:
+    """Return audio duration in seconds using ffprobe.
+
+    Raises ``subprocess.TimeoutExpired`` when the probe outlives ``timeout``;
+    the child is killed first. This deliberately does not fall back to the 5.0
+    below: that value means "ffprobe answered, and the answer was unusable",
+    and handing it back for a probe that never answered would let a stalled
+    mount quietly become a plausible-looking duration. Callers that want a
+    total instead of an exception map it to ``None``; see
+    :func:`get_audio_durations_async`.
+    """
     import subprocess
 
     cmd = [
@@ -24,7 +42,7 @@ def get_audio_duration(audio_path: str) -> float:
         "default=noprint_wrappers=1:nokey=1",
         audio_path,
     ]
-    result = subprocess.run(cmd, capture_output=True, text=True)
+    result = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
     try:
         return float(result.stdout.strip())
     except Exception:
@@ -32,7 +50,12 @@ def get_audio_duration(audio_path: str) -> float:
 
 
 async def get_audio_duration_async(audio_path: str) -> float:
-    """Return audio duration without blocking the event loop."""
+    """Return audio duration without blocking the event loop.
+
+    Propagates the timeout from :func:`get_audio_duration` rather than
+    swallowing it — an API handler that awaits this wants to know the probe
+    never answered, not to receive a made-up number.
+    """
     return await call_blocking(get_audio_duration, audio_path)
 
 
@@ -65,7 +88,11 @@ async def get_audio_durations_async(paths: "Sequence[str]") -> "list[float | Non
     """Probe many audio files with bounded concurrency.
 
     Returns one entry per input, positionally aligned; ``None`` where the probe
-    failed, so a single unreadable file cannot fail the batch.
+    failed or timed out, so a single unreadable file cannot fail the batch.
+
+    Worst-case wall time is bounded: ``ceil(len(paths) / _PROBE_CONCURRENCY) *
+    _PROBE_TIMEOUT_SECONDS``. Before the timeout existed there was no such
+    bound — one stalled file held its semaphore slot forever.
     """
     if not paths:
         return []

--- a/src/novelvideo/utils/media_io.py
+++ b/src/novelvideo/utils/media_io.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import asyncio
+import weakref
+from collections.abc import Sequence
 from pathlib import Path
 
 from novelvideo.utils.async_ops import call_blocking
@@ -31,6 +34,52 @@ def get_audio_duration(audio_path: str) -> float:
 async def get_audio_duration_async(audio_path: str) -> float:
     """Return audio duration without blocking the event loop."""
     return await call_blocking(get_audio_duration, audio_path)
+
+
+# Each probe forks an ffprobe process from a shared thread-pool worker. Left
+# unbounded, one request for a long episode fans out one fork per audio beat at
+# once — and because `call_blocking` uses the default executor, it also starves
+# every other blocking call in the process while it drains. The cap is global,
+# not per-request: two concurrent episode reads must not multiply it.
+_PROBE_CONCURRENCY = 8
+_probe_semaphores: "weakref.WeakKeyDictionary[asyncio.AbstractEventLoop, asyncio.Semaphore]" = (
+    weakref.WeakKeyDictionary()
+)
+
+
+def _probe_semaphore() -> "asyncio.Semaphore":
+    """The probe gate for the running loop.
+
+    Keyed per loop rather than created once at import: a semaphore binds to the
+    loop that first awaits it, and the test suite runs many loops in one process.
+    """
+    loop = asyncio.get_running_loop()
+    semaphore = _probe_semaphores.get(loop)
+    if semaphore is None:
+        semaphore = asyncio.Semaphore(_PROBE_CONCURRENCY)
+        _probe_semaphores[loop] = semaphore
+    return semaphore
+
+
+async def get_audio_durations_async(paths: "Sequence[str]") -> "list[float | None]":
+    """Probe many audio files with bounded concurrency.
+
+    Returns one entry per input, positionally aligned; ``None`` where the probe
+    failed, so a single unreadable file cannot fail the batch.
+    """
+    if not paths:
+        return []
+
+    semaphore = _probe_semaphore()
+
+    async def probe(path: str) -> "float | None":
+        async with semaphore:
+            try:
+                return await get_audio_duration_async(path)
+            except Exception:
+                return None
+
+    return list(await asyncio.gather(*(probe(path) for path in paths)))
 
 
 async def crop_image_to_path(

--- a/tests/contract/test_m03_episodes_scripts_content.py
+++ b/tests/contract/test_m03_episodes_scripts_content.py
@@ -197,6 +197,7 @@ def m03_client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     (tmp_path / "novel.txt").write_text("测试原文", encoding="utf-8")
 
     from novelvideo.api import auth as api_auth
+    from novelvideo.api import deps
     from novelvideo.api.deps import ProjectResolution
     from novelvideo.api.routes import content, episodes, scripts
     from novelvideo.ports.local.usage import NoOpUsageMeter
@@ -244,6 +245,13 @@ def m03_client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
             "get_task_backend",
             lambda: SimpleNamespace(enqueue_project_task=enqueue_project_task),
         )
+
+    # ``/beats`` opens its store through ``sqlite_store_for_context_scope`` /
+    # ``sqlite_store_scope``, and those wrappers resolve the factory as a ``deps``
+    # global when they run — so the per-module patches above never reach that one
+    # route, and it would fall through to the real factory.
+    monkeypatch.setattr(deps, "make_sqlite_store_for_context", make_store_for_context)
+    monkeypatch.setattr(deps, "make_sqlite_store", make_store)
 
     monkeypatch.setattr(content, "resolve_project_scope", resolve_project_scope)
     monkeypatch.setattr(content, "get_usage_meter", NoOpUsageMeter)

--- a/tests/contract/test_m03_episodes_scripts_content.py
+++ b/tests/contract/test_m03_episodes_scripts_content.py
@@ -212,7 +212,7 @@ def m03_client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
             runtime_dir=str(tmp_path / "runtime"),
         )
 
-    async def make_store_for_context(_ctx):
+    async def make_store_for_context(_ctx, **_kwargs):
         return store
 
     async def make_store(username: str, project: str):

--- a/tests/contract/test_m03_episodes_scripts_content.py
+++ b/tests/contract/test_m03_episodes_scripts_content.py
@@ -104,6 +104,9 @@ class _M03Store:
     def get_all_characters(self):
         return []
 
+    async def count_beats_by_episode(self):
+        return {self.episode.number: len(self.beats)} if self.beats else {}
+
     async def get_beats_as_dicts(self, episode_num: int):
         if episode_num != self.episode.number:
             return []

--- a/tests/contract/test_m04_route_contracts.py
+++ b/tests/contract/test_m04_route_contracts.py
@@ -242,7 +242,7 @@ def m04_client_factory(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
         assert project == _PROJECT
         return ctx, "alice", _PROJECT, project_dir, str(project_dir), store
 
-    async def make_store_for_context(_ctx):
+    async def make_store_for_context(_ctx, **_kwargs):
         return store
 
     async def make_store(_username: str, _project: str):

--- a/tests/contract/test_m04_route_contracts.py
+++ b/tests/contract/test_m04_route_contracts.py
@@ -174,6 +174,9 @@ class _FakeTaskBackend:
 def m04_client_factory(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     from novelvideo import project_config
     from novelvideo.api import auth as api_auth
+    # 在函数里 import：``test_m01_auth`` 会把 ``novelvideo.api.*`` 整片从
+    # ``sys.modules`` 弹掉以 CE 模式重建 app，模块级绑定到那时是死对象，打上去会落空。
+    from novelvideo.api import deps
     from novelvideo.api.deps import ProjectResolution
     from novelvideo.api.routes import characters, generation, projects, props, styles
     from novelvideo.services.style_service import StyleService
@@ -256,6 +259,11 @@ def m04_client_factory(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setattr(projects, "resolve_project_context", resolve_project_context)
     monkeypatch.setattr(generation, "_resolve_generation_project", resolve_project_scope)
     monkeypatch.setattr(characters, "_resolve_character_project", resolve_character_project)
+    monkeypatch.setattr(characters, "make_sqlite_store_for_context", make_store_for_context)
+    # 打在 ``deps`` 上：角色列表 / identities 走 ``_character_project_scope``，里头的
+    # ``sqlite_store_for_context_scope`` 是按 ``deps`` 模块全局解析工厂的，打 route
+    # 模块够不着——同时也把 scope 的 ``finally: close()`` 纳进了这条合同的覆盖面。
+    monkeypatch.setattr(deps, "make_sqlite_store_for_context", make_store_for_context)
     monkeypatch.setattr(props, "make_sqlite_store_for_context", make_store_for_context)
     monkeypatch.setattr(props, "make_sqlite_store", make_store)
     monkeypatch.setattr(projects, "make_sqlite_store_for_context", make_store_for_context)

--- a/tests/contract/test_m05_route_contracts.py
+++ b/tests/contract/test_m05_route_contracts.py
@@ -344,7 +344,7 @@ def m05_client_factory(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
         store.resolved_roles.append(("scenes", required_role))
         return ctx, "alice", _PROJECT, project_dir, str(project_dir), store
 
-    async def make_store_for_context(_ctx):
+    async def make_store_for_context(_ctx, **_kwargs):
         return store
 
     monkeypatch.setattr(scenes, "_resolve_scene_project", resolve_scene_project)

--- a/tests/contract/test_m06_route_contracts.py
+++ b/tests/contract/test_m06_route_contracts.py
@@ -292,7 +292,7 @@ def m06_client_factory(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
         assert project_id == _PROJECT
         return ctx
 
-    async def make_store_for_context(_ctx):
+    async def make_store_for_context(_ctx, **_kwargs):
         return store
 
     async def beat_for_capture(*_args, **_kwargs):

--- a/tests/contract/test_m09_route_contracts.py
+++ b/tests/contract/test_m09_route_contracts.py
@@ -138,7 +138,7 @@ class _M09Store:
         assert episode == 1
         return [dict(beat) for beat in self.beats]
 
-    async def list_visual_beats(self):
+    async def list_beat_asset_refs(self):
         return [
             SimpleNamespace(
                 episode_number=1,

--- a/tests/contract/test_m09_route_contracts.py
+++ b/tests/contract/test_m09_route_contracts.py
@@ -288,7 +288,7 @@ def m09_client_factory(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
         assert project == _PROJECT
         return resolution
 
-    async def make_store_for_context(_ctx):
+    async def make_store_for_context(_ctx, **_kwargs):
         return store
 
     async def make_store(username: str, project: str):

--- a/tests/contract/test_m09_route_contracts.py
+++ b/tests/contract/test_m09_route_contracts.py
@@ -212,6 +212,11 @@ class _FakeCreditQuote:
 @pytest.fixture()
 def m09_client_factory(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     from novelvideo.api import auth as api_auth
+    # Imported here rather than at module scope on purpose: ``test_m01_auth``
+    # pops every ``novelvideo.api.*`` entry out of ``sys.modules`` to rebuild the
+    # app in CE mode, so a module-level binding would be a dead object by the
+    # time this fixture runs, and patching it would silently miss the routes.
+    from novelvideo.api import deps
     from novelvideo.api.deps import ProjectResolution
     from novelvideo.api.routes import assets, files, generation
     from novelvideo.generators.video_pool_indexer import add_video_to_pool
@@ -342,7 +347,11 @@ def m09_client_factory(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
 
     monkeypatch.setattr(files, "resolve_project_scope", resolve_project_scope)
     monkeypatch.setattr(assets, "resolve_project_scope", resolve_project_scope)
-    monkeypatch.setattr(assets, "make_sqlite_store_for_context", make_store_for_context)
+    # On ``deps``: the assets route opens its store through
+    # ``sqlite_store_for_context_scope``, which looks the factory up as a ``deps``
+    # global at call time. Patching the route module would leave the real factory
+    # in play.
+    monkeypatch.setattr(deps, "make_sqlite_store_for_context", make_store_for_context)
     monkeypatch.setattr(assets, "get_project_dir", lambda username, project: project_dir, raising=False)
     monkeypatch.setattr(assets, "make_sqlite_store", make_store, raising=False)
 

--- a/tests/test_api_assets.py
+++ b/tests/test_api_assets.py
@@ -1792,7 +1792,7 @@ async def test_asset_references_match_beat_asset_ids(monkeypatch, tmp_path):
         async def load_graph_state(self):
             return None
 
-        async def list_visual_beats(self):
+        async def list_beat_asset_refs(self):
             return [
                 NovelVisualBeat(
                     episode_number=1,
@@ -1876,7 +1876,7 @@ def _patch_asset_references(monkeypatch, tmp_path, beats):
     from novelvideo.api.routes import assets
 
     class Store:
-        async def list_visual_beats(self):
+        async def list_beat_asset_refs(self):
             return beats
 
     ctx = SimpleNamespace(

--- a/tests/test_api_assets.py
+++ b/tests/test_api_assets.py
@@ -1836,8 +1836,10 @@ async def test_asset_references_match_beat_asset_ids(monkeypatch, tmp_path):
             runtime_dir=str(tmp_path / "runtime"),
         )
 
-    async def fake_make_sqlite_store_for_context(ctx_arg):
+    async def fake_make_sqlite_store_for_context(ctx_arg, **kwargs):
         assert ctx_arg is ctx
+        # 引用查询只读 beats 表，不该带上 load_graph_state 的三次全表读。
+        assert kwargs == {"load_graph_state": False}
         return Store()
 
     monkeypatch.setattr(assets, "resolve_project_scope", fake_resolve_project_scope)
@@ -1866,6 +1868,11 @@ async def test_asset_references_match_beat_asset_ids(monkeypatch, tmp_path):
 
 
 def _patch_asset_references(monkeypatch, tmp_path, beats):
+    """Patch the assets routes onto a fixed beat list.
+
+    Returns ``(module, store_kwargs)``; ``store_kwargs`` records how the route
+    opened the store, so a test can assert the graph-state hydration is skipped.
+    """
     from novelvideo.api.routes import assets
 
     class Store:
@@ -1880,77 +1887,102 @@ def _patch_asset_references(monkeypatch, tmp_path, beats):
         state_dir=tmp_path / "state",
         runtime_dir=tmp_path / "runtime",
     )
+    store_kwargs: list[dict] = []
 
     async def fake_resolve_project_scope(project, user, *, required_role="viewer"):
         assert required_role == "viewer"
         return SimpleNamespace(ctx=ctx, username="admin", project_name="demo", project_dir=tmp_path)
 
-    async def fake_make_sqlite_store_for_context(ctx_arg):
+    async def fake_make_sqlite_store_for_context(ctx_arg, **kwargs):
         assert ctx_arg is ctx
+        store_kwargs.append(kwargs)
         return Store()
 
     monkeypatch.setattr(assets, "resolve_project_scope", fake_resolve_project_scope)
     monkeypatch.setattr(
         assets, "make_sqlite_store_for_context", fake_make_sqlite_store_for_context
     )
-    return assets
+    return assets, store_kwargs
+
+
+_REFERENCE_BEATS = [
+    NovelVisualBeat(
+        episode_number=1,
+        beat_number=12,
+        narration="n",
+        visual_description="苏清晏握着[[油泼辣子]]",
+        detected_identities_json='["苏清晏_少女"]',
+        detected_props_json='["油泼辣子"]',
+        scene_ref_json='{"scene_id": "兰州拉面馆"}',
+    ),
+    NovelVisualBeat(
+        episode_number=3,
+        beat_number=4,
+        narration="n",
+        visual_description="v",
+        detected_identities_json='["路人_青年"]',
+        detected_props_json='["木凳"]',
+        scene_ref_json='{"scene_id": "兰州拉面馆"}',
+    ),
+]
 
 
 @pytest.mark.asyncio
-async def test_project_asset_references_indexes_every_asset_in_one_pass(monkeypatch, tmp_path):
-    assets = _patch_asset_references(
-        monkeypatch,
-        tmp_path,
-        [
-            NovelVisualBeat(
-                episode_number=1,
-                beat_number=12,
-                narration="n",
-                visual_description="苏清晏握着[[油泼辣子]]",
-                detected_identities_json='["苏清晏_少女"]',
-                detected_props_json='["油泼辣子"]',
-                scene_ref_json='{"scene_id": "兰州拉面馆"}',
-            ),
-            NovelVisualBeat(
-                episode_number=3,
-                beat_number=4,
-                narration="n",
-                visual_description="v",
-                detected_identities_json='["路人_青年"]',
-                detected_props_json='["木凳"]',
-                scene_ref_json='{"scene_id": "兰州拉面馆"}',
-            ),
-        ],
-    )
+async def test_project_asset_references_counts_every_asset_in_one_pass(monkeypatch, tmp_path):
+    assets, _ = _patch_asset_references(monkeypatch, tmp_path, _REFERENCE_BEATS)
 
     res = await assets.get_project_asset_references(
-        project="proj_demo", user={"username": "admin"}
+        project="proj_demo", ids=[], user={"username": "admin"}
     )
 
     assert res["ok"] is True
+    assert res["data"]["counts"] == {
+        "identity:苏清晏_少女": 1,
+        "identity:路人_青年": 1,
+        "prop:油泼辣子": 1,
+        "prop:木凳": 1,
+        "scene:兰州拉面馆": 2,
+    }
+    # 没点开任何资产时不该附带 beat 列表——那正是随集数无限增长的那一维。
+    assert res["data"]["references"] == {}
+    assert res["data"]["scene_co_occurrence"] == {}
+
+
+@pytest.mark.asyncio
+async def test_project_asset_references_returns_beat_lists_only_for_requested_ids(
+    monkeypatch, tmp_path
+):
+    assets, _ = _patch_asset_references(monkeypatch, tmp_path, _REFERENCE_BEATS)
+
+    res = await assets.get_project_asset_references(
+        project="proj_demo",
+        ids=["scene:兰州拉面馆", "identity:苏清晏_少女"],
+        user={"username": "admin"},
+    )
+
     assert res["data"]["references"] == {
         "identity:苏清晏_少女": [{"episode": 1, "beat_number": 12}],
-        "identity:路人_青年": [{"episode": 3, "beat_number": 4}],
-        "prop:油泼辣子": [{"episode": 1, "beat_number": 12}],
-        "prop:木凳": [{"episode": 3, "beat_number": 4}],
         "scene:兰州拉面馆": [
             {"episode": 1, "beat_number": 12},
             {"episode": 3, "beat_number": 4},
         ],
     }
+    # 共现只为被请求的场景计算。
     assert res["data"]["scene_co_occurrence"] == {
         "兰州拉面馆": {
             "identities": ["苏清晏_少女", "路人_青年"],
             "props": ["木凳", "油泼辣子"],
         }
     }
+    # 计数始终覆盖全项目，与请求了哪些 id 无关。
+    assert res["data"]["counts"]["prop:木凳"] == 1
 
 
 @pytest.mark.asyncio
 async def test_project_asset_references_counts_inline_prop_markers(monkeypatch, tmp_path):
     # 只在 visual_description 里 [[标记]]、从未色绑到 detected_props 的道具，
     # 也必须算作一次引用——否则它的用量角标会恒为 0。
-    assets = _patch_asset_references(
+    assets, _ = _patch_asset_references(
         monkeypatch,
         tmp_path,
         [
@@ -1967,26 +1999,40 @@ async def test_project_asset_references_counts_inline_prop_markers(monkeypatch, 
     )
 
     res = await assets.get_project_asset_references(
-        project="proj_demo", user={"username": "admin"}
+        project="proj_demo", ids=["prop:青瓷碗"], user={"username": "admin"}
     )
 
-    assert res["data"]["references"] == {
-        "prop:青瓷碗": [{"episode": 2, "beat_number": 7}],
-        "prop:竹筷": [{"episode": 2, "beat_number": 7}],
-    }
+    assert res["data"]["counts"] == {"prop:青瓷碗": 1, "prop:竹筷": 1}
+    assert res["data"]["references"] == {"prop:青瓷碗": [{"episode": 2, "beat_number": 7}]}
     # 没有 scene_ref 的 beat 不该凭空造出一个空 key 的场景条目。
     assert res["data"]["scene_co_occurrence"] == {}
 
 
 @pytest.mark.asyncio
 async def test_project_asset_references_empty_project(monkeypatch, tmp_path):
-    assets = _patch_asset_references(monkeypatch, tmp_path, [])
+    assets, _ = _patch_asset_references(monkeypatch, tmp_path, [])
 
     res = await assets.get_project_asset_references(
-        project="proj_demo", user={"username": "admin"}
+        project="proj_demo", ids=[], user={"username": "admin"}
     )
 
-    assert res == {"ok": True, "data": {"references": {}, "scene_co_occurrence": {}}}
+    assert res == {
+        "ok": True,
+        "data": {"counts": {}, "references": {}, "scene_co_occurrence": {}},
+    }
+
+
+@pytest.mark.asyncio
+async def test_project_asset_references_skips_graph_state_hydration(monkeypatch, tmp_path):
+    # load_graph_state() 是 characters/episodes/props 三次全表读；引用索引只碰
+    # beats 表，带上它比这里的查询本身还贵。
+    assets, store_kwargs = _patch_asset_references(monkeypatch, tmp_path, _REFERENCE_BEATS)
+
+    await assets.get_project_asset_references(
+        project="proj_demo", ids=[], user={"username": "admin"}
+    )
+
+    assert store_kwargs == [{"load_graph_state": False}]
 
 
 @pytest.mark.asyncio

--- a/tests/test_api_assets.py
+++ b/tests/test_api_assets.py
@@ -1783,6 +1783,7 @@ async def test_list_props_scope_local_only_returns_episode_local_props(
 
 @pytest.mark.asyncio
 async def test_asset_references_match_beat_asset_ids(monkeypatch, tmp_path):
+    from novelvideo.api import deps
     from novelvideo.api.routes import assets
 
     class Store:
@@ -1843,8 +1844,13 @@ async def test_asset_references_match_beat_asset_ids(monkeypatch, tmp_path):
         return Store()
 
     monkeypatch.setattr(assets, "resolve_project_scope", fake_resolve_project_scope)
+    # Patched on ``deps``, not on the route module: the route now opens the store
+    # through ``sqlite_store_for_context_scope``, and that wrapper resolves the
+    # factory as a ``deps`` global when it runs. Patching the route module would
+    # leave the real factory in play and, worse, would skip the scope's
+    # ``finally`` close — the one thing the wrapper exists to guarantee.
     monkeypatch.setattr(
-        assets, "make_sqlite_store_for_context", fake_make_sqlite_store_for_context
+        deps, "make_sqlite_store_for_context", fake_make_sqlite_store_for_context
     )
 
     res = await assets.get_asset_references(
@@ -1873,6 +1879,7 @@ def _patch_asset_references(monkeypatch, tmp_path, beats):
     Returns ``(module, store_kwargs)``; ``store_kwargs`` records how the route
     opened the store, so a test can assert the graph-state hydration is skipped.
     """
+    from novelvideo.api import deps
     from novelvideo.api.routes import assets
 
     class Store:
@@ -1899,8 +1906,9 @@ def _patch_asset_references(monkeypatch, tmp_path, beats):
         return Store()
 
     monkeypatch.setattr(assets, "resolve_project_scope", fake_resolve_project_scope)
+    # On ``deps`` — see the note in ``test_asset_references_match_beat_asset_ids``.
     monkeypatch.setattr(
-        assets, "make_sqlite_store_for_context", fake_make_sqlite_store_for_context
+        deps, "make_sqlite_store_for_context", fake_make_sqlite_store_for_context
     )
     return assets, store_kwargs
 

--- a/tests/test_api_assets.py
+++ b/tests/test_api_assets.py
@@ -1865,6 +1865,130 @@ async def test_asset_references_match_beat_asset_ids(monkeypatch, tmp_path):
     }
 
 
+def _patch_asset_references(monkeypatch, tmp_path, beats):
+    from novelvideo.api.routes import assets
+
+    class Store:
+        async def list_visual_beats(self):
+            return beats
+
+    ctx = SimpleNamespace(
+        project_id="proj_demo",
+        owner_username="admin",
+        project_name="demo",
+        output_dir=tmp_path,
+        state_dir=tmp_path / "state",
+        runtime_dir=tmp_path / "runtime",
+    )
+
+    async def fake_resolve_project_scope(project, user, *, required_role="viewer"):
+        assert required_role == "viewer"
+        return SimpleNamespace(ctx=ctx, username="admin", project_name="demo", project_dir=tmp_path)
+
+    async def fake_make_sqlite_store_for_context(ctx_arg):
+        assert ctx_arg is ctx
+        return Store()
+
+    monkeypatch.setattr(assets, "resolve_project_scope", fake_resolve_project_scope)
+    monkeypatch.setattr(
+        assets, "make_sqlite_store_for_context", fake_make_sqlite_store_for_context
+    )
+    return assets
+
+
+@pytest.mark.asyncio
+async def test_project_asset_references_indexes_every_asset_in_one_pass(monkeypatch, tmp_path):
+    assets = _patch_asset_references(
+        monkeypatch,
+        tmp_path,
+        [
+            NovelVisualBeat(
+                episode_number=1,
+                beat_number=12,
+                narration="n",
+                visual_description="苏清晏握着[[油泼辣子]]",
+                detected_identities_json='["苏清晏_少女"]',
+                detected_props_json='["油泼辣子"]',
+                scene_ref_json='{"scene_id": "兰州拉面馆"}',
+            ),
+            NovelVisualBeat(
+                episode_number=3,
+                beat_number=4,
+                narration="n",
+                visual_description="v",
+                detected_identities_json='["路人_青年"]',
+                detected_props_json='["木凳"]',
+                scene_ref_json='{"scene_id": "兰州拉面馆"}',
+            ),
+        ],
+    )
+
+    res = await assets.get_project_asset_references(
+        project="proj_demo", user={"username": "admin"}
+    )
+
+    assert res["ok"] is True
+    assert res["data"]["references"] == {
+        "identity:苏清晏_少女": [{"episode": 1, "beat_number": 12}],
+        "identity:路人_青年": [{"episode": 3, "beat_number": 4}],
+        "prop:油泼辣子": [{"episode": 1, "beat_number": 12}],
+        "prop:木凳": [{"episode": 3, "beat_number": 4}],
+        "scene:兰州拉面馆": [
+            {"episode": 1, "beat_number": 12},
+            {"episode": 3, "beat_number": 4},
+        ],
+    }
+    assert res["data"]["scene_co_occurrence"] == {
+        "兰州拉面馆": {
+            "identities": ["苏清晏_少女", "路人_青年"],
+            "props": ["木凳", "油泼辣子"],
+        }
+    }
+
+
+@pytest.mark.asyncio
+async def test_project_asset_references_counts_inline_prop_markers(monkeypatch, tmp_path):
+    # 只在 visual_description 里 [[标记]]、从未色绑到 detected_props 的道具，
+    # 也必须算作一次引用——否则它的用量角标会恒为 0。
+    assets = _patch_asset_references(
+        monkeypatch,
+        tmp_path,
+        [
+            NovelVisualBeat(
+                episode_number=2,
+                beat_number=7,
+                narration="n",
+                visual_description="桌上放着[[青瓷碗]]和[[竹筷]]",
+                detected_identities_json="[]",
+                detected_props_json="[]",
+                scene_ref_json="",
+            )
+        ],
+    )
+
+    res = await assets.get_project_asset_references(
+        project="proj_demo", user={"username": "admin"}
+    )
+
+    assert res["data"]["references"] == {
+        "prop:青瓷碗": [{"episode": 2, "beat_number": 7}],
+        "prop:竹筷": [{"episode": 2, "beat_number": 7}],
+    }
+    # 没有 scene_ref 的 beat 不该凭空造出一个空 key 的场景条目。
+    assert res["data"]["scene_co_occurrence"] == {}
+
+
+@pytest.mark.asyncio
+async def test_project_asset_references_empty_project(monkeypatch, tmp_path):
+    assets = _patch_asset_references(monkeypatch, tmp_path, [])
+
+    res = await assets.get_project_asset_references(
+        project="proj_demo", user={"username": "admin"}
+    )
+
+    assert res == {"ok": True, "data": {"references": {}, "scene_co_occurrence": {}}}
+
+
 @pytest.mark.asyncio
 async def test_update_prop_renames_record_and_asset_directory(tmp_path, monkeypatch):
     from novelvideo.api.routes import props

--- a/tests/test_api_beats_media_urls.py
+++ b/tests/test_api_beats_media_urls.py
@@ -9,6 +9,7 @@ pytestmark = pytest.mark.m03
 
 
 def _client(monkeypatch, tmp_path):
+    from novelvideo.api import deps
     from novelvideo.api.routes import episodes
     from novelvideo.api.deps import ProjectResolution
 
@@ -45,7 +46,9 @@ def _client(monkeypatch, tmp_path):
     async def fake_make_sqlite_store(username: str, project: str):
         return FakeStore()
 
-    monkeypatch.setattr(episodes, "make_sqlite_store", fake_make_sqlite_store)
+    # On ``deps``, not on the route module: ``/beats`` opens the store through
+    # ``sqlite_store_scope``, which looks the factory up as a ``deps`` global.
+    monkeypatch.setattr(deps, "make_sqlite_store", fake_make_sqlite_store)
 
     app = FastAPI()
     app.include_router(episodes.router, prefix="/api/v1")

--- a/tests/test_api_character_voice_samples.py
+++ b/tests/test_api_character_voice_samples.py
@@ -41,17 +41,34 @@ def _patch_project(
     project_dir: Path,
     store: _CharacterStore,
 ) -> None:
-    async def fake_resolve_project(project: str, user: dict, *, required_role: str = "editor"):
-        return (
-            SimpleNamespace(project_id="proj_demo", output_dir=project_dir, is_home_node=True),
-            "admin",
-            "demo",
-            project_dir,
-            str(project_dir),
-            store,
+    # 函数内 import：``tests/contract/test_m01_auth.py`` 会把 ``novelvideo.api.*``
+    # 整片从 ``sys.modules`` 里弹掉重建 app，模块级绑定到那时是死对象，patch 会落空。
+    from novelvideo.api import deps
+
+    ctx = SimpleNamespace(project_id="proj_demo", output_dir=project_dir, is_home_node=True)
+
+    # 打在解析层，不打 ``_resolve_character_project``：角色列表和 identities 两条读取
+    # 路径走的是 ``_character_project_scope``，只打裸版本会打空。塞在这一层，两条路上
+    # 的 ``async with`` / ``try/finally`` 跑的都是真代码。
+    async def fake_resolve_project_scope(project: str, user: dict, *, required_role: str = "viewer"):
+        return SimpleNamespace(
+            ctx=ctx,
+            username="admin",
+            project_name="demo",
+            project_dir=project_dir,
+            output_dir=str(project_dir),
+            state_dir=str(project_dir),
+            runtime_dir=str(project_dir),
         )
 
-    monkeypatch.setattr(module, "_resolve_character_project", fake_resolve_project)
+    async def fake_make_store_for_context(_ctx, *, load_graph_state: bool = True):
+        return store
+
+    monkeypatch.setattr(module, "resolve_project_scope", fake_resolve_project_scope)
+    # 裸 helper 用 ``characters`` 上 import 进来的名字；scope 里的
+    # ``sqlite_store_for_context_scope`` 是在 ``deps`` 上按模块全局解析工厂的。两处都要打。
+    monkeypatch.setattr(module, "make_sqlite_store_for_context", fake_make_store_for_context)
+    monkeypatch.setattr(deps, "make_sqlite_store_for_context", fake_make_store_for_context)
     monkeypatch.setattr(
         module,
         "make_static_url_for_context",

--- a/tests/test_api_characters_asset_contract.py
+++ b/tests/test_api_characters_asset_contract.py
@@ -14,6 +14,9 @@ pytestmark = pytest.mark.m04
 class _CharacterStore:
     def __init__(self, characters: list[NovelCharacter] | None = None):
         self.characters = {character.name: character for character in characters or []}
+        # 真 SQLiteStore 背后是一条 aiosqlite 连接加一个后台线程，路由漏关就是漏一条。
+        # 这里记账，下面的用例据此断言"路由确实收口了"，而不是只断言返回码。
+        self.close_calls = 0
 
     def get_all_characters(self):
         return list(self.characters.values())
@@ -44,24 +47,42 @@ class _CharacterStore:
         # 这里的名字都是干净的，list 接口上那道存量自愈是空跑。
         return {}
 
+    async def close(self):
+        self.close_calls += 1
+
 
 def _client(monkeypatch, tmp_path, store: _CharacterStore):
+    from novelvideo.api import deps
     from novelvideo.api.routes import characters
 
     project_dir = tmp_path / "output" / "admin" / "demo"
     project_dir.mkdir(parents=True)
+    ctx = SimpleNamespace(project_id="proj_demo", output_dir=project_dir, is_home_node=True)
 
-    async def fake_resolve_project(project: str, user: dict, *, required_role: str = "editor"):
-        return (
-            SimpleNamespace(project_id="proj_demo", output_dir=project_dir, is_home_node=True),
-            "admin",
-            "demo",
-            project_dir,
-            str(project_dir),
-            store,
+    # 打在解析层而不是 ``_resolve_character_project`` 上：后者只是裸版本，读取路径
+    # 走的是 ``_character_project_scope``。把假货塞在这一层，两条路上的
+    # ``async with`` / ``try/finally`` 都是真代码在跑，``store.close()`` 才是被生产
+    # 代码调用的，用例里那些 ``close_calls`` 断言才有意义。
+    async def fake_resolve_project_scope(project: str, user: dict, *, required_role: str = "viewer"):
+        return SimpleNamespace(
+            ctx=ctx,
+            username="admin",
+            project_name="demo",
+            project_dir=project_dir,
+            output_dir=str(project_dir),
+            state_dir=str(project_dir),
+            runtime_dir=str(project_dir),
         )
 
-    monkeypatch.setattr(characters, "_resolve_character_project", fake_resolve_project)
+    async def fake_make_store_for_context(_ctx, *, load_graph_state: bool = True):
+        return store
+
+    monkeypatch.setattr(characters, "resolve_project_scope", fake_resolve_project_scope)
+    # 两处都要打。裸 ``_resolve_character_project`` 用的是 ``characters`` 上 import
+    # 进来的名字；scope 里的 ``sqlite_store_for_context_scope`` 是在 ``deps`` 上按
+    # 模块全局解析工厂的，只打 route 模块会打空——本轮修的正是这个坑。
+    monkeypatch.setattr(characters, "make_sqlite_store_for_context", fake_make_store_for_context)
+    monkeypatch.setattr(deps, "make_sqlite_store_for_context", fake_make_store_for_context)
     monkeypatch.setattr(
         characters,
         "make_static_url_for_context",
@@ -289,3 +310,87 @@ def test_delete_character_route_removes_character(monkeypatch, tmp_path):
         "data": {"name": "秦昭", "deleted": True},
     }
     assert store.get_character("秦昭") is None
+
+
+# 角色页的两条实际读取路径：进页面打角色列表，选中角色打 identities。它们此前拿到的是
+# ``_resolve_character_project()`` 返回的裸 store，正常返回、"角色不存在" 的提前返回、
+# 中途抛错三条路都没人调 ``close()``——每个请求留下一条 aiosqlite 连接加一个后台线程，
+# 指望 GC 收既不及时也不保证。下面按这三条路各钉一条。
+def test_list_characters_closes_the_store_on_the_normal_path(monkeypatch, tmp_path):
+    store = _CharacterStore([NovelCharacter(name="秦昭", role="主角")])
+    client = _client(monkeypatch, tmp_path, store)
+
+    response = client.get("/projects/demo/characters")
+
+    assert response.status_code == 200
+    assert store.close_calls == 1
+
+
+def test_identities_closes_the_store_on_the_normal_path(monkeypatch, tmp_path):
+    store = _CharacterStore(
+        [
+            NovelCharacter(
+                name="秦昭",
+                role="主角",
+                identities=[
+                    CharacterIdentity(
+                        character_name="秦昭",
+                        identity_name="青年",
+                        identity_id="秦昭_青年",
+                    )
+                ],
+            )
+        ]
+    )
+    client = _client(monkeypatch, tmp_path, store)
+
+    response = client.get("/projects/demo/characters/秦昭/identities")
+
+    assert response.status_code == 200
+    assert response.json()["ok"] is True
+    assert store.close_calls == 1
+
+
+def test_identities_closes_the_store_before_the_character_not_found_return(
+    monkeypatch, tmp_path
+):
+    """提前返回那条路最容易漏：函数在中途 ``return``，收口代码在下面永远够不着。"""
+    store = _CharacterStore([NovelCharacter(name="秦昭", role="主角")])
+    client = _client(monkeypatch, tmp_path, store)
+
+    response = client.get("/projects/demo/characters/查无此人/identities")
+
+    assert response.status_code == 200
+    assert response.json()["ok"] is False
+    assert store.close_calls == 1
+
+
+def test_list_characters_closes_the_store_when_the_handler_raises(monkeypatch, tmp_path):
+    """异常路径：读库炸了，连接更得关——这正是重试风暴把连接数堆上去的那条路。"""
+    store = _CharacterStore([NovelCharacter(name="秦昭", role="主角")])
+
+    def boom():
+        raise RuntimeError("store read blew up")
+
+    monkeypatch.setattr(store, "get_all_characters", boom)
+    client = _client(monkeypatch, tmp_path, store)
+
+    with pytest.raises(RuntimeError, match="store read blew up"):
+        client.get("/projects/demo/characters")
+
+    assert store.close_calls == 1
+
+
+def test_identities_closes_the_store_when_the_handler_raises(monkeypatch, tmp_path):
+    store = _CharacterStore([NovelCharacter(name="秦昭", role="主角")])
+
+    def boom():
+        raise RuntimeError("store read blew up")
+
+    monkeypatch.setattr(store, "get_all_characters", boom)
+    client = _client(monkeypatch, tmp_path, store)
+
+    with pytest.raises(RuntimeError, match="store read blew up"):
+        client.get("/projects/demo/characters/秦昭/identities")
+
+    assert store.close_calls == 1

--- a/tests/test_api_characters_asset_contract.py
+++ b/tests/test_api_characters_asset_contract.py
@@ -172,6 +172,52 @@ def test_list_characters_repairs_duplicate_narrator_main(monkeypatch, tmp_path):
     assert store.get_character("沈月白").is_main is False
 
 
+def test_list_characters_carries_identity_ids_for_deep_link_resolution(
+    monkeypatch, tmp_path
+):
+    """角色列表带出每个角色名下的身份 id，且只带 id。
+
+    资产页要把 ``?type=identity&id=`` 深链解析到拥有它的角色。前端此前是逐个角色
+    调 ``/characters/{name}/identities`` 建 id→角色名 的表——角色有多少个就发多少
+    个请求，无条件、每次进页面都发。身份对象已经随角色一起在内存里，这里带出来不
+    多一次查询；带的是一串 id，载荷不随身份的图片/描述增长。
+    """
+    lin = NovelCharacter(name="林昭", role="主角")
+    lin.identities = [
+        CharacterIdentity(
+            identity_id="林昭_青年", character_name="林昭", identity_name="青年"
+        ),
+        CharacterIdentity(
+            identity_id="林昭_少年", character_name="林昭", identity_name="少年"
+        ),
+    ]
+    su = NovelCharacter(name="苏清晏", role="女主")
+    su.identities = [
+        CharacterIdentity(
+            identity_id="苏清晏_少女", character_name="苏清晏", identity_name="少女"
+        )
+    ]
+    bare = NovelCharacter(name="路人", role="配角")
+
+    store = _CharacterStore([lin, su, bare])
+    client = _client(monkeypatch, tmp_path, store)
+
+    response = client.get("/projects/demo/characters")
+
+    assert response.status_code == 200
+    by_name = {item["name"]: item for item in response.json()["data"]}
+
+    assert by_name["林昭"]["identity_ids"] == ["林昭_青年", "林昭_少年"]
+    assert by_name["苏清晏"]["identity_ids"] == ["苏清晏_少女"]
+    # 没有身份的角色出空列表而不是缺字段，前端不必区分「没有」和「没带」。
+    assert by_name["路人"]["identity_ids"] == []
+
+    # 只有 id。身份详情仍走按需的 identities 接口，别让列表载荷跟着长。
+    identity_detail_keys = {"identity_name", "image_url", "appearance_details"}
+    for item in by_name.values():
+        assert identity_detail_keys.isdisjoint(item.keys())
+
+
 def test_character_and_identity_lists_expose_asset_history_links(monkeypatch, tmp_path):
     character = NovelCharacter(name="林昭", role="主角")
     character.identities = [

--- a/tests/test_api_episode_detail.py
+++ b/tests/test_api_episode_detail.py
@@ -31,9 +31,15 @@ def test_episode_asset_task_scope_is_stable_per_episode_and_kind():
 
 
 class _EpisodeStore:
-    def __init__(self, episode: NovelEpisode):
+    def __init__(self, episode: NovelEpisode, beat_counts: dict[int, int] | None = None):
         self.episode = episode
         self.updates: list[tuple[int, dict]] = []
+        self.beat_counts = beat_counts or {}
+        self.count_calls = 0
+
+    async def count_beats_by_episode(self):
+        self.count_calls += 1
+        return dict(self.beat_counts)
 
     def get_episode(self, number: int):
         if number == self.episode.number:
@@ -330,8 +336,44 @@ async def test_list_episodes_returns_fields_needed_by_react_workbench(tmp_path, 
                     "marker_color": "",
                 }
             ],
+            "beat_count": 0,
         }
     ]
+
+
+@pytest.mark.asyncio
+async def test_list_episodes_carries_beat_count_from_one_grouped_query(tmp_path, monkeypatch):
+    """分集列表自带镜头数，前端不必逐集去拉完整 beats 再取长度。
+
+    这是分集页扇出的根因：列表有几集，前端就发几个
+    ``GET /episodes/{n}/beats``，每个都要解析项目上下文、开库、给每个 beat 拼
+    sketch/frame/video URL 并对每条音频 fork 一次 ffprobe——只为了拿一个整数。
+    """
+    from novelvideo.api.routes import episodes
+
+    episode = NovelEpisode(number=1, title="第一集")
+    store = _EpisodeStore(episode, beat_counts={1: 7})
+    _patch_project_and_store(monkeypatch, episodes, tmp_path, store)
+
+    response = await episodes.list_episodes(project="demo", user={"username": "admin"})
+
+    assert response["data"][0]["beat_count"] == 7
+    # 一次分组查询覆盖整张列表，不是每集一次。
+    assert store.count_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_list_episodes_reports_zero_for_unsplit_episode(tmp_path, monkeypatch):
+    """还没拆镜的集要报 0，而不是缺字段——角标读到 undefined 就不渲染了。"""
+    from novelvideo.api.routes import episodes
+
+    episode = NovelEpisode(number=2, title="第二集")
+    store = _EpisodeStore(episode, beat_counts={1: 7})
+    _patch_project_and_store(monkeypatch, episodes, tmp_path, store)
+
+    response = await episodes.list_episodes(project="demo", user={"username": "admin"})
+
+    assert response["data"][0]["beat_count"] == 0
 
 
 @pytest.mark.asyncio

--- a/tests/test_api_store_scope_lifecycle.py
+++ b/tests/test_api_store_scope_lifecycle.py
@@ -1,0 +1,180 @@
+"""Store 生命周期：工厂初始化失败也要关，scope 出了 ``async with`` 一定关。
+
+每个 ``SQLiteStore`` 背后是一条 aiosqlite 连接加一个后台线程。漏关不会立刻报错，
+只会在压测或长跑里表现成连接数和线程数单调上涨——所以这里的断言全部落在
+"``close()`` 被调用了几次"上，而不是落在返回值。
+
+工厂那条尤其容易漏：``*_scope`` 的 ``try/finally`` 只对**工厂成功返回的**实例负责。
+``initialize()`` 已经把连接打开、``load_graph_state()`` 随后抛错时，实例还没交给任
+何人，scope 的 ``finally`` 根本看不见它。
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+
+class _FakeStore:
+    """记账用的假 store：只关心 init 步骤抛不抛、close 被调用几次。"""
+
+    instances: list["_FakeStore"] = []
+
+    def __init__(self, *_args, fail_on: str | None = None, **_kwargs):
+        self.fail_on = fail_on
+        self.initialized = False
+        self.graph_loaded = False
+        self.close_calls = 0
+        _FakeStore.instances.append(self)
+
+    async def initialize(self):
+        if self.fail_on == "initialize":
+            raise RuntimeError("boom in initialize")
+        self.initialized = True
+
+    async def load_graph_state(self):
+        if self.fail_on == "load_graph_state":
+            raise RuntimeError("boom in load_graph_state")
+        self.graph_loaded = True
+
+    async def close(self):
+        self.close_calls += 1
+
+
+def _install_fake_store(monkeypatch, *, fail_on: str | None = None):
+    """把工厂内部 ``from novelvideo.sqlite_store import SQLiteStore`` 换成假货。"""
+    import novelvideo.sqlite_store as sqlite_store_module
+
+    _FakeStore.instances.clear()
+    monkeypatch.setattr(
+        sqlite_store_module,
+        "SQLiteStore",
+        lambda *a, **kw: _FakeStore(*a, fail_on=fail_on, **kw),
+    )
+
+
+def _ctx(tmp_path: Path):
+    return SimpleNamespace(
+        project_id="proj_demo",
+        owner_project_label="demo",
+        output_dir=tmp_path,
+        state_dir=tmp_path,
+        is_home_node=True,
+    )
+
+
+@pytest.fixture
+def deps_module(monkeypatch):
+    # 函数内 import：``tests/contract/test_m01_auth.py`` 会把 ``novelvideo.api.*``
+    # 整片从 ``sys.modules`` 里弹掉再以 CE 模式重建 app，模块级绑定到那时已经是个
+    # 死对象，打在上面的 patch 会静默落空。
+    from novelvideo.api import deps
+
+    # 工厂里这一步只做归属校验，和本文件要验的生命周期无关。
+    monkeypatch.setattr(deps, "require_project_home_node", lambda ctx, operation="": None)
+    return deps
+
+
+async def test_context_factory_closes_store_when_load_graph_state_raises(
+    deps_module, monkeypatch, tmp_path
+):
+    """初始化窗口：连接已经开了，第二步抛错，实例还没交出去——必须自己关掉。"""
+    _install_fake_store(monkeypatch, fail_on="load_graph_state")
+
+    with pytest.raises(RuntimeError, match="boom in load_graph_state"):
+        await deps_module.make_sqlite_store_for_context(_ctx(tmp_path))
+
+    (store,) = _FakeStore.instances
+    assert store.initialized is True, "前提：连接确实开了，否则这条用例没在测它想测的东西"
+    assert store.close_calls == 1
+
+
+async def test_context_factory_closes_store_when_initialize_raises(
+    deps_module, monkeypatch, tmp_path
+):
+    _install_fake_store(monkeypatch, fail_on="initialize")
+
+    with pytest.raises(RuntimeError, match="boom in initialize"):
+        await deps_module.make_sqlite_store_for_context(_ctx(tmp_path))
+
+    (store,) = _FakeStore.instances
+    assert store.close_calls == 1
+
+
+async def test_context_factory_skips_graph_state_but_still_closes_on_init_failure(
+    deps_module, monkeypatch, tmp_path
+):
+    """``load_graph_state=False`` 是 ``/beats`` 走的分支，别在这条上漏掉收口。"""
+    _install_fake_store(monkeypatch, fail_on="initialize")
+
+    with pytest.raises(RuntimeError):
+        await deps_module.make_sqlite_store_for_context(
+            _ctx(tmp_path), load_graph_state=False
+        )
+
+    (store,) = _FakeStore.instances
+    assert store.graph_loaded is False
+    assert store.close_calls == 1
+
+
+async def test_ce_factory_closes_store_when_load_graph_state_raises(
+    deps_module, monkeypatch, tmp_path
+):
+    """CE 路径（按 username/project 开库）享有同样的保证。"""
+    _install_fake_store(monkeypatch, fail_on="load_graph_state")
+    monkeypatch.setattr(deps_module, "get_output_dir", lambda u, p: str(tmp_path))
+    monkeypatch.setattr(deps_module, "get_state_dir", lambda u, p: str(tmp_path))
+
+    with pytest.raises(RuntimeError, match="boom in load_graph_state"):
+        await deps_module.make_sqlite_store("admin", "demo")
+
+    (store,) = _FakeStore.instances
+    assert store.close_calls == 1
+
+
+async def test_successful_factory_does_not_close_the_store_it_returns(
+    deps_module, monkeypatch, tmp_path
+):
+    """反向哨兵：别把"出错就关"写成"总是关"，那样调用方拿到的是条死连接。"""
+    _install_fake_store(monkeypatch)
+
+    store = await deps_module.make_sqlite_store_for_context(_ctx(tmp_path))
+
+    assert store.initialized is True
+    assert store.graph_loaded is True
+    assert store.close_calls == 0
+
+
+async def test_context_scope_closes_on_normal_exit(deps_module, monkeypatch, tmp_path):
+    _install_fake_store(monkeypatch)
+
+    async with deps_module.sqlite_store_for_context_scope(_ctx(tmp_path)) as store:
+        assert store.close_calls == 0
+
+    assert store.close_calls == 1
+
+
+async def test_context_scope_closes_when_the_body_raises(deps_module, monkeypatch, tmp_path):
+    _install_fake_store(monkeypatch)
+
+    with pytest.raises(RuntimeError, match="body blew up"):
+        async with deps_module.sqlite_store_for_context_scope(_ctx(tmp_path)) as store:
+            raise RuntimeError("body blew up")
+
+    assert store.close_calls == 1
+
+
+async def test_context_scope_leaves_no_store_open_when_init_fails(
+    deps_module, monkeypatch, tmp_path
+):
+    """scope 的 ``finally`` 看不见初始化失败的实例，这条守的就是工厂那层的兜底。"""
+    _install_fake_store(monkeypatch, fail_on="load_graph_state")
+
+    with pytest.raises(RuntimeError, match="boom in load_graph_state"):
+        async with deps_module.sqlite_store_for_context_scope(_ctx(tmp_path)):
+            pytest.fail("不该进到 body：工厂就已经抛了")
+
+    (store,) = _FakeStore.instances
+    assert store.close_calls == 1

--- a/tests/test_media_io_probe_concurrency.py
+++ b/tests/test_media_io_probe_concurrency.py
@@ -4,9 +4,13 @@ Reading one episode's beats probes every audio clip for its duration. Issued as
 one unbounded ``gather``, a long episode forks one ffprobe per beat at once —
 and since the probes run on the default thread pool, the burst also stalls every
 other blocking call in the process until it drains.
+
+The cap alone is not enough, so the timeout is pinned here too: a gate only
+limits how many probes may hang at once, it cannot make a hung one let go.
 """
 
 import asyncio
+import subprocess
 import weakref
 
 import pytest
@@ -113,3 +117,63 @@ def test_each_event_loop_gets_its_own_gate():
     asyncio.run(scenario())
 
     assert seen[0] is not seen[1]
+
+
+def test_the_probe_passes_a_finite_timeout_to_ffprobe(monkeypatch):
+    """没有 timeout 的 ffprobe 在网络盘上可以永远挂着，闸门位置全被占死。"""
+    seen: dict = {}
+
+    def fake_run(cmd, **kwargs):
+        seen.update(kwargs)
+        return subprocess.CompletedProcess(cmd, 0, "3.5\n", "")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    assert media_io.get_audio_duration("/tmp/beat.mp3") == 3.5
+    timeout = seen.get("timeout")
+    assert timeout is not None, "ffprobe 必须带超时"
+    assert 0 < timeout < 60
+
+
+@pytest.mark.asyncio
+async def test_a_timed_out_probe_reports_none_rather_than_a_made_up_duration(
+    monkeypatch,
+):
+    """超时走批量接口的失败语义（None），而不是那个看起来很真的 5.0。"""
+
+    def fake_run(cmd, **kwargs):
+        raise subprocess.TimeoutExpired(cmd, kwargs.get("timeout", 0))
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    assert await media_io.get_audio_durations_async(["/tmp/stalled.mp3"]) == [None]
+
+
+def test_a_timed_out_probe_raises_instead_of_returning_the_fallback(monkeypatch):
+    """单文件接口把超时抛出去：调用方要能区分"探测失败"和"探测到了但读不出来"。"""
+
+    def fake_run(cmd, **kwargs):
+        raise subprocess.TimeoutExpired(cmd, kwargs.get("timeout", 0))
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    with pytest.raises(subprocess.TimeoutExpired):
+        media_io.get_audio_duration("/tmp/stalled.mp3")
+
+
+def test_an_unreadable_answer_still_falls_back(monkeypatch):
+    """5.0 的语义没变：ffprobe 答了、但答案解析不出来时仍然回落。"""
+
+    def fake_run(cmd, **kwargs):
+        return subprocess.CompletedProcess(cmd, 0, "N/A\n", "")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    assert media_io.get_audio_duration("/tmp/weird.mp3") == 5.0
+
+
+def test_the_worst_case_wall_time_is_bounded():
+    """闸门 × 超时决定了一集 beats 最坏要等多久；两个都得是有限小值。"""
+    assert 0 < media_io._PROBE_TIMEOUT_SECONDS <= 30
+    worst_case = -(-40 // media_io._PROBE_CONCURRENCY) * media_io._PROBE_TIMEOUT_SECONDS
+    assert worst_case <= 60

--- a/tests/test_media_io_probe_concurrency.py
+++ b/tests/test_media_io_probe_concurrency.py
@@ -1,0 +1,115 @@
+"""ffprobe fan-out must stay bounded.
+
+Reading one episode's beats probes every audio clip for its duration. Issued as
+one unbounded ``gather``, a long episode forks one ffprobe per beat at once —
+and since the probes run on the default thread pool, the burst also stalls every
+other blocking call in the process until it drains.
+"""
+
+import asyncio
+import weakref
+
+import pytest
+
+from novelvideo.utils import media_io
+
+
+async def _run_with_cap(monkeypatch, cap: int, count: int) -> int:
+    """Probe ``count`` paths under ``cap`` and report the observed peak overlap."""
+    in_flight = 0
+    peak = 0
+
+    async def fake_probe(path: str) -> float:
+        nonlocal in_flight, peak
+        in_flight += 1
+        peak = max(peak, in_flight)
+        # Yield twice so every admitted probe is still in flight when the next
+        # one starts: without a gate the whole batch would overlap.
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+        in_flight -= 1
+        return 1.0
+
+    monkeypatch.setattr(media_io, "get_audio_duration_async", fake_probe)
+    monkeypatch.setattr(media_io, "_PROBE_CONCURRENCY", cap)
+    # The gate is memoised per loop; drop any semaphore built before the patch.
+    monkeypatch.setattr(media_io, "_probe_semaphores", weakref.WeakKeyDictionary())
+
+    results = await media_io.get_audio_durations_async(
+        [f"/tmp/beat_{i:03d}.mp3" for i in range(count)]
+    )
+    assert len(results) == count
+    return peak
+
+
+@pytest.mark.asyncio
+async def test_probe_fan_out_never_exceeds_the_cap(monkeypatch):
+    # Peak is asserted against the literal, not against the module constant:
+    # reading the constant back makes the bound move with the implementation and
+    # the assertion vacuous.
+    assert await _run_with_cap(monkeypatch, 3, 64) == 3
+    assert await _run_with_cap(monkeypatch, 8, 64) == 8
+
+
+@pytest.mark.asyncio
+async def test_a_batch_smaller_than_the_cap_runs_fully_parallel(monkeypatch):
+    """闸门是上限不是队列——没超过上限的批次不该被串行化。"""
+    assert await _run_with_cap(monkeypatch, 8, 5) == 5
+
+
+def test_default_cap_is_small_enough_to_matter():
+    """默认值得比线程池默认宽度小，否则这个闸门等于没装。"""
+    assert 1 < media_io._PROBE_CONCURRENCY <= 16
+
+
+@pytest.mark.asyncio
+async def test_results_stay_aligned_and_one_bad_file_does_not_fail_the_batch(
+    monkeypatch,
+):
+    async def fake_probe(path: str) -> float:
+        if path.endswith("bad.mp3"):
+            raise OSError("ffprobe exploded")
+        return 1.5
+
+    monkeypatch.setattr(media_io, "get_audio_duration_async", fake_probe)
+
+    results = await media_io.get_audio_durations_async(
+        ["a.mp3", "bad.mp3", "c.mp3"]
+    )
+
+    # Positional alignment is the contract: the caller zips these back onto beats.
+    assert results == [1.5, None, 1.5]
+
+
+@pytest.mark.asyncio
+async def test_empty_input_probes_nothing(monkeypatch):
+    async def fake_probe(path: str) -> float:  # pragma: no cover - must not run
+        raise AssertionError("probed an empty batch")
+
+    monkeypatch.setattr(media_io, "get_audio_duration_async", fake_probe)
+
+    assert await media_io.get_audio_durations_async([]) == []
+
+
+def test_the_cap_is_shared_across_requests_on_one_loop():
+    """两个并发请求不该把上限翻倍——闸门按事件循环取，不是按调用取。"""
+
+    async def scenario():
+        first = media_io._probe_semaphore()
+        second = media_io._probe_semaphore()
+        assert first is second
+
+    asyncio.run(scenario())
+
+
+def test_each_event_loop_gets_its_own_gate():
+    """信号量绑定首次 await 它的循环；进程里跑多个循环时不能共用一个。"""
+    seen = []
+
+    async def scenario():
+        seen.append(media_io._probe_semaphore())
+
+    asyncio.run(scenario())
+    asyncio.run(scenario())
+
+    assert seen[0] is not seen[1]

--- a/tests/test_project_id_route_paths.py
+++ b/tests/test_project_id_route_paths.py
@@ -50,7 +50,7 @@ async def test_asset_references_resolves_project_id_before_opening_store(monkeyp
             runtime_dir=str(ctx.runtime_dir),
         )
 
-    async def fake_make_sqlite_store_for_context(ctx_arg):
+    async def fake_make_sqlite_store_for_context(ctx_arg, **_kwargs):
         assert ctx_arg is ctx
         calls.append((ctx_arg.owner_username, ctx_arg.project_name))
         return Store()
@@ -113,7 +113,7 @@ async def test_verification_routes_resolve_project_id_before_opening_project_dir
             runtime_dir=str(ctx.runtime_dir),
         )
 
-    async def fake_make_sqlite_store_for_context(ctx_arg):
+    async def fake_make_sqlite_store_for_context(ctx_arg, **_kwargs):
         assert ctx_arg is ctx
         return Store()
 

--- a/tests/test_project_id_route_paths.py
+++ b/tests/test_project_id_route_paths.py
@@ -11,7 +11,7 @@ async def test_asset_references_resolves_project_id_before_opening_store(monkeyp
     from novelvideo.models import NovelVisualBeat
 
     class Store:
-        async def list_visual_beats(self):
+        async def list_beat_asset_refs(self):
             return [
                 NovelVisualBeat(
                     episode_number=1,

--- a/tests/test_project_id_route_paths.py
+++ b/tests/test_project_id_route_paths.py
@@ -7,6 +7,7 @@ import pytest
 
 @pytest.mark.asyncio
 async def test_asset_references_resolves_project_id_before_opening_store(monkeypatch, tmp_path):
+    from novelvideo.api import deps
     from novelvideo.api.routes import assets
     from novelvideo.models import NovelVisualBeat
 
@@ -59,11 +60,15 @@ async def test_asset_references_resolves_project_id_before_opening_store(monkeyp
         raise AssertionError("route must not treat project_id as a filesystem project name")
 
     monkeypatch.setattr(assets, "resolve_project_scope", fake_resolve_project_scope, raising=False)
+    # Patched on ``deps``, not on the route module: the route opens the store via
+    # ``sqlite_store_for_context_scope``, and that wrapper resolves the factory as
+    # a ``deps`` global when it runs. Note there is no ``raising=False`` here —
+    # the attribute genuinely exists, and asserting on it is what makes this test
+    # fail loudly instead of silently patching a name nobody reads.
     monkeypatch.setattr(
-        assets,
+        deps,
         "make_sqlite_store_for_context",
         fake_make_sqlite_store_for_context,
-        raising=False,
     )
     monkeypatch.setattr(assets, "get_project_dir", legacy_get_project_dir, raising=False)
 

--- a/tests/test_sqlite_store.py
+++ b/tests/test_sqlite_store.py
@@ -556,6 +556,44 @@ async def test_episode_and_beats(tmp_project):
 
 
 @pytest.mark.asyncio
+async def test_count_beats_by_episode_groups_in_one_query(tmp_project):
+    """分集列表的镜头数走一次分组查询，未拆镜的集不出现在结果里。
+
+    这个方法存在的意义就是替掉「前端逐集拉完整 beats 再取 len()」。
+    """
+    from novelvideo.cognee.pipeline import NovelEpisode, NovelVisualBeat
+
+    store = tmp_project
+    await store._ensure_db()
+    await store.add_episodes([NovelEpisode(number=n, title=f"第{n}集") for n in (1, 2, 3)])
+
+    await store.add_visual_beats(
+        [
+            NovelVisualBeat(beat_number=i, episode_number=1, narration="", visual_description="")
+            for i in range(3)
+        ]
+        + [
+            NovelVisualBeat(beat_number=i, episode_number=3, narration="", visual_description="")
+            for i in range(5)
+        ]
+    )
+
+    counts = await store.count_beats_by_episode()
+
+    assert counts == {1: 3, 3: 5}
+    # 第 2 集还没拆镜——缺席而不是 0，路由层用 .get(number, 0) 补齐。
+    assert 2 not in counts
+
+
+@pytest.mark.asyncio
+async def test_count_beats_by_episode_on_empty_project(tmp_project):
+    store = tmp_project
+    await store._ensure_db()
+
+    assert await store.count_beats_by_episode() == {}
+
+
+@pytest.mark.asyncio
 async def test_replace_episodes_rolls_back_delete_when_new_plan_write_fails(
     tmp_path,
     monkeypatch,

--- a/tests/test_sqlite_store.py
+++ b/tests/test_sqlite_store.py
@@ -594,6 +594,73 @@ async def test_count_beats_by_episode_on_empty_project(tmp_project):
 
 
 @pytest.mark.asyncio
+async def test_list_beat_asset_refs_returns_reference_columns_in_order(tmp_project):
+    """窄列读回来的六个字段要和完整 beat 对得上，包括 scene_ref 的解码。
+
+    资产反向索引拿它替掉 ``list_visual_beats()``。字段名和 ``NovelVisualBeat``
+    一致（含 ``scene_ref`` 属性），扫描代码才能对两种形状一视同仁——这个测试就是
+    钉住这条等价性。
+    """
+    from novelvideo.models import SceneRef
+    from novelvideo.cognee.pipeline import NovelVisualBeat
+
+    store = tmp_project
+    await store._ensure_db()
+    await store.add_visual_beats(
+        [
+            NovelVisualBeat(
+                beat_number=2,
+                episode_number=1,
+                narration="旁白",
+                visual_description="[[红酒杯]] 摆在桌上",
+                detected_identities_json='["苏清晏_少女"]',
+                detected_props_json='["红酒杯"]',
+                scene_ref_json=SceneRef(scene_id="书房", variant_id="").model_dump_json(),
+            ),
+            NovelVisualBeat(
+                beat_number=1,
+                episode_number=1,
+                narration="旁白",
+                visual_description="空镜",
+            ),
+        ]
+    )
+
+    rows = await store.list_beat_asset_refs()
+
+    assert [(r.episode_number, r.beat_number) for r in rows] == [(1, 1), (1, 2)]
+
+    first, second = rows
+    # 没有场景/身份/道具的 beat 读出来是空值而不是 None，扫描直接 json.loads。
+    assert first.detected_identities_json == "[]"
+    assert first.detected_props_json == "[]"
+    assert first.scene_ref_json == ""
+    assert first.scene_id == ""
+
+    assert second.detected_identities_json == '["苏清晏_少女"]'
+    assert second.detected_props_json == '["红酒杯"]'
+    assert second.visual_description == "[[红酒杯]] 摆在桌上"
+    assert second.scene_id == "书房"
+
+    # 和完整读法逐字段等价——两条路径不能对同一行给出不同答案。
+    full = {(b.episode_number, b.beat_number): b for b in await store.list_visual_beats()}
+    for row in rows:
+        beat = full[(row.episode_number, row.beat_number)]
+        assert row.visual_description == beat.visual_description
+        assert row.detected_identities_json == beat.detected_identities_json
+        assert row.detected_props_json == beat.detected_props_json
+        assert row.scene_id == beat.scene_id
+
+
+@pytest.mark.asyncio
+async def test_list_beat_asset_refs_on_empty_project(tmp_project):
+    store = tmp_project
+    await store._ensure_db()
+
+    assert await store.list_beat_asset_refs() == []
+
+
+@pytest.mark.asyncio
 async def test_replace_episodes_rolls_back_delete_when_new_plan_write_fails(
     tmp_path,
     monkeypatch,


### PR DESCRIPTION
## 问题

打开虾塘（资产页）会在 network 里打出**大量 `GET /episodes/{n}/beats`** —— 有几集就打几个，集数越多越卡。

根因：虾塘每张资产卡片上的「用于 N 个镜头」角标需要一份反向索引（asset → beats）。后端此前只有 per-asset 的 references 端点，没有聚合入口，前端于是把每一集的完整 beats 载荷全量拉下来，在浏览器里自己建索引。三个子页签（角色/场景/道具）都会触发。

代价远不止网络：`get_beats` 对每个 beat 做 4 次文件系统 stat，并对每个音频 beat fork 一个 ffprobe 进程，全部走共享的 `asyncio.to_thread` 线程池 —— 扇出时会挤占其它接口。

## 改动

### 1. 聚合接口取代按集扇出

新增 `GET /api/v1/projects/{project}/assets/references`：一次 `list_visual_beats()` 单查询扫一遍全项目 beats。已有的 per-asset `get_asset_references` 重构到同两个 helper（`_beat_asset_refs` / `_load_visual_beats`）上。

> 顺带修掉一处口径不一致：`[[道具]]` 内联标记此前**只有前端**会并入索引，per-asset 端点不会 —— 现在两个端点一致。

### 2. 只回计数，明细按需取

聚合接口如果把全项目引用明细一次性回给前端，payload 会随「总引用数」增长 —— 而总引用数正是随集数无限涨的那个维度。所以拆成两个形状，仍然一次扫描：

| 字段 | 范围 | 规模由谁决定 |
|---|---|---|
| `counts` | 始终返回，全项目每个资产一个整数 | 资产数 |
| `references` / `scene_co_occurrence` | 只返回 `?ids=` 点名的资产 | 当前屏幕上渲染了几个 |

所有网格的角标、面板的排序与求和都只用 `counts`，所以它必须覆盖全项目；beat 列表只在用户真正看到它时才取。调用形如 `?ids=identity:foo&ids=scene:bar`，键统一为 `"{type}:{id}"`。

前端相应从单个 `useAssetReferenceIndex` 拆成 `useAssetReferenceCounts` + `useAssetReferences(project, refs)`。后者把 `refs` 归一成排序去重后的签名做 query key，所以数组身份/顺序变化不会造成重复请求，空集合不发请求。

场景/道具面板的明细挂在弹窗上（`editing` 为真才取）。**角色页是特例**：`IdentityCard` 把 beat 列表内联渲染在每张卡上而非藏在弹窗后，所以明细必须覆盖选中角色的全部身份 —— 仍是一个小请求，取的是该角色的身份，不是全项目的。

### 3. beats 路由不再水合图谱状态

`make_sqlite_store_for_context` 增加 `load_graph_state: bool = True` 开关。`load_graph_state()` 是三次全表读（`list_characters` + `list_episodes` + `list_props`），用来水合角色/集/道具的内存缓存；只碰 beats 表的调用方付的是纯开销，比它们自己的查询还贵。

改动只落在明确不需要的两处：`GET /episodes/{n}/beats` 和资产引用扫描。默认仍为 `True`，其余调用方行为不变。`get_beats` 顺带补上了之前缺失的 store 关闭（此前每次请求泄漏一个连接）。

### 缓存失效

新的 query key 不在 `queryKeys.beats` 前缀下，失效不再搭便车，因此在 6 个会改变 beat↔资产关系的 mutation 上显式接入 `invalidateAssetReferences`：`useUpdateBeat`、`useSaveScript`、`useInsertManualShot`、`useDeleteManualShot`、`useAssignColors`、`useDetectIdentities`。明细 key 嵌套在计数 key 之下，一次前缀失效同时覆盖两者。漏接的后果是角标过期而非数据错误，另有 30s `staleTime` 与路由重挂载兜底。

### 4. 分集列表自带镜头数

进入虾镜（分集列表）同样会打出「有几集就几个」的 `GET /episodes/{n}/beats`，响应往往还是空的。根因在 `EpisodeListItem`：每张卡片自己调 `useEpisodeBeats(episode.number)`，只为了取 `.length` 显示「N 个分镜」。

同一张卡片上的身份/场景/道具数本来就读列表接口带出的 `identity_ids` / `scene_menu` / `prop_menu`，零额外请求 —— 只有分镜数是特例。现在补齐：`count_beats_by_episode()` 一次 `GROUP BY` 带出每集 beat 数，`list_episodes` 加一个 `beat_count` 字段，前端直接读 `episode.beat_count`。这一页的 beats 扇出归零。

`beat_count` 会变的三个时机补上 `queryKeys.episodes` 失效：拆镜任务完成（0 → N 的那一步）、手动插入分镜、删除手动分镜。其余只改 beat 内容而不改数量的 mutation 不需要。

选中集 header 那一处 `useEpisodeBeats` 保留：它只发一个请求，且顺带预热了用户马上要进入的那一集。

## 测试

- `pytest`（全量，覆盖 1–3 项）→ **2474 passed / 2 failed**。两个失败项（`test_model_gateway_settings.py::test_newapi_text_model_defaults_to_300_second_timeout`、`test_newapi_image_gateway.py::test_fixed_asset_image_providers_default_to_newapi_when_env_is_empty`）已 stash 验证为**既有问题**，与本 PR 无关。
- `pytest`（第 4 项相关：`test_sqlite_store` / `test_api_episode_detail` / `test_m03_*` / `test_api_pipeline_manual_shots` / `test_project_spine_template` / `test_m07_tasks`）→ **84 passed**，含新增 4 个用例。
- `npx tsc --noEmit` → 干净
- `npx vitest run` → **2485 passed / 1 failed**。失败项 `ingest.test.tsx` 同样已 stash 验证为既有问题，属本 PR 未触及的 ingest 模块。第 4 项另跑 episodes / task-center 相关 16 个文件 **151 passed**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NZ6eSvT14x9BskGKX1HxgL
