### PR TITLE
fix(projects): show inactive grants

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -28,7 +28,7 @@ RUN pnpm build
 
 # Parse the rendered runtime template in CI without building the SPA image.
 FROM nginx:1.27-alpine AS nginx-config-test
-ENV BACKEND_HOST=backend.invalid \
+ENV BACKEND_HOST=127.0.0.1 \
     BACKEND_PORT=8780 \
     NGINX_ENVSUBST_FILTER="^(BACKEND_HOST|BACKEND_PORT)$"
 COPY docker/nginx.conf.template /etc/nginx/templates/default.conf.template

--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -1387,7 +1387,7 @@
       "loadingMembers": "Loading members",
       "removeMember": "Remove member",
       "inactive": "Inactive",
-      "inactiveScopeChanged": "User scope has changed",
+      "inactiveAccessChanged": "User currently cannot access this project",
       "roleViewer": "View only",
       "roleEditor": "Can edit and run tasks",
       "roleAdmin": "Can manage shared members",

--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -1386,6 +1386,8 @@
       "projectOwner": "Project owner",
       "loadingMembers": "Loading members",
       "removeMember": "Remove member",
+      "inactive": "Inactive",
+      "inactiveScopeChanged": "User scope has changed",
       "roleViewer": "View only",
       "roleEditor": "Can edit and run tasks",
       "roleAdmin": "Can manage shared members",

--- a/frontend/public/locales/zh/translation.json
+++ b/frontend/public/locales/zh/translation.json
@@ -1386,6 +1386,8 @@
       "projectOwner": "项目所有者",
       "loadingMembers": "加载成员",
       "removeMember": "移除成员",
+      "inactive": "已失效",
+      "inactiveScopeChanged": "用户作用域已变化",
       "roleViewer": "只读查看",
       "roleEditor": "可编辑与运行任务",
       "roleAdmin": "可管理共享成员",

--- a/frontend/public/locales/zh/translation.json
+++ b/frontend/public/locales/zh/translation.json
@@ -1387,7 +1387,7 @@
       "loadingMembers": "加载成员",
       "removeMember": "移除成员",
       "inactive": "已失效",
-      "inactiveScopeChanged": "用户作用域已变化",
+      "inactiveAccessChanged": "用户当前无法访问此项目",
       "roleViewer": "只读查看",
       "roleEditor": "可编辑与运行任务",
       "roleAdmin": "可管理共享成员",

--- a/frontend/src/__tests__/components/projects/share-project-dialog.test.tsx
+++ b/frontend/src/__tests__/components/projects/share-project-dialog.test.tsx
@@ -26,7 +26,7 @@ const SHARE_DIALOG_ZH: Record<string, string> = {
   "project.shareDialog.roleEditor": "可编辑与运行任务",
   "project.shareDialog.roleAdmin": "可管理共享成员",
   "project.shareDialog.inactive": "已失效",
-  "project.shareDialog.inactiveScopeChanged": "用户作用域已变化",
+  "project.shareDialog.inactiveAccessChanged": "用户当前无法访问此项目",
   "common.close": "关闭",
 };
 
@@ -106,7 +106,7 @@ describe("ShareProjectDialog (edition gating)", () => {
     expect(screen.queryByText("共享项目")).not.toBeInTheDocument();
   });
 
