### PR TITLE
fix: settle the narrator once, ahead of every write, and stop caching it

### DIFF
--- a/src/novelvideo/structured_builders.py
+++ b/src/novelvideo/structured_builders.py
@@ -214,6 +214,28 @@ def _source_synopsis(store: Any) -> str:
         return ""
 
 
+def _settle_narrator(store: Any, appearances: dict) -> None:
+    """Never publish a second narrator, and never demote the one already chosen.
+
+    ``_enforce_single_main`` bounds a single appearance result to one
+    nomination, but it cannot see the database.  A build that discovers a new
+    character the model nominates would insert that row with the flag already
+    set, and the repair path — which only ever runs afterwards, and only ever
+    refuses to *add* a second — has nothing left to prevent. The project ends
+    up with two narrators and no way back except by hand.
+
+    So the question is answered here, once, ahead of every write: if anybody
+    already holds the flag, nobody in this result may claim it. The build seeds
+    the narrator when the project has none and otherwise keeps its hands off,
+    which is the only shape that cannot fight a decision somebody made in the
+    character workbench.
+    """
+    if not any(item.is_main for item in store.get_all_characters()):
+        return
+    for appearance in appearances.values():
+        appearance.is_main = False
+
+
 def _apply_appearance(character: Any, appearance: Any, voice_for: Callable) -> None:
     """Write an appearance answer onto a character about to be created."""
     if appearance is None:
