### PR TITLE
perf(assets): load media only near the viewport

### DIFF
--- a/frontend/src/__tests__/components/viewport-lazy-image.test.tsx
+++ b/frontend/src/__tests__/components/viewport-lazy-image.test.tsx
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: Elastic-2.0
+// Copyright (c) 2026 ClaymoreLab
+import { act, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ViewportLazyImage } from "@/components/viewport-lazy-image";
+
+describe("ViewportLazyImage", () => {
+  let callback!: IntersectionObserverCallback;
+  const observe = vi.fn();
+  const disconnect = vi.fn();
+
+  beforeEach(() => {
+    observe.mockClear();
+    disconnect.mockClear();
+    class MockIntersectionObserver {
+      root = null;
+      rootMargin = "160px 0px";
+      thresholds = [0];
+      observe = observe;
+      disconnect = disconnect;
+      unobserve = vi.fn();
+      takeRecords = vi.fn(() => []);
+
+      constructor(nextCallback: IntersectionObserverCallback) {
+        callback = nextCallback;
+      }
+    }
+    vi.stubGlobal("IntersectionObserver", MockIntersectionObserver);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("does not expose src until the image intersects the viewport", () => {
+    render(<ViewportLazyImage src="/portrait.png" alt="郑家悦" />);
+
+    const image = screen.getByRole("img", { name: "郑家悦" });
+    expect(image).not.toHaveAttribute("src");
+    expect(observe).toHaveBeenCalledWith(image);
+
+    act(() => {
+      callback(
+        [{ isIntersecting: true } as IntersectionObserverEntry],
+        {} as IntersectionObserver,
+      );
+    });
+
+    expect(image).toHaveAttribute("src", "/portrait.png");
+    expect(disconnect).toHaveBeenCalled();
+  });
+
+  it("does not leak a replacement src before it intersects", () => {
+    const view = render(
+      <ViewportLazyImage src="/portrait-v1.png" alt="郑家悦" />,
+    );
+    act(() => {
+      callback(
+        [{ isIntersecting: true } as IntersectionObserverEntry],
+        {} as IntersectionObserver,
+      );
+    });
+    expect(screen.getByRole("img")).toHaveAttribute(
+      "src",
+      "/portrait-v1.png",
+    );
+
+    view.rerender(
+      <ViewportLazyImage src="/portrait-v2.png" alt="郑家悦" />,
+    );
+
+    expect(screen.getByRole("img")).not.toHaveAttribute("src");
+  });
+
+  it("falls back to native lazy loading when observers are unavailable", () => {
+    vi.stubGlobal("IntersectionObserver", undefined);
+
+    render(<ViewportLazyImage src="/portrait.png" alt="郑家悦" />);
+
+    expect(screen.getByRole("img")).toHaveAttribute("src", "/portrait.png");
+    expect(screen.getByRole("img")).toHaveAttribute("loading", "lazy");
+  });
+});

--- a/frontend/src/components/assets/scene-asset-card.tsx
+++ b/frontend/src/components/assets/scene-asset-card.tsx
@@ -35,6 +35,7 @@ import {
 import { ASSET_CARD_META_BADGE_CLASS } from "@/components/assets/asset-card-styles";
 import { CopyAssetLinkButton } from "@/components/assets/copy-asset-link-button";
 import { CreditCostInline } from "@/components/credit-cost-inline";
+import { ViewportLazyImage } from "@/components/viewport-lazy-image";
 import type { CreditPromotionDisplay } from "@/components/credits/credit-visual";
 import { resolveMediaUrl } from "@/lib/media-url";
 import { sceneTypeLabel } from "@/lib/scene-type";
@@ -111,12 +112,10 @@ function AssetImageSlot({
           <>
             {/* Blurred background fill for contain mode */}
             {fit === "contain" && (
-              <img
+              <ViewportLazyImage
                 src={resolved}
                 alt=""
                 aria-hidden="true"
-                loading="lazy"
-                decoding="async"
                 className="absolute inset-0 h-full w-full scale-110 object-cover opacity-50 blur-md"
               />
             )}
@@ -129,11 +128,9 @@ function AssetImageSlot({
                 onPreview ? "cursor-zoom-in" : "cursor-default",
               )}
             >
-              <img
+              <ViewportLazyImage
                 src={resolved}
                 alt={label}
-                loading="lazy"
-                decoding="async"
                 className={cn(
                   "h-full w-full",
                   fit === "contain" ? "object-contain" : "object-cover",

--- a/frontend/src/components/assets/scenes-panel.tsx
+++ b/frontend/src/components/assets/scenes-panel.tsx
@@ -9,6 +9,7 @@ import { toast } from "sonner";
 import { AssetHeaderActions } from "@/components/assets/asset-header-actions-slot";
 import { CharacterImageSourceSelect } from "@/components/assets/character-image-source-select";
 import { SceneAssetCard } from "@/components/assets/scene-asset-card";
+import { ViewportLazyImage } from "@/components/viewport-lazy-image";
 import { AssetBeatReferences } from "@/components/assets/asset-beat-references";
 import {
   SceneEnvironmentPromptFields,
@@ -1154,12 +1155,10 @@ function SceneGroupListItem({
     >
       <div className="relative flex size-12 shrink-0 items-center justify-center overflow-hidden rounded-[8px] border border-white/[0.08] bg-black/20">
         {visiblePreviewUrl ? (
-          <img
+          <ViewportLazyImage
             src={visiblePreviewUrl}
             alt=""
             aria-hidden="true"
-            loading="lazy"
-            decoding="async"
             onError={() => setFailedPreviewUrl(previewUrl)}
             className="h-full w-full object-cover"
           />

--- a/frontend/src/components/lightbox-image.tsx
+++ b/frontend/src/components/lightbox-image.tsx
@@ -5,6 +5,7 @@ import { useState } from "react";
 
 import { useEscapeToClose } from "@/hooks/use-escape-to-close";
 import { cn } from "@/lib/utils";
+import { ViewportLazyImage } from "@/components/viewport-lazy-image";
 
 export function LightboxImage({
   src,
@@ -38,20 +39,16 @@ export function LightboxImage({
         )}
       >
         {!fluid && fit === "contain" && blurBackdrop && (
-          <img
+          <ViewportLazyImage
             src={src}
             alt=""
             aria-hidden="true"
-            loading="lazy"
-            decoding="async"
             className="absolute inset-0 h-full w-full scale-110 object-cover opacity-20 blur-md"
           />
         )}
-        <img
+        <ViewportLazyImage
           src={src}
           alt={alt}
-          loading="lazy"
-          decoding="async"
           onError={onError}
           className={cn(
             "relative z-10",

--- a/frontend/src/components/viewport-lazy-image.tsx
+++ b/frontend/src/components/viewport-lazy-image.tsx
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: Elastic-2.0
+// Copyright (c) 2026 ClaymoreLab
+import { useEffect, useRef, useState } from "react";
+import type { ImgHTMLAttributes } from "react";
+
+type ViewportLazyImageProps = Omit<
+  ImgHTMLAttributes<HTMLImageElement>,
+  "src"
+> & {
+  src: string;
+  rootMargin?: string;
+};
+
+/**
+ * Keeps `src` off the DOM until the image is near the visible viewport.
+ *
+ * Native `loading="lazy"` is deliberately heuristic and may eagerly fetch an
+ * entire list inside a nested scroll container. Asset paths are conventional,
+ * so an eager list can turn every not-yet-generated image into a cold 404. This
+ * component keeps metadata loading independent from media loading without
+ * adding file-existence state to the database.
+ */
+export function ViewportLazyImage({
+  src,
+  rootMargin = "160px 0px",
+  ...props
+}: ViewportLazyImageProps) {
+  const imageRef = useRef<HTMLImageElement>(null);
+  const [revealedSrc, setRevealedSrc] = useState<string | null>(null);
+
+  useEffect(() => {
+    const image = imageRef.current;
+    if (!image || !src) return;
+
+    if (typeof IntersectionObserver === "undefined") {
+      setRevealedSrc(src);
+      return;
+    }
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (!entries.some((entry) => entry.isIntersecting)) return;
+        setRevealedSrc(src);
+        observer.disconnect();
+      },
+      { rootMargin },
+    );
+    observer.observe(image);
+    return () => observer.disconnect();
+  }, [rootMargin, src]);
+
+  return (
+    <img
+      ref={imageRef}
+      {...props}
+      src={revealedSrc === src ? src : undefined}
+      loading="lazy"
+      decoding={props.decoding ?? "async"}
+    />
+  );
+}

--- a/frontend/src/routes/_app/projects.$project/characters.lazy.tsx
+++ b/frontend/src/routes/_app/projects.$project/characters.lazy.tsx
@@ -82,6 +82,7 @@ import { NarratorVoicePanel } from "@/components/assets/narrator-voice-panel";
 import { ProjectStyleChip } from "@/components/assets/project-style-chip";
 import { ScenesPanel } from "@/components/assets/scenes-panel";
 import { PropsPanel } from "@/components/assets/props-panel";
+import { ViewportLazyImage } from "@/components/viewport-lazy-image";
 import { CopyAssetLinkButton } from "@/components/assets/copy-asset-link-button";
 import { LazyAssetBeatReferences } from "@/components/assets/asset-beat-references";
 import type { AssetRefType } from "@/lib/queries/asset-references";
@@ -507,11 +508,9 @@ function CharacterAvatar({
   }, [portraitUrl]);
   if (portraitUrl && failedPortraitUrl !== portraitUrl) {
     return (
-      <img
+      <ViewportLazyImage
         src={resolveMediaUrl(portraitUrl) ?? ""}
         alt={character.name}
-        loading="lazy"
-        decoding="async"
         onError={() => setFailedPortraitUrl(portraitUrl)}
         className={cn(
           "shrink-0 rounded-full border border-border object-cover",

--- a/license-inventory.csv
+++ b/license-inventory.csv
@@ -346,6 +346,7 @@ frontend/src/__tests__/components/task-center/task-logs.test.tsx,Elastic-2.0,202
 frontend/src/__tests__/components/task-center/task-row.test.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/__tests__/components/themed-toaster.test.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/__tests__/components/ui/header-refresh-button.test.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
+frontend/src/__tests__/components/viewport-lazy-image.test.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/__tests__/deployment/org-brand-assets.test.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/__tests__/features/canvas/asset-drag-director-bundle.test.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/__tests__/features/canvas/asset-drag-hydrate.test.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
@@ -836,6 +837,7 @@ frontend/src/components/ui/tabs.tsx,Elastic-2.0,2026 SuperTale contributors,REUS
 frontend/src/components/ui/textarea.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/components/ui/tooltip.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/components/ui/useDialogTransition.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
+frontend/src/components/viewport-lazy-image.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/env.d.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/features/app/errorDialogEvents.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/features/canvas/Canvas.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation


### PR DESCRIPTION
## Summary

- defer character, scene, and prop image requests until each image is near the visible viewport
- keep conventional asset URLs and existing 404 fallback behavior without adding file-state configuration
- prevent native lazy-loading heuristics from prefetching every missing asset in nested scroll lists

## Why

Chromium may fetch native lazy images more than 1000px before they enter the viewport. A 27-character list therefore issued 27 cold portrait requests even though only a small subset was visible.

## Verification

- `npm test` — 375 files, 2704 tests passed
- `npm run build` — TypeScript and production Vite build passed

## Impact

Frontend-only. No API, schema, model-provider, billing, or compliance changes.