-  it("marks scope-invalid grants inactive while keeping removal available", () => {
+  it("marks ineffective grants inactive while keeping removal available", () => {
     queryMocks.grants = [
       {
         id: "g1",
@@ -116,14 +116,14 @@ describe("ShareProjectDialog (edition gating)", () => {
         principal_username: "dev09",
         role: "editor",
         effective: false,
-        inactive_reason: "principal_scope_changed",
+        inactive_reason: "principal_access_changed",
       },
     ];
 
     renderDialog();
 
     expect(screen.getByText("已失效")).toBeInTheDocument();
-    expect(screen.getByText("用户作用域已变化")).toBeInTheDocument();
+    expect(screen.getByText("用户当前无法访问此项目")).toBeInTheDocument();
     const memberRow = screen.getByText("dev09").parentElement?.parentElement;
     expect(memberRow).toBeInstanceOf(HTMLElement);
     expect(within(memberRow as HTMLElement).getByRole("combobox")).toBeDisabled();

--- a/frontend/src/__tests__/components/projects/share-project-dialog.test.tsx
+++ b/frontend/src/__tests__/components/projects/share-project-dialog.test.tsx
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Elastic-2.0
 // Copyright (c) 2026 ClaymoreLab
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { ShareProjectDialog } from "@/components/projects/share-project-dialog";
@@ -25,6 +25,8 @@ const SHARE_DIALOG_ZH: Record<string, string> = {
   "project.shareDialog.roleViewer": "只读查看",
   "project.shareDialog.roleEditor": "可编辑与运行任务",
   "project.shareDialog.roleAdmin": "可管理共享成员",
+  "project.shareDialog.inactive": "已失效",
+  "project.shareDialog.inactiveScopeChanged": "用户作用域已变化",
   "common.close": "关闭",
 };
 
@@ -43,21 +45,31 @@ vi.mock("react-i18next", () => ({
 }));
 
 const runtimeState = vi.hoisted(() => ({ isCeRuntime: false }));
-const queryMocks = vi.hoisted(() => ({ useUserSearch: vi.fn() }));
+const queryMocks = vi.hoisted(() => ({
+  grants: [] as Array<Record<string, unknown>>,
+  deleteGrant: vi.fn(),
+  useUserSearch: vi.fn(),
+}));
 
 vi.mock("@/lib/runtime-config", () => ({
   isCeRuntime: () => runtimeState.isCeRuntime,
 }));
 
 vi.mock("@/lib/queries/projects", () => ({
-  useProjectGrants: () => ({ data: { data: [] } }),
+  useProjectGrants: () => ({
+    data: { data: queryMocks.grants },
+    isLoading: false,
+  }),
   useUserSearch: (...args: unknown[]) => {
     queryMocks.useUserSearch(...args);
     return { data: { data: [] } };
   },
   useAddProjectGrant: () => ({ mutateAsync: vi.fn(), isPending: false }),
   useUpdateProjectGrant: () => ({ mutateAsync: vi.fn(), isPending: false }),
-  useDeleteProjectGrant: () => ({ mutateAsync: vi.fn(), isPending: false }),
+  useDeleteProjectGrant: () => ({
+    mutateAsync: queryMocks.deleteGrant,
+    isPending: false,
+  }),
 }));
 
 const project = {
@@ -76,6 +88,8 @@ function renderDialog() {
 describe("ShareProjectDialog (edition gating)", () => {
   beforeEach(() => {
     runtimeState.isCeRuntime = false;
+    queryMocks.grants = [];
+    queryMocks.deleteGrant.mockReset();
     queryMocks.useUserSearch.mockClear();
   });
 
@@ -90,5 +104,51 @@ describe("ShareProjectDialog (edition gating)", () => {
     const { container } = renderDialog();
     expect(container.firstChild).toBeNull();
     expect(screen.queryByText("共享项目")).not.toBeInTheDocument();
+  });
+
+  it("marks scope-invalid grants inactive while keeping removal available", () => {
+    queryMocks.grants = [
+      {
+        id: "g1",
+        project_id: "p1",
+        principal_type: "user",
+        principal_id: "u9",
+        principal_username: "dev09",
+        role: "editor",
+        effective: false,
+        inactive_reason: "principal_scope_changed",
+      },
+    ];
+
+    renderDialog();
+
+    expect(screen.getByText("已失效")).toBeInTheDocument();
+    expect(screen.getByText("用户作用域已变化")).toBeInTheDocument();
+    const memberRow = screen.getByText("dev09").parentElement?.parentElement;
+    expect(memberRow).toBeInstanceOf(HTMLElement);
+    expect(within(memberRow as HTMLElement).getByRole("combobox")).toBeDisabled();
+    expect(
+      within(memberRow as HTMLElement).getByRole("button", { name: "移除成员" }),
+    ).toBeEnabled();
+  });
+
+  it("treats grants without effective as active during rolling deploys", () => {
+    queryMocks.grants = [
+      {
+        id: "g1",
+        project_id: "p1",
+        principal_type: "user",
+        principal_id: "u9",
+        principal_username: "dev09",
+        role: "editor",
+      },
+    ];
+
+    renderDialog();
+
+    expect(screen.queryByText("已失效")).not.toBeInTheDocument();
+    const memberRow = screen.getByText("dev09").parentElement?.parentElement;
+    expect(memberRow).toBeInstanceOf(HTMLElement);
+    expect(within(memberRow as HTMLElement).getByRole("combobox")).toBeEnabled();
   });
 });

--- a/frontend/src/__tests__/deployment/org-brand-assets.test.ts
+++ b/frontend/src/__tests__/deployment/org-brand-assets.test.ts
@@ -57,6 +57,18 @@ describe("organization brand asset deployment contract", () => {
     expect(packageJson).not.toContain("build:org-brand-proxy");
   });
 
+  it("uses a resolvable loopback upstream when validating the Nginx template", () => {
+    const dockerfile = readFileSync("Dockerfile", "utf8");
+    const configTest = dockerfile.match(
+      /FROM nginx:1\.27-alpine AS nginx-config-test([\s\S]*?)FROM nginx:1\.27-alpine AS runtime/,
+    )?.[1];
+
+    expect(configTest).toBeDefined();
+    expect(configTest).toContain("BACKEND_HOST=127.0.0.1");
+    expect(configTest).not.toContain("backend.invalid");
+    expect(dockerfile).toContain("BACKEND_HOST=novelvideo-ui-staging");
+  });
+
   it("does not retain the removed companion implementation", () => {
     for (const file of [
       "docker/org-brand-assets.ts",

--- a/frontend/src/components/projects/share-project-dialog.tsx
+++ b/frontend/src/components/projects/share-project-dialog.tsx
@@ -43,6 +43,10 @@ function grantDisplayName(grant: ProjectGrant): string {
   return grant.principal_username || grant.principal_id;
 }
 
+function grantIsEffective(grant: ProjectGrant): boolean {
+  return grant.effective !== false;
+}
+
 function roleCaption(role: GrantRole, t: (key: string) => string): string {
   switch (role) {
     case "viewer":
@@ -239,42 +243,54 @@ export function ShareProjectDialog({
                   {t("project.shareDialog.loadingMembers")}
                 </div>
               )}
-              {!grants.isLoading && grantRows.map((grant) => (
-                <div key={grant.id} className="flex items-center gap-3 rounded-[10px] border border-border/60 bg-background/45 px-3 py-2.5">
-                  <Users className="size-4 text-muted-foreground" />
-                  <div className="min-w-0 flex-1">
-                    <div className="truncate text-sm font-medium">{grantDisplayName(grant)}</div>
-                    <div className="text-xs text-muted-foreground">{roleCaption(grant.role, t)}</div>
+              {!grants.isLoading && grantRows.map((grant) => {
+                const effective = grantIsEffective(grant);
+                return (
+                  <div key={grant.id} className="flex items-center gap-3 rounded-[10px] border border-border/60 bg-background/45 px-3 py-2.5">
+                    <Users className="size-4 text-muted-foreground" />
+                    <div className="min-w-0 flex-1">
+                      <div className="truncate text-sm font-medium">{grantDisplayName(grant)}</div>
+                      <div className="text-xs text-muted-foreground">
+                        {effective
+                          ? roleCaption(grant.role, t)
+                          : t("project.shareDialog.inactiveScopeChanged")}
+                      </div>
+                    </div>
+                    {!effective ? (
+                      <span className="rounded-full bg-muted px-2 py-0.5 text-xs text-muted-foreground">
+                        {t("project.shareDialog.inactive")}
+                      </span>
+                    ) : null}
+                    <Select
+                      value={grant.role}
+                      onValueChange={(value) => void handleRoleChange(grant, value as GrantRole)}
+                      disabled={!effective || updateGrant.isPending}
+                    >
+                      <SelectTrigger size="sm" className="w-24 rounded-[8px]">
+                        <SelectValue>
+                          {(value: string) => projectRoleLabel(value as ProjectRole)}
+                        </SelectValue>
+                      </SelectTrigger>
+                      <SelectContent alignItemWithTrigger={false}>
+                        {GRANT_ROLES.map((item) => (
+                          <SelectItem key={item} value={item}>
+                            {projectRoleLabel(item)}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                    <Button
+                      variant="ghost"
+                      size="icon-sm"
+                      onClick={() => void handleRevoke(grant)}
+                      disabled={deleteGrant.isPending}
+                      aria-label={t("project.shareDialog.removeMember")}
+                    >
+                      <Trash2 className="size-4 text-destructive" />
+                    </Button>
                   </div>
-                  <Select
-                    value={grant.role}
-                    onValueChange={(value) => void handleRoleChange(grant, value as GrantRole)}
-                    disabled={updateGrant.isPending}
-                  >
-                    <SelectTrigger size="sm" className="w-24 rounded-[8px]">
-                      <SelectValue>
-                        {(value: string) => projectRoleLabel(value as ProjectRole)}
-                      </SelectValue>
-                    </SelectTrigger>
-                    <SelectContent alignItemWithTrigger={false}>
-                      {GRANT_ROLES.map((item) => (
-                        <SelectItem key={item} value={item}>
-                          {projectRoleLabel(item)}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                  <Button
-                    variant="ghost"
-                    size="icon-sm"
-                    onClick={() => void handleRevoke(grant)}
-                    disabled={deleteGrant.isPending}
-                    aria-label={t("project.shareDialog.removeMember")}
-                  >
-                    <Trash2 className="size-4 text-destructive" />
-                  </Button>
-                </div>
-              ))}
+                );
+              })}
             </div>
           </section>
         </div>

--- a/frontend/src/components/projects/share-project-dialog.tsx
+++ b/frontend/src/components/projects/share-project-dialog.tsx
@@ -253,7 +253,7 @@ export function ShareProjectDialog({
                       <div className="text-xs text-muted-foreground">
                         {effective
                           ? roleCaption(grant.role, t)
-                          : t("project.shareDialog.inactiveScopeChanged")}
+                          : t("project.shareDialog.inactiveAccessChanged")}
                       </div>
                     </div>
                     {!effective ? (

--- a/frontend/src/lib/queries/projects.ts
+++ b/frontend/src/lib/queries/projects.ts
@@ -185,6 +185,8 @@ export interface ProjectGrant {
   principal_username?: string | null;
   role: Exclude<ProjectRole, "owner">;
   created_at?: string | null;
+  effective?: boolean;
+  inactive_reason?: "principal_scope_changed" | null;
 }
 
 export interface UserSearchResult {

--- a/frontend/src/lib/queries/projects.ts
+++ b/frontend/src/lib/queries/projects.ts
@@ -186,7 +186,7 @@ export interface ProjectGrant {
   role: Exclude<ProjectRole, "owner">;
   created_at?: string | null;
   effective?: boolean;
-  inactive_reason?: "principal_scope_changed" | null;
+  inactive_reason?: "principal_access_changed" | null;
 }
 
 export interface UserSearchResult {

--- a/src/novelvideo/api/schemas.py
+++ b/src/novelvideo/api/schemas.py
@@ -80,7 +80,7 @@ class ProjectGrantSummary(BaseModel):
     role: str
     created_at: Optional[str] = None
     effective: bool = True
-    inactive_reason: Literal["principal_scope_changed"] | None = None
+    inactive_reason: Literal["principal_access_changed"] | None = None
 
 
 class ProjectUpdate(BaseModel):

--- a/src/novelvideo/api/schemas.py
+++ b/src/novelvideo/api/schemas.py
@@ -79,6 +79,8 @@ class ProjectGrantSummary(BaseModel):
     principal_username: Optional[str] = None
     role: str
     created_at: Optional[str] = None
+    effective: bool = True
+    inactive_reason: Literal["principal_scope_changed"] | None = None
 
 
 class ProjectUpdate(BaseModel):


### PR DESCRIPTION
## Summary
- display ineffective project sharing entries as inactive
- disable role editing for inactive entries while keeping removal available
- preserve compatibility with older responses that omit the effective state
- make the Nginx configuration test use a resolvable loopback upstream

## Test plan
- pnpm exec vitest run src/__tests__/deployment/org-brand-assets.test.ts src/__tests__/components/projects/share-project-dialog.test.tsx src/__tests__/lib/project-permissions.test.ts
- pnpm build
- docker build --no-cache --target nginx-config-test --file Dockerfile .