### PR TITLE
chore(branches): back-merge main hotfix #338 into staging

### DIFF
--- a/frontend/src/__tests__/features/canvas/video-model-capabilities.test.ts
+++ b/frontend/src/__tests__/features/canvas/video-model-capabilities.test.ts
@@ -20,11 +20,13 @@ import {
   resolveVideoKeyframeUrls,
   videoEmptyStateCtaModes,
   videoModeForcesAutomaticAspectRatio,
+  videoModeRequiresMedia,
   videoModeRequiresPrompt,
   videoModelDefaultGenerateAudio,
   videoModelSupportsGenerateAudio,
   videoModelReferenceDisabledReason,
   videoMultiImageAutoSwitchMode,
+  videoNoUpstreamResetMode,
   videoReferenceAutoSwitchAction,
   type VideoReferenceAutoSwitchAction,
   videoSubmitMediaRejectionReason,
@@ -1182,5 +1184,90 @@ describe("videoModeRequiresPrompt — submit validation by mode", () => {
     ] as VideoGenMode[]) {
       expect(videoModeRequiresPrompt(mode)).toBe(false);
     }
+  });
+});
+
+describe("videoModeRequiresMedia — 该模式是否必须有上游素材", () => {
+  it("文生视频是唯一不需要素材的模式", () => {
+    expect(videoModeRequiresMedia("textToVideo")).toBe(false);
+  });
+
+  it("全能参考同样需要素材（omni 端点没素材就发不出去）", () => {
+    // 与 videoModeRequiresPrompt 是**并列**关系而非二选一：全能参考两条都要。
+    // 只看提示词的话，素材撤空后按钮仍然可点，点了却被 handleSubmit 的
+    // references.length === 0 静默拦下 —— 用户看到的就是「点了没反应」。
+    expect(videoModeRequiresMedia("allReference")).toBe(true);
+    expect(videoModeRequiresPrompt("allReference")).toBe(true);
+  });
+
+  it("其余生成模式都要素材", () => {
+    for (const mode of [
+      "firstFrame",
+      "imageToVideo",
+      "imageReference",
+      "firstLastFrame",
+      "videoEdit",
+    ] as VideoGenMode[]) {
+      expect(videoModeRequiresMedia(mode)).toBe(true);
+    }
+  });
+});
+
+describe("videoNoUpstreamResetMode — 素材撤空后退回文生视频", () => {
+  const EMPTY = { images: 0, videos: 0, audios: 0 };
+
+  it("上游清空后，任何素材模式都退回文生视频", () => {
+    for (const mode of [
+      "allReference",
+      "imageReference",
+      "firstFrame",
+      "imageToVideo",
+      "firstLastFrame",
+      "videoEdit",
+    ] as VideoGenMode[]) {
+      expect(videoNoUpstreamResetMode(mode, EMPTY)).toBe("textToVideo");
+    }
+  });
+
+  it("已经是文生视频就不动（避免每帧都发一次 patch）", () => {
+    expect(videoNoUpstreamResetMode("textToVideo", EMPTY)).toBeNull();
+  });
+
+  it.each([
+    ["图片", { images: 1, videos: 0, audios: 0 }],
+    ["视频", { images: 0, videos: 1, audios: 0 }],
+    ["音频", { images: 0, videos: 0, audios: 1 }],
+  ] as const)("上游还有%s素材时不动", (_label, counts) => {
+    expect(videoNoUpstreamResetMode("allReference", counts)).toBeNull();
+  });
+});
+
+describe("VideoNode 接线：素材撤空 → 文生视频", () => {
+  const source = readFileSync("src/features/canvas/nodes/VideoNode.tsx", "utf8");
+
+  it("反向复位 effect 按节点类型口径判定，不用已解析 URL 口径", () => {
+    // upstreamCounts（已解析 URL）会把空态 CTA 刚铺好、还没出图的图片节点算成 0 张，
+    // 用它当场就会把三个 CTA 顶回文生视频。
+    expect(source).toContain(
+      "videoNoUpstreamResetMode(genMode, upstreamTypeCounts)",
+    );
+  });
+
+  it("复位不进撤销栈", () => {
+    // 这是「用户删素材」的衍生结果而非独立改动；记进 past 会让 ⌘Z 被本 effect 立刻
+    // 撤销回去、redo 栈还被清空，等于把「回到连线之前」这条路堵死。
+    expect(source).toContain(
+      "updateNodeData(id, { genMode: target }, { recordHistory: false });",
+    );
+  });
+
+  it("提交闸门把提示词与素材拆成两条并列判定", () => {
+    expect(source).toContain(
+      "(videoModeRequiresPrompt(genMode) && !hasPromptText) ||\n      (videoModeRequiresMedia(genMode) && !hasRequiredMediaForMode);",
+    );
+    // 旧的三元写法：要提示词的模式就不再看素材 —— 全能参考因此漏网。
+    expect(source).not.toContain(
+      "videoModeRequiresPrompt(genMode)\n        ? !hasPromptText\n        : !hasRequiredMediaForMode",
+    );
   });
 });

