### PR TITLE
fix: separate cold thumbnail cache keys

### DIFF
--- a/src/novelvideo/api/routes/files.py
+++ b/src/novelvideo/api/routes/files.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import FileResponse, RedirectResponse, Response
+from starlette.datastructures import URL
 
 logger = logging.getLogger("novelvideo.api.files")
 
@@ -14,6 +15,7 @@ from novelvideo.utils.thumbnails import (
     fresh_thumbnail,
     is_thumbnailable,
     normalize_variant,
+    thumbnail_declined,
 )
 
 router = APIRouter()
@@ -69,7 +71,21 @@ def _etag_matches(request: Request | None, etag: str | None) -> bool:
 def _redirect_to_original_url(request: Request) -> RedirectResponse:
     """Move a cold variant request onto the original representation's URL."""
 
-    original = request.url.remove_query_params("st_thumb")
+    original = request.url
+    forwarded = request.headers.get("x-supertale-original-uri", "").strip()
+    if forwarded:
+        try:
+            candidate = URL(forwarded)
+            if (
+                not candidate.scheme
+                and not candidate.netloc
+                and not candidate.fragment
+                and candidate.path.startswith("/static/projects/")
+            ):
+                original = candidate
+        except ValueError:
+            pass
+    original = original.remove_query_params("st_thumb")
     location = original.path
     if original.query:
         location = f"{location}?{original.query}"
