### PR TITLE
fix(login): 公告 JSON 改直连 OSS，绕开 CDN 那 30 天刷不动的边缘缓存

### DIFF
--- a/frontend/src/__tests__/components/login/announcement-entry.test.tsx
+++ b/frontend/src/__tests__/components/login/announcement-entry.test.tsx
@@ -73,8 +73,10 @@ describe("AnnouncementEntry", () => {
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
     const [url, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
-    expect(url).toBe("https://nfg-web-assets.cdnfg.com/dramaclaw/announcements.json");
-    // 登录页是未登录状态下打开的，别把 cookie 带去 CDN。
+    // 直连 OSS，不是 `media.ts` 那个 CDN 前缀：CDN 有 30 天边缘缓存，且查询串被过滤出缓存键，
+    // 挂时间戳也刷不动，改完公告一个月才见效。这行钉住域名，防止有人顺手"统一"回 cdn()。
+    expect(url).toBe("https://nfg-web.cdnfg.com/dramaclaw/announcements.json");
+    // 登录页是未登录状态下打开的，别把 cookie 带去 OSS。
     expect(init).toMatchObject({ credentials: "omit", cache: "no-cache" });
   });
 

--- a/frontend/src/components/login/cinematic/announcements.ts
+++ b/frontend/src/components/login/cinematic/announcements.ts
@@ -3,8 +3,6 @@
 import { useCallback, useEffect, useState } from "react";
 import { z } from "zod";
 
-import { cdn } from "./media";
-
 /**
  * 登录页公告中心的数据层。
  *
@@ -80,13 +78,21 @@ const PayloadSchema = z.union([
 ]);
 
 /**
- * 跟登录页的二维码、片花走同一个 CDN 前缀（`media.ts` 的 `cdn()`），换域名只改那一处。
+ * 公告故意**不**跟二维码、片花共用 `media.ts` 的 `cdn()` 前缀，而是直连 OSS。
  *
- * 注意它跟那些图片视频有一点关键差别：`<img>`/`<video>` 是浏览器自己加载、JS 读不到内容，
- * 不查 CORS；公告要 `fetch()` 把 JSON 交给 JS，**必须**这个域名回 `Access-Control-Allow-Origin`。
- * 少了那个头，对象本身 200、地址栏也能打开，但页面上就是静默的「没有公告」。
+ * 那些图片视频由 `<img>`/`<video>` 加载，浏览器自己读、JS 拿不到内容，不查 CORS，
+ * 而且发一次就不再变，挂在 CDN 上吃 30 天边缘缓存正合适。公告两条都反过来：
+ *
+ * - 它要 `fetch()` 把 JSON 交给 JS，**必须**回 `Access-Control-Allow-Origin`。少了那个头，
+ *   对象本身 200、地址栏也打得开，但页面上就是静默的「没有公告」。
+ * - 运营改完要尽快见效，而 CDN 那层 30 天的边缘缓存（`X-Swift-CacheTime: 2592000`）会把
+ *   旧公告钉在边缘节点上：源站改了也不回源，且**挂 query 绕不开** —— 这个 CDN 把查询串
+ *   从缓存键里过滤掉了，`?t=<时间戳>` 照样命中同一份旧副本。
+ *
+ * 直连 OSS 就没有那层边缘缓存，对象自己的 `Cache-Control: max-age=60` 是唯一一层，
+ * 覆盖上传后最多一分钟全网见效。代价是这个域名必须在 OSS 的跨域设置里放行本站来源。
  */
-export const DEFAULT_ANNOUNCEMENTS_URL = cdn("announcements.json");
+export const DEFAULT_ANNOUNCEMENTS_URL = "https://nfg-web.cdnfg.com/dramaclaw/announcements.json";
 
 export function announcementsUrl(): string {
   const override = import.meta.env.VITE_LOGIN_ANNOUNCEMENTS_URL?.trim();


### PR DESCRIPTION
## 问题

#379 把登录页公告改成从远端拉 JSON 之后，地址走的是 `media.ts` 的 `cdn()` 前缀（`nfg-web-assets.cdnfg.com`）。那个 CDN 域名对这个对象是 30 天边缘缓存，运营覆盖上传之后改不动：

```
CDN  nfg-web-assets   ETag 994C0F32…  LM 10:04:21  X-Swift-CacheTime: 2592000  Age 8557
OSS  nfg-web          ETag 686D0C29…  LM 12:27:35  Cache-Control: max-age=60
```

ETag 对不上——源站已经是新的，边缘节点还在发上午那份，而且 30 天内不会回源。

**挂时间戳绕不开**，这个 CDN 把查询串过滤出了缓存键，实测四种参数全命中同一份旧副本：

```
?t=1      ETag 994C0F32  X-Cache: HIT
?t=99999  ETag 994C0F32  X-Cache: HIT
?v=abc    ETag 994C0F32  X-Cache: HIT
无参数     ETag 994C0F32  X-Cache: HIT
```

也就是说前端侧没有任何办法把它刷掉，只能等运维手动刷 URL——公告这种「改完要立刻见效」的东西不该依赖人工操作。

## 改法

默认地址改成直连 OSS 域名，不再共用 `cdn()` 前缀：

```ts
export const DEFAULT_ANNOUNCEMENTS_URL = "https://nfg-web.cdnfg.com/dramaclaw/announcements.json";
```

直连之后没有边缘缓存那一层，对象自己的 `Cache-Control: max-age=60` 是唯一一层，覆盖上传后最多一分钟全网生效。

图片、片花继续走 `cdn()`：它们由 `<img>`/`<video>` 加载、不查 CORS，而且发一次就不再变，30 天边缘缓存对它们是好事。这次分岔是有意的，两边的取舍写在 `DEFAULT_ANNOUNCEMENTS_URL` 上面的注释里，免得以后有人顺手「统一」回去。测试里那行 URL 断言也钉住了域名，配了说明。

## 部署前置条件（已完成）

OSS 那个域名需要在跨域设置里放行本站来源。运维已配好，线上现在的头：

```
GET      → Access-Control-Allow-Origin: *
           Access-Control-Allow-Methods: GET
           Cache-Control: max-age=60
OPTIONS  → 200（配之前是 403）
```

## 验证

- `tsc -b` 干净，`pnpm build` 通过，`announcement-entry.test.tsx` 14 个用例全绿
- 真实浏览器打开登录页点开公告中心：1 条 li、「1 条未读」、标题正文和时间高亮都在
- 确认读的是线上而不是仓库里的 fixture——两份文案不同，页面显示的是 OSS 那版（正文带「8月25日」，仓库那份没有）