### PR TITLE
feat(login): 公告内容改从 CDN 拉 JSON，不再写死在前端

### DIFF
--- a/frontend/public/announcements.json
+++ b/frontend/public/announcements.json
@@ -1,0 +1,19 @@
+{
+  "announcements": [
+    {
+      "id": "channel-release-2026-08",
+      "publishedAt": "2026-08-24T10:00:00+08:00",
+      "pinned": false,
+      "i18n": {
+        "zh": {
+          "title": "渠道版本更新",
+          "body": "<hl>渠道版本</hl>即将上线，更新时间在 <time>18:00-19:00</time> 点，请避开这个时间段使用。敬请期待！"
+        },
+        "en": {
+          "title": "Channel release update",
+          "body": "A <hl>channel release</hl> is going live between <time>18:00 and 19:00</time>. Please avoid using the product during that window. Stay tuned!"
+        }
+      }
+    }
+  ]
+}

--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -35,14 +35,7 @@
       "unread": "{{n}} unread",
       "pinned": "Pinned",
       "expand": "Expand this announcement",
-      "collapse": "Collapse this announcement",
-      "empty": "No announcements yet",
-      "items": {
-        "channel-release-2026-08": {
-          "title": "Channel release update",
-          "body": "A <hl>channel release</hl> is going live between <time>18:00 and 19:00</time>. Please avoid using the product during that window. Stay tuned!"
-        }
-      }
+      "collapse": "Collapse this announcement"
     }
   },
   "downloadPage": {

--- a/frontend/public/locales/zh/translation.json
+++ b/frontend/public/locales/zh/translation.json
@@ -35,14 +35,7 @@
       "unread": "{{n}} 条未读",
       "pinned": "置顶",
       "expand": "展开这条公告",
-      "collapse": "收起这条公告",
-      "empty": "暂时没有公告",
-      "items": {
-        "channel-release-2026-08": {
-          "title": "渠道版本更新",
-          "body": "<hl>渠道版本</hl>即将上线，更新时间在 <time>18:00-19:00</time> 点，请避开这个时间段使用。敬请期待！"
-        }
-      }
+      "collapse": "收起这条公告"
     }
   },
   "downloadPage": {

--- a/frontend/src/__tests__/components/login/announcement-entry.test.tsx
+++ b/frontend/src/__tests__/components/login/announcement-entry.test.tsx
@@ -2,7 +2,7 @@
 // Copyright (c) 2026 ClaymoreLab
 import { readFileSync } from "node:fs";
 
-import { beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import i18next from "i18next";
@@ -10,8 +10,8 @@ import { initReactI18next } from "react-i18next";
 
 import { AnnouncementEntry } from "@/components/login/cinematic/AnnouncementEntry";
 
-// 用真实译文跑，而不是 mock 掉 react-i18next —— 正文里的 <time>/<hl> 标记是文案的一部分，
-// 只有真 i18next 解析才能验出「高亮标签写漏了」这类改文案时最容易犯的错。
+// 用真实译文跑，而不是 mock 掉 react-i18next —— 界面词也是文案的一部分，
+// 只有真 i18next 才能验出「新加的 key 忘了补翻译」。
 beforeAll(async () => {
   await i18next.use(initReactI18next).init({
     lng: "zh",
@@ -21,9 +21,29 @@ beforeAll(async () => {
   });
 });
 
+// 公告内容来自 OSS 上的 JSON。仓库里 public/announcements.json 就是要传上去的那份，
+// 直接拿它当夹具：既测组件，也顺手验这份 JSON 的形状能过 schema。
+const SHIPPED_PAYLOAD = JSON.parse(readFileSync("public/announcements.json", "utf8"));
+
+function stubFetch(impl: () => unknown) {
+  const fetchMock = vi.fn(async () => impl() as Response);
+  vi.stubGlobal("fetch", fetchMock);
+  return fetchMock;
+}
+
+function jsonResponse(body: unknown) {
+  return { ok: true, status: 200, json: async () => body } as unknown as Response;
+}
+
 // 已读状态落在 localStorage 里，用例之间不清就会互相串。
 beforeEach(() => {
   window.localStorage.clear();
+  stubFetch(() => jsonResponse(SHIPPED_PAYLOAD));
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
 });
 
 const DIALOG = { name: "公告中心" };
@@ -33,12 +53,33 @@ async function openCenter() {
   render(<AnnouncementEntry />);
   const trigger = screen.getByRole("button", { name: "查看公告" });
   await user.click(trigger);
-  return { user, trigger, dialog: await screen.findByRole("dialog", DIALOG) };
+  const dialog = await screen.findByRole("dialog", DIALOG);
+  return { user, trigger, dialog };
+}
+
+async function openLoadedCenter() {
+  const opened = await openCenter();
+  await waitFor(() =>
+    expect(within(opened.dialog).queryAllByRole("listitem").length).toBeGreaterThan(0),
+  );
+  return opened;
 }
 
 describe("AnnouncementEntry", () => {
+  it("pulls the announcements from the OSS json instead of a bundled list", async () => {
+    const fetchMock = stubFetch(() => jsonResponse(SHIPPED_PAYLOAD));
+
+    await openLoadedCenter();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
+    expect(url).toBe("https://nfg-web-assets.cdnfg.com/dramaclaw/announcements.json");
+    // 登录页是未登录状态下打开的，别把 cookie 带去 CDN。
+    expect(init).toMatchObject({ credentials: "omit", cache: "no-cache" });
+  });
+
   it("keeps the red dot on the trigger even after everything was marked read", async () => {
-    const { user, trigger } = await openCenter();
+    const { user, trigger } = await openLoadedCenter();
 
     await user.click(screen.getByRole("button", { name: "全部已读" }));
     await user.click(screen.getByRole("button", { name: "确认" }));
@@ -48,7 +89,7 @@ describe("AnnouncementEntry", () => {
   });
 
   it("lists each announcement as its own card and closes from the confirm button", async () => {
-    const { user, dialog } = await openCenter();
+    const { user, dialog } = await openLoadedCenter();
 
     const items = within(dialog).getAllByRole("listitem");
     expect(items).toHaveLength(1);
@@ -61,16 +102,88 @@ describe("AnnouncementEntry", () => {
   });
 
   it("renders the subject and the time window as separate highlight spans", async () => {
-    await openCenter();
+    await openLoadedCenter();
 
-    // 高亮片段各自成元素，说明 <time>/<hl> 真的被 Trans 换成了带样式的 span，
+    // 高亮片段各自成元素，说明 <time>/<hl> 真的被换成了带样式的 span，
     // 而不是当成纯文本原样打在正文里。
     expect(screen.getByText("渠道版本").tagName).toBe("SPAN");
     expect(screen.getByText("18:00-19:00").tagName).toBe("SPAN");
   });
 
+  it("prints any other markup in the remote copy as literal text", async () => {
+    stubFetch(() =>
+      jsonResponse({
+        announcements: [
+          {
+            id: "escape-check",
+            publishedAt: "2026-08-24T10:00:00+08:00",
+            i18n: { zh: { title: "转义", body: "先看 <img src=x onerror=alert(1)> 再看正文" } },
+          },
+        ],
+      }),
+    );
+
+    const { dialog } = await openLoadedCenter();
+
+    // 远端文案是不受信任的输入：认识的只有 <hl>/<time>，别的标签只能当字面量。
+    expect(dialog).toHaveTextContent("先看 <img src=x onerror=alert(1)> 再看正文");
+    expect(dialog.querySelector("img")).toBeNull();
+  });
+
+  it("falls back to another language when the current one is missing from the json", async () => {
+    stubFetch(() =>
+      jsonResponse({
+        announcements: [
+          {
+            id: "en-only",
+            publishedAt: "2026-08-24T10:00:00+08:00",
+            i18n: { en: { title: "English only", body: "Body in English" } },
+          },
+        ],
+      }),
+    );
+
+    const { dialog } = await openLoadedCenter();
+
+    // 少一种翻译不该让整条公告消失 —— 显示成另一种语言至少信息还在。
+    expect(within(dialog).getByRole("heading", { name: "English only" })).toBeInTheDocument();
+  });
+
+  it("sorts pinned announcements first, then newest", async () => {
+    stubFetch(() =>
+      jsonResponse({
+        announcements: [
+          {
+            id: "old",
+            publishedAt: "2026-08-01T10:00:00+08:00",
+            i18n: { zh: { title: "旧公告", body: "旧" } },
+          },
+          {
+            id: "new",
+            publishedAt: "2026-08-20T10:00:00+08:00",
+            i18n: { zh: { title: "新公告", body: "新" } },
+          },
+          {
+            id: "pinned",
+            publishedAt: "2026-07-01T10:00:00+08:00",
+            pinned: true,
+            i18n: { zh: { title: "置顶公告", body: "顶" } },
+          },
+        ],
+      }),
+    );
+
+    const { dialog } = await openLoadedCenter();
+
+    // 顺序由数据层定，JSON 里怎么排都不影响展示。
+    const titles = within(dialog)
+      .getAllByRole("heading", { level: 3 })
+      .map((node) => node.textContent);
+    expect(titles).toEqual(["置顶公告", "新公告", "旧公告"]);
+  });
+
   it("expands and collapses a single announcement", async () => {
-    const { user } = await openCenter();
+    const { user } = await openLoadedCenter();
 
     const toggle = screen.getByRole("button", { name: "展开这条公告" });
     expect(toggle).toHaveAttribute("aria-expanded", "false");
@@ -91,7 +204,7 @@ describe("AnnouncementEntry", () => {
   });
 
   it("clears a card's unread dot once it is expanded, and remembers it across mounts", async () => {
-    const { user, dialog } = await openCenter();
+    const { user, dialog } = await openLoadedCenter();
 
     expect(within(dialog).getByText("1 条未读")).toBeInTheDocument();
 
@@ -105,7 +218,7 @@ describe("AnnouncementEntry", () => {
   });
 
   it("marks everything read from the footer", async () => {
-    const { user } = await openCenter();
+    const { user } = await openLoadedCenter();
 
     const markAll = screen.getByRole("button", { name: "全部已读" });
     expect(markAll).toBeEnabled();
@@ -116,8 +229,35 @@ describe("AnnouncementEntry", () => {
     expect(screen.getByRole("button", { name: "全部已读" })).toBeDisabled();
   });
 
+  it("keeps the trigger but drops the dot and the list when the json cannot be loaded", async () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    stubFetch(() => {
+      throw new Error("network down");
+    });
+
+    const { dialog, trigger } = await openCenter();
+
+    // 拉不到就是「没有公告」：喇叭照常在，只是不打红点、点开是空的。
+    // 不摆「重新加载」——刷新登录页本来就会重来一次。
+    await waitFor(() => expect(trigger.querySelector("span")).toBeNull());
+    expect(within(dialog).queryAllByRole("listitem")).toHaveLength(0);
+    expect(within(dialog).getByRole("button", { name: "全部已读" })).toBeDisabled();
+  });
+
+  it("treats a malformed payload as no announcements rather than half a card", async () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    stubFetch(() =>
+      jsonResponse({ announcements: [{ id: "broken", publishedAt: "not-a-date", i18n: {} }] }),
+    );
+
+    const { dialog, trigger } = await openCenter();
+
+    await waitFor(() => expect(trigger.querySelector("span")).toBeNull());
+    expect(within(dialog).queryAllByRole("listitem")).toHaveLength(0);
+  });
+
   it("traps focus in the dialog and hands it back to the trigger on close", async () => {
-    const { user, trigger, dialog } = await openCenter();
+    const { user, trigger, dialog } = await openLoadedCenter();
 
     // 回归用例：手搓 portal 的那版没有焦点管理，Tab 会直接跑到弹窗背后的页面上。
     await waitFor(() => expect(dialog.contains(document.activeElement)).toBe(true));
@@ -132,7 +272,7 @@ describe("AnnouncementEntry", () => {
   });
 
   it("closes the dialog on Escape", async () => {
-    const { user } = await openCenter();
+    const { user } = await openLoadedCenter();
 
     await user.keyboard("{Escape}");
 

--- a/frontend/src/components/login/cinematic/AnnouncementEntry.tsx
+++ b/frontend/src/components/login/cinematic/AnnouncementEntry.tsx
@@ -1,11 +1,18 @@
 // SPDX-License-Identifier: Elastic-2.0
 // Copyright (c) 2026 ClaymoreLab
-import { useId, useMemo, useState } from "react";
+import { Fragment, useId, useMemo, useState } from "react";
 import { Dialog } from "@base-ui/react/dialog";
 import { Bell, ChevronDown, Megaphone, X } from "lucide-react";
-import { Trans, useTranslation } from "react-i18next";
+import { useTranslation } from "react-i18next";
 import styles from "@/components/login/login.module.css";
-import { type Announcement, loadAnnouncements, useAnnouncementReadState } from "./announcements";
+import {
+  type Announcement,
+  type AnnouncementText,
+  parseAnnouncementBody,
+  pickAnnouncementText,
+  useAnnouncementReadState,
+  useAnnouncements,
+} from "./announcements";
 
 /**
  * 登录页顶栏的公告入口：图标 + 常驻红点，点开是公告中心。
@@ -13,13 +20,16 @@ import { type Announcement, loadAnnouncements, useAnnouncementReadState } from "
  * 顶栏那颗红点不跟已读联动 —— 公告是拿来拦人的，看过一次就熄灭等于白挂。
  * 弹窗里每条公告各有一枚未读点，那个才跟已读状态走（状态在 announcements.ts）。
  *
+ * 没有公告可展示时（还没拉到 / 拉失败 / OSS 上真的是空的）喇叭照常在，只是不打红点、
+ * 点开是一张空弹窗：失败不值得摆个「重新加载」让人去按 —— 刷新登录页就会重来一次。
+ *
  * 弹窗用 Base UI 的 Dialog 原语而不是手搓 portal：焦点陷阱、关闭后焦点回到触发器、
  * 背景滚动锁都由它负责。动效是 data-starting-style / data-ending-style 上的 CSS
  * 过渡，所以 prefers-reduced-motion 能真的关掉它 —— framer-motion 的 JS 动画关不掉。
  */
 export function AnnouncementEntry() {
-  const { t } = useTranslation();
-  const announcements = useMemo(() => loadAnnouncements(), []);
+  const { t, i18n } = useTranslation();
+  const announcements = useAnnouncements();
   const ids = useMemo(() => announcements.map((item) => item.id), [announcements]);
   const { isRead, markRead, markAllRead, unreadCount } = useAnnouncementReadState();
   const [expandedId, setExpandedId] = useState<string | null>(null);
@@ -34,7 +44,9 @@ export function AnnouncementEntry() {
           aria-label={t("loginCinematic.announcement.open")}
         >
           <Megaphone aria-hidden="true" />
-          <span className={styles.announcementDot} aria-hidden="true" />
+          {announcements.length > 0 ? (
+            <span className={styles.announcementDot} aria-hidden="true" />
+          ) : null}
         </Dialog.Trigger>
       </div>
 
@@ -60,24 +72,22 @@ export function AnnouncementEntry() {
           </header>
 
           <div className={styles.announcementBody}>
-            {announcements.length === 0 ? (
-              <p className={styles.announcementEmpty}>{t("loginCinematic.announcement.empty")}</p>
-            ) : (
-              <ul className={styles.announcementList}>
-                {announcements.map((item) => (
-                  <AnnouncementCard
-                    key={item.id}
-                    announcement={item}
-                    read={isRead(item.id)}
-                    expanded={expandedId === item.id}
-                    onToggle={() => {
-                      setExpandedId((current) => (current === item.id ? null : item.id));
-                      markRead(item.id);
-                    }}
-                  />
-                ))}
-              </ul>
-            )}
+            {/* 没有公告就是一张空弹窗：与其写「暂时没有公告」，不如什么都不说。 */}
+            <ul className={styles.announcementList}>
+              {announcements.map((item) => (
+                <AnnouncementCard
+                  key={item.id}
+                  announcement={item}
+                  text={pickAnnouncementText(item, i18n.language)}
+                  read={isRead(item.id)}
+                  expanded={expandedId === item.id}
+                  onToggle={() => {
+                    setExpandedId((current) => (current === item.id ? null : item.id));
+                    markRead(item.id);
+                  }}
+                />
+              ))}
+            </ul>
           </div>
 
           <footer className={styles.announcementFooter}>
@@ -101,11 +111,13 @@ export function AnnouncementEntry() {
 
 function AnnouncementCard({
   announcement,
+  text,
   read,
   expanded,
   onToggle,
 }: {
   announcement: Announcement;
+  text: AnnouncementText;
   read: boolean;
   expanded: boolean;
   onToggle: () => void;
@@ -128,6 +140,9 @@ function AnnouncementCard({
     [announcement.publishedAt, i18n.language],
   );
 
+  // 正文里的 <time>/<hl> 由文案自己标，高亮位置跟着语序走而不是写死下标。
+  const tokens = useMemo(() => parseAnnouncementBody(text.body), [text.body]);
+
   return (
     <li className={styles.announcementItem}>
       <span className={styles.announcementItemIcon}>
@@ -137,9 +152,7 @@ function AnnouncementCard({
 
       <div className={styles.announcementItemMain}>
         <div className={styles.announcementItemTop}>
-          <h3 className={styles.announcementItemTitle}>
-            {t(`loginCinematic.announcement.items.${announcement.id}.title`)}
-          </h3>
+          <h3 className={styles.announcementItemTitle}>{text.title}</h3>
           {announcement.pinned ? (
             <span className={styles.announcementPinned}>
               {t("loginCinematic.announcement.pinned")}
@@ -155,14 +168,19 @@ function AnnouncementCard({
               : styles.announcementItemBody
           }
         >
-          {/* 正文里的 <time>/<hl> 由译文自己标，高亮位置跟着语序走而不是写死下标。 */}
-          <Trans
-            i18nKey={`loginCinematic.announcement.items.${announcement.id}.body`}
-            components={{
-              time: <span className={styles.announcementTime} />,
-              hl: <span className={styles.announcementHighlight} />,
-            }}
-          />
+          {tokens.map((token, index) => {
+            if (token.kind === "text") return <Fragment key={index}>{token.text}</Fragment>;
+            return (
+              <span
+                key={index}
+                className={
+                  token.kind === "time" ? styles.announcementTime : styles.announcementHighlight
+                }
+              >
+                {token.text}
+              </span>
+            );
+          })}
         </p>
 
         <time className={styles.announcementItemMeta} dateTime={announcement.publishedAt}>

--- a/frontend/src/components/login/cinematic/announcements.ts
+++ b/frontend/src/components/login/cinematic/announcements.ts
@@ -1,22 +1,48 @@
 // SPDX-License-Identifier: Elastic-2.0
 // Copyright (c) 2026 ClaymoreLab
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
+import { z } from "zod";
+
+import { cdn } from "./media";
 
 /**
  * 登录页公告中心的数据层。
  *
- * 目前是前端静态清单：条目的元数据（id / 发布时间 / 是否置顶）写在下面的
- * `ANNOUNCEMENTS` 里，标题和正文走 i18n
- * （`loginCinematic.announcement.items.<id>.title` / `.body`），
- * 改文案只动翻译文件，不用碰这里。
+ * 公告不再写死在前端：内容是 OSS 上的一份 JSON，运营改公告 = 覆盖那个对象，
+ * 不用发版、不用动翻译文件。默认地址是 `DEFAULT_ANNOUNCEMENTS_URL`，本地或
+ * 私有化部署用 `VITE_LOGIN_ANNOUNCEMENTS_URL` 覆盖（dev 下指到
+ * `/announcements.json` 就会读仓库里 `frontend/public/announcements.json`
+ * 那份，内容跟线上那份保持一致，改公告时两边一起改）。
  *
- * 加一条公告 = 在 `ANNOUNCEMENTS` 里加一项 + 在 zh/en 两个 translation.json 的
- * `items` 下按同一个 id 补 title/body。正文支持 <hl>…</hl> 标重点、<time>…</time>
- * 标时间窗，两个标记由 `<Trans>` 换成带样式的 span。
+ * JSON 形状（`announcements` 数组，也接受最外层直接是数组）：
  *
- * 之后要换成后端下发，只需要把 `loadAnnouncements()` 换成一个请求，
- * `Announcement` 的形状保持不变，UI 层一行都不用改。
+ * ```json
+ * {
+ *   "announcements": [
+ *     {
+ *       "id": "channel-release-2026-08",
+ *       "publishedAt": "2026-08-24T10:00:00+08:00",
+ *       "pinned": false,
+ *       "i18n": {
+ *         "zh": { "title": "渠道版本更新", "body": "<hl>渠道版本</hl>即将上线…" },
+ *         "en": { "title": "Channel release update", "body": "A <hl>channel release</hl>…" }
+ *       }
+ *     }
+ *   ]
+ * }
+ * ```
+ *
+ * 正文里的 `<hl>…</hl>` 标重点、`<time>…</time>` 标时间窗，由
+ * `parseAnnouncementBody` 切成 token、UI 层换成带样式的 span。**只认这两个标记**，
+ * 其余尖括号一律当普通文本，所以远端文案改坏了最多是显示成字面量，注不进 HTML。
+ *
+ * 拉不到（对象没传上去 / 断网 / 新域名没配 CORS）时不做本地缓存也不回落写死内容，就是「没有公告」：
+ * 公告是拿来传达当下状态的，宁可空着也不要拿旧的糊弄人。
  */
+
+/** 单条公告在某一种语言下的文案。 */
+export type AnnouncementText = { title: string; body: string };
+
 export type Announcement = {
   /**
    * 已读状态的主键。它会被写进 localStorage，所以**改 id 等于让这条公告对
@@ -27,21 +53,154 @@ export type Announcement = {
   publishedAt: string;
   /** 置顶的排在最前面，且带一枚「置顶」角标。 */
   pinned?: boolean;
+  /** 语言码（`zh` / `en` / `zh-CN` 都行，大小写不敏感）→ 该语言的文案。 */
+  i18n: Record<string, AnnouncementText>;
 };
 
-const ANNOUNCEMENTS: readonly Announcement[] = [
-  { id: "channel-release-2026-08", publishedAt: "2026-08-24T10:00:00+08:00" },
-];
+const AnnouncementTextSchema = z.object({
+  title: z.string().trim().min(1),
+  body: z.string().trim().min(1),
+});
+
+const AnnouncementSchema = z.object({
+  id: z.string().trim().min(1),
+  publishedAt: z
+    .string()
+    .refine((value) => Number.isFinite(Date.parse(value)), "publishedAt 必须是可解析的 ISO 8601"),
+  pinned: z.boolean().optional(),
+  // 至少得有一种语言，否则这条公告渲染出来是张空卡。
+  i18n: z.record(z.string(), AnnouncementTextSchema).refine((map) => Object.keys(map).length > 0),
+});
+
+// 最外层写成 `{ "announcements": [...] }` 或者直接一个数组都收 —— 传错外壳是
+// 手工维护 JSON 最容易犯的错，为此让整页公告消失不值得。
+const PayloadSchema = z.union([
+  z.object({ announcements: z.array(AnnouncementSchema) }),
+  z.array(AnnouncementSchema),
+]);
 
 /**
- * 置顶优先，其余按发布时间倒序。排序放在数据层而不是组件里，是为了让「换成
- * 后端下发」那天，前后端对顺序的定义只有一处。
+ * 跟登录页的二维码、片花走同一个 CDN 前缀（`media.ts` 的 `cdn()`），换域名只改那一处。
+ *
+ * 注意它跟那些图片视频有一点关键差别：`<img>`/`<video>` 是浏览器自己加载、JS 读不到内容，
+ * 不查 CORS；公告要 `fetch()` 把 JSON 交给 JS，**必须**这个域名回 `Access-Control-Allow-Origin`。
+ * 少了那个头，对象本身 200、地址栏也能打开，但页面上就是静默的「没有公告」。
  */
-export function loadAnnouncements(): Announcement[] {
-  return [...ANNOUNCEMENTS].sort((left, right) => {
+export const DEFAULT_ANNOUNCEMENTS_URL = cdn("announcements.json");
+
+export function announcementsUrl(): string {
+  const override = import.meta.env.VITE_LOGIN_ANNOUNCEMENTS_URL?.trim();
+  return override ? override : DEFAULT_ANNOUNCEMENTS_URL;
+}
+
+/**
+ * 置顶优先，其余按发布时间倒序。排序放在数据层而不是组件里，是为了让前后端
+ * 对顺序的定义只有一处 —— JSON 里怎么排都不影响最终展示。
+ */
+function sortAnnouncements(items: Announcement[]): Announcement[] {
+  return [...items].sort((left, right) => {
     if (Boolean(left.pinned) !== Boolean(right.pinned)) return left.pinned ? -1 : 1;
     return Date.parse(right.publishedAt) - Date.parse(left.publishedAt);
   });
+}
+
+export async function fetchAnnouncements(signal?: AbortSignal): Promise<Announcement[]> {
+  const url = announcementsUrl();
+  // `no-cache` 是「带 ETag 回源校验」而不是「不缓存」：公告改完刷新就能看到新的，
+  // 又不至于每次登录页都全量重下。前提是那个对象带短 Cache-Control，
+  // 否则改完公告要等 CDN 边缘缓存自己过期。
+  const res = await fetch(url, { credentials: "omit", cache: "no-cache", signal });
+  if (!res.ok) throw new Error(`GET ${url} → ${res.status}`);
+
+  const parsed = PayloadSchema.safeParse(await res.json());
+  if (!parsed.success) throw new Error(`invalid announcements payload: ${parsed.error.message}`);
+
+  const items = Array.isArray(parsed.data) ? parsed.data : parsed.data.announcements;
+  return sortAnnouncements(items);
+}
+
+/**
+ * 按界面语言挑一份文案：先精确匹配（`zh-CN`），再退到主语言（`zh`），最后退到
+ * JSON 里的第一份。**永远返回一份**而不是 null —— 少一种翻译不该让整条公告消失，
+ * 显示成另一种语言至少信息还在。
+ */
+export function pickAnnouncementText(item: Announcement, language: string): AnnouncementText {
+  const byLowerKey = new Map(
+    Object.entries(item.i18n).map(([key, value]) => [key.toLowerCase(), value]),
+  );
+  const tag = language.toLowerCase();
+  const candidates = [tag, tag.split("-")[0], "zh", "en"];
+
+  for (const candidate of candidates) {
+    const hit = byLowerKey.get(candidate);
+    if (hit) return hit;
+  }
+  // schema 保证至少有一项，这里的 ?? 只是让类型收敛。
+  return Object.values(item.i18n)[0] ?? { title: "", body: "" };
+}
+
+export type AnnouncementBodyToken = { kind: "text" | "hl" | "time"; text: string };
+
+const BODY_MARKUP_RE = /<(hl|time)>([\s\S]*?)<\/\1>/g;
+
+/**
+ * 把正文切成「普通文本 / 高亮 / 时间窗」三种 token。
+ *
+ * 远端文案是不受信任的输入，所以这里既不 `dangerouslySetInnerHTML` 也不走
+ * i18next 的 HTML 解析：只认 `<hl>` 和 `<time>` 这两个闭合标记，其它尖括号原样
+ * 当文本输出。文案里写了别的标签，看到的就是标签本身，不会变成 DOM。
+ */
+export function parseAnnouncementBody(body: string): AnnouncementBodyToken[] {
+  const tokens: AnnouncementBodyToken[] = [];
+  let cursor = 0;
+
+  for (const match of body.matchAll(BODY_MARKUP_RE)) {
+    const start = match.index ?? 0;
+    if (start > cursor) tokens.push({ kind: "text", text: body.slice(cursor, start) });
+    tokens.push({ kind: match[1] as "hl" | "time", text: match[2] });
+    cursor = start + match[0].length;
+  }
+  if (cursor < body.length) tokens.push({ kind: "text", text: body.slice(cursor) });
+
+  return tokens;
+}
+
+/**
+ * 拉公告。挂载时拉一次，拉不到就是空数组 —— 调用方据此把整个入口收起来。
+ *
+ * 没有 loading / error 态：调用方对「还没拉到」「拉失败」「本来就没有」的处理
+ * 完全一样（都不显示），多分一层状态只会让 UI 多几条走不到的分支。
+ *
+ * 请求在组件卸载时 abort：登录页的公告入口会随着登录成功一起卸载，让一个已经
+ * 没人看的请求继续 setState 只会换来 React 的警告。
+ */
+export function useAnnouncements(): Announcement[] {
+  const [announcements, setAnnouncements] = useState<Announcement[]>([]);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    let alive = true;
+
+    fetchAnnouncements(controller.signal)
+      .then((items) => {
+        if (alive) setAnnouncements(items);
+      })
+      .catch((error: unknown) => {
+        if (!alive || controller.signal.aborted) return;
+        // 只留一条日志：登录页拿不到公告不是用户能处理的问题，界面上安静地少一个入口，
+        // 排查时靠这行知道是 CDN/CORS 还是 JSON 写坏了。
+        // eslint-disable-next-line no-console
+        console.warn("[announcements] load failed:", error);
+        setAnnouncements([]);
+      });
+
+    return () => {
+      alive = false;
+      controller.abort();
+    };
+  }, []);
+
+  return announcements;
 }
 
 const READ_STORAGE_KEY = "dramaclaw.login.announcements.read";

--- a/frontend/src/components/login/cinematic/media.ts
+++ b/frontend/src/components/login/cinematic/media.ts
@@ -1,6 +1,7 @@
 const CDN_BASE = "https://nfg-web-assets.cdnfg.com/dramaclaw";
 
-const cdn = (path: string) => encodeURI(`${CDN_BASE}/${path}`);
+/** 登录页所有外链资源的唯一拼装口子 —— 换 CDN 只改 `CDN_BASE` 一处。 */
+export const cdn = (path: string) => encodeURI(`${CDN_BASE}/${path}`);
 
 export const businessWechatQrUrl = cdn("contact/wechat.png");
 

--- a/frontend/src/components/login/login.module.css
+++ b/frontend/src/components/login/login.module.css
@@ -240,7 +240,8 @@
   color: rgba(255, 255, 255, 0.94);
 }
 
-/* 红点常驻，不跟已读联动。外圈描边压在深色顶栏上，滚动到浅色画面时也不会糊掉。 */
+/* 有公告才打点，且不跟已读联动 —— 看过一次就熄灭等于白挂。
+   外圈描边压在深色顶栏上，滚动到浅色画面时也不会糊掉。 */
 .announcementDot {
   position: absolute;
   top: -2px;
@@ -372,15 +373,6 @@
   overflow-y: auto;
   padding: 12px;
   overscroll-behavior: contain;
-}
-
-.announcementEmpty {
-  margin: 0;
-  padding: 28px 8px;
-  color: rgba(255, 255, 255, 0.52);
-  font-size: 12.5px;
-  line-height: 1.6;
-  text-align: center;
 }
 
 .announcementList {

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -10,6 +10,7 @@ interface ImportMetaEnv {
   readonly VITE_SUPERCHAT_WS_URL?: string;
   readonly VITE_CLUSTER_MODE?: "none" | "multi-region";
   readonly VITE_CLUSTER_REGIONS_URL?: string;
+  readonly VITE_LOGIN_ANNOUNCEMENTS_URL?: string;
 }
 
 interface ImportMeta {

--- a/license-inventory.csv
+++ b/license-inventory.csv
@@ -121,6 +121,7 @@ frontend/index.html,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate
 frontend/package.json,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/pnpm-lock.yaml,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/pnpm-workspace.yaml,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
+frontend/public/announcements.json,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/public/brand/dclogo.png,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/public/brand/dramaclaw-logo-login.png,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/public/brand/dramaclaw-wordmark.png,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation


### PR DESCRIPTION
接在 #366（登录页公告中心入口）后面的一步:把公告内容从前端硬编码换成 CDN 上的一份 JSON。运营覆盖那个对象就能改公告,不用发版、也不用动翻译文件。

从 `feat/login-announcement-entry` cherry-pick 过来、基于 `staging` 重开的分支,净改动就是这一件事。

## 数据源

```
https://nfg-web-assets.cdnfg.com/dramaclaw/announcements.json
```

地址走 `media.ts` 的 `cdn()`,跟登录页其它外链资源共用一个前缀。本地和私有化部署用 `VITE_LOGIN_ANNOUNCEMENTS_URL` 覆盖。

JSON 形状(最外层写成对象或直接一个数组都收):

```json
{
  "announcements": [
    {
      "id": "channel-release-2026-08",
      "publishedAt": "2026-08-24T10:00:00+08:00",
      "pinned": false,
      "i18n": {
        "zh": { "title": "渠道版本更新", "body": "<hl>渠道版本</hl>即将上线,更新时间在 <time>18:00-19:00</time> 点..." },
        "en": { "title": "Channel release update", "body": "A <hl>channel release</hl> is going live between <time>18:00 and 19:00</time>..." }
      }
    }
  ]
}
```

文案跟着每条公告走,不再散在 `translation.json` 的 `loginCinematic.announcement.items` 下(那棵子树连同 `empty` 一起删了,界面词保留)。

`frontend/public/announcements.json` 是线上那份的副本,同时兼作测试夹具 —— 顺手验这份 JSON 的形状能过 schema。**改公告时两边一起改。**

## 几个刻意的决定

- **正文只认 `<hl>` / `<time>`**:远端文案是不受信任的输入,切成 token 后由 UI 换成带样式的 span,不用 `dangerouslySetInnerHTML`、也不再走 `<Trans>` 的 HTML 解析。别的尖括号一律当字面量输出,注不进 HTML(有用例覆盖)。
- **拉不到就是「没有公告」**:喇叭图标照常显示,只是不打红点、点开是空弹窗。不做本地缓存、不回落写死内容、也不摆「重新加载」按钮 —— 公告传达的是当下状态,宁可空着也不拿旧的糊弄人;刷新登录页本来就会重来一次。
- **`id` 仍是已读状态的主键**:它写进 localStorage,所以改 `id` 等于让这条公告对所有人重新变成未读。这是让一条旧公告重新弹到人眼前的唯一手段。
- **少一种翻译不该让整条公告消失**:按 `zh-CN` → `zh` → `en` → JSON 里第一份的顺序回落。

## 部署前提(已完成)

CDN 域名 `nfg-web-assets.cdnfg.com` 需要回 `Access-Control-Allow-Origin`。同一个域名上的图片和视频不需要这个头,是因为 `<img>`/`<video>` 由浏览器加载、JS 读不到内容,压根不走 CORS 检查 —— 公告是这批资源里第一个要被 JS 读内容的。

运维已配好并刷新缓存,实测该 URL 带 `Access-Control-Allow-Origin: *`。

## 验证

- `tsc -b` ✅
- `pnpm build` ✅
- 登录页测试 29/29 ✅(公告部分 14 个用例:CDN 地址与请求参数、排序、语言回落、标记转义、失败/脏数据降级、焦点陷阱、Escape、已读落盘)
- headless Chrome 实测:登录页里 `fetch` 该 CDN JSON 返回 200,控制台无 CORS 报错

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PJ9xkuPnxGxHGg8tPtZJ3Z