### PR TITLE
Fix organization brand Nginx configuration

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -42,3 +42,5 @@ jobs:
         run: pnpm build
       - name: Unit tests (vitest)
         run: pnpm test
+      - name: Validate rendered Nginx configuration
+        run: docker build --target nginx-config-test --file Dockerfile .

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -26,6 +26,14 @@ RUN pnpm install --frozen-lockfile
 COPY . .
 RUN pnpm build
 
+# Parse the rendered runtime template in CI without building the SPA image.
+FROM nginx:1.27-alpine AS nginx-config-test
+ENV BACKEND_HOST=backend.invalid \
+    BACKEND_PORT=8780 \
+    NGINX_ENVSUBST_FILTER="^(BACKEND_HOST|BACKEND_PORT)$"
+COPY docker/nginx.conf.template /etc/nginx/templates/default.conf.template
+RUN /docker-entrypoint.sh nginx -t
+
 # Stage 2: serve via nginx + reverse-proxy /api /static to the backend Service.
 FROM nginx:1.27-alpine AS runtime
 

--- a/frontend/docker/nginx.conf.template
+++ b/frontend/docker/nginx.conf.template
@@ -66,7 +66,7 @@ server {
 
     # Exact organization-logo path only. The EE backend owns validation and
     # trusted response metadata; malformed paths fall through to /assets/ =404.
-    location ~ ^/assets/org-brand/([A-Za-z0-9_-]{1,64})/logo$ {
+    location ~ "^/assets/org-brand/([A-Za-z0-9_-]{1,64})/logo$" {
         if ($args != "") { return 404; }
         limit_except GET HEAD { deny all; }
         proxy_pass http://supertale_backend/api/v1/org-brand/$1/logo;

--- a/frontend/src/__tests__/deployment/org-brand-assets.test.ts
+++ b/frontend/src/__tests__/deployment/org-brand-assets.test.ts
@@ -32,7 +32,7 @@ describe("organization brand asset deployment contract", () => {
   it("routes only the exact fixed logo path directly to the existing backend", () => {
     const config = readFileSync("docker/nginx.conf.template", "utf8");
     const block = config.match(
-      /location ~ \^\/assets\/org-brand([\s\S]*?)\n    \}/,
+      /location ~ "\^\/assets\/org-brand([\s\S]*?)\n    \}/,
     )?.[1];
 
     expect(block).toContain("/([A-Za-z0-9_-]{1,64})/logo$");
@@ -41,7 +41,7 @@ describe("organization brand asset deployment contract", () => {
     expect(block).toContain("proxy_pass http://supertale_backend/api/v1/org-brand/$1/logo");
     expect(block).toContain("proxy_pass_request_headers off");
     expect(block).not.toContain("127.0.0.1:3001");
-    expect(config.indexOf("location ~ ^/assets/org-brand")).toBeLessThan(
+    expect(config.indexOf('location ~ "^/assets/org-brand')).toBeLessThan(
       config.indexOf("location /assets/"),
     );
   });


### PR DESCRIPTION
## Summary

- quote the bounded organization-brand location regex so Nginx parses it correctly
- add a lightweight Docker target that renders the runtime template and runs `nginx -t`
- run the configuration check in frontend CI and update the deployment contract test

## Verification

- `docker build --target nginx-config-test --file Dockerfile .`
- `pnpm exec vitest run src/__tests__/deployment/org-brand-assets.test.ts` (4 passed)
- `pnpm run build`