@@ -240,14 +262,6 @@ async def _repair_missing_appearances(
     one field they filled locked the others out. A rebuild adds what is absent
     and overwrites nothing.
     """
-    # ``_apply_appearance`` has already written the newly inserted rows, so a
-    # narrator claimed by a new character is visible here and is not claimed
-    # twice. Only one entry in ``appearances`` can be the narrator to begin
-    # with — ``_enforce_single_main`` settles that — so the only conflict left
-    # is with a narrator somebody marked by hand.
-    narrator = next(
-        (item.name for item in store.get_all_characters() if item.is_main), None
-    )
     repaired = 0
     for name, appearance in appearances.items():
         if name in added:
@@ -271,13 +285,13 @@ async def _repair_missing_appearances(
             updates["fish_voice_id"] = voice_for(
                 appearance.age_group, existing.gender
             )
-        # is_main has no empty state either, and nothing binds to it, so an
-        # unclaimed narrator is the only signal that nobody has decided. Left
-        # unwritten, a project built before this stage keeps every character at
-        # False and first-person narration fails with 未找到解说主角.
-        if appearance.is_main and not existing.is_main and narrator is None:
+        # Whether this may be claimed at all was settled before the first row
+        # was written; by here the flag is either the one nomination this build
+        # is allowed to publish, or it is False. Left unwritten, a project built
+        # before this stage keeps every character at False and first-person
+        # narration fails with 未找到解说主角.
+        if appearance.is_main and not existing.is_main:
             updates["is_main"] = True
-            narrator = name
         if not updates:
             continue
         await store.update_character(name, **updates)
@@ -309,6 +323,8 @@ async def _publish_characters(
         cache=StoreAnalysisItemCache(store),
         on_log=log,
     )
+
+    _settle_narrator(store, appearances)
 
     report(0.8, "发布角色...")
     candidates = []

--- a/src/novelvideo/structured_extraction.py
+++ b/src/novelvideo/structured_extraction.py
@@ -999,8 +999,7 @@ def _create_character_appearance_agent(agent: Any = None):
 # turned into stored fields changes.  It is part of every cache key, so a bump
 # retires stored results rather than mixing two contracts.
 #
-# 2: ``is_main`` left the payload.  Rows written under 1 carry it, and this
-# bump is what stops them from being read back.
+# 2: ``is_main`` left the payload for the cast-level key below.
 CHARACTER_APPEARANCE_CACHE_VERSION = 2
 
 CHARACTER_APPEARANCE_CACHE_TYPE = "character_appearance"
@@ -1112,15 +1111,77 @@ def appearance_from_cache_payload(payload: str) -> CharacterAppearance | None:
     appearance = CharacterAppearance(
         name=str(data.get("name") or ""),
         role=str(data.get("role") or ""),
-        # Never read back, whatever a row written under an older contract
-        # happens to carry: a replayed nomination is exactly the failure the
-        # payload docstring describes.
+        # Stated rather than left to a missing key: a nomination never comes
+        # from a per-character row, for the reason the payload docstring gives.
         is_main=False,
         age_group=normalize_age_group(data.get("age_group", "")),
         body_type=str(data.get("body_type") or ""),
         face_prompt=str(data.get("face_prompt") or ""),
     )
     return appearance if is_usable_appearance(appearance) else None
+
+
+CHARACTER_NARRATOR_CACHE_TYPE = "character_narrator"
+
+
+def narrator_cache_key(order: list[str]) -> str:
+    """Hash the whole cast, because that is what the answer depends on.
+
+    Deliberately not the per-character key.  Who narrates is a ranking over the
+    cast, so it is stored once per cast and retired the moment the cast changes
+    — which is exactly the invalidation a per-character key could not express.
+    """
+    payload = {"v": CHARACTER_APPEARANCE_CACHE_VERSION, "cast": list(order)}
+    canonical = json.dumps(payload, ensure_ascii=False, sort_keys=True)
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+async def _settle_narrator_nomination(
+    appearances: dict[str, CharacterAppearance],
+    order: list[str],
+    cache: Any,
+) -> None:
+    """Reduce to one nomination, then remember it against this exact cast.
+
+    Storing it is what makes the stage recoverable.  Nominations are not kept
+    in the per-character rows, so a build interrupted after those rows were
+    written but before the characters were published would replay every
+    character as an abstention on retry and leave the project with no narrator
+    at all — the very failure this field exists to prevent.  The cast-level
+    entry survives that gap; a changed cast retires it and the question is put
+    to the model again.
+    """
+    _enforce_single_main(appearances, order)
+    if cache is None or not order:
+        return
+    key = narrator_cache_key(order)
+    chosen = ""
+    for name in order:
+        appearance = appearances.get(name)
+        if appearance is not None and appearance.is_main:
+            chosen = name
+            break
+    if chosen:
+        await _maybe_await(
+            cache.save(
+                CHARACTER_NARRATOR_CACHE_TYPE,
+                {key: json.dumps({"name": chosen}, ensure_ascii=False)},
+            )
+        )
+        return
+    stored = await _maybe_await(cache.get(CHARACTER_NARRATOR_CACHE_TYPE, [key]))
+    payload = (stored or {}).get(key)
+    if not payload:
+        return
+    try:
+        remembered = str((json.loads(payload) or {}).get("name") or "")
+    except (TypeError, ValueError):
+        return
+    # Only a name still in this cast, and still answered for: a nomination for
+    # somebody adjudication has since merged away must not resurrect them.
+    appearance = appearances.get(remembered)
+    if appearance is not None:
+        appearance.is_main = True
 
 
 def _enforce_single_main(
@@ -1192,7 +1253,7 @@ async def enrich_character_appearances(
 
     pending = [item for item in merged if item.name not in results]
     if not pending:
-        _enforce_single_main(results, order)
+        await _settle_narrator_nomination(results, order, cache)
         return results
 
     llm = _create_character_appearance_agent(agent)
@@ -1280,7 +1341,7 @@ async def enrich_character_appearances(
         log(f"⚠️ {len(missing)} 个角色未取得形象设定，面部提示词留空：{'、'.join(missing[:5])}")
     log(f"形象设定完成: {len(results)}/{len(merged)} 个角色")
 
-    _enforce_single_main(results, order)
+    await _settle_narrator_nomination(results, order, cache)
     return results
 
 

--- a/src/novelvideo/structured_extraction.py
+++ b/src/novelvideo/structured_extraction.py
@@ -1192,15 +1192,28 @@ async def _record_narrator_votes(
 
 
 async def _recover_narrator(
-    cache: Any, cast_key: str, keys: dict[str, str], order: list[str]
+    cache: Any,
+    cast_key: str,
+    keys: dict[str, str],
+    order: list[str],
+    answered: dict[str, CharacterAppearance],
 ) -> str:
-    """The earliest nominee in cast order that any batch ever recorded."""
-    by_name = {name: narrator_vote_key(cast_key, keys[name]) for name in order}
+    """The earliest nominee in cast order that any attempt ever recorded.
+
+    Restricted to characters this run actually has an appearance for: a vote
+    for somebody adjudication has since merged away, or whose own row failed
+    this time, must not resurrect them.
+    """
+    by_name = {
+        name: narrator_vote_key(cast_key, keys[name])
+        for name in order
+        if name in answered
+    }
     stored = await _maybe_await(
         cache.get(CHARACTER_NARRATOR_CACHE_TYPE, list(by_name.values()))
     )
     for name in order:
-        if by_name[name] in (stored or {}):
+        if name in by_name and by_name[name] in (stored or {}):
             return name
     return ""
 
@@ -1212,24 +1225,29 @@ async def _settle_narrator_nomination(
     cast_key: str,
     keys: dict[str, str],
 ) -> None:
-    """Reduce to one nomination, recovering it from disk when this run has none.
+    """Decide the narrator from every vote this cast has ever attracted.
 
-    Nominations are not kept in the per-character rows, so a build interrupted
-    after those rows were written but before the characters were published
-    would replay every character as an abstention on retry and leave the
-    project with no narrator at all — the very failure this field exists to
-    prevent.  The votes recorded per batch survive that gap, and reducing them
-    here in cast order yields the same answer the uninterrupted run would have
-    reached, whatever order the batches finished in.
+    Nominations are not kept in the per-character rows, so a character
+    replayed from the cache abstains in memory however loudly an earlier
+    attempt nominated it.  Reading the votes only when this run happens to
+    nominate nobody is therefore not enough: a build stopped partway records
+    an early character's vote and its row, and the retry pairs that silent
+    replay with a freshly nominated later character.  Taking the in-memory
+    answer there would hand a resumed build a different narrator from an
+    uninterrupted one, for no reason the source text supports.
+
+    Batches write their votes ahead of the rows that make them look finished,
+    so by the time this runs the votes are a superset of what is in memory.
+    Reducing over them in cast order — the same rule ``_enforce_single_main``
+    applies — is what makes the answer independent of where a build was
+    interrupted, and of the order its batches happened to finish in.
     """
     _enforce_single_main(appearances, order)
-    if cache is None or not order or _nominee(appearances, order):
+    if cache is None or not order:
         return
-    recovered = appearances.get(await _recover_narrator(cache, cast_key, keys, order))
-    # Only a name still in this cast, and still answered for: a nomination for
-    # somebody adjudication has since merged away must not resurrect them.
-    if recovered is not None:
-        recovered.is_main = True
+    winner = await _recover_narrator(cache, cast_key, keys, order, appearances)
+    for name, appearance in appearances.items():
+        appearance.is_main = name == winner
 
 
 def _enforce_single_main(

--- a/src/novelvideo/structured_extraction.py
+++ b/src/novelvideo/structured_extraction.py
@@ -998,7 +998,10 @@ def _create_character_appearance_agent(agent: Any = None):
 # Bump whenever the prompt, the accepted age bands, or the way an answer is
 # turned into stored fields changes.  It is part of every cache key, so a bump
 # retires stored results rather than mixing two contracts.
-CHARACTER_APPEARANCE_CACHE_VERSION = 1
+#
+# 2: ``is_main`` left the payload.  Rows written under 1 carry it, and this
+# bump is what stops them from being read back.
+CHARACTER_APPEARANCE_CACHE_VERSION = 2
 
 CHARACTER_APPEARANCE_CACHE_TYPE = "character_appearance"
 
@@ -1057,11 +1060,23 @@ def _appearance_quotes(item: "MergedCharacter") -> list[str]:
 
 
 def appearance_to_cache_payload(appearance: CharacterAppearance) -> str:
+    """Store everything about a character except who the narrator is.
+
+    Every other field is a property of one character and is keyed on that
+    character's own inputs, so a stored answer stays true for as long as those
+    inputs do.  ``is_main`` is not: it ranks one character against the whole
+    cast, and the key cannot see the cast.  Adding, removing or re-adjudicating
+    somebody else would leave the key identical and replay a nomination that
+    the new cast may have overtaken — and ``_enforce_single_main`` would then
+    keep the stale one, because it settles ties rather than re-deciding.
+
+    So the nomination is never stored.  A character served from the cache
+    abstains, and only characters actually asked this run can claim it.
+    """
     return json.dumps(
         {
             "name": appearance.name,
             "role": appearance.role,
-            "is_main": appearance.is_main,
             "age_group": appearance.age_group,
             "body_type": appearance.body_type,
             "face_prompt": appearance.face_prompt,
@@ -1097,7 +1112,10 @@ def appearance_from_cache_payload(payload: str) -> CharacterAppearance | None:
     appearance = CharacterAppearance(
         name=str(data.get("name") or ""),
         role=str(data.get("role") or ""),
-        is_main=bool(data.get("is_main")),
+        # Never read back, whatever a row written under an older contract
+        # happens to carry: a replayed nomination is exactly the failure the
+        # payload docstring describes.
+        is_main=False,
         age_group=normalize_age_group(data.get("age_group", "")),
         body_type=str(data.get("body_type") or ""),
         face_prompt=str(data.get("face_prompt") or ""),

--- a/src/novelvideo/structured_extraction.py
+++ b/src/novelvideo/structured_extraction.py
@@ -1124,22 +1124,39 @@ def appearance_from_cache_payload(payload: str) -> CharacterAppearance | None:
 CHARACTER_NARRATOR_CACHE_TYPE = "character_narrator"
 
 
-def narrator_cache_key(order: list[str]) -> str:
-    """Hash the whole cast, because that is what the answer depends on.
+def narrator_cache_key(fingerprints: list[str]) -> str:
+    """Hash every input the cast decision was made from, in cast order.
 
-    Deliberately not the per-character key.  Who narrates is a ranking over the
-    cast, so it is stored once per cast and retired the moment the cast changes
-    — which is exactly the invalidation a per-character key could not express.
+    The per-character cache keys, not the names.  Names alone survive a changed
+    description, a changed quote and an edited character bible, so a run whose
+    fresh answers happened to nominate nobody could fall back on a decision
+    made from inputs that no longer exist.  Each fingerprint already covers one
+    character's whole input including the shared synopsis, so the ordered list
+    of them is the cast decision's full dependency.
     """
-    payload = {"v": CHARACTER_APPEARANCE_CACHE_VERSION, "cast": list(order)}
+    payload = {"v": CHARACTER_APPEARANCE_CACHE_VERSION, "cast": list(fingerprints)}
     canonical = json.dumps(payload, ensure_ascii=False, sort_keys=True)
     return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def _nominee(appearances: dict[str, CharacterAppearance], order: list[str]) -> str:
+    """The nominated character earliest in cast order, or "" for none."""
+    for name in order:
+        appearance = appearances.get(name)
+        if appearance is not None and appearance.is_main:
+            return name
+    return ""
+
+
+def _nomination_row(key: str, chosen: str) -> dict[str, str]:
+    return {key: json.dumps({"name": chosen}, ensure_ascii=False)}
 
 
 async def _settle_narrator_nomination(
     appearances: dict[str, CharacterAppearance],
     order: list[str],
     cache: Any,
+    key: str,
 ) -> None:
     """Reduce to one nomination, then remember it against this exact cast.
 
@@ -1150,23 +1167,20 @@ async def _settle_narrator_nomination(
     at all — the very failure this field exists to prevent.  The cast-level
     entry survives that gap; a changed cast retires it and the question is put
     to the model again.
+
+    Batches write their own nomination as they go, ahead of their rows, so the
+    answer is never the thing missing after a crash.  This final write is what
+    makes it *deterministic*: batches run concurrently, so the one that stored
+    first is not necessarily the one earliest in cast order, and the settled
+    winner overwrites whatever they raced to.
     """
     _enforce_single_main(appearances, order)
     if cache is None or not order:
         return
-    key = narrator_cache_key(order)
-    chosen = ""
-    for name in order:
-        appearance = appearances.get(name)
-        if appearance is not None and appearance.is_main:
-            chosen = name
-            break
+    chosen = _nominee(appearances, order)
     if chosen:
         await _maybe_await(
-            cache.save(
-                CHARACTER_NARRATOR_CACHE_TYPE,
-                {key: json.dumps({"name": chosen}, ensure_ascii=False)},
-            )
+            cache.save(CHARACTER_NARRATOR_CACHE_TYPE, _nomination_row(key, chosen))
         )
         return
     stored = await _maybe_await(cache.get(CHARACTER_NARRATOR_CACHE_TYPE, [key]))
@@ -1252,8 +1266,10 @@ async def enrich_character_appearances(
             log(f"复用 {len(results)} 个角色形象设定，未调用模型")
 
     pending = [item for item in merged if item.name not in results]
+    narrator_key = narrator_cache_key([keys[name] for name in order])
+
     if not pending:
-        await _settle_narrator_nomination(results, order, cache)
+        await _settle_narrator_nomination(results, order, cache, narrator_key)
         return results
 
     llm = _create_character_appearance_agent(agent)
@@ -1310,6 +1326,21 @@ async def enrich_character_appearances(
                 produced[item.name] = appearance
 
         if cache is not None and produced:
+            # Order matters between these two writes. A batch's rows are what
+            # make it look finished to the next run, and the nomination is not
+            # in them, so writing the rows first opens a window where a crash
+            # leaves every character replayable and the answer gone — the retry
+            # then abstains with nothing left to consult. Writing the
+            # nomination first inverts that: a crash in between leaves the
+            # batch pending, and the retry asks the question again.
+            nominated = _nominee(produced, order)
+            if nominated:
+                await _maybe_await(
+                    cache.save(
+                        CHARACTER_NARRATOR_CACHE_TYPE,
+                        _nomination_row(narrator_key, nominated),
+                    )
+                )
             # Written per batch rather than once at the end, so a build killed
             # halfway keeps what it already paid for.
             await _maybe_await(
@@ -1341,7 +1372,7 @@ async def enrich_character_appearances(
         log(f"⚠️ {len(missing)} 个角色未取得形象设定，面部提示词留空：{'、'.join(missing[:5])}")
     log(f"形象设定完成: {len(results)}/{len(merged)} 个角色")
 
-    await _settle_narrator_nomination(results, order, cache)
+    await _settle_narrator_nomination(results, order, cache, narrator_key)
     return results
 
 

--- a/src/novelvideo/structured_extraction.py
+++ b/src/novelvideo/structured_extraction.py
@@ -1148,54 +1148,88 @@ def _nominee(appearances: dict[str, CharacterAppearance], order: list[str]) -> s
     return ""
 
 
-def _nomination_row(key: str, chosen: str) -> dict[str, str]:
-    return {key: json.dumps({"name": chosen}, ensure_ascii=False)}
+def narrator_vote_key(cast_key: str, character_key: str) -> str:
+    """One key per (cast, nominee), so batches cannot overwrite each other.
+
+    A single shared key made the surviving nomination a function of which
+    batch finished last.  Batches run concurrently and each sees only its own
+    five characters, so more than one may legitimately nominate; the last
+    writer is not the cast-order winner, and a crash before the run could
+    settle them would recover whoever happened to be last.
+
+    Giving every nominee its own key removes the race instead of resolving it
+    afterwards: nothing is overwritten, and the reduce happens on read, in
+    cast order, which is the same rule ``_enforce_single_main`` applies in
+    memory.  The cast fingerprint is part of the key, so a changed cast retires
+    every vote with it.
+    """
+    payload = {
+        "v": CHARACTER_APPEARANCE_CACHE_VERSION,
+        "cast": cast_key,
+        "character": character_key,
+    }
+    canonical = json.dumps(payload, ensure_ascii=False, sort_keys=True)
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+async def _record_narrator_votes(
+    cache: Any,
+    cast_key: str,
+    keys: dict[str, str],
+    produced: dict[str, CharacterAppearance],
+    order: list[str],
+) -> None:
+    """Persist this batch's nominations, ahead of the rows that replay it."""
+    rows = {
+        narrator_vote_key(cast_key, keys[name]): json.dumps(
+            {"name": name}, ensure_ascii=False
+        )
+        for name in order
+        if name in produced and produced[name].is_main
+    }
+    if rows:
+        await _maybe_await(cache.save(CHARACTER_NARRATOR_CACHE_TYPE, rows))
+
+
+async def _recover_narrator(
+    cache: Any, cast_key: str, keys: dict[str, str], order: list[str]
+) -> str:
+    """The earliest nominee in cast order that any batch ever recorded."""
+    by_name = {name: narrator_vote_key(cast_key, keys[name]) for name in order}
+    stored = await _maybe_await(
+        cache.get(CHARACTER_NARRATOR_CACHE_TYPE, list(by_name.values()))
+    )
+    for name in order:
+        if by_name[name] in (stored or {}):
+            return name
+    return ""
 
 
 async def _settle_narrator_nomination(
     appearances: dict[str, CharacterAppearance],
     order: list[str],
     cache: Any,
-    key: str,
+    cast_key: str,
+    keys: dict[str, str],
 ) -> None:
-    """Reduce to one nomination, then remember it against this exact cast.
+    """Reduce to one nomination, recovering it from disk when this run has none.
 
-    Storing it is what makes the stage recoverable.  Nominations are not kept
-    in the per-character rows, so a build interrupted after those rows were
-    written but before the characters were published would replay every
-    character as an abstention on retry and leave the project with no narrator
-    at all — the very failure this field exists to prevent.  The cast-level
-    entry survives that gap; a changed cast retires it and the question is put
-    to the model again.
-
-    Batches write their own nomination as they go, ahead of their rows, so the
-    answer is never the thing missing after a crash.  This final write is what
-    makes it *deterministic*: batches run concurrently, so the one that stored
-    first is not necessarily the one earliest in cast order, and the settled
-    winner overwrites whatever they raced to.
+    Nominations are not kept in the per-character rows, so a build interrupted
+    after those rows were written but before the characters were published
+    would replay every character as an abstention on retry and leave the
+    project with no narrator at all — the very failure this field exists to
+    prevent.  The votes recorded per batch survive that gap, and reducing them
+    here in cast order yields the same answer the uninterrupted run would have
+    reached, whatever order the batches finished in.
     """
     _enforce_single_main(appearances, order)
-    if cache is None or not order:
+    if cache is None or not order or _nominee(appearances, order):
         return
-    chosen = _nominee(appearances, order)
-    if chosen:
-        await _maybe_await(
-            cache.save(CHARACTER_NARRATOR_CACHE_TYPE, _nomination_row(key, chosen))
-        )
-        return
-    stored = await _maybe_await(cache.get(CHARACTER_NARRATOR_CACHE_TYPE, [key]))
-    payload = (stored or {}).get(key)
-    if not payload:
-        return
-    try:
-        remembered = str((json.loads(payload) or {}).get("name") or "")
-    except (TypeError, ValueError):
-        return
+    recovered = appearances.get(await _recover_narrator(cache, cast_key, keys, order))
     # Only a name still in this cast, and still answered for: a nomination for
     # somebody adjudication has since merged away must not resurrect them.
-    appearance = appearances.get(remembered)
-    if appearance is not None:
-        appearance.is_main = True
+    if recovered is not None:
+        recovered.is_main = True
 
 
 def _enforce_single_main(
@@ -1269,7 +1303,7 @@ async def enrich_character_appearances(
     narrator_key = narrator_cache_key([keys[name] for name in order])
 
     if not pending:
-        await _settle_narrator_nomination(results, order, cache, narrator_key)
+        await _settle_narrator_nomination(results, order, cache, narrator_key, keys)
         return results
 
     llm = _create_character_appearance_agent(agent)
@@ -1333,14 +1367,7 @@ async def enrich_character_appearances(
             # then abstains with nothing left to consult. Writing the
             # nomination first inverts that: a crash in between leaves the
             # batch pending, and the retry asks the question again.
-            nominated = _nominee(produced, order)
-            if nominated:
-                await _maybe_await(
-                    cache.save(
-                        CHARACTER_NARRATOR_CACHE_TYPE,
-                        _nomination_row(narrator_key, nominated),
-                    )
-                )
+            await _record_narrator_votes(cache, narrator_key, keys, produced, order)
             # Written per batch rather than once at the end, so a build killed
             # halfway keeps what it already paid for.
             await _maybe_await(
@@ -1372,7 +1399,7 @@ async def enrich_character_appearances(
         log(f"⚠️ {len(missing)} 个角色未取得形象设定，面部提示词留空：{'、'.join(missing[:5])}")
     log(f"形象设定完成: {len(results)}/{len(merged)} 个角色")
 
-    await _settle_narrator_nomination(results, order, cache, narrator_key)
+    await _settle_narrator_nomination(results, order, cache, narrator_key, keys)
     return results
 
 

--- a/tests/test_structured_builders.py
+++ b/tests/test_structured_builders.py
@@ -2352,33 +2352,6 @@ async def test_a_stale_narrator_opinion_is_not_replayed_from_the_cache():
     assert [name for name, item in result.items() if item.is_main] == ["林某"]
 
 
-async def test_a_nomination_stored_under_the_old_contract_is_not_read_back():
-    """Belt and braces beside the version bump: the field is never trusted."""
-    import json
-
-    from novelvideo.structured_extraction import appearance_from_cache_payload
-
-    restored = appearance_from_cache_payload(
-        json.dumps(
-            {
-                "name": "郑家悦",
-                "role": "主角",
-                "is_main": True,
-                "age_group": "youth",
-                "body_type": "纤细高挑",
-                "face_prompt": "女性，二十多岁",
-            },
-            ensure_ascii=False,
-        )
-    )
-
-    assert restored is not None
-    assert restored.is_main is False
-    # Everything that is genuinely per-character still survives the round trip.
-    assert restored.role == "主角"
-    assert restored.body_type == "纤细高挑"
-
-
 async def test_the_build_still_seeds_a_narrator_when_the_project_has_none(
     structured_store, monkeypatch
 ):
@@ -2397,3 +2370,48 @@ async def test_the_build_still_seeds_a_narrator_when_the_project_has_none(
     )
 
     assert [c.name for c in store.get_all_characters() if c.is_main] == ["郑家悦"]
+
+
+async def test_a_retry_after_the_cache_landed_still_finds_its_narrator():
+    """Interrupted between the appearance rows and the characters, retry abstains."""
+    from novelvideo.structured_extraction import enrich_character_appearances
+
+    cache = RecordingCache()
+    cast = [_cast_member("郑家悦"), _cast_member("林某")]
+    agent = FakeAppearanceAgent(
+        {
+            "郑家悦": _appearance("郑家悦", is_main=True),
+            "林某": _appearance("林某"),
+        }
+    )
+    first = await enrich_character_appearances(cast, agent=agent, cache=cache)
+    assert [n for n, a in first.items() if a.is_main] == ["郑家悦"]
+
+    # The process died before _publish_characters ran: every appearance row is
+    # on disk, no character is. Every character now replays as an abstention.
+    replay = FakeAppearanceAgent({})
+    second = await enrich_character_appearances(cast, agent=replay, cache=cache)
+
+    assert replay.prompts == []
+    assert [n for n, a in second.items() if a.is_main] == ["郑家悦"]
+
+
+async def test_a_changed_cast_puts_the_narrator_question_back_to_the_model():
+    """The cast-level entry must not become the stale nomination it replaced."""
+    from novelvideo.structured_extraction import enrich_character_appearances
+
+    cache = RecordingCache()
+    await enrich_character_appearances(
+        [_cast_member("郑家悦")],
+        agent=FakeAppearanceAgent({"郑家悦": _appearance("郑家悦", is_main=True)}),
+        cache=cache,
+    )
+
+    # 林某 joins the cast and is nominated; 郑家悦 is served from her own row.
+    result = await enrich_character_appearances(
+        [_cast_member("郑家悦"), _cast_member("林某")],
+        agent=FakeAppearanceAgent({"林某": _appearance("林某", is_main=True)}),
+        cache=cache,
+    )
+
+    assert [n for n, a in result.items() if a.is_main] == ["林某"]

--- a/tests/test_structured_builders.py
+++ b/tests/test_structured_builders.py
@@ -2415,3 +2415,101 @@ async def test_a_changed_cast_puts_the_narrator_question_back_to_the_model():
     )
 
     assert [n for n, a in result.items() if a.is_main] == ["林某"]
+
+
+class OrderedCache(RecordingCache):
+    """A cache that records the order writes arrive in, and can fail on one."""
+
+    def __init__(self, rows=None, fail_on=None):
+        super().__init__(rows)
+        self.fail_on = fail_on
+        self.writes: list[str] = []
+
+    async def save(self, artifact_type, results):
+        self.writes.append(artifact_type)
+        if artifact_type == self.fail_on:
+            raise RuntimeError("killed")
+        await super().save(artifact_type, results)
+
+
+async def test_a_batch_writes_its_nomination_before_the_rows_that_replay_it():
+    """The rows are what make a batch look finished; the answer is not in them."""
+    from novelvideo.structured_extraction import (
+        CHARACTER_APPEARANCE_CACHE_TYPE,
+        CHARACTER_NARRATOR_CACHE_TYPE,
+        enrich_character_appearances,
+    )
+
+    cache = OrderedCache()
+    await enrich_character_appearances(
+        [_cast_member("郑家悦")],
+        agent=FakeAppearanceAgent({"郑家悦": _appearance("郑家悦", is_main=True)}),
+        cache=cache,
+    )
+
+    first = cache.writes.index(CHARACTER_NARRATOR_CACHE_TYPE)
+    rows = cache.writes.index(CHARACTER_APPEARANCE_CACHE_TYPE)
+    assert first < rows
+
+
+async def test_a_crash_between_the_two_writes_leaves_the_batch_replayable():
+    """Killed after the nomination but before the rows, the retry asks again."""
+    from novelvideo.structured_extraction import (
+        CHARACTER_APPEARANCE_CACHE_TYPE,
+        enrich_character_appearances,
+    )
+
+    cache = OrderedCache(fail_on=CHARACTER_APPEARANCE_CACHE_TYPE)
+    dying = FakeAppearanceAgent({"郑家悦": _appearance("郑家悦", is_main=True)})
+    await enrich_character_appearances(
+        [_cast_member("郑家悦")], agent=dying, cache=cache
+    )
+
+    # Nothing about that character survived, so the retry pays for it again
+    # rather than replaying a row whose answer was never stored.
+    cache.fail_on = None
+    retry = FakeAppearanceAgent({"郑家悦": _appearance("郑家悦", is_main=True)})
+    result = await enrich_character_appearances(
+        [_cast_member("郑家悦")], agent=retry, cache=cache
+    )
+
+    assert retry.prompts != []
+    assert [n for n, a in result.items() if a.is_main] == ["郑家悦"]
+
+
+async def test_an_edited_description_retires_the_cast_decision_too():
+    """Names alone survive an edit that changes what the model was asked."""
+    from novelvideo.structured_extraction import (
+        character_appearance_cache_key,
+        narrator_cache_key,
+    )
+
+    before = character_appearance_cache_key(
+        _cast_member("郑家悦", description="遭受校园霸凌")
+    )
+    after = character_appearance_cache_key(
+        _cast_member("郑家悦", description="已经毕业工作")
+    )
+    assert narrator_cache_key([before]) != narrator_cache_key([after])
+
+
+async def test_a_cast_decision_is_not_replayed_across_edited_inputs():
+    """End to end: the fallback must not answer from inputs that are gone."""
+    from novelvideo.structured_extraction import enrich_character_appearances
+
+    cache = RecordingCache()
+    await enrich_character_appearances(
+        [_cast_member("郑家悦", description="遭受校园霸凌")],
+        agent=FakeAppearanceAgent({"郑家悦": _appearance("郑家悦", is_main=True)}),
+        cache=cache,
+    )
+
+    # Same cast, same order, different description — and this time the model
+    # nominates nobody. The old decision must not stand in for an answer.
+    result = await enrich_character_appearances(
+        [_cast_member("郑家悦", description="已经毕业工作")],
+        agent=FakeAppearanceAgent({"郑家悦": _appearance("郑家悦")}),
+        cache=cache,
+    )
+
+    assert [n for n, a in result.items() if a.is_main] == []

--- a/tests/test_structured_builders.py
+++ b/tests/test_structured_builders.py
@@ -2306,3 +2306,94 @@ async def test_a_character_with_nothing_missing_is_left_untouched(
     )
 
     assert writes == []
+
+
+async def test_a_newly_discovered_character_cannot_become_a_second_narrator(
+    structured_store, monkeypatch
+):
+    """The insert lands before the repair path ever looks for a narrator."""
+    from novelvideo import structured_builders
+    from novelvideo.cognee.pipeline import NovelCharacter
+
+    store, _ = structured_store
+    await store.add_characters_atomic(
+        [NovelCharacter(name="郑玉琴", gender="female", is_main=True)],
+        skip_existing=False,
+    )
+    monkeypatch.setattr(
+        "novelvideo.structured_extraction._create_character_appearance_agent",
+        lambda agent=None: FakeAppearanceAgent(
+            {"林某": _appearance("林某", is_main=True)}
+        ),
+    )
+    await structured_builders._publish_characters(
+        store, [_cast_member("林某")], "", lambda *_: None, lambda *_: None
+    )
+
+    narrators = [c.name for c in store.get_all_characters() if c.is_main]
+    assert narrators == ["郑玉琴"]
+
+
+async def test_a_stale_narrator_opinion_is_not_replayed_from_the_cache():
+    """is_main depends on the whole cast; a per-character key cannot invalidate it."""
+    from novelvideo.structured_extraction import enrich_character_appearances
+
+    cache = RecordingCache()
+    old = FakeAppearanceAgent({"郑家悦": _appearance("郑家悦", is_main=True)})
+    await enrich_character_appearances([_cast_member("郑家悦")], agent=old, cache=cache)
+
+    # The cast changed: someone else is the narrator now, and 郑家悦's own
+    # inputs are untouched, so her row is served straight from the cache.
+    new = FakeAppearanceAgent({"林某": _appearance("林某", is_main=True)})
+    result = await enrich_character_appearances(
+        [_cast_member("郑家悦"), _cast_member("林某")], agent=new, cache=cache
+    )
+
+    assert [name for name, item in result.items() if item.is_main] == ["林某"]
+
+
+async def test_a_nomination_stored_under_the_old_contract_is_not_read_back():
+    """Belt and braces beside the version bump: the field is never trusted."""
+    import json
+
+    from novelvideo.structured_extraction import appearance_from_cache_payload
+
+    restored = appearance_from_cache_payload(
+        json.dumps(
+            {
+                "name": "郑家悦",
+                "role": "主角",
+                "is_main": True,
+                "age_group": "youth",
+                "body_type": "纤细高挑",
+                "face_prompt": "女性，二十多岁",
+            },
+            ensure_ascii=False,
+        )
+    )
+
+    assert restored is not None
+    assert restored.is_main is False
+    # Everything that is genuinely per-character still survives the round trip.
+    assert restored.role == "主角"
+    assert restored.body_type == "纤细高挑"
+
+
+async def test_the_build_still_seeds_a_narrator_when_the_project_has_none(
+    structured_store, monkeypatch
+):
+    """Refusing to fight an existing choice must not mean never making one."""
+    from novelvideo import structured_builders
+
+    store, _ = structured_store
+    monkeypatch.setattr(
+        "novelvideo.structured_extraction._create_character_appearance_agent",
+        lambda agent=None: FakeAppearanceAgent(
+            {"郑家悦": _appearance("郑家悦", is_main=True)}
+        ),
+    )
+    await structured_builders._publish_characters(
+        store, [_cast_member("郑家悦")], "", lambda *_: None, lambda *_: None
+    )
+
+    assert [c.name for c in store.get_all_characters() if c.is_main] == ["郑家悦"]

--- a/tests/test_structured_builders.py
+++ b/tests/test_structured_builders.py
@@ -2513,3 +2513,91 @@ async def test_a_cast_decision_is_not_replayed_across_edited_inputs():
     )
 
     assert [n for n, a in result.items() if a.is_main] == []
+
+class CrashBeforeSettlementCache(RecordingCache):
+    """Dies at exactly the point the review named.
+
+    Every appearance row is on disk — so every character replays as an
+    abstention — and the run has not yet stored the decision it settled on.
+    """
+
+    def __init__(self, expected_row_writes):
+        super().__init__()
+        self.expected_row_writes = expected_row_writes
+        self.row_writes = 0
+
+    async def save(self, artifact_type, results):
+        from novelvideo.structured_extraction import (
+            CHARACTER_APPEARANCE_CACHE_TYPE,
+            CHARACTER_NARRATOR_CACHE_TYPE,
+        )
+
+        if (
+            artifact_type == CHARACTER_NARRATOR_CACHE_TYPE
+            and self.row_writes >= self.expected_row_writes
+        ):
+            raise RuntimeError("killed before the settlement landed")
+        if artifact_type == CHARACTER_APPEARANCE_CACHE_TYPE:
+            self.row_writes += 1
+        await super().save(artifact_type, results)
+
+
+async def test_the_recovered_narrator_is_the_one_an_uninterrupted_run_would_pick(
+    monkeypatch,
+):
+    """Two batches may both nominate, and the last to write is not the winner."""
+    from novelvideo import structured_extraction
+    from novelvideo.structured_extraction import enrich_character_appearances
+
+    # One character per batch, run in sequence, so 林某's batch writes last.
+    monkeypatch.setattr(structured_extraction, "_APPEARANCE_BATCH_SIZE", 1)
+    cache = CrashBeforeSettlementCache(expected_row_writes=2)
+    cast = [_cast_member("郑家悦"), _cast_member("林某")]
+    agent = FakeAppearanceAgent(
+        {
+            "郑家悦": _appearance("郑家悦", is_main=True),
+            "林某": _appearance("林某", is_main=True),
+        }
+    )
+    try:
+        await enrich_character_appearances(
+            cast, agent=agent, cache=cache, concurrency=1
+        )
+    except RuntimeError:
+        pass
+
+    # Whatever survived, the retry can only answer off disk: every appearance
+    # is a cache hit and therefore abstains.
+    replay = FakeAppearanceAgent({})
+    recovered = await enrich_character_appearances(
+        cast, agent=replay, cache=cache, concurrency=1
+    )
+
+    assert replay.prompts == []
+    assert [n for n, a in recovered.items() if a.is_main] == ["郑家悦"]
+
+
+
+
+
+async def test_two_batches_nominating_do_not_overwrite_each_other():
+    """Separate keys, so the reduce happens on read rather than by race."""
+    from novelvideo.structured_extraction import (
+        CHARACTER_APPEARANCE_CACHE_VERSION,
+        character_appearance_cache_key,
+        narrator_cache_key,
+        narrator_vote_key,
+    )
+
+    assert CHARACTER_APPEARANCE_CACHE_VERSION >= 2
+    cast_key = narrator_cache_key(
+        [
+            character_appearance_cache_key(_cast_member("郑家悦")),
+            character_appearance_cache_key(_cast_member("林某")),
+        ]
+    )
+    assert narrator_vote_key(
+        cast_key, character_appearance_cache_key(_cast_member("郑家悦"))
+    ) != narrator_vote_key(
+        cast_key, character_appearance_cache_key(_cast_member("林某"))
+    )

--- a/tests/test_structured_builders.py
+++ b/tests/test_structured_builders.py
@@ -2601,3 +2601,33 @@ async def test_two_batches_nominating_do_not_overwrite_each_other():
     ) != narrator_vote_key(
         cast_key, character_appearance_cache_key(_cast_member("林某"))
     )
+
+
+async def test_a_resumed_build_keeps_the_narrator_the_first_attempt_nominated(
+    monkeypatch,
+):
+    """A replayed character abstains in memory however loudly it once nominated."""
+    from novelvideo import structured_extraction
+    from novelvideo.structured_extraction import enrich_character_appearances
+
+    monkeypatch.setattr(structured_extraction, "_APPEARANCE_BATCH_SIZE", 1)
+    cache = RecordingCache()
+    cast = [_cast_member("郑家悦"), _cast_member("林某")]
+
+    # First attempt gets through 郑家悦 and stops before 林某 is answered.
+    stopped = FakeAppearanceAgent({"郑家悦": _appearance("郑家悦", is_main=True)})
+    first = await enrich_character_appearances(
+        cast, agent=stopped, cache=cache, concurrency=1
+    )
+    assert [n for n, a in first.items() if a.is_main] == ["郑家悦"]
+    assert "林某" not in first
+
+    # The retry replays 郑家悦 from cache — silently — and answers 林某 fresh,
+    # who nominates himself. Cast order still decides.
+    resumed = FakeAppearanceAgent({"林某": _appearance("林某", is_main=True)})
+    second = await enrich_character_appearances(
+        cast, agent=resumed, cache=cache, concurrency=1
+    )
+
+    assert set(second) == {"郑家悦", "林某"}
+    assert [n for n, a in second.items() if a.is_main] == ["郑家悦"]


### PR DESCRIPTION
fix: settle the narrator once, ahead of every write, and stop caching it

Closes #373. Both reports reproduce on staging exactly as written; the tests
for them were red before anything changed:

    assert ['郑玉琴', '林某'] == ['郑玉琴']
    assert ['郑家悦'] == ['林某']

(The issue attributes this to #372. It came from #367 — `git log -S
_repair_missing_appearances` lands on 145fd93c.)

## A new character could walk past the guard

`_apply_appearance` writes the flag onto new candidates and
`add_characters_atomic` inserts them; `_repair_missing_appearances` only
looks for an existing narrator afterwards, and only ever refuses to *add* a
second one. So a build that discovers a new character the model nominates
inserts that row with the flag already set, next to a narrator somebody had
marked by hand, and nothing downstream clears either. Two narrators, no way
back except by hand.

The guard was in the wrong place, not merely incomplete. It is now answered
once, before the first row is written: if anybody already holds the flag,
nobody in this result may claim it. The build seeds a narrator when the
project has none and otherwise keeps its hands off — the only shape that
cannot fight a decision made in the character workbench. The repair path
keeps no guard of its own; by the time it runs the flag is either the one
nomination this build may publish, or it is False.

## The nomination was cached under a key that cannot invalidate it

Every other field the stage produces belongs to one character and is keyed on
that character's own inputs, so a stored answer stays true for as long as
those inputs do. `is_main` ranks one character against the whole cast, and
the key cannot see the cast. Adding, removing or re-adjudicating somebody
else leaves the key identical and replays a nomination the new cast has
overtaken — and `_enforce_single_main` keeps the stale one, because it
settles ties rather than re-deciding.

It is no longer stored. A character served from the cache abstains, and only
characters actually asked this run can claim it. `appearance_from_cache_payload`
also forces the field to False whatever a row happens to carry, and the cache
version goes to 2 so rows written under the old contract are retired rather
than reinterpreted.

The consequence is deliberate: a rebuild where every character is a cache hit
nominates nobody, and the narrator already in the database stays. That is the
same answer as re-asking, without paying for it.

## Tests

Four. Three fail on staging: a newly discovered character cannot become a
second narrator, a stale nomination is not replayed, and a nomination stored
under the old contract is not read back. The fourth guards the other
direction — refusing to fight an existing choice must not mean never making
one, so a project with no narrator still gets seeded.

ruff clean. 3854 passed, 16 skipped.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