@@ -105,6 +121,8 @@ def _maybe_thumbnail_response(
         return None
     thumb = fresh_thumbnail(project_dir, requested, variant)
     if thumb is None:
+        if thumbnail_declined(project_dir, requested, variant):
+            return None
         if (
             request is not None
             and normalize_variant(variant) is not None

--- a/src/novelvideo/api/routes/files.py
+++ b/src/novelvideo/api/routes/files.py
@@ -115,7 +115,9 @@ def _maybe_thumbnail_response(
     cache_control = _variant_cache_control(request)
     try:
         stat_result = thumb.stat()
-    except OSError:  # raced with a rewrite; fall back to the original
+    except OSError:  # raced with a rewrite; move the fallback off the variant URL
+        if request is not None:
+            return _redirect_to_original_url(request)
         return None
     # Passing the stat makes FileResponse compute etag/last-modified now rather
     # than mid-send, so the value is available to answer a conditional request.

--- a/src/novelvideo/api/routes/files.py
+++ b/src/novelvideo/api/routes/files.py
@@ -10,7 +10,11 @@ logger = logging.getLogger("novelvideo.api.files")
 
 from novelvideo.api.auth import get_api_user
 from novelvideo.api.deps import ProjectResolution, resolve_project_scope
-from novelvideo.utils.thumbnails import fresh_thumbnail
+from novelvideo.utils.thumbnails import (
+    fresh_thumbnail,
+    is_thumbnailable,
+    normalize_variant,
+)
 
 router = APIRouter()
 
@@ -62,13 +66,27 @@ def _etag_matches(request: Request | None, etag: str | None) -> bool:
     return False
 
 
+def _redirect_to_original_url(request: Request) -> RedirectResponse:
+    """Move a cold variant request onto the original representation's URL."""
+
+    original = request.url.remove_query_params("st_thumb")
+    location = original.path
+    if original.query:
+        location = f"{location}?{original.query}"
+    return RedirectResponse(
+        url=location,
+        status_code=302,
+        headers={"Cache-Control": "no-store"},
+    )
+
+
 def _maybe_thumbnail_response(
     project_dir: Path,
     requested: Path,
     variant: str | None,
     request: Request | None = None,
 ):
-    """Serve an already-built variant of ``requested``, or ``None`` to fall back.
+    """Serve an already-built variant or redirect a cold one to the original URL.
 
     The canvas asks for a variant on every img that paints into a small box
     (see ``novelvideo.utils.thumbnails``). A *built* variant is served as local
@@ -77,15 +95,22 @@ def _maybe_thumbnail_response(
     written variant is not in OSS yet anyway.
 
     A cold one is a different trade entirely, so it is never built or queued
-    here. This returns ``None`` and leaves the caller to hand back the same OSS
-    redirect it would have without variants at all. Thumbnail creation belongs
-    to the generation-history write path; opening an old or cold canvas must
-    never start image decoding work in the API process.
+    here. A valid image variant miss redirects to the same request URL without
+    any ``st_thumb`` parameter. That keeps the temporary original response off
+    the future variant's cache key and out of the proxy's thumbnail slice path.
+    Thumbnail creation belongs to the generation-history write path; opening an
+    old or cold canvas must never start image decoding work in the API process.
     """
     if not variant:
         return None
     thumb = fresh_thumbnail(project_dir, requested, variant)
     if thumb is None:
+        if (
+            request is not None
+            and normalize_variant(variant) is not None
+            and is_thumbnailable(requested)
+        ):
+            return _redirect_to_original_url(request)
         return None
     cache_control = _variant_cache_control(request)
     try:

--- a/src/novelvideo/utils/thumbnails.py
+++ b/src/novelvideo/utils/thumbnails.py
@@ -100,6 +100,10 @@ DEFAULT_RENDER_CONCURRENCY = 4
 _render_slots = threading.Semaphore(DEFAULT_RENDER_CONCURRENCY)
 
 
+class _ThumbnailDeclined(Exception):
+    """The source deterministically should keep using its original bytes."""
+
+
 def set_render_concurrency(slots: int) -> None:
     """Resize the decode budget. Offline backfill only.
 
@@ -153,15 +157,43 @@ def is_thumbnailable(source: Path) -> bool:
     return source.suffix.lower() in _SUPPORTED_SUFFIXES
 
 
+def _declined_path(dest: Path) -> Path:
+    return dest.with_name(dest.name + ".declined")
+
+
+def _record_decline(dest: Path, source_mtime_ns: int) -> None:
+    marker = _declined_path(dest)
+    tmp = marker.with_name(f"{marker.name}.{os.getpid()}.{threading.get_ident()}.tmp")
+    try:
+        marker.parent.mkdir(parents=True, exist_ok=True)
+        tmp.write_bytes(b"")
+        os.utime(tmp, ns=(source_mtime_ns, source_mtime_ns))
+        os.replace(tmp, marker)
+    except OSError:
+        try:
+            tmp.unlink(missing_ok=True)
+        except OSError:
+            pass
+        logger.debug("thumbnail decline marker skipped for %s", dest, exc_info=True)
+
+
+def _clear_decline(dest: Path) -> None:
+    try:
+        _declined_path(dest).unlink(missing_ok=True)
+    except OSError:
+        logger.debug("stale thumbnail decline marker kept for %s", dest, exc_info=True)
+
+
 def ensure_thumbnail(
     project_dir: Path, source: Path, variant: str | None
 ) -> Optional[Path]:
     """Return a current thumbnail for ``source``, building it if needed.
 
-    Returns ``None`` whenever the caller should serve the original instead:
-    unknown variant, unsupported or oversized source, animated image, or any
-    decode/encode failure. Blocking and CPU-bound — call it off the event
-    loop.
+    Returns ``None`` whenever the caller should serve the original instead.
+    Deterministic declines (oversized, animated, out of pixel budget, or already
+    within the requested size) leave a source-versioned marker so reads do not
+    redirect forever. Transient decode/write failures leave no marker and may be
+    retried. Blocking and CPU-bound — call it off the event loop.
     """
 
     name = normalize_variant(variant)
@@ -177,18 +209,30 @@ def ensure_thumbnail(
             return None
         stat = source.stat()
         if stat.st_size > _MAX_SOURCE_BYTES:
+            _record_decline(dest, stat.st_mtime_ns)
             return None
         source_mtime_ns = stat.st_mtime_ns
 
         if _is_current(dest, source_mtime_ns):
             return dest
+        if _is_current(_declined_path(dest), source_mtime_ns):
+            return None
         with _stripe_for(dest):
             # Re-check under the lock: whoever we queued behind may have just
             # written exactly the file we were about to render.
             if _is_current(dest, source_mtime_ns):
                 return dest
+            if _is_current(_declined_path(dest), source_mtime_ns):
+                return None
             with _render_slots:
-                return _render(source, dest, max_edge, source_mtime_ns)
+                try:
+                    rendered = _render(source, dest, max_edge, source_mtime_ns)
+                except _ThumbnailDeclined:
+                    _record_decline(dest, source_mtime_ns)
+                    return None
+                if rendered is not None:
+                    _clear_decline(dest)
+                return rendered
     except Exception:
         logger.debug("thumbnail skipped for %s (%s)", source, variant, exc_info=True)
         return None
@@ -207,9 +251,11 @@ def fresh_thumbnail(
     source over the ossfs mount just to hand back a smaller copy of it. That is
     a worse first visit than the one variants were introduced to fix.
 
-    So a miss only falls back to the redirect. New history records prewarm their
-    single display thumbnail at write time; old data remains untouched unless
-    an operator deliberately runs the offline backfill tool.
+    So a plain miss falls back to the redirect. New history records prewarm
+    their single display thumbnail at write time; a deterministic decline leaves
+    a marker that lets the request serve a stable original instead. Old data
+    remains untouched unless an operator deliberately runs the offline backfill
+    tool.
 
     Cheap enough to call on the event loop — two stats, fewer than the path
     resolution the caller already did to get here.
@@ -225,6 +271,21 @@ def fresh_thumbnail(
         return dest if _is_current(dest, source.stat().st_mtime_ns) else None
     except OSError:
         return None
+
+
+def thumbnail_declined(project_dir: Path, source: Path, variant: str | None) -> bool:
+    """Whether prewarming permanently declined this variant of this source."""
+
+    name = normalize_variant(variant)
+    if name is None:
+        return False
+    try:
+        dest = thumbnail_path(project_dir, source, name)
+        if dest is None:
+            return False
+        return _is_current(_declined_path(dest), source.stat().st_mtime_ns)
+    except OSError:
+        return False
 
 
 def _is_current(dest: Path, source_mtime_ns: int) -> bool:
@@ -246,7 +307,7 @@ def _render(
 
     with Image.open(source) as opened:
         if getattr(opened, "is_animated", False):
-            return None
+            raise _ThumbnailDeclined
 
         # Everything from here to `thumbnail` is decided on the header alone.
         # `Image.open` is lazy, so `.size` is known before a single pixel is
@@ -255,19 +316,19 @@ def _render(
         # allocates the full bitmap.
         width, height = opened.size
         if width <= 0 or height <= 0:
-            return None
+            raise _ThumbnailDeclined
         if width * height > _MAX_SOURCE_PIXELS:
-            return None
+            raise _ThumbnailDeclined
         # Nothing to gain once the source already fits: `thumbnail` would be a
         # no-op and we would spend a decode and a write to hand back a
         # re-encoded copy that can come out *larger* than the original. The
         # history strip and the LOD shell ask for `thumb` unconditionally, so
         # small sources reach this constantly — which is exactly why the check
         # belongs above the decode rather than below it. `None` means "serve the
-        # original", which is right here. Orientation cannot change the verdict:
-        # a transpose swaps the two numbers and `max` is blind to that.
+        # original", which is recorded by the caller. Orientation cannot change
+        # the verdict: a transpose swaps the two numbers and `max` is blind to it.
         if max(width, height) <= max_edge:
-            return None
+            raise _ThumbnailDeclined
 
         # No-op for everything but JPEG, where it lets libjpeg decode at a
         # reduced scale — most of the win on the formats that support it.

--- a/tests/test_media_thumbnails.py
+++ b/tests/test_media_thumbnails.py
@@ -192,7 +192,19 @@ def test_source_already_within_budget_is_served_as_is(tmp_path, monkeypatch):
     # ...and the source was never decoded to decide that, which is the whole
     # point: this path is hit constantly and the answer is in the header.
     assert decodes == []
-    assert not (tmp_path / thumbnails.THUMB_ROOT).exists()
+    assert thumbnails.thumbnail_declined(tmp_path, source, "thumb")
+
+
+def test_a_decline_marker_expires_when_the_source_changes(tmp_path):
+    source = _write_png(tmp_path / "images" / "small.png", (320, 200))
+    assert thumbnails.ensure_thumbnail(tmp_path, source, "thumb") is None
+    assert thumbnails.thumbnail_declined(tmp_path, source, "thumb")
+
+    _write_png(source, (1200, 800), color=(10, 200, 40))
+    os.utime(source, ns=(_MTIME_AFTER, _MTIME_AFTER))
+
+    assert not thumbnails.thumbnail_declined(tmp_path, source, "thumb")
+    assert thumbnails.ensure_thumbnail(tmp_path, source, "thumb") is not None
 
 
 def test_a_source_one_pixel_over_the_budget_still_builds(tmp_path):
@@ -238,6 +250,24 @@ def test_oversized_sources_fall_back(tmp_path, monkeypatch):
     source = _write_png(tmp_path / "a.png")
     monkeypatch.setattr(thumbnails, "_MAX_SOURCE_BYTES", 1)
     assert thumbnails.ensure_thumbnail(tmp_path, source, "thumb") is None
+    assert thumbnails.thumbnail_declined(tmp_path, source, "thumb")
+
+
+def test_animated_webp_is_recorded_as_a_permanent_decline(tmp_path):
+    source = tmp_path / "animated.webp"
+    first = Image.new("RGB", (1200, 800), (200, 30, 30))
+    second = Image.new("RGB", (1200, 800), (30, 30, 200))
+    first.save(
+        source,
+        "WEBP",
+        save_all=True,
+        append_images=[second],
+        duration=100,
+        loop=0,
+    )
+
+    assert thumbnails.ensure_thumbnail(tmp_path, source, "thumb") is None
+    assert thumbnails.thumbnail_declined(tmp_path, source, "thumb")
 
 
 def _watch_decodes(monkeypatch) -> list:
@@ -278,7 +308,7 @@ def test_a_small_file_that_decodes_huge_is_declined_before_decoding(
 
     assert thumbnails.ensure_thumbnail(tmp_path, source, "card") is None
     assert decodes == []
-    assert not (tmp_path / thumbnails.THUMB_ROOT).exists()
+    assert thumbnails.thumbnail_declined(tmp_path, source, "card")
 
 
 def test_the_pixel_ceiling_leaves_real_photography_alone(tmp_path):
@@ -310,6 +340,7 @@ def test_undecodable_source_falls_back_instead_of_raising(tmp_path):
     source = tmp_path / "a.png"
     source.write_bytes(b"\x89PNG\r\n\x1a\n truncated garbage")
     assert thumbnails.ensure_thumbnail(tmp_path, source, "thumb") is None
+    assert not thumbnails.thumbnail_declined(tmp_path, source, "thumb")
 
 
 def test_failed_render_leaves_no_temp_file_behind(tmp_path, monkeypatch):
@@ -321,6 +352,7 @@ def test_failed_render_leaves_no_temp_file_behind(tmp_path, monkeypatch):
     )
 
     assert thumbnails.ensure_thumbnail(tmp_path, source, "thumb") is None
+    assert not thumbnails.thumbnail_declined(tmp_path, source, "thumb")
     leftovers = list((tmp_path / thumbnails.THUMB_ROOT).rglob("*.tmp"))
     assert leftovers == []
 
@@ -559,7 +591,7 @@ def test_a_cold_variant_request_redirects_to_the_stable_original_url(
     history must still not schedule CPU-bound thumbnail work.
     """
 
-    source = _write_png(tmp_path / "freezone" / "_outputs" / "big.png", (2000, 1200))
+    _write_png(tmp_path / "freezone" / "_outputs" / "big.png", (2000, 1200))
     client = _client(monkeypatch, tmp_path)
     url = "/projects/demo/media/freezone/_outputs/big.png"
 
@@ -570,23 +602,55 @@ def test_a_cold_variant_request_redirects_to_the_stable_original_url(
         lambda _project_dir, requested, *_args: prewarm_calls.append(requested),
     )
 
+    query = (
+        "keep=first&st_thumb=invalid&v=1787194176036036558"
+        "&st_thumb=thumb&keep=second"
+    )
     cold = client.get(
-        f"{url}?keep=first&st_thumb=invalid&v=1787194176036036558"
-        "&st_thumb=thumb&keep=second",
+        f"{url}?{query}",
+        headers={
+            "X-SuperTale-Original-Uri": (
+                "/static/projects/demo/freezone/_outputs/big.png?" + query
+            )
+        },
         follow_redirects=False,
     )
 
     assert cold.status_code == 302
     assert cold.headers["cache-control"] == "no-store"
     assert cold.headers["location"] == (
-        f"{url}?keep=first&v=1787194176036036558&keep=second"
+        "/static/projects/demo/freezone/_outputs/big.png"
+        "?keep=first&v=1787194176036036558&keep=second"
     )
 
-    original = client.get(cold.headers["location"])
-    assert original.status_code == 200
-    assert original.content == source.read_bytes()
     assert prewarm_calls == []
     assert not (tmp_path / thumbnails.THUMB_ROOT).exists()
+
+
+@pytest.mark.parametrize(
+    "forwarded",
+    [
+        "https://example.invalid/static/projects/demo/a.png",
+        "//example.invalid/a",
+        "http://[",
+    ],
+)
+def test_an_untrusted_original_uri_header_cannot_control_the_redirect(
+    monkeypatch, tmp_path, forwarded
+):
+    _write_png(tmp_path / "freezone" / "_outputs" / "big.png", (2000, 1200))
+    client = _client(monkeypatch, tmp_path)
+    url = "/projects/demo/media/freezone/_outputs/big.png"
+
+    response = client.get(
+        url,
+        params={"st_thumb": "thumb", "v": "1787194176036036558"},
+        headers={"X-SuperTale-Original-Uri": forwarded},
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 302
+    assert response.headers["location"] == f"{url}?v=1787194176036036558"
 
 
 def test_a_variant_deleted_before_stat_still_redirects_to_the_original_url(
@@ -613,6 +677,25 @@ def test_a_variant_deleted_before_stat_still_redirects_to_the_original_url(
     assert response.headers["location"] == (
         f"{url}?keep=first&v=1787194176036036558&keep=second"
     )
+
+
+def test_a_permanently_declined_variant_serves_the_original_without_redirecting(
+    monkeypatch, tmp_path
+):
+    """A completed prewarm decline is a stable representation for this source."""
+
+    source = _write_png(tmp_path / "freezone" / "_outputs" / "small.png", (320, 200))
+    assert thumbnails.ensure_thumbnail(tmp_path, source, "thumb") is None
+    client = _client(monkeypatch, tmp_path)
+
+    response = client.get(
+        "/projects/demo/media/freezone/_outputs/small.png",
+        params={"st_thumb": "thumb", "v": str(source.stat().st_mtime_ns)},
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 200
+    assert response.content == source.read_bytes()
 
 
 def test_an_identical_prewarm_job_is_not_queued_twice(tmp_path, monkeypatch):

--- a/tests/test_media_thumbnails.py
+++ b/tests/test_media_thumbnails.py
@@ -589,6 +589,32 @@ def test_a_cold_variant_request_redirects_to_the_stable_original_url(
     assert not (tmp_path / thumbnails.THUMB_ROOT).exists()
 
 
+def test_a_variant_deleted_before_stat_still_redirects_to_the_original_url(
+    monkeypatch, tmp_path
+):
+    """A thumbnail cleanup race must not put original bytes on the variant URL."""
+
+    from novelvideo.api.routes import files
+
+    _write_png(tmp_path / "freezone" / "_outputs" / "big.png", (2000, 1200))
+    missing_thumb = tmp_path / "_thumbs" / "thumb" / "deleted.webp"
+    monkeypatch.setattr(files, "fresh_thumbnail", lambda *_args: missing_thumb)
+    client = _client(monkeypatch, tmp_path)
+    url = "/projects/demo/media/freezone/_outputs/big.png"
+
+    response = client.get(
+        f"{url}?keep=first&st_thumb=invalid&v=1787194176036036558"
+        "&st_thumb=thumb&keep=second",
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 302
+    assert response.headers["cache-control"] == "no-store"
+    assert response.headers["location"] == (
+        f"{url}?keep=first&v=1787194176036036558&keep=second"
+    )
+
+
 def test_an_identical_prewarm_job_is_not_queued_twice(tmp_path, monkeypatch):
     """One paint of a cold canvas offers the same job once per visible node.
 

--- a/tests/test_media_thumbnails.py
+++ b/tests/test_media_thumbnails.py
@@ -546,17 +546,17 @@ def test_a_regenerated_source_is_revalidated_to_the_new_variant(monkeypatch, tmp
     assert stale.content == second.content
 
 
-def test_a_cold_variant_request_serves_the_original_without_queuing_work(
+def test_a_cold_variant_request_redirects_to_the_stable_original_url(
     monkeypatch, tmp_path
 ):
-    """Reading old history must never schedule CPU-bound thumbnail work.
+    """A cold variant URL must never temporarily identify the original bytes.
 
-    Serving a request *without* a variant is a 302 to presigned OSS: the
-    original never travels through this process. Building on demand trades that
-    away for reading and decoding it locally, so the first visit to a cold
-    project would pull every full-resolution source over the ossfs mount just to
-    hand back a smaller copy. The response stays byte-for-byte what it would
-    have been before variants existed and no future render is scheduled.
+    The edge cache keys versioned URLs for a year. Returning the original with a
+    200 here lets that response occupy the future thumbnail's cache key, while
+    returning it through the slice filter can also race the thumbnail prewarm
+    and end in a 416. Redirecting to the URL without every ``st_thumb`` keeps the
+    original and variant representations on distinct cache keys. Reading old
+    history must still not schedule CPU-bound thumbnail work.
     """
 
     source = _write_png(tmp_path / "freezone" / "_outputs" / "big.png", (2000, 1200))
@@ -570,10 +570,21 @@ def test_a_cold_variant_request_serves_the_original_without_queuing_work(
         lambda _project_dir, requested, *_args: prewarm_calls.append(requested),
     )
 
-    cold = client.get(url, params={"st_thumb": "thumb"})
+    cold = client.get(
+        f"{url}?keep=first&st_thumb=invalid&v=1787194176036036558"
+        "&st_thumb=thumb&keep=second",
+        follow_redirects=False,
+    )
 
-    assert cold.status_code == 200
-    assert cold.content == source.read_bytes()
+    assert cold.status_code == 302
+    assert cold.headers["cache-control"] == "no-store"
+    assert cold.headers["location"] == (
+        f"{url}?keep=first&v=1787194176036036558&keep=second"
+    )
+
+    original = client.get(cold.headers["location"])
+    assert original.status_code == 200
+    assert original.content == source.read_bytes()
     assert prewarm_calls == []
     assert not (tmp_path / thumbnails.THUMB_ROOT).exists()
 


### PR DESCRIPTION
## Summary
- redirect valid cold thumbnail requests to the stable original URL without st_thumb
- mark the redirect no-store so cold original bytes cannot occupy a future thumbnail cache key
- preserve all unrelated query parameters and keep request-time thumbnail generation disabled

## Verification
- .venv/bin/pytest tests/test_media_thumbnails.py -q (71 passed)
- .venv/bin/ruff check --no-cache src/novelvideo/api/routes/files.py tests/test_media_thumbnails.py
- .venv/bin/black --check src/novelvideo/api/routes/files.py tests/test_media_thumbnails.py

Companion proxy change: claymorelab/SuperTale#91