### PR TITLE
perf(assets): load file state on demand

### DIFF
--- a/frontend/src/__tests__/components/assets/asset-panels-rename.test.tsx
+++ b/frontend/src/__tests__/components/assets/asset-panels-rename.test.tsx
@@ -224,7 +224,7 @@ describe("asset panel rename behavior", () => {
     renderWithProviders(<ScenesPanel project="demo" />);
 
     expect(await screen.findAllByText("Hall")).not.toHaveLength(0);
-    fireEvent.click(screen.getByRole("button", { name: "Edit" }));
+    fireEvent.click(await screen.findByRole("button", { name: "Edit" }));
     fireEvent.change(screen.getByDisplayValue("Hall"), {
       target: { value: "GrandHall" },
     });
@@ -258,7 +258,7 @@ describe("asset panel rename behavior", () => {
     );
 
     expect(await screen.findAllByText("Hall")).not.toHaveLength(0);
-    fireEvent.click(screen.getByRole("button", { name: "Delete" }));
+    fireEvent.click(await screen.findByRole("button", { name: "Delete" }));
 
     const dialog = await screen.findByRole("alertdialog");
     expect(within(dialog).getByText('Delete scene "Hall"?')).toBeInTheDocument();
@@ -322,7 +322,7 @@ describe("asset panel rename behavior", () => {
     renderWithProviders(<ScenesPanel project="demo" />);
 
     expect(await screen.findAllByText("Hall")).not.toHaveLength(0);
-    expect(screen.getByText("室内")).toBeInTheDocument();
+    expect(await screen.findByText("室内")).toBeInTheDocument();
     expect(screen.queryByText("interior")).not.toBeInTheDocument();
   });
 
@@ -497,7 +497,7 @@ describe("asset panel rename behavior", () => {
     renderWithProviders(<ScenesPanel project="demo" />);
 
     await screen.findByRole("button", { name: "选择场景 Hall" });
-    await user.click(screen.getByRole("button", { name: "添加场景变体" }));
+    await user.click(await screen.findByRole("button", { name: "添加场景变体" }));
 
     const dialog = screen.getByRole("dialog");
     expect(within(dialog).getByText("填写变体或时间后自动生成")).toBeInTheDocument();
@@ -654,7 +654,9 @@ describe("asset panel rename behavior", () => {
     renderWithProviders(<ScenesPanel project="demo" />);
 
     expect(await screen.findAllByText("Hall")).not.toHaveLength(0);
-    const openWorldButtons = screen.getAllByRole("button", { name: "Open Director World" });
+    const openWorldButtons = await screen.findAllByRole("button", {
+      name: "Open Director World",
+    });
     await user.click(openWorldButtons[openWorldButtons.length - 1]);
     await user.click(await screen.findByRole("button", { name: "mock-save-scene-world" }));
 

--- a/frontend/src/__tests__/components/assets/asset-tabs-beats-contract.test.tsx
+++ b/frontend/src/__tests__/components/assets/asset-tabs-beats-contract.test.tsx
@@ -130,7 +130,7 @@ describe("asset tabs do not read the beats table", () => {
     renderWithProviders(<ScenesPanel project="demo" />);
 
     await waitFor(() => expect(requests.length).toBe(2));
-    expect(requests[0].searchParams.get("summary")).toBeNull();
+    expect(requests[0].searchParams.get("summary")).toBe("true");
     expect(requests[0].searchParams.getAll("names")).toEqual([]);
     expect(requests[1].searchParams.get("summary")).toBe("false");
     expect(requests[1].searchParams.getAll("names").sort()).toEqual([

--- a/frontend/src/__tests__/components/assets/asset-tabs-beats-contract.test.tsx
+++ b/frontend/src/__tests__/components/assets/asset-tabs-beats-contract.test.tsx
@@ -96,6 +96,48 @@ function renderWithProviders(ui: ReactNode) {
 }
 
 describe("asset tabs do not read the beats table", () => {
+  it("loads a SQLite-only scene summary before the selected group's details", async () => {
+    window.localStorage.clear();
+    const requests: URL[] = [];
+    server.use(
+      http.get(
+        "http://localhost:3000/api/v1/projects/demo/scenes",
+        ({ request }) => {
+          const url = new URL(request.url);
+          requests.push(url);
+          if (url.searchParams.get("summary") !== "false") {
+            return HttpResponse.json({
+              ok: true,
+              data: [
+                { name: "Hall", base_scene_id: "", description: "" },
+                {
+                  name: "Hall_Night",
+                  base_scene_id: "Hall",
+                  description: "",
+                },
+                { name: "Alley", base_scene_id: "", description: "" },
+              ],
+            });
+          }
+          return HttpResponse.json({
+            ok: true,
+            data: url.searchParams.getAll("names").map((name) => ({ name })),
+          });
+        },
+      ),
+    );
+
+    renderWithProviders(<ScenesPanel project="demo" />);
+
+    await waitFor(() => expect(requests.length).toBe(2));
+    expect(requests[0].searchParams.get("summary")).toBeNull();
+    expect(requests[0].searchParams.getAll("names")).toEqual([]);
+    expect(requests[1].searchParams.get("summary")).toBe("false");
+    expect(requests[1].searchParams.getAll("names").sort()).toEqual([
+      "Alley",
+    ]);
+  });
+
   it("opens the scenes tab without requesting any episode's beats", async () => {
     const seen = recordRequests();
     server.use(

--- a/frontend/src/__tests__/components/assets/character-stats-strip.test.tsx
+++ b/frontend/src/__tests__/components/assets/character-stats-strip.test.tsx
@@ -9,7 +9,6 @@ vi.mock("react-i18next", () => ({
       ({
         "characters.stats.strip.total": "总角色",
         "characters.stats.strip.mainCharacter": "解说主角",
-        "characters.stats.strip.portrait": "头像",
         "characters.stats.strip.identity": "身份",
         "characters.stats.strip.voice": "声线",
         "characters.stats.strip.ariaLabel": "角色统计",
@@ -46,10 +45,9 @@ const characters: Character[] = [
 ];
 
 describe("deriveCharacterStats", () => {
-  it("counts portraits, main characters, identities, and ready voice paths", () => {
+  it("counts main characters, identities, and ready voice paths", () => {
     expect(deriveCharacterStats(characters, { Mira: 2, Jun: 1 })).toEqual({
       total: 3,
-      withPortraits: 2,
       mainCharacters: 1,
       identityReady: 2,
       voiceReady: 1,
@@ -58,6 +56,15 @@ describe("deriveCharacterStats", () => {
 
   it("defaults identity ready to zero when identityCounts is omitted", () => {
     expect(deriveCharacterStats(characters).identityReady).toBe(0);
+  });
+
+  it("uses list-projected identity ids when explicit counts are omitted", () => {
+    expect(
+      deriveCharacterStats([
+        { name: "Mira", identity_ids: ["Mira_default"] },
+        { name: "Jun", identity_ids: [] },
+      ]).identityReady,
+    ).toBe(1);
   });
 });
 
@@ -75,12 +82,11 @@ describe("CharacterStatsStrip", () => {
     expect(strip).toHaveClass("custom-strip");
     expect(strip).toHaveTextContent("总角色3");
     expect(strip).toHaveTextContent("解说主角1");
-    expect(strip).toHaveTextContent("头像2/3");
+    expect(strip).not.toHaveTextContent("头像");
     expect(strip).toHaveTextContent("身份2/3");
     expect(strip).toHaveTextContent("声线1/3");
 
     expect(screen.getByLabelText("总角色: 3")).toBeInTheDocument();
-    expect(screen.getByLabelText("头像: 2/3")).toBeInTheDocument();
     expect(screen.getByLabelText("声线: 1/3")).toBeInTheDocument();
   });
 

--- a/frontend/src/__tests__/components/assets/characters-identities-contract.test.tsx
+++ b/frontend/src/__tests__/components/assets/characters-identities-contract.test.tsx
@@ -18,7 +18,7 @@ import { I18nextProvider, initReactI18next } from "react-i18next";
 import { http, HttpResponse } from "msw";
 import ky from "ky";
 import type { ReactNode } from "react";
-import { beforeAll, describe, expect, it, vi } from "vitest";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { server } from "@/__mocks__/msw/server";
 
@@ -84,6 +84,10 @@ beforeAll(async () => {
   });
 });
 
+beforeEach(() => {
+  window.localStorage.clear();
+});
+
 const CHARACTERS = [
   { name: "苏清晏", is_main: true, identity_ids: ["苏清晏_少女", "苏清晏_嫡女"] },
   { name: "沈砚", is_main: false, identity_ids: ["沈砚_少年"] },
@@ -142,7 +146,22 @@ describe("the characters tab does not fan identities out per character", () => {
     // 这里列出具体路径而不是数个数——回归的形状就是"每个角色一条"，列出来才看得
     // 出漏的是哪几个。
     expect(identityRequests).toEqual(["/api/v1/projects/demo/characters/苏清晏/identities"]);
-    // 侧栏的用量统计走 ``/assets/references`` 那一个聚合，不再按集翻 beats。
+    // 资产页不再为了展示全局用量统计而扫描所有分集 beats。
     expect(seen.filter((path) => path.includes("/beats"))).toEqual([]);
+  });
+
+  it("does not load character assets when the remembered tab is scenes", async () => {
+    window.localStorage.setItem("supertale-asset-tab:demo", "scenes");
+    const seen = recordRequests();
+
+    renderWithProviders(<CharactersPage />);
+
+    await waitFor(() =>
+      expect(seen).toContain("/api/v1/projects/demo/scenes"),
+    );
+    expect(seen).not.toContain("/api/v1/projects/demo/characters");
+    expect(seen).not.toContain(
+      "/api/v1/projects/demo/character-image-selection",
+    );
   });
 });

--- a/frontend/src/__tests__/components/assets/prop-asset-card.test.tsx
+++ b/frontend/src/__tests__/components/assets/prop-asset-card.test.tsx
@@ -125,6 +125,42 @@ describe("PropAssetCard", () => {
     expect(screen.getByRole("button", { name: "生成参考图" })).toBeInTheDocument();
   });
 
+  it("retries the convention URL after an upload finishes", () => {
+    const prop: PropAsset = {
+      name: "密信",
+      aliases: [],
+      prop_type: "document",
+      visual_prompt: "",
+      description: "折叠的牛皮纸密信",
+      owner: "",
+      notes: "",
+      reference_url: "/static/projects/demo/assets/props/密信/reference_3view.png",
+    };
+    const handlers = {
+      onEdit: vi.fn(),
+      onDelete: vi.fn(),
+      onGenerateReference: vi.fn(),
+      onUploadReference: vi.fn(),
+      onOpenFreezone: vi.fn(),
+    };
+    const view = render(
+      <I18nextProvider i18n={i18n}>
+        <PropAssetCard prop={prop} uploading {...handlers} />
+      </I18nextProvider>,
+    );
+
+    fireEvent.error(screen.getByAltText("密信 参考图"));
+    expect(screen.getByText("未生成参考图")).toBeInTheDocument();
+
+    view.rerender(
+      <I18nextProvider i18n={i18n}>
+        <PropAssetCard prop={prop} uploading={false} {...handlers} />
+      </I18nextProvider>,
+    );
+
+    expect(screen.getByAltText("密信 参考图")).toBeInTheDocument();
+  });
+
   it("renders NiceGUI prop type labels instead of raw prop type codes", () => {
     renderCard({
       name: "TOKEN",

--- a/frontend/src/__tests__/components/assets/prop-asset-card.test.tsx
+++ b/frontend/src/__tests__/components/assets/prop-asset-card.test.tsx
@@ -107,6 +107,24 @@ describe("PropAssetCard", () => {
     expect(screen.getByRole("button", { name: "生成参考图" })).toBeInTheDocument();
   });
 
+  it("falls back when a convention URL points at a missing file", () => {
+    renderCard({
+      name: "密信",
+      aliases: [],
+      prop_type: "document",
+      visual_prompt: "",
+      description: "折叠的牛皮纸密信",
+      owner: "",
+      notes: "",
+      reference_url: "/static/projects/demo/assets/props/密信/reference_3view.png",
+    });
+
+    fireEvent.error(screen.getByAltText("密信 参考图"));
+
+    expect(screen.getByText("未生成参考图")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "生成参考图" })).toBeInTheDocument();
+  });
+
   it("renders NiceGUI prop type labels instead of raw prop type codes", () => {
     renderCard({
       name: "TOKEN",

--- a/frontend/src/__tests__/components/assets/scenes-panel-build-visibility.test.tsx
+++ b/frontend/src/__tests__/components/assets/scenes-panel-build-visibility.test.tsx
@@ -32,6 +32,11 @@ vi.mock("@/lib/queries/projects", () => ({
 
 vi.mock("@/lib/queries/scenes", () => ({
   useScenes: () => ({ isLoading: false, data: { ok: true, data: [] }, refetch: vi.fn() }),
+  useSceneDetails: () => ({
+    isLoading: false,
+    data: { ok: true, data: [] },
+    refetch: vi.fn(),
+  }),
   useBuildScenes: mutation,
   useCreateScene: mutation,
   useDeleteScene: mutation,

--- a/frontend/src/__tests__/components/assets/scenes-panel-detail-authority.test.ts
+++ b/frontend/src/__tests__/components/assets/scenes-panel-detail-authority.test.ts
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: Elastic-2.0
+// Copyright (c) 2026 ClaymoreLab
+import { describe, expect, it } from "vitest";
+
+import { selectAuthoritativeSceneDetails } from "@/components/assets/scenes-panel";
+import type { SceneAsset } from "@/types/scene";
+
+const summary = [
+  { name: "Hall", master_url: "/canonical/master.png?v=1" },
+] as SceneAsset[];
+
+describe("scene detail authority", () => {
+  it("uses summary data only while authoritative details are unresolved", () => {
+    expect(selectAuthoritativeSceneDetails(summary, undefined, false)).toBe(
+      summary,
+    );
+  });
+
+  it("does not treat an empty successful detail response as existing media", () => {
+    expect(selectAuthoritativeSceneDetails(summary, [], true)).toBeNull();
+  });
+
+  it("uses the authoritative detail payload after it succeeds", () => {
+    const details = [{ name: "Hall", master_url: null }] as SceneAsset[];
+    expect(selectAuthoritativeSceneDetails(summary, details, true)).toBe(
+      details,
+    );
+  });
+});

--- a/frontend/src/__tests__/lib/queries/identity-owner-index.test.tsx
+++ b/frontend/src/__tests__/lib/queries/identity-owner-index.test.tsx
@@ -13,11 +13,13 @@ vi.mock("@/lib/api", () => ({
 }));
 
 import {
+  useCharacters,
   useCreateIdentity,
   useDeleteIdentity,
   useIdentityOwnerIndex,
   useUpdateIdentity,
 } from "@/lib/queries/characters";
+import { queryKeys } from "@/lib/query-keys";
 // Shared server, not a second `setupServer()` — two listening instances dispatch
 // every request twice, which doubles the request counters these tests assert on.
 import { server } from "@/__mocks__/msw/server";
@@ -46,17 +48,22 @@ describe("useIdentityOwnerIndex", () => {
   // 100 requests on every visit to the assets page, to build a lookup table
   // that is only read when an `?type=identity&id=` deep link is present.
   it("resolves owners from the character list without per-character requests", async () => {
+    const characterUrls: URL[] = [];
     const identityPaths: string[] = [];
     server.use(
-      http.get("http://localhost:3000/api/v1/projects/demo/characters", () =>
-        HttpResponse.json({
-          ok: true,
-          data: [
-            { name: "林昭", identity_ids: ["林昭_青年", "林昭_少年"] },
-            { name: "苏清晏", identity_ids: ["苏清晏_少女"] },
-            { name: "路人", identity_ids: [] },
-          ],
-        }),
+      http.get(
+        "http://localhost:3000/api/v1/projects/demo/characters",
+        ({ request }) => {
+          characterUrls.push(new URL(request.url));
+          return HttpResponse.json({
+            ok: true,
+            data: [
+              { name: "林昭", identity_ids: ["林昭_青年", "林昭_少年"] },
+              { name: "苏清晏", identity_ids: ["苏清晏_少女"] },
+              { name: "路人", identity_ids: [] },
+            ],
+          });
+        },
       ),
       http.get(
         "http://localhost:3000/api/v1/projects/demo/characters/:name/identities",
@@ -78,6 +85,48 @@ describe("useIdentityOwnerIndex", () => {
     expect(result.current.ownerOf("不存在的身份")).toBeNull();
     // The whole point: the owner index costs the character list and nothing else.
     expect(identityPaths).toEqual([]);
+    expect(characterUrls.map((url) => url.searchParams.get("summary"))).toEqual([
+      "true",
+    ]);
+  });
+
+  it("keeps the shared character query lightweight after invalidation", async () => {
+    const summaryValues: Array<string | null> = [];
+    server.use(
+      http.get(
+        "http://localhost:3000/api/v1/projects/demo/characters",
+        ({ request }) => {
+          summaryValues.push(new URL(request.url).searchParams.get("summary"));
+          return HttpResponse.json({
+            ok: true,
+            data: [{ name: "林昭", identity_ids: ["林昭_青年"] }],
+          });
+        },
+      ),
+    );
+    const qc = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const stableWrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+    );
+
+    const { result } = renderHook(
+      () => ({
+        characters: useCharacters("demo"),
+        index: useIdentityOwnerIndex("demo"),
+      }),
+      { wrapper: stableWrapper },
+    );
+
+    await waitFor(() => expect(result.current.characters.isSuccess).toBe(true));
+    await act(async () => {
+      await qc.invalidateQueries({ queryKey: queryKeys.characters("demo") });
+    });
+    await waitFor(() => expect(summaryValues.length).toBe(2));
+
+    expect(summaryValues).toEqual(["true", "true"]);
+    expect(result.current.index.ownerOf("林昭_青年")).toBe("林昭");
   });
 
   it("reports no owner while the character list is still loading", async () => {

--- a/frontend/src/__tests__/routes/characters.ce.test.tsx
+++ b/frontend/src/__tests__/routes/characters.ce.test.tsx
@@ -144,6 +144,26 @@ vi.mock("@/lib/queries/characters", () => ({
       ],
     },
   }),
+  useCharacterDetails: () => ({
+    isLoading: false,
+    data: {
+      ok: true,
+      data: [
+        {
+          name: "Li Qing",
+          aliases: [],
+          role: "主角",
+          gender: "男",
+          age_group: "middle",
+          is_main: true,
+          description: "Lead character",
+          face_prompt: "sharp eyes",
+          body_type: "slim",
+          portrait_url: "",
+        },
+      ],
+    },
+  }),
   useBuildCharacters: () => ({
     mutateAsync: buildCharactersMutationMock,
     isPending: false,

--- a/frontend/src/components/assets/character-stats-strip.tsx
+++ b/frontend/src/components/assets/character-stats-strip.tsx
@@ -4,7 +4,6 @@ import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import {
   Fingerprint,
-  Image,
   Star,
   Users,
   Volume2,
@@ -16,7 +15,6 @@ import type { Character } from "@/types/character";
 
 export type CharacterStats = {
   total: number;
-  withPortraits: number;
   mainCharacters: number;
   identityReady: number;
   voiceReady: number;
@@ -48,23 +46,21 @@ export function deriveCharacterStats(
 ): CharacterStats {
   const stats: CharacterStats = {
     total: characters.length,
-    withPortraits: 0,
     mainCharacters: 0,
     identityReady: 0,
     voiceReady: 0,
   };
 
   for (const character of characters) {
-    if (hasValue(character.portrait_path) || hasValue(character.portrait_url)) {
-      stats.withPortraits += 1;
-    }
     if (character.is_main === true) {
       stats.mainCharacters += 1;
     }
     if (hasValue(character.reference_audio_path)) {
       stats.voiceReady += 1;
     }
-    if ((identityCounts?.[character.name] ?? 0) > 0) {
+    if (
+      (identityCounts?.[character.name] ?? character.identity_ids?.length ?? 0) > 0
+    ) {
       stats.identityReady += 1;
     }
   }
@@ -96,13 +92,6 @@ export function CharacterStatsStrip({
       label: mainCharacterLabel ?? t("characters.stats.strip.mainCharacter"),
       icon: Star,
       display: `${stats.mainCharacters}`,
-    },
-    {
-      key: "withPortraits",
-      label: t("characters.stats.strip.portrait"),
-      icon: Image,
-      display: `${stats.withPortraits}/${stats.total}`,
-      tone: "ready",
     },
     {
       key: "identityReady",

--- a/frontend/src/components/assets/prop-asset-card.tsx
+++ b/frontend/src/components/assets/prop-asset-card.tsx
@@ -66,12 +66,20 @@ export function PropAssetCard({
   const resolvedReferenceUrl = resolveMediaUrl(prop.reference_url);
   const [failedReferenceUrl, setFailedReferenceUrl] = useState("");
   const wasGenerating = useRef(generating);
+  const wasUploading = useRef(uploading);
   useEffect(() => {
-    if (wasGenerating.current && !generating) {
+    if (
+      (wasGenerating.current && !generating) ||
+      (wasUploading.current && !uploading)
+    ) {
       setFailedReferenceUrl("");
     }
     wasGenerating.current = generating;
-  }, [generating]);
+    wasUploading.current = uploading;
+  }, [generating, uploading]);
+  useEffect(() => {
+    setFailedReferenceUrl("");
+  }, [resolvedReferenceUrl]);
   const referenceUrl =
     resolvedReferenceUrl && failedReferenceUrl !== resolvedReferenceUrl
       ? resolvedReferenceUrl

--- a/frontend/src/components/assets/prop-asset-card.tsx
+++ b/frontend/src/components/assets/prop-asset-card.tsx
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Elastic-2.0
 // Copyright (c) 2026 ClaymoreLab
-import { useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import {
   Edit3,
   ExternalLink,
@@ -63,7 +63,19 @@ export function PropAssetCard({
     if (file) onUploadReference(file);
     event.target.value = "";
   }
-  const referenceUrl = resolveMediaUrl(prop.reference_url);
+  const resolvedReferenceUrl = resolveMediaUrl(prop.reference_url);
+  const [failedReferenceUrl, setFailedReferenceUrl] = useState("");
+  const wasGenerating = useRef(generating);
+  useEffect(() => {
+    if (wasGenerating.current && !generating) {
+      setFailedReferenceUrl("");
+    }
+    wasGenerating.current = generating;
+  }, [generating]);
+  const referenceUrl =
+    resolvedReferenceUrl && failedReferenceUrl !== resolvedReferenceUrl
+      ? resolvedReferenceUrl
+      : null;
   const referenceAlt = `${prop.name} ${t("assets.props.reference")}`;
   const description =
     prop.description?.trim() || prop.visual_prompt?.trim() || t("assets.props.noDescription");
@@ -149,6 +161,7 @@ export function PropAssetCard({
             alt={referenceAlt}
             fit="contain"
             blurBackdrop={false}
+            onError={() => setFailedReferenceUrl(referenceUrl)}
             className="aspect-[16/9] w-full rounded-[8px]"
           />
         ) : (

--- a/frontend/src/components/assets/scenes-panel.tsx
+++ b/frontend/src/components/assets/scenes-panel.tsx
@@ -93,6 +93,7 @@ import {
   useClearSceneDirectorWorld,
   useSaveSceneDirectorWorld,
   useSceneDirectorStageManifest,
+  useSceneDetails,
   useScenePanoManifest,
   useScenes,
   useUpdateScene,
@@ -1286,8 +1287,22 @@ export function ScenesPanel({
     sceneGroups,
     selectedBaseName,
   ]);
-  const selectedGroup =
+  const selectedSummaryGroup =
     sceneGroups.find((group) => group.baseName === selectedBaseName) ?? null;
+  const selectedSceneNames = useMemo(
+    () => selectedSummaryGroup?.scenes.map((scene) => scene.name) ?? [],
+    [selectedSummaryGroup],
+  );
+  const selectedSceneDetails = useSceneDetails(project, selectedSceneNames);
+  const selectedGroup = selectedSummaryGroup
+    ? {
+        baseName: selectedSummaryGroup.baseName,
+        scenes:
+          selectedSceneDetails.data?.data?.length
+            ? selectedSceneDetails.data.data
+            : selectedSummaryGroup.scenes,
+      }
+    : null;
   const selectedBaseScene =
     selectedGroup?.scenes.find((scene) => scene.name === selectedGroup.baseName) ??
     selectedGroup?.scenes[0] ??
@@ -1373,8 +1388,13 @@ export function ScenesPanel({
         <HeaderRefreshButton
           label={t("common.refresh")}
           onRefresh={async () => {
-            const result = await scenes.refetch();
-            if (result.isError) {
+            const [listResult, detailResult] = await Promise.all([
+              scenes.refetch(),
+              selectedSceneNames.length
+                ? selectedSceneDetails.refetch()
+                : Promise.resolve(null),
+            ]);
+            if (listResult.isError || detailResult?.isError) {
               toast.error(t("common.error"));
               return false;
             }
@@ -1507,6 +1527,23 @@ export function ScenesPanel({
             {!selectedGroup ? (
               <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
                 {t("assets.common.noMatch")}
+              </div>
+            ) : selectedSceneDetails.isLoading ? (
+              <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
+                <Loader2 className="mr-2 size-4 animate-spin" />
+                {t("common.loading")}
+              </div>
+            ) : selectedSceneDetails.isError ? (
+              <div className="flex h-full flex-col items-center justify-center gap-3 text-sm text-muted-foreground">
+                <span>{t("common.error")}</span>
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  onClick={() => void selectedSceneDetails.refetch()}
+                >
+                  {t("common.refresh")}
+                </Button>
               </div>
             ) : (
               <div className="@container h-full overflow-y-auto px-4 py-3">

--- a/frontend/src/components/assets/scenes-panel.tsx
+++ b/frontend/src/components/assets/scenes-panel.tsx
@@ -1084,6 +1084,15 @@ interface SceneGroup {
   scenes: SceneAsset[];
 }
 
+export function selectAuthoritativeSceneDetails(
+  summaryScenes: SceneAsset[],
+  details: SceneAsset[] | undefined,
+  detailSucceeded: boolean,
+): SceneAsset[] | null {
+  if (!detailSucceeded) return summaryScenes;
+  return details?.length ? details : null;
+}
+
 const SCENE_GROUP_SELECTION_STORAGE_KEY_PREFIX = "supertale-scene-group:";
 
 function sceneGroupSelectionStorageKey(project: string): string {
@@ -1301,15 +1310,20 @@ export function ScenesPanel({
     [selectedSummaryGroup],
   );
   const selectedSceneDetails = useSceneDetails(project, selectedSceneNames);
-  const selectedGroup = selectedSummaryGroup
-    ? {
-        baseName: selectedSummaryGroup.baseName,
-        scenes:
-          selectedSceneDetails.data?.data?.length
-            ? selectedSceneDetails.data.data
-            : selectedSummaryGroup.scenes,
-      }
+  const selectedSceneAssets = selectedSummaryGroup
+    ? selectAuthoritativeSceneDetails(
+        selectedSummaryGroup.scenes,
+        selectedSceneDetails.data?.data,
+        selectedSceneDetails.isSuccess,
+      )
     : null;
+  const selectedGroup =
+    selectedSummaryGroup && selectedSceneAssets
+      ? {
+          baseName: selectedSummaryGroup.baseName,
+          scenes: selectedSceneAssets,
+        }
+      : null;
   const selectedBaseScene =
     selectedGroup?.scenes.find((scene) => scene.name === selectedGroup.baseName) ??
     selectedGroup?.scenes[0] ??

--- a/frontend/src/components/assets/scenes-panel.tsx
+++ b/frontend/src/components/assets/scenes-panel.tsx
@@ -1121,6 +1121,12 @@ function SceneGroupListItem({
 }) {
   const { t } = useTranslation();
   const previewUrl = sceneGroupPreviewUrl(group);
+  const [failedPreviewUrl, setFailedPreviewUrl] = useState("");
+  useEffect(() => {
+    setFailedPreviewUrl("");
+  }, [previewUrl]);
+  const visiblePreviewUrl =
+    previewUrl && failedPreviewUrl !== previewUrl ? previewUrl : "";
   return (
     <button
       type="button"
@@ -1138,13 +1144,14 @@ function SceneGroupListItem({
       ].join(" ")}
     >
       <div className="relative flex size-12 shrink-0 items-center justify-center overflow-hidden rounded-[8px] border border-white/[0.08] bg-black/20">
-        {previewUrl ? (
+        {visiblePreviewUrl ? (
           <img
-            src={previewUrl}
+            src={visiblePreviewUrl}
             alt=""
             aria-hidden="true"
             loading="lazy"
             decoding="async"
+            onError={() => setFailedPreviewUrl(previewUrl)}
             className="h-full w-full object-cover"
           />
         ) : (

--- a/frontend/src/components/lightbox-image.tsx
+++ b/frontend/src/components/lightbox-image.tsx
@@ -13,6 +13,7 @@ export function LightboxImage({
   fluid = false,
   fit = "cover",
   blurBackdrop = true,
+  onError,
 }: {
   src: string;
   alt: string;
@@ -20,6 +21,7 @@ export function LightboxImage({
   fluid?: boolean;
   fit?: "cover" | "contain";
   blurBackdrop?: boolean;
+  onError?: React.ReactEventHandler<HTMLImageElement>;
 }) {
   const [open, setOpen] = useState(false);
   useEscapeToClose(open, () => setOpen(false));
@@ -50,6 +52,7 @@ export function LightboxImage({
           alt={alt}
           loading="lazy"
           decoding="async"
+          onError={onError}
           className={cn(
             "relative z-10",
             fluid

--- a/frontend/src/lib/queries/character-image-selection.ts
+++ b/frontend/src/lib/queries/character-image-selection.ts
@@ -51,14 +51,14 @@ export function useAssetImageSourceSelection(
   });
 }
 
-export function useCharacterImageSelection(project: string) {
+export function useCharacterImageSelection(project: string, enabled = true) {
   return useQuery({
     queryKey: characterImageSelectionQueryKey(project),
     queryFn: ({ signal }) =>
       api
         .get(p`api/v1/projects/${project}/character-image-selection`, { signal })
         .json<OkResponse<CharacterImageSelection>>(),
-    enabled: !!project,
+    enabled: enabled && !!project,
   });
 }
 

--- a/frontend/src/lib/queries/characters.ts
+++ b/frontend/src/lib/queries/characters.ts
@@ -25,14 +25,37 @@ export type CharacterUpdateResponse = {
   renamed_from?: string;
 };
 
-export function useCharacters(project: string) {
+export function useCharacters(project: string, enabled = true) {
   return useQuery({
     queryKey: queryKeys.characters(project),
     queryFn: ({ signal }) =>
       api
         .get(p`api/v1/projects/${project}/characters`, { signal })
         .json<OkResponse<Character[]>>(),
-    enabled: !!project,
+    enabled: enabled && !!project,
+  });
+}
+
+/** Full filesystem-derived state for only the character currently being edited. */
+export function useCharacterDetails(
+  project: string,
+  name: string | null,
+  enabled = true,
+) {
+  const characterName = name?.trim() ?? "";
+  return useQuery({
+    queryKey: queryKeys.characterDetails(project, characterName),
+    queryFn: ({ signal }) =>
+      api
+        .get(p`api/v1/projects/${project}/characters`, {
+          signal,
+          searchParams: {
+            summary: "false",
+            names: characterName,
+          },
+        })
+        .json<OkResponse<Character[]>>(),
+    enabled: enabled && !!project && !!characterName,
   });
 }
 
@@ -400,14 +423,14 @@ export function useCharacterIdentities(project: string, name: string) {
  * read. Identity *details* are still lazy per selected character; only the ids
  * ride along with the list.
  */
-export function useIdentityOwnerIndex(project: string) {
+export function useIdentityOwnerIndex(project: string, enabled = true) {
   const charactersRes = useQuery({
     queryKey: queryKeys.characters(project),
     queryFn: ({ signal }) =>
       api
         .get(p`api/v1/projects/${project}/characters`, { signal })
         .json<OkResponse<Character[]>>(),
-    enabled: !!project,
+    enabled: enabled && !!project,
   });
 
   const characters = charactersRes.data?.data;

--- a/frontend/src/lib/queries/characters.ts
+++ b/frontend/src/lib/queries/characters.ts
@@ -30,7 +30,10 @@ export function useCharacters(project: string, enabled = true) {
     queryKey: queryKeys.characters(project),
     queryFn: ({ signal }) =>
       api
-        .get(p`api/v1/projects/${project}/characters`, { signal })
+        .get(p`api/v1/projects/${project}/characters`, {
+          signal,
+          searchParams: { summary: "true" },
+        })
         .json<OkResponse<Character[]>>(),
     enabled: enabled && !!project,
   });

--- a/frontend/src/lib/queries/characters.ts
+++ b/frontend/src/lib/queries/characters.ts
@@ -427,14 +427,7 @@ export function useCharacterIdentities(project: string, name: string) {
  * ride along with the list.
  */
 export function useIdentityOwnerIndex(project: string, enabled = true) {
-  const charactersRes = useQuery({
-    queryKey: queryKeys.characters(project),
-    queryFn: ({ signal }) =>
-      api
-        .get(p`api/v1/projects/${project}/characters`, { signal })
-        .json<OkResponse<Character[]>>(),
-    enabled: enabled && !!project,
-  });
+  const charactersRes = useCharacters(project, enabled);
 
   const characters = charactersRes.data?.data;
 

--- a/frontend/src/lib/queries/props.ts
+++ b/frontend/src/lib/queries/props.ts
@@ -24,7 +24,10 @@ export function useProps(project: string) {
     queryKey: queryKeys.props(project),
     queryFn: ({ signal }) =>
       api
-        .get(p`api/v1/projects/${project}/props`, { signal })
+        .get(p`api/v1/projects/${project}/props`, {
+          signal,
+          searchParams: { summary: "true" },
+        })
         .json<OkResponse<PropAsset[]>>(),
     enabled: !!project,
   });

--- a/frontend/src/lib/queries/scenes.ts
+++ b/frontend/src/lib/queries/scenes.ts
@@ -51,7 +51,10 @@ export function useScenes(project: string) {
     queryKey: queryKeys.scenes(project),
     queryFn: ({ signal }) =>
       api
-        .get(p`api/v1/projects/${project}/scenes`, { signal })
+        .get(p`api/v1/projects/${project}/scenes`, {
+          signal,
+          searchParams: { summary: "true" },
+        })
         .json<OkResponse<SceneAsset[]>>(),
     enabled: !!project,
   });

--- a/frontend/src/lib/queries/scenes.ts
+++ b/frontend/src/lib/queries/scenes.ts
@@ -57,6 +57,26 @@ export function useScenes(project: string) {
   });
 }
 
+/** Full file/manifests payload for only the scene group currently on screen. */
+export function useSceneDetails(project: string, names: string[]) {
+  const signature = JSON.stringify(
+    [...new Set(names.map((name) => name.trim()).filter(Boolean))].sort(),
+  );
+  const requestedNames = JSON.parse(signature) as string[];
+  return useQuery({
+    queryKey: queryKeys.sceneDetails(project, signature),
+    queryFn: ({ signal }) => {
+      const searchParams = new URLSearchParams();
+      searchParams.set("summary", "false");
+      for (const name of requestedNames) searchParams.append("names", name);
+      return api
+        .get(p`api/v1/projects/${project}/scenes`, { signal, searchParams })
+        .json<OkResponse<SceneAsset[]>>();
+    },
+    enabled: !!project && requestedNames.length > 0,
+  });
+}
+
 export function useScenePlatePreview(
   project: string,
   sceneId: string,

--- a/frontend/src/lib/query-keys.ts
+++ b/frontend/src/lib/query-keys.ts
@@ -27,6 +27,8 @@ export const queryKeys = {
     ["users", "search", project, q] as const,
   pipelineStatus: (p: string) => ["projects", p, "pipeline-status"] as const,
   characters: (p: string) => ["projects", p, "characters"] as const,
+  characterDetails: (p: string, name: string) =>
+    ["projects", p, "characters", "details", name] as const,
   character: (p: string, name: string) =>
     ["projects", p, "characters", name] as const,
   characterVoiceSamples: (p: string, name: string) =>
@@ -43,6 +45,8 @@ export const queryKeys = {
   assetReferenceDetail: (p: string, signature: string) =>
     ["projects", p, "asset-references", "detail", signature] as const,
   scenes: (p: string) => ["projects", p, "scenes"] as const,
+  sceneDetails: (p: string, signature: string) =>
+    ["projects", p, "scenes", "details", signature] as const,
   scenePlatePreview: (
     p: string,
     sceneId: string,

--- a/frontend/src/routes/_app/projects.$project/characters.lazy.tsx
+++ b/frontend/src/routes/_app/projects.$project/characters.lazy.tsx
@@ -502,6 +502,9 @@ function CharacterAvatar({
   const textSize = size === "lg" ? "text-xl" : "text-sm";
   const portraitUrl = character.portrait_url ?? "";
   const [failedPortraitUrl, setFailedPortraitUrl] = useState("");
+  useEffect(() => {
+    setFailedPortraitUrl("");
+  }, [portraitUrl]);
   if (portraitUrl && failedPortraitUrl !== portraitUrl) {
     return (
       <img
@@ -3232,8 +3235,9 @@ function CharactersPageContent() {
     selectedSummaryChar?.name ?? null,
     assetTab === "characters",
   );
-  const selectedChar =
-    selectedCharacterDetail.data?.data?.[0] ?? selectedSummaryChar;
+  const selectedChar = selectedCharacterDetail.data
+    ? (selectedCharacterDetail.data.data[0] ?? null)
+    : selectedSummaryChar;
 
   // Auto-select first character when nothing is selected
   useEffect(() => {

--- a/frontend/src/routes/_app/projects.$project/characters.lazy.tsx
+++ b/frontend/src/routes/_app/projects.$project/characters.lazy.tsx
@@ -36,6 +36,7 @@ import {
 
 import {
   useBuildCharacters,
+  useCharacterDetails,
   useCharacterAssetHistory,
   useCharacterIdentities,
   useCharacters,
@@ -499,13 +500,16 @@ function CharacterAvatar({
   );
   const dim = size === "lg" ? "size-16" : size === "sm" ? "size-9" : "size-10";
   const textSize = size === "lg" ? "text-xl" : "text-sm";
-  if (character.portrait_url) {
+  const portraitUrl = character.portrait_url ?? "";
+  const [failedPortraitUrl, setFailedPortraitUrl] = useState("");
+  if (portraitUrl && failedPortraitUrl !== portraitUrl) {
     return (
       <img
-        src={resolveMediaUrl(character.portrait_url) ?? ""}
+        src={resolveMediaUrl(portraitUrl) ?? ""}
         alt={character.name}
         loading="lazy"
         decoding="async"
+        onError={() => setFailedPortraitUrl(portraitUrl)}
         className={cn(
           "shrink-0 rounded-full border border-border object-cover",
           dim,
@@ -2922,6 +2926,9 @@ function CharactersSplit({
   selectedName,
   setSelectedName,
   selectedChar,
+  selectedDetailLoading,
+  selectedDetailError,
+  onRetrySelectedDetail,
   attempts,
   handleAttempt,
   onRebuild,
@@ -2942,6 +2949,9 @@ function CharactersSplit({
   selectedName: string | null;
   setSelectedName: (name: string | null) => void;
   selectedChar: Character | null;
+  selectedDetailLoading: boolean;
+  selectedDetailError: boolean;
+  onRetrySelectedDetail: () => void;
   attempts: Record<string, number>;
   handleAttempt: (name: string) => void;
   onRebuild: () => void;
@@ -3075,7 +3085,19 @@ function CharactersSplit({
     </>
   );
 
-  const detailPane = (
+  const detailPane = selectedDetailLoading ? (
+    <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
+      <Loader2 className="mr-2 size-4 animate-spin" />
+      {t("common.loading")}
+    </div>
+  ) : selectedDetailError ? (
+    <div className="flex h-full flex-col items-center justify-center gap-3 text-sm text-muted-foreground">
+      <span>{t("common.error")}</span>
+      <Button type="button" variant="outline" size="sm" onClick={onRetrySelectedDetail}>
+        {t("common.refresh")}
+      </Button>
+    </div>
+  ) : (
     <DetailPanel
       character={selectedChar}
       project={project}
@@ -3114,12 +3136,23 @@ function CharactersSplit({
 function CharactersPageContent() {
   const { t } = useTranslation();
   const { project } = Route.useParams();
-  const { data: charsRes, isLoading } = useCharacters(project);
+  const deepLink = useAssetsDeepLink();
+  const [assetTab, setAssetTab] = useState<AssetTab>(() =>
+    deepLink.type ? TAB_BY_ASSET_TYPE[deepLink.type] : readStoredAssetTab(project),
+  );
+  const charactersVisible = assetTab === "characters" || assetTab === "voices";
+  const { data: charsRes, isLoading } = useCharacters(project, charactersVisible);
   const { data: projectRes } = useProject(project);
-  const { data: imageSelectionRes } = useCharacterImageSelection(project);
+  const { data: imageSelectionRes } = useCharacterImageSelection(
+    project,
+    assetTab === "characters",
+  );
   const buildChars = useBuildCharacters(project);
   const isDesktop = useMediaQuery("(min-width: 1024px)");
-  const buildCharactersCost = useGenerationCreditCost("feature", "mainline.build_characters");
+  const buildCharactersCost = useGenerationCreditCost(
+    "feature",
+    assetTab === "characters" ? "mainline.build_characters" : null,
+  );
   const buildCharactersCostDisplay =
     buildCharactersCost.data?.data.display ??
     (buildCharactersCost.error instanceof BillingRuleNotConfiguredError
@@ -3132,12 +3165,8 @@ function CharactersPageContent() {
   const [rebuildDialogOpen, setRebuildDialogOpen] = useState(false);
   const [addDialogOpen, setAddDialogOpen] = useState(false);
   const [attempts, setAttempts] = useState<Record<string, number>>({});
-  const deepLink = useAssetsDeepLink();
-  const ownerIndex = useIdentityOwnerIndex(project);
+  const ownerIndex = useIdentityOwnerIndex(project, charactersVisible);
   const appliedIdentityDeepLink = useRef<string | null>(null);
-  const [assetTab, setAssetTab] = useState<AssetTab>(() =>
-    deepLink.type ? TAB_BY_ASSET_TYPE[deepLink.type] : readStoredAssetTab(project),
-  );
   const [searchQuery, setSearchQuery] = useState("");
   const [imageModel, setImageModel] = useState("");
 
@@ -3196,8 +3225,15 @@ function CharactersPageContent() {
         : -1,
     [filteredCharacters, selectedName],
   );
-  const selectedChar =
+  const selectedSummaryChar =
     selectedIndex >= 0 ? filteredCharacters[selectedIndex] : null;
+  const selectedCharacterDetail = useCharacterDetails(
+    project,
+    selectedSummaryChar?.name ?? null,
+    assetTab === "characters",
+  );
+  const selectedChar =
+    selectedCharacterDetail.data?.data?.[0] ?? selectedSummaryChar;
 
   // Auto-select first character when nothing is selected
   useEffect(() => {
@@ -3288,6 +3324,9 @@ function CharactersPageContent() {
             selectedName={selectedName}
             setSelectedName={setSelectedName}
             selectedChar={selectedChar}
+            selectedDetailLoading={selectedCharacterDetail.isLoading}
+            selectedDetailError={selectedCharacterDetail.isError}
+            onRetrySelectedDetail={() => void selectedCharacterDetail.refetch()}
             attempts={attempts}
             handleAttempt={handleAttempt}
             onRebuild={() => setRebuildDialogOpen(true)}

--- a/license-inventory.csv
+++ b/license-inventory.csv
@@ -288,6 +288,7 @@ frontend/src/__tests__/components/assets/props-panel.ce.test.tsx,Elastic-2.0,202
 frontend/src/__tests__/components/assets/scene-asset-card.test.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/__tests__/components/assets/scene-environment-prompt.test.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/__tests__/components/assets/scenes-panel-build-visibility.test.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
+frontend/src/__tests__/components/assets/scenes-panel-detail-authority.test.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/__tests__/components/confirm-dialog-host.test.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/__tests__/components/credit-cost-inline.ce.test.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/__tests__/components/credit-promotion-coverage.test.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation

--- a/src/novelvideo/api/deps.py
+++ b/src/novelvideo/api/deps.py
@@ -209,7 +209,12 @@ async def make_cognee_store(username: str, project: str) -> "CogneeStore":
     return await _close_on_init_failure(store, store.initialize)
 
 
-async def make_sqlite_store(username: str, project: str) -> "SQLiteStore":
+async def make_sqlite_store(
+    username: str,
+    project: str,
+    *,
+    load_graph_state: bool = True,
+) -> "SQLiteStore":
     """按请求创建 SQLiteStore 实例。"""
     from novelvideo.sqlite_store import SQLiteStore
 
@@ -217,7 +222,10 @@ async def make_sqlite_store(username: str, project: str) -> "SQLiteStore":
     output_dir = get_output_dir(username, project)
     state_dir = get_state_dir(username, project)
     store = SQLiteStore(project_name, output_dir=output_dir, state_dir=state_dir)
-    return await _close_on_init_failure(store, store.initialize, store.load_graph_state)
+    steps = [store.initialize]
+    if load_graph_state:
+        steps.append(store.load_graph_state)
+    return await _close_on_init_failure(store, *steps)
 
 
 async def make_sqlite_store_for_context(
@@ -228,11 +236,12 @@ async def make_sqlite_store_for_context(
     """Create a SQLiteStore from the resolved project owner/home paths.
 
     ``load_graph_state()`` hydrates the in-memory character/episode/prop caches
-    with three full-table reads. Callers that only touch ``beats`` (and never
-    ``get_character`` / ``get_episode`` / ``get_cached_prop`` / ``resolve_name``)
-    should pass ``load_graph_state=False`` — otherwise those three reads cost
-    more than the query they precede. Default stays ``True`` so existing callers
-    keep the hydrated behaviour they rely on.
+    with three full-table reads. Callers that use direct ``list_*`` queries or
+    only touch ``beats`` (and never ``get_character`` / ``get_episode`` /
+    ``get_cached_prop`` / ``resolve_name``) should pass
+    ``load_graph_state=False`` — otherwise unrelated tables can cost more than
+    the query they precede. Default stays ``True`` so existing callers keep the
+    hydrated behaviour they rely on.
     """
     from novelvideo.sqlite_store import SQLiteStore
 
@@ -272,8 +281,21 @@ async def _make_cognee_store_scope(username: str, project: str) -> AsyncIterator
             await close()
 
 
-async def _make_sqlite_store_scope(username: str, project: str) -> AsyncIterator["SQLiteStore"]:
-    store = await make_sqlite_store(username, project)
+async def _make_sqlite_store_scope(
+    username: str,
+    project: str,
+    *,
+    load_graph_state: bool = True,
+) -> AsyncIterator["SQLiteStore"]:
+    store = (
+        await make_sqlite_store(username, project)
+        if load_graph_state
+        else await make_sqlite_store(
+            username,
+            project,
+            load_graph_state=False,
+        )
+    )
     try:
         yield store
     finally:

--- a/src/novelvideo/api/routes/characters.py
+++ b/src/novelvideo/api/routes/characters.py
@@ -1,5 +1,6 @@
 """角色列表 & 肖像/身份图生成端点。"""
 
+import asyncio
 import io
 import logging
 import re
@@ -458,7 +459,12 @@ def _voice_sample_url(
 
 
 def _convention_asset_url(
-    ctx: ProjectContext, project_dir: Path, path: str | Path
+    ctx: ProjectContext | None,
+    project_dir: Path,
+    path: str | Path,
+    *,
+    version: str = "",
+    project_id: str = "",
 ) -> str:
     """Build a canonical asset URL without probing OSSFS.
 
@@ -472,7 +478,9 @@ def _convention_asset_url(
         rel_path = asset_path.relative_to(project_dir).as_posix()
     except ValueError:
         return ""
-    return project_static_url(ctx.project_id, rel_path)
+    asset_project = str(getattr(ctx, "project_id", "") or project_id).strip()
+    url = project_static_url(asset_project, rel_path)
+    return f"{url}?v={quote(version, safe='')}" if version else url
 
 
 def _voice_slot_payload(
@@ -620,7 +628,17 @@ async def _repair_duplicate_main_characters(
             seen_main = True
             repaired.append(character)
             continue
-        await store.update_character(character.name, is_main=False)
+        set_main = getattr(store, "set_character_main", None)
+        if set_main is not None:
+            if not await set_main(character.name, False):
+                raise RuntimeError(
+                    f"Failed to repair duplicate main character: {character.name}"
+                )
+        else:
+            # Store test doubles and older compatible facades retain the
+            # object-merge operation. Real SQLiteStore uses the cache-free,
+            # column-level branch above.
+            await store.update_character(character.name, is_main=False)
         character.is_main = False
         repaired.append(character)
     return repaired
@@ -648,20 +666,20 @@ async def _heal_path_unsafe_character_names(
 @router.get("/projects/{project}/characters")
 async def list_characters(
     project: str,
-    summary: bool = True,
+    summary: bool = False,
     names: Annotated[list[str] | None, Query()] = None,
     user: dict = Depends(get_api_user),
 ):
-    """获取角色列表；默认不探测资产文件，详情请求显式关闭 summary。"""
+    """获取角色列表；资产工作台可显式使用 summary 跳过文件探测。"""
     async with _character_project_scope(
         project,
         user,
         required_role="viewer",
         load_graph_state=False,
     ) as (ctx, _username, _project_name, project_dir, _output_dir, store):
-        characters = await store.list_characters()
         if may_run_asset_repair(ctx):
             await _heal_path_unsafe_character_names(store, project_dir)
+        characters = await store.list_characters()
         characters = await _repair_duplicate_main_characters(
             store, characters
         )
@@ -672,16 +690,13 @@ async def list_characters(
     if requested_names:
         characters = [c for c in characters if c.name in requested_names]
 
-    data = []
     asset_project = getattr(ctx, "project_id", "") or project
-    for c in characters:
+    def build_item(c) -> dict:
         canonical_portrait = canonical_portrait_path(project_dir, c.name)
-        abs_portrait = (
-            str(canonical_portrait)
-            if summary
-            else compute_portrait_path(project_dir, c.name)
+        abs_portrait = str(canonical_portrait) if summary else compute_portrait_path(
+            project_dir, c.name
         )
-        item = {
+        item: dict = {
             "name": c.name,
             "aliases": c.aliases if hasattr(c, "aliases") else [],
             "description": c.description if hasattr(c, "description") else "",
@@ -693,7 +708,13 @@ async def list_characters(
             "is_main": c.is_main if hasattr(c, "is_main") else False,
             "portrait_path": abs_portrait,
             "portrait_url": (
-                _convention_asset_url(ctx, project_dir, canonical_portrait)
+                _convention_asset_url(
+                    ctx,
+                    project_dir,
+                    canonical_portrait,
+                    version=getattr(c, "updated_at", "") or "",
+                    project_id=project,
+                )
                 if summary
                 else _asset_url(ctx, project_dir, abs_portrait)
                 if abs_portrait
@@ -732,7 +753,11 @@ async def list_characters(
                 ctx, project_dir, c, probe_files=not summary
             )
         )
-        data.append(item)
+        return item
+
+    # Full details still perform authoritative filesystem checks. Keep those
+    # blocking OSSFS operations away from the API worker's event loop.
+    data = await asyncio.to_thread(lambda: [build_item(c) for c in characters])
 
     return {"ok": True, "data": data}
 
@@ -1614,6 +1639,9 @@ async def generate_single_portrait(
     char_dir.mkdir(parents=True, exist_ok=True)
     final_path = char_dir / "portrait.png"
     shutil.copy(paths[0], final_path)
+    # Canonical URLs in the lightweight list are versioned by the SQLite row,
+    # so publishing a new file must advance that revision as part of the write.
+    await store.touch_character_asset(name)
 
     portrait_url = _asset_url(ctx, project_dir, final_path)
 
@@ -1653,6 +1681,7 @@ async def upload_portrait(
         shutil.copy(portrait_path, backup)
 
     img.save(str(portrait_path), format="PNG")
+    await store.touch_character_asset(name)
 
     portrait_url = _asset_url(ctx, project_dir, portrait_path)
 

--- a/src/novelvideo/api/routes/characters.py
+++ b/src/novelvideo/api/routes/characters.py
@@ -1156,6 +1156,8 @@ async def restore_character_asset_history(
     backup = _backup_character_asset(target)
     shutil.copy2(source, target)
     await _sync_restored_identity_asset(store, name, identity, kind, target)
+    if kind == "portrait":
+        await store.touch_character_asset(name)
 
     return {
         "ok": True,

--- a/src/novelvideo/api/routes/characters.py
+++ b/src/novelvideo/api/routes/characters.py
@@ -7,10 +7,10 @@ import shutil
 from contextlib import asynccontextmanager
 from datetime import datetime
 from pathlib import Path
-from typing import AsyncIterator
+from typing import Annotated, AsyncIterator
 from urllib.parse import quote, urlencode
 
-from fastapi import APIRouter, Depends, UploadFile, File
+from fastapi import APIRouter, Depends, UploadFile, File, Query
 from fastapi.responses import JSONResponse
 
 logger = logging.getLogger("novelvideo.api.characters")
@@ -67,6 +67,7 @@ from novelvideo.utils.path_resolver import (
     canonical_identity_costume_path,
     canonical_identity_portrait_path,
 )
+from novelvideo.utils.static_urls import project_static_url
 from novelvideo.seedance2_i2v.character_voice_storage import (
     AGE_GROUP_SLOTS as VOICE_AGE_GROUP_SLOTS,
     ALL_SLOTS as VOICE_SAMPLE_SLOTS,
@@ -131,6 +132,7 @@ async def _character_project_scope(
     user: dict,
     *,
     required_role: str = "editor",
+    load_graph_state: bool = True,
 ) -> "AsyncIterator[tuple[ProjectContext | None, str, str, Path, str, SQLiteStore]]":
     """``_resolve_character_project`` 的作用域版：出了 ``async with`` 一定关连接。
 
@@ -144,9 +146,16 @@ async def _character_project_scope(
     """
     resolved = await resolve_project_scope(project, user, required_role=required_role)
     store_scope = (
-        sqlite_store_for_context_scope(resolved.ctx)
+        sqlite_store_for_context_scope(
+            resolved.ctx,
+            load_graph_state=load_graph_state,
+        )
         if resolved.ctx
-        else sqlite_store_scope(resolved.username, resolved.project_name)
+        else sqlite_store_scope(
+            resolved.username,
+            resolved.project_name,
+            load_graph_state=load_graph_state,
+        )
     )
     async with store_scope as store:
         yield (
@@ -448,6 +457,24 @@ def _voice_sample_url(
     return _asset_url(ctx, project_dir, project_dir / rel_path)
 
 
+def _convention_asset_url(
+    ctx: ProjectContext, project_dir: Path, path: str | Path
+) -> str:
+    """Build a canonical asset URL without probing OSSFS.
+
+    Asset slots are convention-based. List views can let the browser lazily
+    request the URL and fall back on image error; only selected-asset detail
+    needs authoritative file-existence checks.
+    """
+
+    asset_path = Path(path)
+    try:
+        rel_path = asset_path.relative_to(project_dir).as_posix()
+    except ValueError:
+        return ""
+    return project_static_url(ctx.project_id, rel_path)
+
+
 def _voice_slot_payload(
     *,
     ctx: ProjectContext,
@@ -496,14 +523,22 @@ def _voice_samples_payload(
     }
 
 
-def _character_voice_fields(ctx: ProjectContext, project_dir: Path, character) -> dict:
+def _character_voice_fields(
+    ctx: ProjectContext,
+    project_dir: Path,
+    character,
+    *,
+    probe_files: bool = True,
+) -> dict:
     rel_path = getattr(character, "reference_audio_path", "") or ""
     return {
         "reference_audio_path": rel_path,
-        "reference_audio_url": _voice_sample_url(
-            ctx=ctx,
-            project_dir=project_dir,
-            rel_path=rel_path,
+        "reference_audio_url": (
+            _voice_sample_url(ctx=ctx, project_dir=project_dir, rel_path=rel_path)
+            if probe_files
+            else _convention_asset_url(ctx, project_dir, project_dir / rel_path)
+            if rel_path
+            else ""
         ),
         "reference_audio_sha256": getattr(character, "reference_audio_sha256", "")
         or "",
@@ -613,22 +648,39 @@ async def _heal_path_unsafe_character_names(
 @router.get("/projects/{project}/characters")
 async def list_characters(
     project: str,
+    summary: bool = True,
+    names: Annotated[list[str] | None, Query()] = None,
     user: dict = Depends(get_api_user),
 ):
-    """获取项目角色列表。"""
+    """获取角色列表；默认不探测资产文件，详情请求显式关闭 summary。"""
     async with _character_project_scope(
-        project, user, required_role="viewer"
+        project,
+        user,
+        required_role="viewer",
+        load_graph_state=False,
     ) as (ctx, _username, _project_name, project_dir, _output_dir, store):
+        characters = await store.list_characters()
         if may_run_asset_repair(ctx):
             await _heal_path_unsafe_character_names(store, project_dir)
         characters = await _repair_duplicate_main_characters(
-            store, store.get_all_characters()
+            store, characters
         )
+
+    requested_names = {
+        str(name or "").strip() for name in (names or []) if str(name or "").strip()
+    }
+    if requested_names:
+        characters = [c for c in characters if c.name in requested_names]
 
     data = []
     asset_project = getattr(ctx, "project_id", "") or project
     for c in characters:
-        abs_portrait = compute_portrait_path(project_dir, c.name)
+        canonical_portrait = canonical_portrait_path(project_dir, c.name)
+        abs_portrait = (
+            str(canonical_portrait)
+            if summary
+            else compute_portrait_path(project_dir, c.name)
+        )
         item = {
             "name": c.name,
             "aliases": c.aliases if hasattr(c, "aliases") else [],
@@ -641,11 +693,21 @@ async def list_characters(
             "is_main": c.is_main if hasattr(c, "is_main") else False,
             "portrait_path": abs_portrait,
             "portrait_url": (
-                _asset_url(ctx, project_dir, abs_portrait) if abs_portrait else ""
+                _convention_asset_url(ctx, project_dir, canonical_portrait)
+                if summary
+                else _asset_url(ctx, project_dir, abs_portrait)
+                if abs_portrait
+                else ""
             ),
-            "updated_at": newest_updated_at(
-                getattr(c, "updated_at", ""),
-                tree_updated_at(project_dir / "assets" / "characters" / c.name),
+            "updated_at": (
+                getattr(c, "updated_at", "")
+                if summary
+                else newest_updated_at(
+                    getattr(c, "updated_at", ""),
+                    tree_updated_at(
+                        project_dir / "assets" / "characters" / c.name
+                    ),
+                )
             ),
             # 只出 id，不出身份详情。资产页要把 ``?type=identity&id=`` 深链解析到
             # 拥有它的角色，此前是遍历每个角色各调一次 ``/characters/{name}/identities``
@@ -665,7 +727,11 @@ async def list_characters(
                 kind="portrait",
             )
         )
-        item.update(_character_voice_fields(ctx, project_dir, c))
+        item.update(
+            _character_voice_fields(
+                ctx, project_dir, c, probe_files=not summary
+            )
+        )
         data.append(item)
 
     return {"ok": True, "data": data}
@@ -886,9 +952,12 @@ async def get_character_identities(
     # store 只用来取角色，取完就关：后面拼载荷读的是已经在内存里的模型对象和
     # 文件系统，不再需要连接。"角色不存在" 的提前返回因此也发生在关闭之后。
     async with _character_project_scope(
-        project, user, required_role="viewer"
+        project,
+        user,
+        required_role="viewer",
+        load_graph_state=False,
     ) as (ctx, _username, _project_name, project_dir, _output_dir, store):
-        characters = store.get_all_characters()
+        characters = await store.list_characters()
 
     target = None
     for c in characters:

--- a/src/novelvideo/api/routes/freezone.py
+++ b/src/novelvideo/api/routes/freezone.py
@@ -237,6 +237,7 @@ from novelvideo.freezone.skill_registry import (
     list_skills,
 )
 from novelvideo.freezone.slots import (
+    SCENE_ASSET_KINDS,
     IdentityTarget,
     PushTarget,
     backup_slot_if_exists,
@@ -4218,7 +4219,30 @@ def _parse_skill_output_push_target(output: dict) -> PushTarget | None:
         return None
 
 
-def _copy_skill_output_to_slot(
+async def _touch_canonical_slot_revision(
+    ctx: ProjectContext,
+    target: PushTarget,
+) -> None:
+    """Advance the owning entity revision after a canonical asset write.
+
+    Canonical paths remain a PathResolver convention. The database timestamp
+    is only the cache-busting revision used by lightweight asset summaries.
+    Keeping this beside the shared Freezone slot writer prevents push and skill
+    auto-commit paths from publishing new bytes under an unchanged URL.
+    """
+
+    if target.kind not in {"portrait", "prop_ref", *SCENE_ASSET_KINDS}:
+        return
+    store = await make_sqlite_store_for_context(ctx)
+    if target.kind == "portrait":
+        await store.touch_character_asset(target.character)
+    elif target.kind == "prop_ref":
+        await store.touch_prop_asset(target.prop_id)
+    else:
+        await store.touch_scene_asset(target.scene_id)
+
+
+async def _copy_skill_output_to_slot(
     *,
     project_dir: Path,
     ctx: ProjectContext,
@@ -4251,6 +4275,7 @@ def _copy_skill_output_to_slot(
         image_adaptation = {"adapted": False}
         shutil.copy2(source_path, target_path)
     sync_slot_after_write(project_dir, target, target_path)
+    await _touch_canonical_slot_revision(ctx, target)
     rel = target_path.relative_to(project_dir).as_posix()
     return (
         target_path,
@@ -4280,7 +4305,7 @@ async def _finalize_skill_run_outputs(
                 source_path = resolve_static_url_to_path(image_url, project_dir)
                 if not source_path.exists() or not source_path.is_file():
                     raise FileNotFoundError(source_path)
-                target_path, target_url, backup, image_adaptation = _copy_skill_output_to_slot(
+                target_path, target_url, backup, image_adaptation = await _copy_skill_output_to_slot(
                     project_dir=project_dir,
                     ctx=ctx,
                     source_path=source_path,
@@ -13242,33 +13267,12 @@ async def freezone_push(project: str, body: PushRequest, user: dict = Depends(ge
         raise HTTPException(400, str(exc)) from exc
     if not source_path.exists():
         raise HTTPException(404, f"source file not found: {source_path}")
-    validate_source_for_slot(source_path, body.target)
-
-    target = slot_target_path(project_dir, body.target)
-    if body.target.kind == "scene_3gs_custom_scene":
-        target = target.with_suffix(source_path.suffix.lower())
-    target.parent.mkdir(parents=True, exist_ok=True)
-    same_file = False
-    try:
-        same_file = source_path.resolve() == target.resolve()
-    except OSError:
-        same_file = False
-    should_match_existing_size = (
-        target.exists()
-        and not same_file
-        and body.target.kind in {"frame", "sketch", "director_render"}
-        and source_path.suffix.lower() in {".png", ".jpg", ".jpeg", ".webp"}
-        and target.suffix.lower() in {".png", ".jpg", ".jpeg", ".webp"}
+    target, target_url, backup, image_adaptation = await _copy_skill_output_to_slot(
+        project_dir=project_dir,
+        ctx=ctx,
+        source_path=source_path,
+        target=body.target,
     )
-    backup = None if same_file else backup_slot_if_exists(target)
-    if same_file:
-        image_adaptation = {"adapted": False, "same_file": True}
-    elif should_match_existing_size:
-        image_adaptation = _copy_image_matching_existing_target(source_path, target)
-    else:
-        image_adaptation = {"adapted": False}
-        shutil.copy2(source_path, target)
-    sync_slot_after_write(project_dir, body.target, target)
     if body.target.kind == "selected_background":
         await _persist_freezone_selected_background_scene_ref(
             ctx=ctx,
@@ -13327,7 +13331,6 @@ async def freezone_push(project: str, body: PushRequest, user: dict = Depends(ge
         except Exception as exc:
             logger.warning("identity cognee sync best-effort failed: %s", exc)
 
-    rel = target.relative_to(project_dir).as_posix()
     _append_canvas_event(
         project_dir=project_dir,
         project_id=project,
@@ -13338,7 +13341,7 @@ async def freezone_push(project: str, body: PushRequest, user: dict = Depends(ge
             "source_url": body.source_url,
             "target": body.target.model_dump(mode="json"),
             "target_path": str(target),
-            "target_url": make_static_url_for_context(ctx, rel, local_path=target),
+            "target_url": target_url,
             "backup": str(backup) if backup else None,
             "stale_marked": stale_marked,
             "affected_count": len(impacted),
@@ -13348,7 +13351,7 @@ async def freezone_push(project: str, body: PushRequest, user: dict = Depends(ge
         "ok": True,
         "data": {
             "target_path": str(target),
-            "target_url": make_static_url_for_context(ctx, rel, local_path=target),
+            "target_url": target_url,
             "backup": str(backup) if backup else None,
             "image_adaptation": image_adaptation,
             "stale_marked": stale_marked,

--- a/src/novelvideo/api/routes/freezone.py
+++ b/src/novelvideo/api/routes/freezone.py
@@ -33,6 +33,7 @@ from novelvideo.api.deps import (
     make_sqlite_store,
     make_sqlite_store_for_context,
     make_static_url_for_context,
+    sqlite_store_for_context_scope,
 )
 from novelvideo.api.schemas import (
     CanvasPayload,
@@ -4233,13 +4234,13 @@ async def _touch_canonical_slot_revision(
 
     if target.kind not in {"portrait", "prop_ref", *SCENE_ASSET_KINDS}:
         return
-    store = await make_sqlite_store_for_context(ctx)
-    if target.kind == "portrait":
-        await store.touch_character_asset(target.character)
-    elif target.kind == "prop_ref":
-        await store.touch_prop_asset(target.prop_id)
-    else:
-        await store.touch_scene_asset(target.scene_id)
+    async with sqlite_store_for_context_scope(ctx, load_graph_state=False) as store:
+        if target.kind == "portrait":
+            await store.touch_character_asset(target.character)
+        elif target.kind == "prop_ref":
+            await store.touch_prop_asset(target.prop_id)
+        else:
+            await store.touch_scene_asset(target.scene_id)
 
 
 async def _copy_skill_output_to_slot(

--- a/src/novelvideo/api/routes/props.py
+++ b/src/novelvideo/api/routes/props.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import asyncio
 from pathlib import Path
 from typing import Annotated, Any
+from urllib.parse import quote
 
 from fastapi import APIRouter, Depends, Query
 
@@ -55,6 +57,7 @@ def _convention_asset_url(
     path: str | Path,
     *,
     project_id: str,
+    version: str = "",
 ) -> str:
     """Project-static URL for a canonical slot, without an OSSFS probe."""
 
@@ -64,7 +67,8 @@ def _convention_asset_url(
     except ValueError:
         return ""
     asset_project = str(getattr(ctx, "project_id", "") or project_id).strip()
-    return project_static_url(asset_project, rel_path)
+    url = project_static_url(asset_project, rel_path)
+    return f"{url}?v={quote(version, safe='')}" if version else url
 
 
 def _prop_payload(
@@ -109,6 +113,7 @@ def _prop_payload(
                 project_dir,
                 canonical_reference,
                 project_id=project_id,
+                version=getattr(prop, "updated_at", "") or "",
             )
         ),
     }
@@ -189,6 +194,7 @@ async def _heal_path_unsafe_prop_names(store: SQLiteStore, project_dir: Path) ->
 async def list_props(
     project: str,
     scope: Annotated[str, Query(pattern="^(global|local|all)$")] = "global",
+    summary: bool = False,
     user: dict = Depends(get_api_user),
 ):
     resolved = await resolve_project_scope(project, user, required_role="viewer")
@@ -204,16 +210,19 @@ async def list_props(
     global_names = {prop.name for prop in props}
     data: list[dict[str, Any]] = []
     if scope in {"global", "all"}:
-        data.extend(
-            _prop_payload(
-                prop,
-                ctx=resolved.ctx,
-                project_dir=project_dir,
-                probe_files=False,
-                project_id=project,
-            )
-            for prop in props
+        global_payloads = await asyncio.to_thread(
+            lambda: [
+                _prop_payload(
+                    prop,
+                    ctx=resolved.ctx,
+                    project_dir=project_dir,
+                    probe_files=not summary,
+                    project_id=project,
+                )
+                for prop in props
+            ]
         )
+        data.extend(global_payloads)
     if scope in {"local", "all"}:
         data.extend(await _local_episode_prop_payloads(store=store, global_prop_names=global_names))
     return {

--- a/src/novelvideo/api/routes/props.py
+++ b/src/novelvideo/api/routes/props.py
@@ -24,7 +24,11 @@ from novelvideo.ports import get_task_backend
 from novelvideo.task_scopes import prop_reference_asset_scope
 from novelvideo.task_identity import project_task_state_key
 from novelvideo.utils.asset_names import move_asset_dir, path_safe_asset_name
-from novelvideo.utils.path_resolver import compute_prop_reference_path
+from novelvideo.utils.path_resolver import (
+    canonical_prop_reference_path,
+    compute_prop_reference_path,
+)
+from novelvideo.utils.static_urls import project_static_url
 
 router = APIRouter()
 
@@ -45,6 +49,24 @@ def _asset_url(ctx, project_dir: Path, abs_path: str | Path) -> str:
     return make_static_url_for_context(ctx, rel_path, local_path=path)
 
 
+def _convention_asset_url(
+    ctx,
+    project_dir: Path,
+    path: str | Path,
+    *,
+    project_id: str,
+) -> str:
+    """Project-static URL for a canonical slot, without an OSSFS probe."""
+
+    asset_path = Path(path)
+    try:
+        rel_path = asset_path.relative_to(project_dir).as_posix()
+    except ValueError:
+        return ""
+    asset_project = str(getattr(ctx, "project_id", "") or project_id).strip()
+    return project_static_url(asset_project, rel_path)
+
+
 def _prop_payload(
     prop: NovelProp,
     *,
@@ -52,8 +74,15 @@ def _prop_payload(
     project_dir: Path,
     scope: str = "global",
     source_episode: int | None = None,
+    probe_files: bool = True,
+    project_id: str = "",
 ) -> dict[str, Any]:
-    reference_path = compute_prop_reference_path(project_dir, prop.name)
+    canonical_reference = canonical_prop_reference_path(project_dir, prop.name)
+    reference_path = (
+        compute_prop_reference_path(project_dir, prop.name)
+        if probe_files
+        else str(canonical_reference)
+    )
     payload = {
         "name": prop.name,
         "aliases": prop.aliases,
@@ -62,14 +91,25 @@ def _prop_payload(
         "description": prop.description,
         "owner": prop.owner,
         "notes": prop.notes,
-        "updated_at": newest_updated_at(
-            getattr(prop, "updated_at", ""),
-            tree_updated_at(project_dir / "assets" / "props" / prop.name),
+        "updated_at": (
+            newest_updated_at(
+                getattr(prop, "updated_at", ""),
+                tree_updated_at(project_dir / "assets" / "props" / prop.name),
+            )
+            if probe_files
+            else getattr(prop, "updated_at", "")
         ),
         "scope": scope,
         "reference_path": reference_path,
         "reference_url": (
-            _asset_url(ctx, project_dir, reference_path) if reference_path else ""
+            (_asset_url(ctx, project_dir, reference_path) if reference_path else "")
+            if probe_files
+            else _convention_asset_url(
+                ctx,
+                project_dir,
+                canonical_reference,
+                project_id=project_id,
+            )
         ),
     }
     if source_episode is not None:
@@ -153,7 +193,7 @@ async def list_props(
 ):
     resolved = await resolve_project_scope(project, user, required_role="viewer")
     store = (
-        await make_sqlite_store_for_context(resolved.ctx)
+        await make_sqlite_store_for_context(resolved.ctx, load_graph_state=False)
         if resolved.ctx
         else await make_sqlite_store(resolved.username, resolved.project_name)
     )
@@ -165,7 +205,13 @@ async def list_props(
     data: list[dict[str, Any]] = []
     if scope in {"global", "all"}:
         data.extend(
-            _prop_payload(prop, ctx=resolved.ctx, project_dir=project_dir)
+            _prop_payload(
+                prop,
+                ctx=resolved.ctx,
+                project_dir=project_dir,
+                probe_files=False,
+                project_id=project,
+            )
             for prop in props
         )
     if scope in {"local", "all"}:

--- a/src/novelvideo/api/routes/scenes.py
+++ b/src/novelvideo/api/routes/scenes.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
+import asyncio
 import io
 import logging
 import shutil
 import tempfile
 import time
 from pathlib import Path
+from urllib.parse import quote
 from typing import Annotated, Any
 
 from fastapi import APIRouter, Depends, File, Query, UploadFile
@@ -62,6 +64,7 @@ from novelvideo.utils.path_resolver import (
     compute_scene_master_path,
     compute_scene_reverse_master_path,
 )
+from novelvideo.utils.static_urls import project_static_url
 
 router = APIRouter()
 logger = logging.getLogger("novelvideo.api.scenes")
@@ -522,6 +525,9 @@ def _scene_payload(
 def _scene_summary_payload(
     scene: NovelScene,
     *,
+    ctx: ProjectContext | None,
+    project_dir: Path,
+    project_id: str = "",
     base_scene: NovelScene | None = None,
 ) -> dict[str, Any]:
     """Return the SQLite-only fields needed to group/search the scene list.
@@ -533,6 +539,13 @@ def _scene_summary_payload(
     """
 
     base_scene_id = str(getattr(scene, "base_scene_id", "") or "").strip()
+    updated_at = str(getattr(scene, "updated_at", "") or "")
+    master_path = canonical_scene_master_path(project_dir, scene.name)
+    master_rel = master_path.relative_to(project_dir).as_posix()
+    asset_project = str(getattr(ctx, "project_id", "") or project_id).strip()
+    master_url = project_static_url(asset_project, master_rel)
+    if updated_at:
+        master_url = f"{master_url}?v={quote(updated_at, safe='')}"
     return {
         "name": scene.name,
         "aliases": scene.aliases,
@@ -549,7 +562,12 @@ def _scene_summary_payload(
         "derived_from_scene": base_scene_id,
         "spatial_layout_image": scene.spatial_layout_image,
         "notes": scene.notes,
-        "updated_at": getattr(scene, "updated_at", ""),
+        "updated_at": updated_at,
+        # The canonical preview slot is a projection, not proof that the file
+        # exists. The browser loads it lazily; authoritative state remains in
+        # the selected-scene detail response.
+        "master_path": str(master_path),
+        "master_url": master_url,
     }
 
 
@@ -681,7 +699,7 @@ async def _heal_path_unsafe_scene_names(store: SQLiteStore, project_dir: Path) -
 @router.get("/projects/{project}/scenes")
 async def list_scenes(
     project: str,
-    summary: bool = True,
+    summary: bool = False,
     names: Annotated[list[str] | None, Query()] = None,
     user: dict = Depends(get_api_user),
 ):
@@ -705,6 +723,9 @@ async def list_scenes(
             "data": [
                 _scene_summary_payload(
                     scene,
+                    ctx=ctx,
+                    project_dir=project_dir,
+                    project_id=project,
                     base_scene=scenes_by_name.get(
                         str(getattr(scene, "base_scene_id", "") or "")
                     ),
@@ -712,9 +733,8 @@ async def list_scenes(
                 for scene in scenes
             ],
         }
-    return {
-        "ok": True,
-        "data": [
+    data = await asyncio.to_thread(
+        lambda: [
             _scene_payload(
                 scene,
                 ctx=ctx,
@@ -727,8 +747,9 @@ async def list_scenes(
                 ),
             )
             for scene in scenes
-        ],
-    }
+        ]
+    )
+    return {"ok": True, "data": data}
 
 
 @router.get("/projects/{project}/scenes/plate-preview")
@@ -1168,6 +1189,8 @@ async def upload_scene_master(
     if master_path.exists():
         master_path.replace(master_path.parent / f"master_{int(time.time())}.png")
     img.save(master_path, format="PNG")
+    await store.touch_scene_asset(scene.name)
+    scene = await _require_scene(store, scene.name) or scene
 
     return {
         "ok": True,
@@ -1196,6 +1219,7 @@ async def delete_scene_master(
     if master_path:
         Path(master_path).unlink(missing_ok=True)
         deleted = True
+        await store.touch_scene_asset(scene.name)
     return {"ok": True, "data": {"deleted": deleted}}
 
 

--- a/src/novelvideo/api/routes/scenes.py
+++ b/src/novelvideo/api/routes/scenes.py
@@ -8,7 +8,7 @@ import shutil
 import tempfile
 import time
 from pathlib import Path
-from typing import Any
+from typing import Annotated, Any
 
 from fastapi import APIRouter, Depends, File, Query, UploadFile
 
@@ -110,7 +110,10 @@ async def _resolve_scene_project(
         project_id=project,
         required_role=required_role,
     )
-    store = await make_sqlite_store_for_context(ctx)
+    # Scene routes use SQLite's direct async methods. Hydrating the legacy
+    # character/episode/prop caches here adds three unrelated full-table reads
+    # to every scene request and was especially visible on OSS-backed homes.
+    store = await make_sqlite_store_for_context(ctx, load_graph_state=False)
     return (
         ctx,
         ctx.owner_username,
@@ -516,6 +519,40 @@ def _scene_payload(
     }
 
 
+def _scene_summary_payload(
+    scene: NovelScene,
+    *,
+    base_scene: NovelScene | None = None,
+) -> dict[str, Any]:
+    """Return the SQLite-only fields needed to group/search the scene list.
+
+    The full payload probes master/reverse/pano files, loads several manifests,
+    and recursively walks asset directories. Doing that for every scene before
+    the first paint makes list latency scale with OSSFS round trips rather than
+    the tiny scenes table. Full payloads are fetched for the selected group.
+    """
+
+    base_scene_id = str(getattr(scene, "base_scene_id", "") or "").strip()
+    return {
+        "name": scene.name,
+        "aliases": scene.aliases,
+        "scene_type": scene.scene_type,
+        "base_scene_id": base_scene_id,
+        "variant_id": str(getattr(scene, "variant_id", "") or "").strip(),
+        "time_of_day": str(getattr(scene, "time_of_day", "") or "").strip(),
+        "environment_prompt": scene.environment_prompt,
+        "variant_prompt": getattr(scene, "variant_prompt", ""),
+        "effective_environment_prompt": build_scene_effective_prompt(
+            scene, base_scene
+        ),
+        "description": scene.description,
+        "derived_from_scene": base_scene_id,
+        "spatial_layout_image": scene.spatial_layout_image,
+        "notes": scene.notes,
+        "updated_at": getattr(scene, "updated_at", ""),
+    }
+
+
 async def _require_scene(store: SQLiteStore, name: str) -> NovelScene | None:
     return await store.get_scene(name)
 
@@ -644,6 +681,8 @@ async def _heal_path_unsafe_scene_names(store: SQLiteStore, project_dir: Path) -
 @router.get("/projects/{project}/scenes")
 async def list_scenes(
     project: str,
+    summary: bool = True,
+    names: Annotated[list[str] | None, Query()] = None,
     user: dict = Depends(get_api_user),
 ):
     ctx, _username, _project_name, project_dir, _output_dir, store = (
@@ -655,6 +694,24 @@ async def list_scenes(
     scenes_by_name = {
         scene.name: scene for scene in scenes if str(scene.name or "").strip()
     }
+    requested_names = {
+        str(name or "").strip() for name in (names or []) if str(name or "").strip()
+    }
+    if requested_names:
+        scenes = [scene for scene in scenes if scene.name in requested_names]
+    if summary:
+        return {
+            "ok": True,
+            "data": [
+                _scene_summary_payload(
+                    scene,
+                    base_scene=scenes_by_name.get(
+                        str(getattr(scene, "base_scene_id", "") or "")
+                    ),
+                )
+                for scene in scenes
+            ],
+        }
     return {
         "ok": True,
         "data": [

--- a/src/novelvideo/chat/service.py
+++ b/src/novelvideo/chat/service.py
@@ -2262,7 +2262,9 @@ async def _fallback_display_tool_ui_specs(
             )
 
         if tool_name == "dramaclaw_get_scene_images":
-            resp = _backend_api_get(f"/api/v1/projects/{project_q}/scenes", token)
+            resp = _backend_api_get(
+                f"/api/v1/projects/{project_q}/scenes?summary=false", token
+            )
             media_items = []
             include_reverse = bool(args.get("include_reverse", True))
             include_pano = bool(args.get("include_pano", False))
@@ -2310,7 +2312,9 @@ async def _fallback_display_tool_ui_specs(
             )
 
         if tool_name == "dramaclaw_get_character_media":
-            resp = _backend_api_get(f"/api/v1/projects/{project_q}/characters", token)
+            resp = _backend_api_get(
+                f"/api/v1/projects/{project_q}/characters?summary=false", token
+            )
             media_kind = (
                 str(args.get("media_kind") or args.get("kind") or "all").strip().lower()
             )

--- a/src/novelvideo/sqlite_store.py
+++ b/src/novelvideo/sqlite_store.py
@@ -915,6 +915,32 @@ class SQLiteStore:
         await self.add_character(char)
         console.print(f"[green]已更新角色: {name}[/green]")
 
+    async def set_character_main(self, name: str, is_main: bool) -> bool:
+        """Update only the narrator-main flag without requiring the graph cache.
+
+        Lightweight asset-list requests intentionally skip ``load_graph_state``.
+        Repairs discovered by that list must therefore use a column-level write,
+        not ``update_character()``, whose object merge contract is cache-backed.
+        """
+
+        updated = await self._update_character_field(name, "is_main", 1 if is_main else 0)
+        cached = self._characters.get(name)
+        if updated and cached is not None:
+            cached.is_main = is_main
+        return updated
+
+    async def touch_character_asset(self, name: str) -> bool:
+        """Advance the row revision after publishing a convention-path asset."""
+
+        db = await self._ensure_db()
+        cursor = await db.execute(
+            "UPDATE characters SET updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now') "
+            "WHERE name = ?",
+            (name,),
+        )
+        await db.commit()
+        return (cursor.rowcount or 0) > 0
+
     async def delete_all_characters(self) -> int:
         try:
             db = await self._ensure_db()
@@ -1387,6 +1413,18 @@ class SQLiteStore:
         await db.commit()
         return (cursor.rowcount or 0) > 0
 
+    async def touch_scene_asset(self, name: str) -> bool:
+        """Advance the row revision after publishing a convention-path asset."""
+
+        db = await self._ensure_db()
+        cursor = await db.execute(
+            "UPDATE scenes SET updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now') "
+            "WHERE name = ?",
+            (name,),
+        )
+        await db.commit()
+        return (cursor.rowcount or 0) > 0
+
     async def rename_scene(self, old_name: str, new_name: str) -> bool:
         """重命名场景记录。资源目录迁移由调用方处理。"""
         old_name = str(old_name or "").strip()
@@ -1520,6 +1558,18 @@ class SQLiteStore:
                     prop.aliases = value
                 elif hasattr(prop, key):
                     setattr(prop, key, value)
+        return (cursor.rowcount or 0) > 0
+
+    async def touch_prop_asset(self, name: str) -> bool:
+        """Advance the row revision after publishing a convention-path asset."""
+
+        db = await self._ensure_db()
+        cursor = await db.execute(
+            "UPDATE props SET updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now') "
+            "WHERE name = ?",
+            (name,),
+        )
+        await db.commit()
         return (cursor.rowcount or 0) > 0
 
     async def rename_prop(self, old_name: str, new_name: str) -> bool:

--- a/src/novelvideo/task_backend/runners/character_image.py
+++ b/src/novelvideo/task_backend/runners/character_image.py
@@ -190,6 +190,8 @@ async def _run_character_image(
             )
         else:
             raise RuntimeError(f"未知角色图像生成模式: {mode}")
+        if mode == "portrait":
+            await store.sqlite_store.touch_character_asset(character.name)
         return {
             "mode": mode,
             "character_name": character.name,

--- a/src/novelvideo/task_backend/runners/prop_reference.py
+++ b/src/novelvideo/task_backend/runners/prop_reference.py
@@ -90,6 +90,7 @@ async def _run_prop_reference_asset(
             )
         if not result_path:
             raise RuntimeError("图像 API 未返回有效图像")
+        await store.sqlite_store.touch_prop_asset(prop.name)
         return {"prop_name": prop.name, "path": str(result_path), "style": style}
     finally:
         await store.close()

--- a/src/novelvideo/task_backend/runners/scene_reference.py
+++ b/src/novelvideo/task_backend/runners/scene_reference.py
@@ -130,6 +130,8 @@ async def _run_scene_reference_asset(
         if kind == "spatial_layout":
             rel_path = str(Path(output_path).relative_to(output_dir))
             await store.sqlite_store.update_scene(scene_name, spatial_layout_image=rel_path)
+        else:
+            await store.sqlite_store.touch_scene_asset(scene_name)
         return {
             "scene_name": scene_name,
             "kind": kind,

--- a/tests/contract/test_m04_route_contracts.py
+++ b/tests/contract/test_m04_route_contracts.py
@@ -83,6 +83,9 @@ class _M04Store:
         for key, value in updates.items():
             setattr(character, key, value)
 
+    async def touch_character_asset(self, name: str):
+        return name in self.characters
+
     async def rename_character(self, old_name: str, new_name: str):
         character = self.characters.pop(old_name)
         character.name = new_name

--- a/tests/contract/test_m04_route_contracts.py
+++ b/tests/contract/test_m04_route_contracts.py
@@ -65,6 +65,9 @@ class _M04Store:
     def get_all_characters(self):
         return list(self.characters.values())
 
+    async def list_characters(self):
+        return list(self.characters.values())
+
     async def repair_path_unsafe_asset_names(self, kind: str, move_assets=None):
         # 这里的名字都是干净的，list 接口上那道存量自愈是空跑。
         return {}

--- a/tests/contract/test_m05_route_contracts.py
+++ b/tests/contract/test_m05_route_contracts.py
@@ -227,6 +227,9 @@ class _M05Store:
             setattr(scene, key, value)
         return True
 
+    async def touch_scene_asset(self, name: str):
+        return name in self.scenes
+
     async def rename_scene(self, old_name: str, new_name: str):
         scene = self.scenes.pop(old_name)
         scene.name = new_name

--- a/tests/test_api_assets.py
+++ b/tests/test_api_assets.py
@@ -301,7 +301,6 @@ async def test_list_scenes_returns_master_reverse_and_pano_urls(tmp_path, monkey
 
     res = await scenes.list_scenes(
         project="demo",
-        summary=False,
         user={"username": "admin"},
     )
 
@@ -365,6 +364,7 @@ async def test_list_scenes_summary_never_builds_filesystem_payload(
 
     response = await scenes.list_scenes(
         project="demo",
+        summary=True,
         names=None,
         user={"username": "admin"},
     )
@@ -372,7 +372,11 @@ async def test_list_scenes_summary_never_builds_filesystem_payload(
     assert [item["name"] for item in response["data"]] == ["故宫", "故宫_雪夜"]
     assert response["data"][1]["derived_from_scene"] == "故宫"
     assert response["data"][1]["effective_environment_prompt"]
-    assert "master_url" not in response["data"][0]
+    assert response["data"][0]["master_url"].endswith(
+        "/assets/scenes/%E6%95%85%E5%AE%AB/master.png"
+    ) or response["data"][0]["master_url"].endswith(
+        "/assets/scenes/故宫/master.png"
+    )
     assert "stage_3gs" not in response["data"][0]
 
 
@@ -1740,13 +1744,13 @@ async def test_list_props_returns_convention_url_without_filesystem_probes(
 
     res = await props.list_props(
         project="demo",
+        summary=True,
         user={"username": "admin"},
     )
 
     asset = res["data"][0]
-    assert (
-        asset["reference_url"]
-        == "/static/projects/demo/assets/props/Sword/reference_3view.png"
+    assert asset["reference_url"].startswith(
+        "/static/projects/demo/assets/props/Sword/reference_3view.png?v="
     )
     assert asset["scope"] == "global"
     assert asset["updated_at"] == "2026-08-24T01:02:03+00:00"

--- a/tests/test_api_assets.py
+++ b/tests/test_api_assets.py
@@ -301,6 +301,7 @@ async def test_list_scenes_returns_master_reverse_and_pano_urls(tmp_path, monkey
 
     res = await scenes.list_scenes(
         project="demo",
+        summary=False,
         user={"username": "admin"},
     )
 
@@ -336,6 +337,70 @@ async def test_list_scenes_returns_master_reverse_and_pano_urls(tmp_path, monkey
     assert "viewer_url" not in asset["stage_3gs"]
     assert "pano_viewer_url" not in asset
     assert asset["updated_at"]
+
+
+@pytest.mark.asyncio
+async def test_list_scenes_summary_never_builds_filesystem_payload(
+    tmp_path, monkeypatch
+):
+    from novelvideo.api.routes import scenes
+
+    store = _SceneStore(
+        [
+            NovelScene(name="故宫", environment_prompt="宫墙"),
+            NovelScene(
+                name="故宫_雪夜",
+                base_scene_id="故宫",
+                variant_id="雪夜",
+                variant_prompt="积雪",
+            ),
+        ]
+    )
+    _patch_project(monkeypatch, scenes, tmp_path, store)
+
+    def fail_full_payload(*_args, **_kwargs):
+        raise AssertionError("summary list must not probe scene files or manifests")
+
+    monkeypatch.setattr(scenes, "_scene_payload", fail_full_payload)
+
+    response = await scenes.list_scenes(
+        project="demo",
+        names=None,
+        user={"username": "admin"},
+    )
+
+    assert [item["name"] for item in response["data"]] == ["故宫", "故宫_雪夜"]
+    assert response["data"][1]["derived_from_scene"] == "故宫"
+    assert response["data"][1]["effective_environment_prompt"]
+    assert "master_url" not in response["data"][0]
+    assert "stage_3gs" not in response["data"][0]
+
+
+@pytest.mark.asyncio
+async def test_list_scenes_full_payload_filters_to_requested_names(
+    tmp_path, monkeypatch
+):
+    from novelvideo.api.routes import scenes
+
+    store = _SceneStore([NovelScene(name="大厅"), NovelScene(name="后院")])
+    _patch_project(monkeypatch, scenes, tmp_path, store)
+    built: list[str] = []
+
+    def fake_payload(scene, **_kwargs):
+        built.append(scene.name)
+        return {"name": scene.name}
+
+    monkeypatch.setattr(scenes, "_scene_payload", fake_payload)
+
+    response = await scenes.list_scenes(
+        project="demo",
+        summary=False,
+        names=["后院"],
+        user={"username": "admin"},
+    )
+
+    assert response["data"] == [{"name": "后院"}]
+    assert built == ["后院"]
 
 
 @pytest.mark.asyncio
@@ -941,7 +1006,9 @@ async def test_list_scenes_reports_saved_scene_director_world_pano_source(
         snapshot={"schemaVersion": 1, "world": {"activeSourceId": "scene-pano:Hall"}},
     )
 
-    response = await scenes.list_scenes(project="demo", user={"username": "admin"})
+    response = await scenes.list_scenes(
+        project="demo", summary=False, user={"username": "admin"}
+    )
 
     stage = response["data"][0]["stage_3gs"]
     assert stage["active_source"] == "360"
@@ -1651,15 +1718,25 @@ async def test_build_scenes_allows_supplement_when_derived_scenes_exist(
 
 
 @pytest.mark.asyncio
-async def test_list_props_returns_reference_url(tmp_path, monkeypatch):
+async def test_list_props_returns_convention_url_without_filesystem_probes(
+    tmp_path, monkeypatch
+):
     from novelvideo.api.routes import props
 
-    prop = NovelProp(name="Sword", visual_prompt="silver sword")
+    prop = NovelProp(
+        name="Sword",
+        visual_prompt="silver sword",
+        updated_at="2026-08-24T01:02:03+00:00",
+    )
     store = _PropStore([prop])
     _patch_project(monkeypatch, props, tmp_path, store)
-    prop_dir = tmp_path / "assets" / "props" / "Sword"
-    prop_dir.mkdir(parents=True)
-    (prop_dir / "reference_3view.png").write_bytes(b"ref")
+
+    def fail_probe(*_args, **_kwargs):
+        raise AssertionError("the prop list must not probe OSSFS")
+
+    monkeypatch.setattr(props, "compute_prop_reference_path", fail_probe)
+    monkeypatch.setattr(props, "tree_updated_at", fail_probe)
+    monkeypatch.setattr(props, "_asset_url", fail_probe)
 
     res = await props.list_props(
         project="demo",
@@ -1669,10 +1746,38 @@ async def test_list_props_returns_reference_url(tmp_path, monkeypatch):
     asset = res["data"][0]
     assert (
         asset["reference_url"]
-        == "/static/projects/proj_demo/assets/props/Sword/reference_3view.png"
+        == "/static/projects/demo/assets/props/Sword/reference_3view.png"
     )
     assert asset["scope"] == "global"
-    assert asset["updated_at"]
+    assert asset["updated_at"] == "2026-08-24T01:02:03+00:00"
+
+
+@pytest.mark.asyncio
+async def test_list_props_skips_unrelated_graph_state_hydration(tmp_path, monkeypatch):
+    from novelvideo.api.routes import props
+
+    resolved = _resolution(tmp_path)
+    store = _PropStore([])
+    calls: list[bool] = []
+
+    async def fake_resolve_project_scope(*_args, **_kwargs):
+        return resolved
+
+    async def fake_make_store(_ctx, *, load_graph_state=True):
+        calls.append(load_graph_state)
+        return store
+
+    monkeypatch.setattr(props, "resolve_project_scope", fake_resolve_project_scope)
+    monkeypatch.setattr(props, "make_sqlite_store_for_context", fake_make_store)
+    monkeypatch.setattr(props, "may_run_asset_repair", lambda _ctx: False)
+
+    response = await props.list_props(
+        project="demo",
+        user={"username": "admin"},
+    )
+
+    assert response["data"] == []
+    assert calls == [False]
 
 
 @pytest.mark.asyncio

--- a/tests/test_api_character_identity_costume.py
+++ b/tests/test_api_character_identity_costume.py
@@ -16,6 +16,7 @@ class _CharacterStore:
         self.character = character
         self.identity_updates: list[tuple[str, str, dict]] = []
         self.added_identities: list[CharacterIdentity] = []
+        self.touched_character_assets: list[str] = []
 
     def get_character(self, name: str):
         if name == self.character.name:
@@ -35,6 +36,10 @@ class _CharacterStore:
         identities = self.character.identities
         identities.append(identity)
         self.character.identities = identities
+        return True
+
+    async def touch_character_asset(self, name: str):
+        self.touched_character_assets.append(name)
         return True
 
 
@@ -368,3 +373,32 @@ async def test_restore_character_asset_history_backs_up_current_and_restores_bac
     ]
     assert len(new_backups) == 1
     assert new_backups[0].read_bytes() == current_bytes
+
+
+@pytest.mark.asyncio
+async def test_restore_character_portrait_advances_summary_revision(tmp_path, monkeypatch):
+    from novelvideo.api.routes import characters
+
+    character = NovelCharacter(name="秦")
+    store = _CharacterStore(character)
+    _patch_character_project(monkeypatch, characters, tmp_path, store)
+
+    target = tmp_path / "assets" / "characters" / "秦" / "portrait.png"
+    _write_png(target, (200, 20, 30))
+    backup = target.parent / "portrait_20260603112233.png"
+    restored_bytes = _write_png(backup, (10, 20, 30))
+
+    response = await characters.restore_character_asset_history(
+        project="demo",
+        name="秦",
+        body=SimpleNamespace(
+            kind="portrait",
+            identity_id="",
+            history_id=backup.name,
+        ),
+        user={"username": "admin"},
+    )
+
+    assert response["ok"] is True
+    assert target.read_bytes() == restored_bytes
+    assert store.touched_character_assets == ["秦"]

--- a/tests/test_api_character_voice_samples.py
+++ b/tests/test_api_character_voice_samples.py
@@ -128,6 +128,7 @@ async def test_list_characters_returns_indextts2_voice_fields(tmp_path, monkeypa
 
     response = await characters.list_characters(
         project="demo",
+        summary=True,
         user={"username": "admin"},
     )
 

--- a/tests/test_api_character_voice_samples.py
+++ b/tests/test_api_character_voice_samples.py
@@ -23,6 +23,9 @@ class _CharacterStore:
     def get_all_characters(self):
         return list(self.characters.values())
 
+    async def list_characters(self):
+        return list(self.characters.values())
+
     async def update_character(self, name: str, **updates):
         self.updates.append((name, updates))
         character = self.characters[name]
@@ -133,7 +136,7 @@ async def test_list_characters_returns_indextts2_voice_fields(tmp_path, monkeypa
     assert "fish_voice_id" not in asset
     assert asset["reference_audio_path"] == "assets/characters/秦/voices/voice_default.wav"
     assert asset["reference_audio_url"] == (
-        "/static/projects/proj_demo/assets/characters/秦/voices/voice_default.wav"
+        "/static/projects/proj_demo/assets/characters/%E7%A7%A6/voices/voice_default.wav"
     )
     assert asset["reference_audio_sha256"] == "default-sha"
     assert asset["reference_audio_updated_at"] == "2026-05-13T00:00:00+00:00"

--- a/tests/test_api_characters_asset_contract.py
+++ b/tests/test_api_characters_asset_contract.py
@@ -189,7 +189,7 @@ def test_list_characters_repairs_duplicate_narrator_main(monkeypatch, tmp_path):
     )
     client = _client(monkeypatch, tmp_path, store)
 
-    response = client.get("/projects/demo/characters")
+    response = client.get("/projects/demo/characters?summary=true")
 
     assert response.status_code == 200
     mains = [item["name"] for item in response.json()["data"] if item["is_main"]]
@@ -243,7 +243,7 @@ def test_list_characters_carries_identity_ids_for_deep_link_resolution(
         assert identity_detail_keys.isdisjoint(item.keys())
 
 
-def test_list_characters_defaults_to_convention_urls_without_filesystem_probes(
+def test_list_characters_summary_uses_convention_urls_without_filesystem_probes(
     monkeypatch, tmp_path
 ):
     from novelvideo.api.routes import characters
@@ -258,7 +258,7 @@ def test_list_characters_defaults_to_convention_urls_without_filesystem_probes(
     monkeypatch.setattr(characters, "tree_updated_at", fail_probe)
     monkeypatch.setattr(characters, "_asset_url", fail_probe)
 
-    response = client.get("/projects/demo/characters")
+    response = client.get("/projects/demo/characters?summary=true")
 
     assert response.status_code == 200
     asset = response.json()["data"][0]

--- a/tests/test_api_characters_asset_contract.py
+++ b/tests/test_api_characters_asset_contract.py
@@ -17,8 +17,12 @@ class _CharacterStore:
         # 真 SQLiteStore 背后是一条 aiosqlite 连接加一个后台线程，路由漏关就是漏一条。
         # 这里记账，下面的用例据此断言"路由确实收口了"，而不是只断言返回码。
         self.close_calls = 0
+        self.load_graph_state_flags: list[bool] = []
 
     def get_all_characters(self):
+        return list(self.characters.values())
+
+    async def list_characters(self):
         return list(self.characters.values())
 
     def get_character(self, name: str):
@@ -75,6 +79,7 @@ def _client(monkeypatch, tmp_path, store: _CharacterStore):
         )
 
     async def fake_make_store_for_context(_ctx, *, load_graph_state: bool = True):
+        store.load_graph_state_flags.append(load_graph_state)
         return store
 
     monkeypatch.setattr(characters, "resolve_project_scope", fake_resolve_project_scope)
@@ -232,11 +237,56 @@ def test_list_characters_carries_identity_ids_for_deep_link_resolution(
     assert by_name["苏清晏"]["identity_ids"] == ["苏清晏_少女"]
     # 没有身份的角色出空列表而不是缺字段，前端不必区分「没有」和「没带」。
     assert by_name["路人"]["identity_ids"] == []
-
     # 只有 id。身份详情仍走按需的 identities 接口，别让列表载荷跟着长。
     identity_detail_keys = {"identity_name", "image_url", "appearance_details"}
     for item in by_name.values():
         assert identity_detail_keys.isdisjoint(item.keys())
+
+
+def test_list_characters_defaults_to_convention_urls_without_filesystem_probes(
+    monkeypatch, tmp_path
+):
+    from novelvideo.api.routes import characters
+
+    store = _CharacterStore([NovelCharacter(name="林昭", role="主角")])
+    client = _client(monkeypatch, tmp_path, store)
+
+    def fail_probe(*_args, **_kwargs):
+        raise AssertionError("the character summary must not probe asset files")
+
+    monkeypatch.setattr(characters, "compute_portrait_path", fail_probe)
+    monkeypatch.setattr(characters, "tree_updated_at", fail_probe)
+    monkeypatch.setattr(characters, "_asset_url", fail_probe)
+
+    response = client.get("/projects/demo/characters")
+
+    assert response.status_code == 200
+    asset = response.json()["data"][0]
+    assert asset["portrait_url"].endswith(
+        "/assets/characters/%E6%9E%97%E6%98%AD/portrait.png"
+    ) or asset["portrait_url"].endswith("/assets/characters/林昭/portrait.png")
+    assert store.load_graph_state_flags == [False]
+
+
+def test_character_details_probe_only_the_requested_character(monkeypatch, tmp_path):
+    store = _CharacterStore(
+        [NovelCharacter(name="林昭"), NovelCharacter(name="苏清晏")]
+    )
+    client = _client(monkeypatch, tmp_path, store)
+    project_dir = tmp_path / "output" / "admin" / "demo"
+    portrait = project_dir / "assets" / "characters" / "苏清晏" / "portrait.png"
+    portrait.parent.mkdir(parents=True)
+    portrait.write_bytes(b"portrait")
+
+    response = client.get(
+        "/projects/demo/characters",
+        params={"summary": "false", "names": "苏清晏"},
+    )
+
+    assert response.status_code == 200
+    assert [item["name"] for item in response.json()["data"]] == ["苏清晏"]
+    assert response.json()["data"][0]["portrait_url"]
+    assert store.load_graph_state_flags == [False]
 
 
 def test_character_and_identity_lists_expose_asset_history_links(monkeypatch, tmp_path):
@@ -369,10 +419,10 @@ def test_list_characters_closes_the_store_when_the_handler_raises(monkeypatch, t
     """异常路径：读库炸了，连接更得关——这正是重试风暴把连接数堆上去的那条路。"""
     store = _CharacterStore([NovelCharacter(name="秦昭", role="主角")])
 
-    def boom():
+    async def boom():
         raise RuntimeError("store read blew up")
 
-    monkeypatch.setattr(store, "get_all_characters", boom)
+    monkeypatch.setattr(store, "list_characters", boom)
     client = _client(monkeypatch, tmp_path, store)
 
     with pytest.raises(RuntimeError, match="store read blew up"):
@@ -384,10 +434,10 @@ def test_list_characters_closes_the_store_when_the_handler_raises(monkeypatch, t
 def test_identities_closes_the_store_when_the_handler_raises(monkeypatch, tmp_path):
     store = _CharacterStore([NovelCharacter(name="秦昭", role="主角")])
 
-    def boom():
+    async def boom():
         raise RuntimeError("store read blew up")
 
-    monkeypatch.setattr(store, "get_all_characters", boom)
+    monkeypatch.setattr(store, "list_characters", boom)
     client = _client(monkeypatch, tmp_path, store)
 
     with pytest.raises(RuntimeError, match="store read blew up"):

--- a/tests/test_api_project_resolution.py
+++ b/tests/test_api_project_resolution.py
@@ -91,8 +91,11 @@ async def test_scene_project_resolution_does_not_use_legacy_fallback(monkeypatch
     async def fake_resolve_project_context(**kwargs):
         return ctx
 
-    async def fake_make_sqlite_store_for_context(resolved_ctx):
+    async def fake_make_sqlite_store_for_context(
+        resolved_ctx, *, load_graph_state=True
+    ):
         assert resolved_ctx is ctx
+        assert load_graph_state is False
         return store
 
     def fail_legacy_project_dir(username: str, project: str) -> Path:

--- a/tests/test_chat_service_user_agent_scope.py
+++ b/tests/test_chat_service_user_agent_scope.py
@@ -313,6 +313,36 @@ async def test_fallback_display_prefers_api_project_id(monkeypatch):
     assert specs[0]["elements"][first_child]["props"]["src"] == "/static/projects/api-project/sketch.png?v=1"
 
 
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    ("tool_name", "asset_path"),
+    [
+        ("dramaclaw_get_scene_images", "scenes"),
+        ("dramaclaw_get_character_media", "characters"),
+    ],
+)
+async def test_asset_display_tools_request_authoritative_media_details(
+    monkeypatch, tool_name, asset_path
+):
+    seen_paths = []
+
+    def fake_backend_api_get(path, token):
+        seen_paths.append(path)
+        return {"ok": True, "data": []}
+
+    monkeypatch.setattr(chat_service, "_backend_api_get", fake_backend_api_get)
+
+    await chat_service._fallback_display_tool_ui_specs(
+        "admin",
+        "project-a",
+        tool_name,
+        {},
+        token="token",
+    )
+
+    assert seen_paths == [f"/api/v1/projects/project-a/{asset_path}?summary=false"]
+
+
 def test_claude_and_codex_sessions_are_scope_scoped(monkeypatch, tmp_path):
     monkeypatch.setenv("NOVELVIDEO_STATE_DIR", str(tmp_path / "state"))
     monkeypatch.setenv("NOVELVIDEO_OUTPUT_DIR", str(tmp_path / "output"))

--- a/tests/test_freezone_image_backend.py
+++ b/tests/test_freezone_image_backend.py
@@ -131,6 +131,7 @@ class _FakeAssetRevisionStore:
         self.characters: list[str] = []
         self.scenes: list[str] = []
         self.props: list[str] = []
+        self.closed = False
 
     async def touch_character_asset(self, name: str) -> bool:
         self.characters.append(name)
@@ -143,6 +144,9 @@ class _FakeAssetRevisionStore:
     async def touch_prop_asset(self, name: str) -> bool:
         self.props.append(name)
         return True
+
+    async def close(self) -> None:
+        self.closed = True
 
 
 def _patch_freezone_project(
@@ -1865,11 +1869,16 @@ async def test_freezone_push_advances_canonical_summary_revision(
     _write_image(source)
     store = _FakeAssetRevisionStore()
 
-    async def fake_make_store(_ctx):
+    from novelvideo.api import deps
+
+    scope_calls: list[bool] = []
+
+    async def fake_make_store(_ctx, *, load_graph_state=True):
+        scope_calls.append(load_graph_state)
         return store
 
     monkeypatch.setattr(
-        freezone_routes,
+        deps,
         "make_sqlite_store_for_context",
         fake_make_store,
     )
@@ -1885,6 +1894,8 @@ async def test_freezone_push_advances_canonical_summary_revision(
     assert Path(result["data"]["target_path"]).is_file()
     assert result["data"]["target_url"]
     assert getattr(store, revision_bucket) == [entity_name]
+    assert scope_calls == [False]
+    assert store.closed is True
 
 
 @pytest.mark.asyncio
@@ -1897,11 +1908,16 @@ async def test_skill_auto_commit_advances_canonical_summary_revision(
     _write_image(source)
     store = _FakeAssetRevisionStore()
 
-    async def fake_make_store(_ctx):
+    from novelvideo.api import deps
+
+    scope_calls: list[bool] = []
+
+    async def fake_make_store(_ctx, *, load_graph_state=True):
+        scope_calls.append(load_graph_state)
         return store
 
     monkeypatch.setattr(
-        freezone_routes,
+        deps,
         "make_sqlite_store_for_context",
         fake_make_store,
     )
@@ -1931,6 +1947,8 @@ async def test_skill_auto_commit_advances_canonical_summary_revision(
 
     assert finalized[0]["committed"] is True
     assert store.scenes == ["兰州拉面馆"]
+    assert scope_calls == [False]
+    assert store.closed is True
 
 
 def test_resolve_outpaint_aspect_ratio_supports_original(tmp_path: Path) -> None:

--- a/tests/test_freezone_image_backend.py
+++ b/tests/test_freezone_image_backend.py
@@ -126,6 +126,25 @@ class _FakeContextBeatStore:
         ]
 
 
+class _FakeAssetRevisionStore:
+    def __init__(self) -> None:
+        self.characters: list[str] = []
+        self.scenes: list[str] = []
+        self.props: list[str] = []
+
+    async def touch_character_asset(self, name: str) -> bool:
+        self.characters.append(name)
+        return True
+
+    async def touch_scene_asset(self, name: str) -> bool:
+        self.scenes.append(name)
+        return True
+
+    async def touch_prop_asset(self, name: str) -> bool:
+        self.props.append(name)
+        return True
+
+
 def _patch_freezone_project(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
@@ -1821,6 +1840,97 @@ async def test_freezone_push_can_commit_beat_audio(
     target = project_dir / "audio" / "ep001" / "beat_02.mp3"
     assert target.read_bytes() == b"candidate-audio"
     assert result["data"]["target_path"] == str(target)
+
+
+@pytest.mark.parametrize(
+    ("target", "revision_bucket", "entity_name"),
+    [
+        ({"kind": "portrait", "character": "秦"}, "characters", "秦"),
+        ({"kind": "scene_master", "scene_id": "兰州拉面馆"}, "scenes", "兰州拉面馆"),
+        ({"kind": "prop_ref", "prop_id": "账单"}, "props", "账单"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_freezone_push_advances_canonical_summary_revision(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    target: dict,
+    revision_bucket: str,
+    entity_name: str,
+) -> None:
+    """Freezone push and skill auto-commit share this publication boundary."""
+
+    project_dir, _output_dir = _patch_freezone_project(monkeypatch, tmp_path)
+    source = project_dir / "freezone" / "_outputs" / "candidate.png"
+    _write_image(source)
+    store = _FakeAssetRevisionStore()
+
+    async def fake_make_store(_ctx):
+        return store
+
+    monkeypatch.setattr(
+        freezone_routes,
+        "make_sqlite_store_for_context",
+        fake_make_store,
+    )
+    result = await freezone_routes.freezone_push(
+        project="proj_freezone",
+        body=PushRequest(
+            source_url="freezone/_outputs/candidate.png",
+            target=target,
+        ),
+        user={"username": "admin", "id": "owner_1"},
+    )
+
+    assert Path(result["data"]["target_path"]).is_file()
+    assert result["data"]["target_url"]
+    assert getattr(store, revision_bucket) == [entity_name]
+
+
+@pytest.mark.asyncio
+async def test_skill_auto_commit_advances_canonical_summary_revision(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project_dir, _output_dir = _patch_freezone_project(monkeypatch, tmp_path)
+    source = project_dir / "freezone" / "_outputs" / "candidate.png"
+    _write_image(source)
+    store = _FakeAssetRevisionStore()
+
+    async def fake_make_store(_ctx):
+        return store
+
+    monkeypatch.setattr(
+        freezone_routes,
+        "make_sqlite_store_for_context",
+        fake_make_store,
+    )
+
+    finalized = await freezone_routes._finalize_skill_run_outputs(
+        project="proj_freezone",
+        project_dir=project_dir,
+        ctx=_project_ctx(tmp_path),
+        metadata={
+            "run_id": "run_auto_commit",
+            "skill_id": "skill_demo",
+            "skill_node_id": "skill_node",
+            "canvas_id": "canvas_demo",
+            "status": "running",
+        },
+        outputs=[
+            {
+                "role": "scene_master",
+                "image_url": "freezone/_outputs/candidate.png",
+                "pushable": True,
+                "auto_commit": True,
+                "slot_target": {"kind": "scene_master", "scene_id": "兰州拉面馆"},
+            }
+        ],
+        user={"username": "admin", "id": "owner_1"},
+    )
+
+    assert finalized[0]["committed"] is True
+    assert store.scenes == ["兰州拉面馆"]
 
 
 def test_resolve_outpaint_aspect_ratio_supports_original(tmp_path: Path) -> None:

--- a/tests/test_sqlite_store.py
+++ b/tests/test_sqlite_store.py
@@ -432,6 +432,35 @@ async def test_scene_round_trip_and_update_with_structured_scene_axes(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_duplicate_main_repair_works_without_graph_cache(tmp_path):
+    """The lightweight character list must be able to repair legacy rows."""
+
+    from novelvideo.api.routes.characters import _repair_duplicate_main_characters
+    from novelvideo.models import NovelCharacter
+    from novelvideo.sqlite_store import SQLiteStore
+
+    store = SQLiteStore(
+        "admin/demo",
+        output_dir=str(tmp_path / "output"),
+        state_dir=str(tmp_path / "state"),
+    )
+    try:
+        await store.add_character(NovelCharacter(name="甲", is_main=True))
+        await store.add_character(NovelCharacter(name="乙", is_main=True))
+        store._characters.clear()
+
+        rows = await store.list_characters()
+        repaired = await _repair_duplicate_main_characters(store, rows)
+
+        assert [row.name for row in repaired if row.is_main] == ["甲"]
+        persisted = {row.name: row for row in await store.list_characters()}
+        assert persisted["甲"].is_main is True
+        assert persisted["乙"].is_main is False
+    finally:
+        await store.close()
+
+
+@pytest.mark.asyncio
 async def test_add_scene_is_idempotent_by_scene_name(tmp_path):
     from novelvideo.models import NovelScene
     from novelvideo.sqlite_store import SQLiteStore

--- a/tests/test_task_runner_state_dir.py
+++ b/tests/test_task_runner_state_dir.py
@@ -306,6 +306,9 @@ async def test_prop_reference_passes_context_state_dir_to_generator(
         async def get_prop(self, name: str):
             return SimpleNamespace(name=name, visual_prompt="brass key", description="")
 
+        async def touch_prop_asset(self, name: str):
+            return True
+
     class FakeStore:
         def __init__(self, *args, **kwargs) -> None:
             self.sqlite_store = FakeSQLiteStore()
@@ -474,7 +477,12 @@ async def test_character_image_passes_context_state_to_generation(
 
     class FakeStore:
         def __init__(self, *args, **kwargs) -> None:
-            pass
+            self.sqlite_store = SimpleNamespace(
+                touch_character_asset=self.touch_character_asset
+            )
+
+        async def touch_character_asset(self, name: str):
+            return True
 
         async def initialize(self) -> None:
             pass


### PR DESCRIPTION
## 问题

资产页已经停止全分集 beats 扇出，但角色、场景和道具列表仍把 OSSFS 当本地盘使用：为每个候选同步执行 `exists/stat`，部分路径还递归扫描目录或读取 manifest。MinIO/GooseFS 对不存在路径的一次 miss 约 55ms，几十个资产会把列表 API 放大到数秒并阻塞 API worker。

## 设计原则

本 PR 采用“约定大于配置”，不新增 DB 路径/readiness 字段：

- DB 保存业务语义和实体修订号；资产位置仍全部由 `PathResolver` canonical path 推导。
- 资产工作台显式请求 `summary=true`，列表不盘点 OSSFS；浏览器只懒加载可见的约定 URL。
- API 默认仍返回完整媒体状态，保持旧调用方和聊天工具的既有契约。
- 用户选中详情后才核实真实文件与 manifest；这些同步探盘在 worker thread 中执行，不阻塞事件循环。
- 生成/上传 canonical 文件后只 bump 对应实体 `updated_at`，summary URL 使用它作为 `?v=`；不把路径或存在性写进 DB。

## 改动

- 角色列表 direct `list_characters()`，跳过 episodes/props graph-state hydration；选中角色再取完整详情。
- 修复轻量 Store 下重复主角自愈依赖空内存缓存导致的 500，并用真实 SQLiteStore 回归测试锁住。
- 角色路径名自愈改为先修后读，避免首个响应返回旧主键和旧路径。
- 场景 summary 保留 canonical `master_url` 供左侧懒加载缩略图；404 自动回落。
- 道具列表使用 canonical reference URL，缺图回落；上传、生成及 URL 变化后可恢复显示。
- 角色、场景、道具 canonical URL 恢复版本参数，上传/生成 runner 推进实体修订号。
- `dramaclaw_get_scene_images` / `dramaclaw_get_character_media` 显式请求完整详情。
- 完整角色、场景、道具 payload 的 OSSFS 探测移出 async event loop。
- 删除需要全量文件盘点、且不影响操作的“头像 N/N”统计；业务统计保留。

## 边界

- 不做分页：几十行 SQLite 语义数据不是瓶颈，问题是每行触发的远端文件系统往返。
- 不改 schema、模型、计费或部署。
- `freezone/assets/beat-context` 和单文件 media resolver 的同步探盘是独立热点，不在本 PR 扩大处理。

## 验证

- `uv run pytest -q`：3910 passed, 16 skipped, 2 deselected
- `npm test -- --run`：2694 passed
- `npm run build`：通过
- `uv run ruff check .`：通过
- `git diff --check`：通过

## 回归覆盖

- summary 路径不得调用逐资产文件解析或目录更新时间扫描
- API 默认完整契约，资产工作台显式请求 summary
- 真实 SQLiteStore 在未水合 graph cache 时可修复重复主角
- 聊天媒体工具必须请求 authoritative detail
- 场景列表 canonical 缩略图、角色/道具版本 URL 和缺图回落
- 道具上传完成后从 404 状态恢复
- 生成 runner 写完 canonical 文件后推进实体修订号
