### PR TITLE
fix: request only prewarmed thumbnails

### DIFF
--- a/frontend/src/__tests__/features/canvas/node-body-image-variant.test.ts
+++ b/frontend/src/__tests__/features/canvas/node-body-image-variant.test.ts
@@ -45,12 +45,12 @@ describe("nodeBodyImageSrc", () => {
     window.history.pushState(null, "", "/");
   });
 
-  it("asks for the card variant once the source's real size is known", () => {
-    expect(nodeBodyImageSrc(URL, BIG)).toEqual({
-      src: `${URL}?st_thumb=card`,
+  it("asks only for thumb when the display fits the 320px budget", () => {
+    expect(nodeBodyImageSrc(URL, BIG, { requiredEdge: 320 })).toEqual({
+      src: `${URL}?st_thumb=thumb`,
       original: URL,
       downscaled: true,
-      maxEdge: 1280,
+      maxEdge: 320,
     });
   });
 
@@ -71,7 +71,6 @@ describe("nodeBodyImageSrc", () => {
       { width: edge, height: edge },
       { width: edge, height: 100 },
       { width: 100, height: edge },
-      { width: 640, height: 480 },
     ]) {
       expect(nodeBodyImageSrc(URL, natural)).toEqual({
         src: URL,
@@ -95,7 +94,9 @@ describe("nodeBodyImageSrc", () => {
   });
 
   it("keeps an existing cache-bust token", () => {
-    expect(nodeBodyImageSrc(`${URL}?st_v=17`, BIG).src).toBe(`${URL}?st_v=17&st_thumb=card`);
+    expect(nodeBodyImageSrc(`${URL}?st_v=17`, BIG, { requiredEdge: 320 }).src).toBe(
+      `${URL}?st_v=17&st_thumb=thumb`,
+    );
   });
 
   it("reports downscaled:false whenever the variant cannot apply", () => {
@@ -203,13 +204,13 @@ describe("按显示尺寸 x zoom x DPR 挑档", () => {
     expect(nodeBodyRequiredEdge({ width: 580, height: 326 }, Number.NaN, 0)).toBe(580);
   });
 
-  it("pickMediaVariant 取阶梯上最便宜的那一档", () => {
+  it("pickMediaVariant 只保留 thumb，超过 320px 就回原图", () => {
     expect(pickMediaVariant(315)).toBe("thumb");
     expect(pickMediaVariant(320)).toBe("thumb");
-    expect(pickMediaVariant(321)).toBe("thumb2x");
-    expect(pickMediaVariant(630)).toBe("thumb2x");
-    expect(pickMediaVariant(1160)).toBe("card");
-    expect(pickMediaVariant(1280)).toBe("card");
+    expect(pickMediaVariant(321)).toBeNull();
+    expect(pickMediaVariant(630)).toBeNull();
+    expect(pickMediaVariant(1160)).toBeNull();
+    expect(pickMediaVariant(1280)).toBeNull();
   });
 
   // 放大糊是唯一不能接受的结果：宁可付原图的解码，也不给一张要放大 2.5 倍的副本。
@@ -229,19 +230,15 @@ describe("按显示尺寸 x zoom x DPR 挑档", () => {
     });
   });
 
-  it("默认尺寸的节点在 Retina 上仍然吃到 card", () => {
+  it("默认尺寸的节点在 Retina 上直接使用原图", () => {
     const required = nodeBodyRequiredEdge({ width: 580, height: 326 }, 1, 2);
-    expect(nodeBodyImageSrc(URL, BIG, { requiredEdge: required }).src).toBe(
-      `${URL}?st_thumb=card`,
-    );
+    expect(nodeBodyImageSrc(URL, BIG, { requiredEdge: required }).src).toBe(URL);
   });
 
-  // LOD 最宽的那一档：1x 屏落在 320，2x 屏落到 640——改前两者都是 320，Retina 上
-  // 只有需要的一半分辨率。
-  it("LOD 外壳按 DPR 分档", () => {
+  it("LOD 外壳只有 1x 尺寸落在 thumb 预算内", () => {
     const shell = { width: 900, height: 900 };
     expect(pickMediaVariant(nodeBodyRequiredEdge(shell, 0.35, 1))).toBe("thumb");
-    expect(pickMediaVariant(nodeBodyRequiredEdge(shell, 0.35, 2))).toBe("thumb2x");
+    expect(pickMediaVariant(nodeBodyRequiredEdge(shell, 0.35, 2))).toBeNull();
   });
 
   it("挑到的那一档不比源图小时仍然回原图", () => {
@@ -250,7 +247,8 @@ describe("按显示尺寸 x zoom x DPR 挑档", () => {
     ).toBe(false);
   });
 
-  it("不传 requiredEdge 时维持原来的 card 预算", () => {
+  it("不传 requiredEdge 时只使用 thumb 预算", () => {
     expect(nodeBodyImageSrc(URL, BIG).maxEdge).toBe(NODE_BODY_VARIANT_MAX_EDGE);
+    expect(nodeBodyImageSrc(URL, BIG).maxEdge).toBe(320);
   });
 });

--- a/frontend/src/__tests__/lib/media-url.test.ts
+++ b/frontend/src/__tests__/lib/media-url.test.ts
@@ -168,19 +168,14 @@ describe("resolveMediaUrl variants", () => {
     expect(resolveMediaUrl(path, undefined)).toBe(resolveMediaUrl(path));
   });
 
-  it("carries the card variant used by canvas node bodies", () => {
-    expect(
-      resolveMediaUrl("/static/projects/proj/images/a.png", { variant: "card" }),
-    ).toBe("/static/projects/proj/images/a.png?st_thumb=card");
-  });
 });
 
 // Canvas nodes resolve their URL through resolveImageDisplayUrl +
 // withImageCacheBust, so they need the variant step on its own.
 describe("withMediaVariant", () => {
   it("appends the variant to a protected project image", () => {
-    expect(withMediaVariant("/static/projects/proj/images/a.png", "card")).toBe(
-      "/static/projects/proj/images/a.png?st_thumb=card",
+    expect(withMediaVariant("/static/projects/proj/images/a.png", "thumb")).toBe(
+      "/static/projects/proj/images/a.png?st_thumb=thumb",
     );
   });
 
@@ -193,18 +188,18 @@ describe("withMediaVariant", () => {
   // split(sep, 2) truncates instead of splitting once, so a second separator
   // silently disappears from the URL the backend receives.
   it("keeps everything after the first separator", () => {
-    expect(withMediaVariant("/static/projects/p/a.png#x#y", "card")).toBe(
-      "/static/projects/p/a.png?st_thumb=card#x#y",
+    expect(withMediaVariant("/static/projects/p/a.png#x#y", "thumb")).toBe(
+      "/static/projects/p/a.png?st_thumb=thumb#x#y",
     );
-    expect(withMediaVariant("/static/projects/p/a.png?v=1?z=2", "card")).toBe(
-      "/static/projects/p/a.png?v=1%3Fz%3D2&st_thumb=card",
+    expect(withMediaVariant("/static/projects/p/a.png?v=1?z=2", "thumb")).toBe(
+      "/static/projects/p/a.png?v=1%3Fz%3D2&st_thumb=thumb",
     );
   });
 
   it("replaces a variant rather than stacking a second one", () => {
     expect(
-      withMediaVariant("/static/projects/proj/images/a.png?st_thumb=thumb", "card"),
-    ).toBe("/static/projects/proj/images/a.png?st_thumb=card");
+      withMediaVariant("/static/projects/proj/images/a.png?st_thumb=card", "thumb"),
+    ).toBe("/static/projects/proj/images/a.png?st_thumb=thumb");
   });
 
   // Identity is how callers detect "no downscaled copy was actually requested".
@@ -217,7 +212,7 @@ describe("withMediaVariant", () => {
       "/static/projects/proj/videos/clip.mp4",
       "/static/projects/proj/audio/voice.wav",
     ]) {
-      expect(withMediaVariant(url, "card")).toBe(url);
+      expect(withMediaVariant(url, "thumb")).toBe(url);
     }
   });
 });

--- a/frontend/src/features/canvas/application/imageData.ts
+++ b/frontend/src/features/canvas/application/imageData.ts
@@ -250,18 +250,15 @@ export function withImageCacheBust(imageUrl: string, token: string | number | nu
 // 元素已经没有新东西可教我们，调用方改从记录里读（见 nodeBodyImageMeasurement）。
 // 尺寸未知的节点照旧加载原图、照旧测量、照旧落库，下次挂载自然就用上变体了。
 //
-// 挑哪一档不能写死。同一个 1280px 副本，画进 580 CSS px 的默认节点里绰绰有余，
-// 画进用户拉到 1600px 的节点里就是 1.25 倍放大糊；Retina 上这两个数还要各乘 2。
-// 所以按「这一格到底要多少设备像素」来挑：displayEdge × zoom × devicePixelRatio，
-// 交给 pickMediaVariant 在阶梯上找最便宜的那一档，一档都盖不住就回原图——放大糊
-// 是唯一不能接受的结果，而需要那么多像素的节点本来就没几个能同屏。
+// 前端只请求生产会预热的 320px thumb。按 displayEdge × zoom × devicePixelRatio
+// 算出这一格需要的设备像素；thumb 盖不住就回原图，避免放大模糊。
 //
-// 用 zoom 但不怕抖：pickMediaVariant 的输出只有三个值加一个 null，节点订阅的是这
-// 个结果而不是 zoom 本身，缩放过程中最多换两次 src，且都命中缓存。
+// 用 zoom 但不怕抖：pickMediaVariant 的输出只有 thumb 和 null，节点订阅的是这个
+// 量化结果而不是 zoom 本身，只在跨过 320px 阈值时切换 src。
 //
 // 全屏查看器 / 下载 / 导出 / 各类编辑器一律仍然拿原图，见各调用点的
 // viewerSourceUrl。
-export const NODE_BODY_VARIANT_MAX_EDGE = MEDIA_VARIANT_MAX_EDGE.card;
+export const NODE_BODY_VARIANT_MAX_EDGE = MEDIA_VARIANT_MAX_EDGE.thumb;
 
 /**
  * 节点主体图这一格需要多少设备像素（长边）。
@@ -342,9 +339,10 @@ export function nodeBodyImageSrc(
  * 记录描述的是另一张图。
  *
  * 反过来不成立，这一点必须说清楚：对得上只说明比例对得上。副本的长边被钉死在预
- * 算上，原图有多大这个信息在降采样时就丢了，所以 5504x3072 和 2752x1536 的 card
- * 副本都是 1280x714，拿旧记录去比一样能过。换图时的那条线因此不能只靠这里——各
- * 节点在主图地址变了的当下就直接不信任记录（见 distrustRecord），这里只当兜底：
+ * 算上，原图有多大这个信息在降采样时就丢了，所以 5504x3072 和 2752x1536 的
+ * thumb 副本都是 320x179，拿旧记录去比一样能过。换图时的那条线因此不能只靠
+ * 这里——各节点在主图地址变了的当下就直接不信任记录（见 distrustRecord），
+ * 这里只当兜底：
  * 管挂载时就已经存歪了的旧数据，那种情况没有「上一张」可比。
  */
 export function nodeBodyRecordDescribesImage(

--- a/frontend/src/features/canvas/hooks/useNodeBodyVariantBudget.ts
+++ b/frontend/src/features/canvas/hooks/useNodeBodyVariantBudget.ts
@@ -9,13 +9,13 @@ import { useDevicePixelRatio } from '@/lib/useDevicePixelRatio';
 /**
  * 这个节点的主体图该按多大的长边预算去挑副本。
  *
- * 返回的不是「需要多少像素」的原始值，而是它落在阶梯上的那一档（320 / 640 /
- * 1280），一档都盖不住时返回 Infinity——nodeBodyImageSrc 拿到它会交回原图。
+ * 返回的不是「需要多少像素」的原始值，而是 320px thumb 或 Infinity；thumb
+ * 盖不住时 nodeBodyImageSrc 会交回原图。
  *
  * 之所以先量化再返回：原始值随 zoom 每一帧都在变，而节点订阅的是这个 selector
- * 的结果。量化之后取值只有四个，缩放全程最多重渲染两次、换两次 src，且两次都命
- * 中缓存。这条线原本就是节点为了躲开「平移每帧重渲染」而只订阅布尔值的那条线，
- * 沿用同一个手法。
+ * 的结果。量化之后取值只有两个，缩放跨过 320px 阈值时才重渲染、切换 src。这条
+ * 线原本就是节点为了躲开「平移每帧重渲染」而只订阅布尔值的那条线，沿用同一个
+ * 手法。
  */
 export function useNodeBodyVariant(display: {
   width: number;

--- a/frontend/src/features/canvas/nodes/LodShellNode.tsx
+++ b/frontend/src/features/canvas/nodes/LodShellNode.tsx
@@ -94,10 +94,9 @@ type ShellData = {
  * 个。解码成本只看源图像素数，所以原图在这里是纯浪费：一张 5504x3072 要付
  * 16.9MP，换成 320px 变体是 0.06MP。
  *
- * 但 320 是个 1x 预算：Retina 上那 315 CSS px 要的是 630 设备像素，喂 320 就只有
- * 一半分辨率，糊得看得出来。所以这里不写死档位，交给 useNodeBodyVariant 按
- * 显示尺寸 × zoom × DPR 去挑——1x 屏照旧落在 320，2x 屏落到 640（0.25MP，相对
- * 16.9MP 的原图仍然可以忽略）。
+ * 前端只请求生产会预热的 320px thumb。超过预算的节点主体会使用原图；LOD shell
+ * 仍固定回落 thumb，因为它只在低缩放、大量节点同时出现时使用，避免同时解码几十
+ * 上百张完整原图。
  *
  * 变体不适用时（blob: 预览、遗留路径、抓帧 data:）withMediaVariant 原样返回，
  * 行为与改动前一致。shell 不接 onLoad、不测尺寸、不进查看器/导出，所以这里
@@ -140,9 +139,8 @@ function LodShell({ type, id, data, selected, width, height }: {
   const fallback = SHELL_FALLBACK_SIZES[type] ?? DEFAULT_SHELL_SIZE;
   const w = width ?? fallback.width;
   const h = height ?? fallback.height;
-  // 一格都盖不住的巨型节点在这一档几乎不存在（zoom<0.35 下要 3600 CSS px 才够
-  // 得着），真出现也宁可喂顶档副本：shell 的整个前提就是节点太多、不能解原图。
-  const variant = useNodeBodyVariant({ width: w, height: h }) ?? 'card';
+  // 一格盖不住时也继续喂 thumb：shell 的整个前提就是节点太多、不能同时解原图。
+  const variant = useNodeBodyVariant({ width: w, height: h }) ?? 'thumb';
 
   // 视频缩略图：订阅模块级抓帧缓存；节点从未挂载过完整组件时（首屏即低缩放），
   // 这里负责把抓帧任务排进空闲队列，不依赖完整组件出现过。

--- a/frontend/src/lib/media-url.ts
+++ b/frontend/src/lib/media-url.ts
@@ -31,35 +31,28 @@ export function resolveMediaUrl(
   return withMediaVariant(resolved, options.variant);
 }
 
-// A ladder of downscaled copies, keyed by the longest edge each one fits into.
-// Keep in sync with VARIANTS in novelvideo/utils/thumbnails.py — an unknown
-// name is ignored by the backend and the original is served, so a mismatch
-// degrades rather than breaks.
-export type MediaVariant = "thumb" | "thumb2x" | "card";
+// The single downscaled copy the frontend may request.
+// The frontend intentionally requests only the variant prewarmed by the
+// production history write path. Larger display budgets use the original.
+export type MediaVariant = "thumb";
 
 export const MEDIA_VARIANT_MAX_EDGE: Record<MediaVariant, number> = {
   thumb: 320,
-  thumb2x: 640,
-  card: 1280,
 };
 
-// Ascending, so the first match is the cheapest one that still covers the box.
-const MEDIA_VARIANT_LADDER: MediaVariant[] = ["thumb", "thumb2x", "card"];
+const MEDIA_VARIANT_LADDER: MediaVariant[] = ["thumb"];
 
 /**
- * The cheapest variant that can fill a box `requiredEdge` device pixels on its
- * long side, or `null` when none can.
+ * Return ``thumb`` when its 320px edge can fill the requested device pixels,
+ * or ``null`` so the caller uses the original.
  *
  * Device pixels, not CSS pixels: a 320px copy in a 315 CSS px box is crisp on a
  * 1x display and visibly soft on a 2x one, and that difference is exactly what
  * a fixed budget per call site cannot express. Callers compute the requirement
  * as `displayEdge * zoom * devicePixelRatio` and let this pick.
  *
- * `null` means "serve the original". Upscaling a variant is the one outcome
- * worth avoiding outright: the decode saving is real but so is the blur, and a
- * box that wants more than the top of the ladder belongs to a deliberately
- * enlarged node — there are only ever a few of those on screen, which is
- * precisely when decode cost stops being the bottleneck.
+ * `null` means "serve the original". Upscaling the 320px thumbnail is avoided
+ * because its decode saving would come with visible blur.
  */
 export function pickMediaVariant(requiredEdge: number): MediaVariant | null {
   if (!Number.isFinite(requiredEdge) || requiredEdge <= 0) return null;


### PR DESCRIPTION
## Summary
- restrict frontend thumbnail requests to the production-prewarmed thumb variant
- use the original image when a canvas body needs more than 320 device pixels
- keep low-zoom LOD shells on thumb to avoid decoding many full originals

## Test plan
- pnpm exec vitest run src/__tests__/lib/media-url.test.ts src/__tests__/features/canvas/node-body-image-variant.test.ts
- pnpm build:ce
- git diff --check

## Context
Follow-up to #371. This removes steady-state redirects for frontend-requested thumb2x/card variants that the production history path never prewarms.