--- a/frontend/src/features/canvas/nodes/VideoNode.tsx
+++ b/frontend/src/features/canvas/nodes/VideoNode.tsx
@@ -77,11 +77,13 @@ import {
   resolveVideoKeyframeUrls,
   videoEmptyStateCtaModes,
   videoModeForcesAutomaticAspectRatio,
+  videoModeRequiresMedia,
   videoModeRequiresPrompt,
   videoModelDefaultGenerateAudio,
   videoModelReferenceDisabledReason,
   videoModelSupportsGenerateAudio,
   videoMultiImageAutoSwitchMode,
+  videoNoUpstreamResetMode,
   videoReferenceAutoSwitchAction,
   videoSubmitMediaRejectionReason,
   videoUpstreamImageDefaultMode,
@@ -1672,6 +1674,34 @@ export const VideoNode = memo(
       updateNodeData,
     ]);
 
+    // 上面几条模式推导都是**单向**的：素材接进来就把模式推到能消费它的那一个，却没有
+    // 任何一条负责在素材撤空后把模式推回去。于是「连一张图 → 又把图撤掉」之后节点卡在
+    // 全能参考上：界面看不出异常，提交却会被 handleSubmit 的 references.length === 0
+    // 静默拦下，用户看到的就是「打了字、点发送没反应」。这里补上反向的那一档 ——
+    // 没有任何上游素材 = 文生视频，与 HappyHorse 统一状态机的「无上游 → 文生视频」同规则。
+    //
+    // 用 upstreamTypeCounts（按节点类型）而非 upstreamCounts（已解析 URL）：空态 CTA
+    // 先铺一个还没出图的图片/上传节点、再切模式，按 URL 口径那一瞬间是 0 张，会被这条
+    // 当场顶回文生视频。理由同 videoNoUpstreamResetMode 的注释。
+    //
+    // recordHistory: false —— 这是用户「删掉素材」那一步的**衍生结果**，不是一次独立的
+    // 用户改动。若照常压 past，⌘Z 只会撤掉模式回到「无素材 + 全能参考」，本 effect 立刻
+    // 又把它改回来并清空 redo 栈，撤销看着毫无反应、也再回不到连线之前（成因见上面
+    // 模型自动救场那条 effect 的注释）。不记历史则 ⌘Z 直接回到「有图 + 全能参考」，正向 effect
+    // 看到素材还在便不再改写。
+    useEffect(() => {
+      if (isHappyHorseModel) return;
+      const target = videoNoUpstreamResetMode(genMode, upstreamTypeCounts);
+      if (!target) return;
+      updateNodeData(id, { genMode: target }, { recordHistory: false });
+    }, [
+      genMode,
+      isHappyHorseModel,
+      upstreamTypeCounts,
+      id,
+      updateNodeData,
+    ]);
+
     useEffect(
       () => () => {
         clearTransientPreview();
@@ -1894,11 +1924,13 @@ export const VideoNode = memo(
       updateNodeData,
     ]);
 
-    // 提交可用性按模式区分（对齐后端各端点校验）：
-    // - 文生 / 全能参考：后端强校验 prompt，必须有提示词（自写或上游 text）；
-    // - 首帧 / 图生视频 / 图片参考 / 首尾帧 / 视频编辑：后端不校验 prompt，允许空提示词，
-    //   只要素材齐备即可提交（图片类要 ≥1 张上游图；视频编辑要 ≥1 个上游视频）。
-    //   这修掉「删掉默认提示词后传了首帧仍无法直接生成」的问题。
+    // 提交可用性按模式区分（对齐后端各端点校验），提示词与素材两条**分别**判定：
+    // - 提示词：文生 / 全能参考 后端强校验 prompt，必须有（自写或上游 text）；首帧 /
+    //   图生视频 / 图片参考 / 首尾帧 / 视频编辑允许空提示词 —— 这修掉「删掉默认提示词后
+    //   传了首帧仍无法直接生成」的问题。
+    // - 素材：除文生视频外都要有（图片类要 ≥1 张上游图；视频编辑要 ≥1 个上游视频；
+    //   全能参考图/视频/音频任意一类 ≥1）—— 对齐 handleSubmit 各分支的空素材早退。
+    // 全能参考是唯一两条都要的模式，所以这里不能写成「要提示词的就只看提示词」。
     const hasPromptText =
       prompt.trim().length > 0 || upstreamTextJoined.length > 0;
     const hasRequiredMediaForMode =
@@ -1958,9 +1990,11 @@ export const VideoNode = memo(
       !selectedVideoModel ||
       selectedModelReferenceError !== null ||
       mediaRejectionReason != null ||
-      (videoModeRequiresPrompt(genMode)
-        ? !hasPromptText
-        : !hasRequiredMediaForMode);
+      // 提示词与素材是**两条并列**的要求，不是二选一：全能参考两条都要（后端强校验
+      // prompt，omni 端点又没素材可发）。写成三元的时候，全能参考只看提示词，素材撤空后
+      // 按钮仍是可点态，点下去被 handleSubmit 的 references.length === 0 静默拦掉。
+      (videoModeRequiresPrompt(genMode) && !hasPromptText) ||
+      (videoModeRequiresMedia(genMode) && !hasRequiredMediaForMode);
 
     const handleSubmit = useCallback(async () => {
       if (submitDisabled) return;

--- a/frontend/src/features/canvas/nodes/shared/videoModelCapabilities.ts
+++ b/frontend/src/features/canvas/nodes/shared/videoModelCapabilities.ts
@@ -254,6 +254,43 @@ export function videoModeRequiresPrompt(mode: VideoGenMode): boolean {
 }
 
 /**
+ * 该 genMode 是否**必须有上游素材**才能提交：只有文生视频不需要，其余模式的提交
+ * 分支都会在素材为空时直接 return（见 VideoNode 的 handleSubmit）。
+ *
+ * 和 `videoModeRequiresPrompt` 是**并列**关系，不是二选一 —— 全能参考两条都要：
+ * 后端 omni 端点强校验 prompt，而 references 为空又根本没得可发。曾经写成「要提示词
+ * 的模式就只看提示词」，于是「接过图 → 又把图撤走 → 只打字」这条路上按钮看着可点、
+ * 点下去却被 handleSubmit 的 `references.length === 0` 静默拦掉，表现为「点了没反应」。
+ * 正常情况下 `videoNoUpstreamResetMode` 会先把模式退回文生视频，这条是兜底：上游节点
+ * 还连着、里面的图却被清空时（typeCounts>0 而 counts==0）退回不触发，仍要拦住提交。
+ */
+export function videoModeRequiresMedia(mode: VideoGenMode): boolean {
+  return mode !== "textToVideo";
+}
+
+/**
+ * 上游素材被全部撤走后该退回哪个模式：`"textToVideo"` = 退回文生视频，null = 不动。
+ *
+ * 视频节点的模式推导原本是**单向**的：接入图片/视频/音频时有一堆 effect 把模式推进
+ * 到能消费该素材的模式，却没有任何一条在素材撤空后把它推回来。于是「连一张图 → 又把
+ * 图删掉」之后节点卡在全能参考上，界面上看不出异常，提交却必然被静默拦下。
+ * HappyHorse 那条统一状态机早就有「无上游 → 文生视频」这一档，这里把同一条规则补给
+ * 其余模型。
+ *
+ * 素材计数要传**按节点类型**的口径（`upstreamTypeCounts`，空的图片节点也算），不能用
+ * 「已解析 URL」的口径：空态 CTA（全能参考 / 图片参考 / 首尾帧）正是先铺一个还没出图
+ * 的图片/上传节点、再把模式切过去，按 URL 口径这一瞬间素材数是 0，会被这条规则当场
+ * 顶回文生视频，等于把三个 CTA 全废掉。
+ */
+export function videoNoUpstreamResetMode(
+  mode: VideoGenMode,
+  counts: { images: number; videos: number; audios: number },
+): VideoGenMode | null {
+  if (counts.images > 0 || counts.videos > 0 || counts.audios > 0) return null;
+  return mode === "textToVideo" ? null : "textToVideo";
+}
+
+/**
  * 该模型的 i2v 端点是否放行多图（>1）。后端只在「非 2.0 且非 HappyHorse」时对
  * `len(source_paths) > 1` 直接 400（freezone.py），所以这两族之外的模型（Seedance
  * 1.x 等）一次只能吃一张图 —— 对它们来说换模式救不了，得换模型。


### PR DESCRIPTION
## Purpose

Restore the branch invariant that `staging` is a superset of `main`.

PR #338 was merged directly into `main` as hotfix commit `c7677a35`, but it was not back-merged into `staging`. As a result, PRs originally branched from main expose #338 as an unrelated change when their base is corrected to staging.

## Scope

This PR contains the only commit currently reachable from `main` but not from `staging`:

- `c7677a35 fix(canvas): 视频节点素材撤空后退回文生视频，别再卡在全能参考 (#338)`

This is a history-preserving back-merge, not a cherry-pick, so the original main commit becomes an ancestor of staging and future comparisons do not surface #338 again.

## Verification

- `git rev-list --left-right --count origin/main...origin/staging` before this PR: `1 76`
- `git log origin/staging..origin/main`: only `c7677a35`

No new implementation is introduced here; #338 already passed its original review and CI before merging to main.