### PR TITLE
fix(audio): validate speech voice before enqueue

### DIFF
--- a/frontend/src/__tests__/features/canvas/audio-voice-prereq.test.tsx
+++ b/frontend/src/__tests__/features/canvas/audio-voice-prereq.test.tsx
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: Elastic-2.0
+// Copyright (c) 2026 ClaymoreLab
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { CANVAS_NODE_TYPES } from "@/features/canvas/domain/canvasNodes";
+import type { AudioNodeData } from "@/features/canvas/domain/canvasNodes";
+import { AudioOperationsPanel } from "@/features/canvas/nodes/AudioOperationsPanel";
+import { useCanvasStore } from "@/stores/canvasStore";
+
+vi.mock("@/lib/queries/generation-credit-cost", () => ({
+  useGenerationCreditCost: () => ({
+    data: { ok: true, data: { display: "1", cost: 1 } },
+    error: null,
+  }),
+}));
+
+function renderPanel(data: Partial<AudioNodeData>) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  useCanvasStore.getState().setCanvasData(
+    [
+      {
+        id: "audio-1",
+        type: CANVAS_NODE_TYPES.audio,
+        position: { x: 0, y: 0 },
+        data: { audioUrl: null, ...data },
+      },
+    ],
+    [],
+  );
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <AudioOperationsPanel
+        nodeId="audio-1"
+        data={{ audioUrl: null, ...data }}
+      />
+    </QueryClientProvider>,
+  );
+}
+
+describe("AudioOperationsPanel voice prerequisite", () => {
+  beforeEach(() => {
+    useCanvasStore.getState().setCanvasData([], []);
+  });
+
+  it("disables speech generation after references confirm no usable voice", () => {
+    renderPanel({
+      audioKind: "speech",
+      text: "旁白",
+      voiceAvailable: false,
+    });
+
+    expect(
+      (screen.getByTitle("请先配置或选择声线") as HTMLButtonElement).disabled,
+    ).toBe(true);
+    expect(screen.getByText("请先配置或选择声线")).toBeTruthy();
+  });
+
+  it("does not apply the speech voice prerequisite to music generation", () => {
+    renderPanel({
+      audioKind: "music",
+      text: "紧张的弦乐",
+      voiceAvailable: false,
+    });
+
+    expect(screen.getByTitle("生成")).toBeTruthy();
+    expect(screen.queryByText("请先配置或选择声线")).toBeNull();
+  });
+});

--- a/frontend/src/__tests__/features/canvas/audio-voice-prereq.test.tsx
+++ b/frontend/src/__tests__/features/canvas/audio-voice-prereq.test.tsx
@@ -7,6 +7,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { CANVAS_NODE_TYPES } from "@/features/canvas/domain/canvasNodes";
 import type { AudioNodeData } from "@/features/canvas/domain/canvasNodes";
 import { AudioOperationsPanel } from "@/features/canvas/nodes/AudioOperationsPanel";
+import { createInFlightRequestCache } from "@/features/canvas/nodes/inFlightRequestCache";
 import { useCanvasStore } from "@/stores/canvasStore";
 
 vi.mock("@/lib/queries/generation-credit-cost", () => ({
@@ -44,6 +45,17 @@ function renderPanel(data: Partial<AudioNodeData>) {
 describe("AudioOperationsPanel voice prerequisite", () => {
   beforeEach(() => {
     useCanvasStore.getState().setCanvasData([], []);
+  });
+
+  it("reloads references after an empty request has settled", async () => {
+    let available: string[] = [];
+    const load = vi.fn(async () => ({ available: [...available] }));
+    const getReferences = createInFlightRequestCache(load);
+
+    expect(await getReferences("project-1")).toEqual({ available: [] });
+    available = ["new-voice"];
+    expect(await getReferences("project-1")).toEqual({ available: ["new-voice"] });
+    expect(load).toHaveBeenCalledTimes(2);
   });
 
   it("disables speech generation after references confirm no usable voice", () => {

--- a/frontend/src/features/canvas/domain/canvasNodes.ts
+++ b/frontend/src/features/canvas/domain/canvasNodes.ts
@@ -496,6 +496,8 @@ export interface AudioNodeData extends NodeDisplayData {
   emotionPrompt?: string;
   /** 选中的声线引用（freezone-audio references 接口里的一条记录）。 */
   voiceRef?: AudioVoiceRef | null;
+  /** 最近一次声线列表加载是否确认至少存在一条可用声线；缺省表示尚未确认。 */
+  voiceAvailable?: boolean;
   /** 当前声线的展示名（缓存自 references 接口，避免每次选完都要重新拉列表）。 */
   voiceLabel?: string;
   /** 当前声线的语言标签（来自 references；可空）。 */

--- a/frontend/src/features/canvas/nodes/AudioNode.tsx
+++ b/frontend/src/features/canvas/nodes/AudioNode.tsx
@@ -37,6 +37,7 @@ import { CANVAS_NODE_PANEL_SURFACE_CLASS, canvasNodeFrameClass } from '@/feature
 import { useCanvasStore, useIsBoxSelecting } from '@/stores/canvasStore';
 import { AudioOperationsPanel } from '@/features/canvas/nodes/AudioOperationsPanel';
 import { useAudioGeneration } from '@/features/canvas/nodes/useAudioGeneration';
+import { createInFlightRequestCache } from '@/features/canvas/nodes/inFlightRequestCache';
 import { RegenerateButton } from '@/features/canvas/ui/RegenerateButton';
 import {
   hasMainlineContexts,
@@ -72,26 +73,10 @@ function isAudioFile(file: File): boolean {
   return AUDIO_UPLOAD_EXTENSIONS.has(ext);
 }
 
-// 模块级 references 缓存：同一 project 下所有音频节点共享一次拉取。
-// 用 Promise 而不是 result，保证多个节点同时挂载时也只发一次请求
-// （都 await 同一个 in-flight promise），不会出现并发风暴。
-const audioReferencesPromiseCache = new Map<
-  string,
-  Promise<Awaited<ReturnType<typeof fetchFreezoneAudioReferences>>>
->();
-
-function getCachedAudioReferences(project: string) {
-  let p = audioReferencesPromiseCache.get(project);
-  if (!p) {
-    p = fetchFreezoneAudioReferences(project).catch((err) => {
-      // 失败时把 promise 从缓存里清掉，下一次挂载有机会重试。
-      audioReferencesPromiseCache.delete(project);
-      throw err;
-    });
-    audioReferencesPromiseCache.set(project, p);
-  }
-  return p;
-}
+// 只合并同时发生的请求；settled 后立即失效，避免空结果在上传声线后仍被复用。
+const getCachedAudioReferences = createInFlightRequestCache(
+  fetchFreezoneAudioReferences,
+);
 
 export const AudioNode = memo(({ id, data, selected, width, height }: AudioNodeProps) => {
   const { t } = useTranslation();

--- a/frontend/src/features/canvas/nodes/AudioNode.tsx
+++ b/frontend/src/features/canvas/nodes/AudioNode.tsx
@@ -216,7 +216,13 @@ export const AudioNode = memo(({ id, data, selected, width, height }: AudioNodeP
         const res = await getCachedAudioReferences(project);
         if (cancelled) return;
         const first = (res.available ?? [])[0];
-        if (!first) return;
+        if (!first) {
+          updateNodeData(id, {
+            voiceAvailable: false,
+            voiceLabel: '未配置可用声线',
+          });
+          return;
+        }
         const fresh = useCanvasStore.getState().nodes.find((n) => n.id === id);
         if (!fresh) return;
         const freshData = fresh.data as AudioNodeData;
@@ -256,6 +262,7 @@ export const AudioNode = memo(({ id, data, selected, width, height }: AudioNodeP
         }
         updateNodeData(id, {
           voiceRef: ref,
+          voiceAvailable: true,
           voiceLabel: nextLabel,
           voiceLanguage: nextLanguage,
         });

--- a/frontend/src/features/canvas/nodes/AudioOperationsPanel.tsx
+++ b/frontend/src/features/canvas/nodes/AudioOperationsPanel.tsx
@@ -222,9 +222,10 @@ export function AudioOperationsPanel({ nodeId, data }: AudioOperationsPanelProps
   }, [handleTextChange, isGenerating, isTranslating, modelTaskAccess.blocked, t, text]);
 
   // 文本框为空但引用了非空文本时也允许提交（effectivePrompt 会回退到上游引用）。
+  const voiceMissing = !isMusic && data.voiceAvailable === false;
   const submitDisabled =
     isGenerating || billingRuleMissing || modelTaskAccess.blocked ||
-    effectivePrompt.length === 0;
+    effectivePrompt.length === 0 || voiceMissing;
 
   return (
     <OperationPanelShell
@@ -329,6 +330,12 @@ export function AudioOperationsPanel({ nodeId, data }: AudioOperationsPanelProps
       </div>
       )}
 
+      {voiceMissing ? (
+        <p className="px-3 pb-2 text-[12px] text-amber-300">
+          请先配置或选择声线
+        </p>
+      ) : null}
+
       <div className="flex shrink-0 items-center justify-end gap-2 px-3 pb-3 pt-1">
         <IconButton
           title={modelTaskAccess.message ?? '翻译（中英文互译）'}
@@ -374,7 +381,9 @@ export function AudioOperationsPanel({ nodeId, data }: AudioOperationsPanelProps
         <button
           type="button"
           disabled={submitDisabled}
-          title={modelTaskAccess.message ?? '生成'}
+          title={
+            modelTaskAccess.message ?? (voiceMissing ? '请先配置或选择声线' : '生成')
+          }
           onClick={handleSubmit}
           className={`${NODE_GENERATE_BUTTON_BASE_CLASS} ${
             submitDisabled
@@ -665,6 +674,7 @@ function AudioVoiceSettingsPanel({ nodeId, data }: AudioVoiceSettingsPanelProps)
         onPick={({ ref, label, language }) => {
           updateNodeData(nodeId, {
             voiceRef: ref,
+            voiceAvailable: true,
             voiceLabel: label,
             voiceLanguage: language ?? '',
           });

--- a/frontend/src/features/canvas/nodes/inFlightRequestCache.ts
+++ b/frontend/src/features/canvas/nodes/inFlightRequestCache.ts
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: Elastic-2.0
+// Copyright (c) 2026 ClaymoreLab
+
+export function createInFlightRequestCache<Key, Value>(
+  load: (key: Key) => Promise<Value>,
+) {
+  const requests = new Map<Key, Promise<Value>>();
+
+  return (key: Key): Promise<Value> => {
+    const existing = requests.get(key);
+    if (existing) return existing;
+
+    const request = load(key);
+    requests.set(key, request);
+    const clear = () => {
+      if (requests.get(key) === request) requests.delete(key);
+    };
+    void request.then(clear, clear);
+    return request;
+  };
+}

--- a/frontend/src/features/canvas/nodes/useAudioGeneration.ts
+++ b/frontend/src/features/canvas/nodes/useAudioGeneration.ts
@@ -67,6 +67,10 @@ export function useAudioGeneration(nodeId: string, data: AudioNodeData) {
       }
       return;
     }
+    if (!isMusic && data.voiceAvailable === false) {
+      updateNodeData(nodeId, { generationError: '请先配置或选择声线' });
+      return;
+    }
     const trimmed = effectivePrompt;
     if (trimmed.length === 0) return;
     const project = readUrl().project;
@@ -124,6 +128,7 @@ export function useAudioGeneration(nodeId: string, data: AudioNodeData) {
     data.musicLengthMs,
     data.forceInstrumental,
     data.respectSectionsDurations,
+    data.voiceAvailable,
     data.voiceRef,
     effectivePrompt,
     emotionPrompt,

--- a/license-inventory.csv
+++ b/license-inventory.csv
@@ -353,6 +353,7 @@ frontend/src/__tests__/features/canvas/asset-drag-hydrate.test.ts,Elastic-2.0,20
 frontend/src/__tests__/features/canvas/asset-library-modal-categories.test.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/__tests__/features/canvas/audio-music-settings.test.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/__tests__/features/canvas/audio-node-credit-contract.test.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
+frontend/src/__tests__/features/canvas/audio-voice-prereq.test.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/__tests__/features/canvas/auto-layout.test.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/__tests__/features/canvas/background-cropper-dialog.test.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/__tests__/features/canvas/beat-context-node.test.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
@@ -1568,8 +1569,8 @@ src/novelvideo/generators/wan2-2-FLF-LightX2V.json,Elastic-2.0,2026 SuperTale co
 src/novelvideo/generators/wan2-2-I2V-GGUF-LightX2V.json,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 src/novelvideo/generators/wan2-2-I2V-LightX2V.json,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 src/novelvideo/graph_preview.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
-src/novelvideo/image_request_usage.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 src/novelvideo/identity_prerequisites.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
+src/novelvideo/image_request_usage.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 src/novelvideo/knowledge_pipeline.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 src/novelvideo/llm_instrumentation.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 src/novelvideo/manual_shots.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
@@ -1620,6 +1621,7 @@ src/novelvideo/release-notes.md,Elastic-2.0,2026 SuperTale contributors,REUSE.to
 src/novelvideo/release_notes.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 src/novelvideo/render_plan/__init__.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 src/novelvideo/render_plan/ref_image_hash.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
+src/novelvideo/scene_prerequisites.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 src/novelvideo/security/__init__.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 src/novelvideo/security/operator_auth.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 src/novelvideo/security/sandbox_wrap.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
@@ -1637,7 +1639,6 @@ src/novelvideo/seedance2_i2v/voice_audio_records.py,Elastic-2.0,2026 SuperTale c
 src/novelvideo/seedance2_i2v/voice_audio_task.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 src/novelvideo/seedance2_i2v/voice_clone.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 src/novelvideo/seedance2_i2v/voice_reference_service.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
-src/novelvideo/scene_prerequisites.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 src/novelvideo/service_operation_gate.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 src/novelvideo/services/__init__.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 src/novelvideo/services/background_anchor_service.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
@@ -1664,12 +1665,12 @@ src/novelvideo/sqlite_pragmas.py,Elastic-2.0,2026 SuperTale contributors,REUSE.t
 src/novelvideo/sqlite_schema.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 src/novelvideo/sqlite_store.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 src/novelvideo/stage_asset_tasks.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
+src/novelvideo/storage/__init__.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
+src/novelvideo/storage/media_relay.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 src/novelvideo/story_analysis.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 src/novelvideo/structured_builders.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 src/novelvideo/structured_extraction.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 src/novelvideo/structured_ingest.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
-src/novelvideo/storage/__init__.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
-src/novelvideo/storage/media_relay.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 src/novelvideo/styles/presets/STYLE_DESIGN.md,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 src/novelvideo/styles/presets/anime.json,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 src/novelvideo/styles/presets/anime.png,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
@@ -1939,6 +1940,8 @@ tests/test_freezone_audio_backend.py,Elastic-2.0,2026 SuperTale contributors,REU
 tests/test_freezone_audio_enqueue_projection.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_freezone_audio_node_placement.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_freezone_audio_separate_runner.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
+tests/test_freezone_audio_speech_prereq.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
+tests/test_freezone_audio_task_failure.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_freezone_canvas_generation_history.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_freezone_canvas_lock_timing.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_freezone_canvas_mutex_seam.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation

--- a/license-inventory.csv
+++ b/license-inventory.csv
@@ -971,6 +971,7 @@ frontend/src/features/canvas/nodes/VoiceSelectionModal.tsx,Elastic-2.0,2026 Supe
 frontend/src/features/canvas/nodes/config.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/features/canvas/nodes/contextPromptPalette.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/features/canvas/nodes/imageGenPrompt.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
+frontend/src/features/canvas/nodes/inFlightRequestCache.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/features/canvas/nodes/index.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/features/canvas/nodes/referenceMentions.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/features/canvas/nodes/referenceOrdering.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation

--- a/src/novelvideo/api/routes/freezone.py
+++ b/src/novelvideo/api/routes/freezone.py
@@ -110,6 +110,7 @@ from novelvideo.freezone.audio_node import (
     freezone_audio_eleven_music_output_path,
     freezone_audio_speech_output_path,
     generate_freezone_audio_speech,
+    is_readable_audio_file,
     list_user_audio_voices,
     resolve_speech_voice,
     resolve_user_audio_voice,
@@ -6781,7 +6782,10 @@ def _freezone_audio_ref_payload(
     if rel_path and not abs_path.is_absolute():
         abs_path = project_dir / rel_path
 
-    exists = bool(rel_path and abs_path.exists())
+    try:
+        exists = bool(rel_path and is_readable_audio_file(abs_path))
+    except OSError:
+        exists = False
     url = ""
     if exists:
         try:
@@ -6961,7 +6965,7 @@ async def freezone_audio_references(
     requester_username = ctx.requester_username or username
     user_voices = _attach_user_voice_media_urls(
         project,
-        list_user_audio_voices(requester_username),
+        await asyncio.to_thread(list_user_audio_voices, requester_username),
     )
 
     store = (
@@ -6976,7 +6980,8 @@ async def freezone_audio_references(
         if close:
             await close()
 
-    narrator = _freezone_audio_ref_payload(
+    narrator = await asyncio.to_thread(
+        _freezone_audio_ref_payload,
         username=username,
         project=project_name,
         project_id=ctx.project_id,
@@ -6987,16 +6992,21 @@ async def freezone_audio_references(
         sha256=narrator_descriptor.get("sha256", ""),
         updated_at=narrator_descriptor.get("updated_at", ""),
     )
-    character_payloads = [
-        _freezone_character_audio_refs(
-            username=username,
-            project=project_name,
-            project_id=ctx.project_id,
-            project_dir=project_dir,
-            character=character,
+    character_payloads = list(
+        await asyncio.gather(
+            *(
+                asyncio.to_thread(
+                    _freezone_character_audio_refs,
+                    username=username,
+                    project=project_name,
+                    project_id=ctx.project_id,
+                    project_dir=project_dir,
+                    character=character,
+                )
+                for character in characters
+            )
         )
-        for character in characters
-    ]
+    )
     available = [narrator] if narrator["exists"] else []
     available.extend(item for item in user_voices if item["exists"])
     for character in character_payloads:

--- a/src/novelvideo/api/routes/freezone.py
+++ b/src/novelvideo/api/routes/freezone.py
@@ -25,7 +25,7 @@ from urllib.parse import quote, unquote, urlencode, urlsplit
 from fastapi import (
     APIRouter, Body, Depends, File, Form, HTTPException, Query, UploadFile,
 )
-from fastapi.responses import FileResponse
+from fastapi.responses import FileResponse, JSONResponse
 
 from novelvideo.api.auth import get_api_user
 from novelvideo.api.deps import (
@@ -105,11 +105,13 @@ from novelvideo.media_model_request_schema import (
 )
 from novelvideo.ports.authz import find_authz_error
 from novelvideo.freezone.audio_node import (
+    VoicePrerequisiteError,
     create_user_audio_voice,
     freezone_audio_eleven_music_output_path,
     freezone_audio_speech_output_path,
     generate_freezone_audio_speech,
     list_user_audio_voices,
+    resolve_speech_voice,
     resolve_user_audio_voice,
 )
 from novelvideo.freezone.canvas_lock import CanvasLockBusy
@@ -9366,6 +9368,43 @@ async def freezone_audio_speech(
     billable_chars = count_billable_text_chars(body.text)
 
     voice_ref_payload = body.voice_ref.model_dump() if body.voice_ref else None
+    store = await make_sqlite_store_for_context(ctx)
+    try:
+        narration_style, speech_voice = await resolve_speech_voice(
+            store=store,
+            username=username,
+            project=project_name,
+            account_voice_username=account_voice_username,
+            project_dir=project_dir,
+            voice_ref=voice_ref_payload,
+        )
+    except VoicePrerequisiteError as exc:
+        logger.info(
+            "freezone_audio_speech_voice_prereq_failed",
+            extra={
+                "project_id": ctx.project_id,
+                "voice_ref_present": body.voice_ref is not None,
+                "voice_ref_scope": str((voice_ref_payload or {}).get("scope") or "default"),
+                "error_code": exc.error_code,
+            },
+        )
+        return JSONResponse(
+            status_code=409,
+            content={"ok": False, "code": exc.error_code, "error": str(exc)},
+        )
+    finally:
+        await store.close()
+
+    logger.info(
+        "freezone_audio_speech_voice_resolved",
+        extra={
+            "project_id": ctx.project_id,
+            "narration_style": narration_style,
+            "voice_ref_present": body.voice_ref is not None,
+            "voice_ref_scope": str((voice_ref_payload or {}).get("scope") or "default"),
+            "speech_voice_source": speech_voice.source,
+        },
+    )
 
     try:
         job_id = _new_job_id()

--- a/src/novelvideo/api/routes/freezone.py
+++ b/src/novelvideo/api/routes/freezone.py
@@ -105,6 +105,7 @@ from novelvideo.media_model_request_schema import (
 )
 from novelvideo.ports.authz import find_authz_error
 from novelvideo.freezone.audio_node import (
+    VOICE_FILE_UNREADABLE_MESSAGE,
     VoicePrerequisiteError,
     create_user_audio_voice,
     freezone_audio_eleven_music_output_path,
@@ -7080,7 +7081,9 @@ async def get_freezone_audio_voice_media(
     )
     username = ctx.requester_username if ctx is not None and ctx.requester_username else username
     try:
-        resolved = resolve_user_audio_voice(username, voice_id)
+        resolved = await asyncio.to_thread(resolve_user_audio_voice, username, voice_id)
+    except OSError as exc:
+        raise HTTPException(404, VOICE_FILE_UNREADABLE_MESSAGE) from exc
     except RuntimeError as exc:
         raise HTTPException(404, str(exc)) from exc
     return FileResponse(path=str(resolved.audio_path))

--- a/src/novelvideo/freezone/audio_node.py
+++ b/src/novelvideo/freezone/audio_node.py
@@ -194,12 +194,24 @@ def _user_voice_abs_path(username: str, record: dict) -> Path:
     return Path(OUTPUT_DIR) / username / str(record.get("path") or "")
 
 
+def is_readable_audio_file(path: Path) -> bool:
+    """Return whether ``path`` is a regular file that can actually be opened."""
+    if not path.is_file():
+        return False
+    with path.open("rb") as stream:
+        stream.read(1)
+    return True
+
+
 def public_user_voice_payload(username: str, record: dict) -> dict:
     voice_id = str(record.get("voice_id") or "")
     label = str(record.get("name") or record.get("label") or voice_id or "未命名音色")
     path = str(record.get("path") or "")
     abs_path = _user_voice_abs_path(username, record)
-    exists = bool(path and abs_path.exists())
+    try:
+        exists = bool(path and is_readable_audio_file(abs_path))
+    except OSError:
+        exists = False
     return {
         "scope": USER_VOICE_SCOPE,
         "voice_id": voice_id,
@@ -269,7 +281,7 @@ def resolve_user_audio_voice(
         if str(record.get("voice_id") or "") != target:
             continue
         path = _user_voice_abs_path(username, record)
-        if not path.is_file():
+        if not is_readable_audio_file(path):
             raise RuntimeError(f"用户音色文件不存在: {target}")
         sha = str(record.get("sha256") or "") or file_sha256(path)
         return FreezoneVoiceRefResolution(path, sha, USER_VOICE_SCOPE)
@@ -305,7 +317,7 @@ async def _project_path(project_dir: Path, stored_path: str) -> Path | None:
     path = Path(value)
     if not path.is_absolute():
         path = project_dir / path
-    return path if await asyncio.to_thread(path.is_file) else None
+    return path if await asyncio.to_thread(is_readable_audio_file, path) else None
 
 
 @dataclass(frozen=True)
@@ -445,6 +457,8 @@ async def _resolve_voice_ref(
         )
         if resolved.audio_path is None:
             raise RuntimeError(f"身份实际声线不可用: {identity_id}")
+        if not await asyncio.to_thread(is_readable_audio_file, resolved.audio_path):
+            raise RuntimeError(f"身份实际声线不可用: {identity_id}")
         return FreezoneVoiceRefResolution(
             resolved.audio_path,
             resolved.sha256
@@ -527,6 +541,16 @@ async def resolve_speech_voice(
             )
         except OSError as exc:
             raise VoicePrerequisiteError(VOICE_FILE_UNREADABLE_MESSAGE) from exc
+        if voice.audio_path is not None:
+            try:
+                readable = await asyncio.to_thread(
+                    is_readable_audio_file,
+                    voice.audio_path,
+                )
+            except OSError as exc:
+                raise VoicePrerequisiteError(VOICE_FILE_UNREADABLE_MESSAGE) from exc
+            if not readable:
+                raise VoicePrerequisiteError(VOICE_FILE_UNREADABLE_MESSAGE)
         if voice.audio_path is None:
             if voice.source == "project_narrator":
                 message = (

--- a/src/novelvideo/freezone/audio_node.py
+++ b/src/novelvideo/freezone/audio_node.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 import re
 import subprocess
@@ -296,14 +297,14 @@ def _duration_ms(audio_path: Path) -> int:
         return 0
 
 
-def _project_path(project_dir: Path, stored_path: str) -> Path | None:
+async def _project_path(project_dir: Path, stored_path: str) -> Path | None:
     value = str(stored_path or "").strip()
     if not value:
         return None
     path = Path(value)
     if not path.is_absolute():
         path = project_dir / path
-    return path if path.exists() else None
+    return path if await asyncio.to_thread(path.is_file) else None
 
 
 @dataclass(frozen=True)
@@ -377,7 +378,7 @@ async def _resolve_voice_ref(
 
     if scope == "character_default":
         character = _find_character()
-        path = _project_path(
+        path = await _project_path(
             project_dir,
             getattr(character, "reference_audio_path", "") if character else "",
         )
@@ -385,7 +386,7 @@ async def _resolve_voice_ref(
             raise RuntimeError(f"角色默认声线不可用: {character_name or '<空>'}")
         sha = str(
             getattr(character, "reference_audio_sha256", "") or ""
-        ) or file_sha256(path)
+        ) or await asyncio.to_thread(file_sha256, path)
         return FreezoneVoiceRefResolution(path, sha, "character_default")
 
     if scope == "character_age_group":
@@ -396,7 +397,7 @@ async def _resolve_voice_ref(
             else {}
         )
         entry = samples.get(slot) if isinstance(samples, dict) else None
-        path = _project_path(
+        path = await _project_path(
             project_dir, entry.get("path", "") if isinstance(entry, dict) else ""
         )
         if path is None:
@@ -405,7 +406,7 @@ async def _resolve_voice_ref(
             )
         sha = str(entry.get("sha256", "") or "") if isinstance(entry, dict) else ""
         return FreezoneVoiceRefResolution(
-            path, sha or file_sha256(path), "character_age_group"
+            path, sha or await asyncio.to_thread(file_sha256, path), "character_age_group"
         )
 
     if scope in {"identity", "identity_resolved"}:
@@ -425,16 +426,17 @@ async def _resolve_voice_ref(
                 f"身份声线不可用: {character_name or '<空>'}/{identity_id or '<空>'}"
             )
         if scope == "identity":
-            path = _project_path(
+            path = await _project_path(
                 project_dir, getattr(identity, "reference_audio_path", "")
             )
             if path is None:
                 raise RuntimeError(f"身份声线未配置: {identity_id}")
             sha = str(
                 getattr(identity, "reference_audio_sha256", "") or ""
-            ) or file_sha256(path)
+            ) or await asyncio.to_thread(file_sha256, path)
             return FreezoneVoiceRefResolution(path, sha, "identity")
-        resolved = resolve_character_voice(
+        resolved = await asyncio.to_thread(
+            resolve_character_voice,
             project_dir=project_dir,
             character=character,
             identity=identity,
@@ -443,7 +445,8 @@ async def _resolve_voice_ref(
             raise RuntimeError(f"身份实际声线不可用: {identity_id}")
         return FreezoneVoiceRefResolution(
             resolved.audio_path,
-            resolved.sha256 or file_sha256(resolved.audio_path),
+            resolved.sha256
+            or await asyncio.to_thread(file_sha256, resolved.audio_path),
             f"identity_resolved:{resolved.tier or 'unknown'}",
         )
 
@@ -494,7 +497,7 @@ async def resolve_speech_voice(
             voice_ref=voice_ref,
             characters=voice_characters,
         )
-    except RuntimeError as exc:
+    except (OSError, RuntimeError) as exc:
         raise VoicePrerequisiteError(str(exc)) from exc
     if selected_voice is None:
         if projection is None:
@@ -510,12 +513,16 @@ async def resolve_speech_voice(
                 else None
             )
         narrator_descriptor_present = bool(str(descriptor.get("path") or "").strip())
-        voice = resolve_narrator_source(
-            store=narrator_store,
-            narration_style=narration_style,
-            project_narrator_stored_path=descriptor.get("path", ""),
-            characters=characters,
-        )
+        try:
+            voice = await asyncio.to_thread(
+                resolve_narrator_source,
+                store=narrator_store,
+                narration_style=narration_style,
+                project_narrator_stored_path=descriptor.get("path", ""),
+                characters=characters,
+            )
+        except OSError as exc:
+            raise VoicePrerequisiteError(str(exc)) from exc
         if voice.audio_path is None:
             if voice.source == "project_narrator":
                 message = (

--- a/src/novelvideo/freezone/audio_node.py
+++ b/src/novelvideo/freezone/audio_node.py
@@ -41,6 +41,7 @@ from novelvideo.freezone.paths import outputs_dir
 
 USER_VOICE_EXTENSIONS = {".mp3", ".wav", ".m4a", ".aac", ".ogg", ".webm"}
 USER_VOICE_SCOPE = "user_custom"
+VOICE_FILE_UNREADABLE_MESSAGE = "声线文件无法读取，请重新选择或检查文件是否完整"
 
 
 @dataclass
@@ -268,7 +269,7 @@ def resolve_user_audio_voice(
         if str(record.get("voice_id") or "") != target:
             continue
         path = _user_voice_abs_path(username, record)
-        if not path.exists():
+        if not path.is_file():
             raise RuntimeError(f"用户音色文件不存在: {target}")
         sha = str(record.get("sha256") or "") or file_sha256(path)
         return FreezoneVoiceRefResolution(path, sha, USER_VOICE_SCOPE)
@@ -356,7 +357,8 @@ async def _resolve_voice_ref(
     slot = str(voice_ref.get("slot") or "").strip()
 
     if scope == USER_VOICE_SCOPE:
-        return resolve_user_audio_voice(
+        return await asyncio.to_thread(
+            resolve_user_audio_voice,
             account_voice_username or username,
             str(voice_ref.get("voice_id") or ""),
         )
@@ -497,7 +499,9 @@ async def resolve_speech_voice(
             voice_ref=voice_ref,
             characters=voice_characters,
         )
-    except (OSError, RuntimeError) as exc:
+    except OSError as exc:
+        raise VoicePrerequisiteError(VOICE_FILE_UNREADABLE_MESSAGE) from exc
+    except RuntimeError as exc:
         raise VoicePrerequisiteError(str(exc)) from exc
     if selected_voice is None:
         if projection is None:
@@ -522,7 +526,7 @@ async def resolve_speech_voice(
                 characters=characters,
             )
         except OSError as exc:
-            raise VoicePrerequisiteError(str(exc)) from exc
+            raise VoicePrerequisiteError(VOICE_FILE_UNREADABLE_MESSAGE) from exc
         if voice.audio_path is None:
             if voice.source == "project_narrator":
                 message = (

--- a/src/novelvideo/freezone/audio_node.py
+++ b/src/novelvideo/freezone/audio_node.py
@@ -59,6 +59,10 @@ class FreezoneVoiceRefResolution:
     source: str
 
 
+class VoicePrerequisiteError(RuntimeError):
+    error_code = "voice_prereq_required"
+
+
 def freezone_audio_speech_output_path(project_dir: Path, job_id: str) -> Path:
     return outputs_dir(project_dir, "freezone_audio_speech") / f"{job_id}.mp3"
 
@@ -481,14 +485,17 @@ async def resolve_speech_voice(
         voice_characters = _projected_character_rows(projection.require("voice_character"))
         narrator_store = _PathOnlyStore(str(project_dir))
 
-    selected_voice = await _resolve_voice_ref(
-        store=store,
-        username=username,
-        account_voice_username=account_voice_username,
-        project_dir=project_dir,
-        voice_ref=voice_ref,
-        characters=voice_characters,
-    )
+    try:
+        selected_voice = await _resolve_voice_ref(
+            store=store,
+            username=username,
+            account_voice_username=account_voice_username,
+            project_dir=project_dir,
+            voice_ref=voice_ref,
+            characters=voice_characters,
+        )
+    except RuntimeError as exc:
+        raise VoicePrerequisiteError(str(exc)) from exc
     if selected_voice is None:
         if projection is None:
             descriptor = load_narrator_reference_audio_from_state_dir(store.state_dir)
@@ -502,6 +509,7 @@ async def resolve_speech_voice(
                 if narration_style == "first_person"
                 else None
             )
+        narrator_descriptor_present = bool(str(descriptor.get("path") or "").strip())
         voice = resolve_narrator_source(
             store=narrator_store,
             narration_style=narration_style,
@@ -509,7 +517,15 @@ async def resolve_speech_voice(
             characters=characters,
         )
         if voice.audio_path is None:
-            raise RuntimeError(voice.error or "解说声线缺失")
+            if voice.source == "project_narrator":
+                message = (
+                    "解说人声线文件无法读取，请检查文件是否完整"
+                    if narrator_descriptor_present
+                    else "项目解说人声线未配置，请上传或录制解说人音频"
+                )
+            else:
+                message = voice.error or "解说声线缺失"
+            raise VoicePrerequisiteError(message)
         selected_voice = FreezoneVoiceRefResolution(
             voice.audio_path,
             voice.sha256,

--- a/src/novelvideo/task_backend/run_core.py
+++ b/src/novelvideo/task_backend/run_core.py
@@ -551,9 +551,13 @@ def _project_task_timeout_seconds() -> int:
 def _project_task_failure_for_exception(
     exc: BaseException,
 ) -> tuple[str, dict[str, Any], bool]:
+    from novelvideo.freezone.audio_node import VoicePrerequisiteError
     from novelvideo.identity_prerequisites import IdentityPlanningPrerequisiteError
     from novelvideo.novel_source import NovelImportRequiredError
     from novelvideo.scene_prerequisites import ScenePlanningPrerequisiteError
+
+    if isinstance(exc, VoicePrerequisiteError):
+        return str(exc), {"error_code": exc.error_code}, True
 
     if isinstance(exc, IdentityPlanningPrerequisiteError):
         return str(exc), {"error_code": exc.error_code}, True

--- a/tests/contract/test_m06_route_contracts.py
+++ b/tests/contract/test_m06_route_contracts.py
@@ -228,6 +228,8 @@ def m06_client_factory(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     from novelvideo.api.deps import ProjectResolution
     from novelvideo.api.routes import freezone, ingest
     from novelvideo.freezone.paths import uploads_dir
+    from novelvideo.project_config import set_narrator_reference_audio_in_state_dir
+    from novelvideo.seedance2_i2v.voice_clone import file_sha256
     from novelvideo.utils.path_resolver import (
         canonical_beat_director_env_only_path,
         canonical_beat_selected_background_path,
@@ -251,6 +253,13 @@ def m06_client_factory(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     mask_image = _write_png(uploads_dir(project_dir) / "mask.png")
     video_file = _write_media(uploads_dir(project_dir) / "clip.mp4", b"video")
     audio_file = _write_media(uploads_dir(project_dir) / "voice.mp3", b"audio")
+    store.project_dir = str(project_dir)
+    store.state_dir = str(state_dir)
+    set_narrator_reference_audio_in_state_dir(
+        state_dir,
+        relative_path=audio_file.relative_to(project_dir).as_posix(),
+        sha256=file_sha256(audio_file),
+    )
     scene_master = _write_png(canonical_scene_master_path(project_dir, _SCENE))
     scene_reverse = _write_png(canonical_scene_reverse_master_path(project_dir, _SCENE))
     selected_background = _write_png(canonical_beat_selected_background_path(project_dir, 1, 1))

--- a/tests/test_freezone_audio_backend.py
+++ b/tests/test_freezone_audio_backend.py
@@ -303,6 +303,93 @@ async def test_user_custom_voice_generation_uses_requester_account(
 
 
 @pytest.mark.asyncio
+async def test_resolve_speech_voice_reports_missing_project_narrator(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        audio_node,
+        "load_effective_narration_style_for_voice_from_state_dir",
+        lambda *_args: "third_person",
+    )
+    monkeypatch.setattr(
+        audio_node,
+        "load_narrator_reference_audio_from_state_dir",
+        lambda *_args: {},
+    )
+
+    with pytest.raises(audio_node.VoicePrerequisiteError) as caught:
+        await audio_node.resolve_speech_voice(
+            store=FakeProjectStore(tmp_path),
+            username="alice",
+            project="demo",
+            project_dir=tmp_path,
+            voice_ref={"scope": "project_narrator"},
+        )
+
+    assert caught.value.error_code == "voice_prereq_required"
+    assert str(caught.value) == "项目解说人声线未配置，请上传或录制解说人音频"
+
+
+@pytest.mark.asyncio
+async def test_resolve_speech_voice_reports_unreadable_project_narrator(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        audio_node,
+        "load_effective_narration_style_for_voice_from_state_dir",
+        lambda *_args: "third_person",
+    )
+    monkeypatch.setattr(
+        audio_node,
+        "load_narrator_reference_audio_from_state_dir",
+        lambda *_args: {"path": "assets/narrator/missing.wav"},
+    )
+
+    with pytest.raises(audio_node.VoicePrerequisiteError) as caught:
+        await audio_node.resolve_speech_voice(
+            store=FakeProjectStore(tmp_path),
+            username="alice",
+            project="demo",
+            project_dir=tmp_path,
+            voice_ref={"scope": "project_narrator"},
+        )
+
+    assert str(caught.value) == "解说人声线文件无法读取，请检查文件是否完整"
+
+
+@pytest.mark.asyncio
+async def test_resolve_speech_voice_returns_explicit_user_voice(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    expected = audio_node.FreezoneVoiceRefResolution(
+        tmp_path / "voice.mp3",
+        "sha",
+        USER_VOICE_SCOPE,
+    )
+    monkeypatch.setattr(audio_node, "resolve_user_audio_voice", lambda *_args: expected)
+    monkeypatch.setattr(
+        audio_node,
+        "load_effective_narration_style_for_voice_from_state_dir",
+        lambda *_args: "third_person",
+    )
+
+    narration_style, resolved = await audio_node.resolve_speech_voice(
+        store=SimpleNamespace(state_dir=str(tmp_path)),
+        username="owner",
+        account_voice_username="viewer",
+        project="demo",
+        project_dir=tmp_path,
+        voice_ref={"scope": USER_VOICE_SCOPE, "voice_id": "fv_viewer"},
+    )
+
+    assert narration_style == "third_person"
+    assert resolved is expected
+
+
+@pytest.mark.asyncio
 async def test_freezone_audio_speech_drama_first_person_uses_project_narrator(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_freezone_audio_backend.py
+++ b/tests/test_freezone_audio_backend.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import threading
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -357,6 +358,43 @@ async def test_audio_references_exclude_user_voice_directory(
 
     assert result["data"]["user_voices"][0]["exists"] is False
     assert result["data"]["available"] == []
+
+
+@pytest.mark.asyncio
+async def test_user_voice_media_resolves_off_loop_and_hides_read_error(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    from fastapi import HTTPException
+
+    ctx = SimpleNamespace(requester_username="viewer")
+
+    async def fake_resolve(*_args, **_kwargs):
+        return ctx, "owner", "demo", tmp_path, str(tmp_path)
+
+    event_loop_thread = threading.get_ident()
+    resolver_threads: list[int] = []
+    leaked_path = tmp_path / "private" / "account-voice.wav"
+
+    def unreadable(_username: str, _voice_id: str):
+        resolver_threads.append(threading.get_ident())
+        raise PermissionError(f"permission denied: {leaked_path}")
+
+    monkeypatch.setattr(freezone_routes, "_resolve_freezone_project", fake_resolve)
+    monkeypatch.setattr(freezone_routes, "resolve_user_audio_voice", unreadable)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await freezone_routes.get_freezone_audio_voice_media(
+            "proj_demo",
+            "fv_unreadable",
+            user={"username": "viewer"},
+        )
+
+    assert exc_info.value.status_code == 404
+    assert exc_info.value.detail == "声线文件无法读取，请重新选择或检查文件是否完整"
+    assert str(leaked_path) not in str(exc_info.value.detail)
+    assert resolver_threads
+    assert all(thread_id != event_loop_thread for thread_id in resolver_threads)
 
 
 @pytest.mark.asyncio

--- a/tests/test_freezone_audio_backend.py
+++ b/tests/test_freezone_audio_backend.py
@@ -303,6 +303,63 @@ async def test_user_custom_voice_generation_uses_requester_account(
 
 
 @pytest.mark.asyncio
+async def test_audio_references_exclude_user_voice_directory(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(audio_node, "OUTPUT_DIR", str(tmp_path))
+    relative_path = "_account/freezone/audio/voices/fv_directory/reference.wav"
+    (tmp_path / "viewer" / relative_path).mkdir(parents=True)
+    audio_node._write_user_voice_records(
+        "viewer",
+        [{"voice_id": "fv_directory", "path": relative_path, "sha256": "cached-sha"}],
+    )
+    ctx = SimpleNamespace(
+        project_id="proj_demo",
+        requester_username="viewer",
+        state_dir=tmp_path / "state" / "owner" / "demo",
+    )
+
+    async def fake_resolve(*_args, **_kwargs):
+        return ctx, "owner", "demo", tmp_path, str(tmp_path)
+
+    class Store:
+        async def list_characters(self):
+            return []
+
+        async def close(self):
+            return None
+
+    async def fake_store(_ctx):
+        return Store()
+
+    monkeypatch.setattr(freezone_routes, "_resolve_freezone_project", fake_resolve)
+    monkeypatch.setattr(
+        freezone_routes,
+        "make_sqlite_store_for_context",
+        fake_store,
+    )
+    monkeypatch.setattr(
+        freezone_routes,
+        "load_narrator_reference_audio_from_state_dir",
+        lambda *_args, **_kwargs: {},
+    )
+    monkeypatch.setattr(
+        freezone_routes,
+        "load_effective_narration_style_for_voice_from_state_dir",
+        lambda *_args, **_kwargs: "third_person",
+    )
+
+    result = await freezone_routes.freezone_audio_references(
+        "proj_demo",
+        user={"username": "viewer"},
+    )
+
+    assert result["data"]["user_voices"][0]["exists"] is False
+    assert result["data"]["available"] == []
+
+
+@pytest.mark.asyncio
 async def test_resolve_speech_voice_reports_missing_project_narrator(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_freezone_audio_enqueue_projection.py
+++ b/tests/test_freezone_audio_enqueue_projection.py
@@ -40,6 +40,7 @@ class _FakeCharacterStore:
 
     def __init__(self, characters) -> None:
         self.state_dir = "/state/alice/demo"
+        self.project_dir = "/output/alice/demo"
         self._characters = list(characters)
         self.list_characters_calls = 0
 
@@ -74,6 +75,11 @@ def speech_harness(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
             _character("路人甲"),
         ]
     )
+    store.project_dir = str(project_dir)
+    store.state_dir = str(tmp_path / "state" / "alice" / "demo")
+    voice_path = project_dir / "assets" / "voices" / "小明.wav"
+    voice_path.parent.mkdir(parents=True, exist_ok=True)
+    voice_path.write_bytes(b"voice")
     ctx = SimpleNamespace(
         project_id="proj",
         project_name="demo",
@@ -180,7 +186,7 @@ async def test_speech_projection_carries_only_the_characters_actually_consulted(
     blob = json.dumps(payload["projection"], ensure_ascii=False)
     assert "路人甲" not in blob
     assert blob.count("小明") >= 1
-    assert speech_harness.store.list_characters_calls == 1
+    assert speech_harness.store.list_characters_calls == 2
 
 
 @pytest.mark.asyncio
@@ -201,8 +207,9 @@ async def test_speech_payload_is_unchanged_when_no_projector_is_installed(
         "target_beat",
         "billing",
     }
-    # Rollback also means no extra project store is opened on the enqueue side.
-    assert speech_harness.store.list_characters_calls == 0
+    # Even without a projector, the enqueue-side prerequisite check resolves
+    # the selected voice once before allocating the job.
+    assert speech_harness.store.list_characters_calls == 1
 
 
 @pytest.mark.asyncio

--- a/tests/test_freezone_audio_speech_prereq.py
+++ b/tests/test_freezone_audio_speech_prereq.py
@@ -131,3 +131,68 @@ async def test_valid_voice_is_resolved_before_job_allocation_and_enqueue(
         "voice_id": "fv_viewer",
     }
     store.close.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_explicit_voice_directory_is_a_structured_prerequisite_error(
+    tmp_path: Path,
+) -> None:
+    from novelvideo.freezone.audio_node import (
+        VoicePrerequisiteError,
+        resolve_speech_voice,
+    )
+
+    voice_directory = tmp_path / "voice-directory"
+    voice_directory.mkdir()
+    character = SimpleNamespace(
+        name="主角",
+        reference_audio_path=voice_directory.name,
+        reference_audio_sha256="",
+    )
+    store = SimpleNamespace(
+        state_dir=tmp_path,
+        list_characters=AsyncMock(return_value=[character]),
+    )
+
+    with pytest.raises(VoicePrerequisiteError, match="角色默认声线不可用"):
+        await resolve_speech_voice(
+            store=store,
+            username="owner",
+            project="demo",
+            project_dir=tmp_path,
+            voice_ref={"scope": "character_default", "character_name": "主角"},
+        )
+
+
+@pytest.mark.asyncio
+async def test_explicit_voice_read_error_is_a_structured_prerequisite_error(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    from novelvideo.freezone import audio_node
+
+    voice_file = tmp_path / "voice.wav"
+    voice_file.write_bytes(b"voice")
+    character = SimpleNamespace(
+        name="主角",
+        reference_audio_path=voice_file.name,
+        reference_audio_sha256="",
+    )
+    store = SimpleNamespace(
+        state_dir=tmp_path,
+        list_characters=AsyncMock(return_value=[character]),
+    )
+
+    def unreadable(_path: Path) -> str:
+        raise PermissionError("permission denied")
+
+    monkeypatch.setattr(audio_node, "file_sha256", unreadable)
+
+    with pytest.raises(audio_node.VoicePrerequisiteError, match="permission denied"):
+        await audio_node.resolve_speech_voice(
+            store=store,
+            username="owner",
+            project="demo",
+            project_dir=tmp_path,
+            voice_ref={"scope": "character_default", "character_name": "主角"},
+        )

--- a/tests/test_freezone_audio_speech_prereq.py
+++ b/tests/test_freezone_audio_speech_prereq.py
@@ -177,7 +177,7 @@ async def test_explicit_voice_read_error_is_a_structured_prerequisite_error(
     character = SimpleNamespace(
         name="主角",
         reference_audio_path=voice_file.name,
-        reference_audio_sha256="",
+        reference_audio_sha256="cached-sha",
     )
     store = SimpleNamespace(
         state_dir=tmp_path,
@@ -186,10 +186,10 @@ async def test_explicit_voice_read_error_is_a_structured_prerequisite_error(
 
     leaked_path = tmp_path / "private" / "voice.wav"
 
-    def unreadable(_path: Path) -> str:
+    def unreadable(_path: Path) -> bool:
         raise PermissionError(f"permission denied: {leaked_path}")
 
-    monkeypatch.setattr(audio_node, "file_sha256", unreadable)
+    monkeypatch.setattr(audio_node, "is_readable_audio_file", unreadable)
 
     with pytest.raises(audio_node.VoicePrerequisiteError) as exc_info:
         await audio_node.resolve_speech_voice(
@@ -198,6 +198,44 @@ async def test_explicit_voice_read_error_is_a_structured_prerequisite_error(
             project="demo",
             project_dir=tmp_path,
             voice_ref={"scope": "character_default", "character_name": "主角"},
+        )
+
+    assert str(exc_info.value) == "声线文件无法读取，请重新选择或检查文件是否完整"
+    assert str(leaked_path) not in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_user_custom_cached_sha_still_probes_file_readability(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    from novelvideo.freezone import audio_node
+
+    monkeypatch.setattr(audio_node, "OUTPUT_DIR", str(tmp_path))
+    voice_id = "fv_unreadable"
+    relative_path = "_account/freezone/audio/voices/fv_unreadable/reference.wav"
+    voice_file = tmp_path / "viewer" / relative_path
+    voice_file.parent.mkdir(parents=True)
+    voice_file.write_bytes(b"voice")
+    audio_node._write_user_voice_records(
+        "viewer",
+        [{"voice_id": voice_id, "path": relative_path, "sha256": "cached-sha"}],
+    )
+    leaked_path = tmp_path / "private" / "account-voice.wav"
+
+    def unreadable(_path: Path) -> bool:
+        raise PermissionError(f"permission denied: {leaked_path}")
+
+    monkeypatch.setattr(audio_node, "is_readable_audio_file", unreadable)
+    store = SimpleNamespace(state_dir=tmp_path, list_characters=AsyncMock())
+
+    with pytest.raises(audio_node.VoicePrerequisiteError) as exc_info:
+        await audio_node.resolve_speech_voice(
+            store=store,
+            username="viewer",
+            project="demo",
+            project_dir=tmp_path,
+            voice_ref={"scope": "user_custom", "voice_id": voice_id},
         )
 
     assert str(exc_info.value) == "声线文件无法读取，请重新选择或检查文件是否完整"

--- a/tests/test_freezone_audio_speech_prereq.py
+++ b/tests/test_freezone_audio_speech_prereq.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import threading
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
@@ -183,12 +184,14 @@ async def test_explicit_voice_read_error_is_a_structured_prerequisite_error(
         list_characters=AsyncMock(return_value=[character]),
     )
 
+    leaked_path = tmp_path / "private" / "voice.wav"
+
     def unreadable(_path: Path) -> str:
-        raise PermissionError("permission denied")
+        raise PermissionError(f"permission denied: {leaked_path}")
 
     monkeypatch.setattr(audio_node, "file_sha256", unreadable)
 
-    with pytest.raises(audio_node.VoicePrerequisiteError, match="permission denied"):
+    with pytest.raises(audio_node.VoicePrerequisiteError) as exc_info:
         await audio_node.resolve_speech_voice(
             store=store,
             username="owner",
@@ -196,3 +199,47 @@ async def test_explicit_voice_read_error_is_a_structured_prerequisite_error(
             project_dir=tmp_path,
             voice_ref={"scope": "character_default", "character_name": "主角"},
         )
+
+    assert str(exc_info.value) == "声线文件无法读取，请重新选择或检查文件是否完整"
+    assert str(leaked_path) not in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_user_custom_directory_is_rejected_off_the_event_loop_thread(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    from novelvideo.freezone import audio_node
+
+    monkeypatch.setattr(audio_node, "OUTPUT_DIR", str(tmp_path))
+    voice_id = "fv_directory"
+    relative_path = "_account/freezone/audio/voices/fv_directory/reference.wav"
+    voice_directory = tmp_path / "viewer" / relative_path
+    voice_directory.mkdir(parents=True)
+    audio_node._write_user_voice_records(
+        "viewer",
+        [{"voice_id": voice_id, "path": relative_path, "sha256": "recorded-sha"}],
+    )
+
+    event_loop_thread = threading.get_ident()
+    resolver_threads: list[int] = []
+    original_resolver = audio_node.resolve_user_audio_voice
+
+    def tracked_resolver(username: str, selected_voice_id: str):
+        resolver_threads.append(threading.get_ident())
+        return original_resolver(username, selected_voice_id)
+
+    monkeypatch.setattr(audio_node, "resolve_user_audio_voice", tracked_resolver)
+    store = SimpleNamespace(state_dir=tmp_path, list_characters=AsyncMock())
+
+    with pytest.raises(audio_node.VoicePrerequisiteError, match="用户音色文件不存在"):
+        await audio_node.resolve_speech_voice(
+            store=store,
+            username="viewer",
+            project="demo",
+            project_dir=tmp_path,
+            voice_ref={"scope": "user_custom", "voice_id": voice_id},
+        )
+
+    assert resolver_threads
+    assert all(thread_id != event_loop_thread for thread_id in resolver_threads)

--- a/tests/test_freezone_audio_speech_prereq.py
+++ b/tests/test_freezone_audio_speech_prereq.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+
+def _project_context(tmp_path: Path) -> SimpleNamespace:
+    return SimpleNamespace(
+        project_id="proj",
+        owner_username="owner",
+        project_name="demo",
+        requester_username="viewer",
+        output_dir=str(tmp_path),
+    )
+
+
+@pytest.mark.asyncio
+async def test_missing_voice_returns_409_without_allocating_or_enqueuing(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    from novelvideo.api.routes import freezone
+    from novelvideo.api.schemas import FreezoneAudioSpeechRequest
+    from novelvideo.freezone.audio_node import VoicePrerequisiteError
+
+    calls = {"job": 0, "enqueue": 0}
+    ctx = _project_context(tmp_path)
+    store = SimpleNamespace(close=AsyncMock())
+
+    async def fake_resolve_project(*_args, **_kwargs):
+        return ctx, "owner", "demo", tmp_path, str(tmp_path)
+
+    async def missing_voice(**_kwargs):
+        raise VoicePrerequisiteError("项目解说人声线未配置，请上传或录制解说人音频")
+
+    def allocate_job() -> str:
+        calls["job"] += 1
+        return "job-1"
+
+    async def enqueue(**_kwargs):
+        calls["enqueue"] += 1
+        return {"ok": True}
+
+    monkeypatch.setattr(freezone, "_resolve_freezone_project", fake_resolve_project)
+    monkeypatch.setattr(
+        freezone,
+        "make_sqlite_store_for_context",
+        AsyncMock(return_value=store),
+    )
+    monkeypatch.setattr(freezone, "resolve_speech_voice", missing_voice, raising=False)
+    monkeypatch.setattr(freezone, "_new_job_id", allocate_job)
+    monkeypatch.setattr(freezone, "_enqueue_freezone_background_job", enqueue)
+
+    response = await freezone.freezone_audio_speech(
+        "proj",
+        FreezoneAudioSpeechRequest(text="旁白"),
+        user={"username": "viewer"},
+    )
+
+    assert response.status_code == 409
+    assert json.loads(response.body) == {
+        "ok": False,
+        "code": "voice_prereq_required",
+        "error": "项目解说人声线未配置，请上传或录制解说人音频",
+    }
+    assert calls == {"job": 0, "enqueue": 0}
+    store.close.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_valid_voice_is_resolved_before_job_allocation_and_enqueue(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    from novelvideo.api.routes import freezone
+    from novelvideo.api.schemas import FreezoneAudioSpeechRequest, FreezoneAudioVoiceRef
+    from novelvideo.freezone.audio_node import FreezoneVoiceRefResolution
+
+    events: list[str] = []
+    ctx = _project_context(tmp_path)
+    store = SimpleNamespace(close=AsyncMock())
+    resolution = (
+        "third_person",
+        FreezoneVoiceRefResolution(tmp_path / "voice.wav", "sha", "user_custom"),
+    )
+
+    async def fake_resolve_project(*_args, **_kwargs):
+        return ctx, "owner", "demo", tmp_path, str(tmp_path)
+
+    async def resolve_voice(**_kwargs):
+        events.append("resolve")
+        return resolution
+
+    def allocate_job() -> str:
+        events.append("allocate")
+        return "job-1"
+
+    async def enqueue(**kwargs):
+        events.append("enqueue")
+        return {"ok": True, "payload": kwargs["payload"]}
+
+    monkeypatch.setattr(freezone, "_resolve_freezone_project", fake_resolve_project)
+    monkeypatch.setattr(
+        freezone,
+        "make_sqlite_store_for_context",
+        AsyncMock(return_value=store),
+    )
+    monkeypatch.setattr(freezone, "resolve_speech_voice", resolve_voice, raising=False)
+    monkeypatch.setattr(freezone, "_new_job_id", allocate_job)
+    monkeypatch.setattr(freezone, "_enqueue_freezone_background_job", enqueue)
+
+    result = await freezone.freezone_audio_speech(
+        "proj",
+        FreezoneAudioSpeechRequest(
+            text="旁白",
+            voice_ref=FreezoneAudioVoiceRef(scope="user_custom", voice_id="fv_viewer"),
+        ),
+        user={"username": "viewer"},
+    )
+
+    assert events == ["resolve", "allocate", "enqueue"]
+    assert result["payload"]["voice_ref"] == {
+        "scope": "user_custom",
+        "character_name": "",
+        "identity_id": "",
+        "slot": "",
+        "voice_id": "fv_viewer",
+    }
+    store.close.assert_awaited_once()

--- a/tests/test_freezone_audio_task_failure.py
+++ b/tests/test_freezone_audio_task_failure.py
@@ -1,0 +1,12 @@
+from novelvideo.freezone.audio_node import VoicePrerequisiteError
+from novelvideo.task_backend.run_core import _project_task_failure_for_exception
+
+
+def test_voice_prerequisite_is_a_handled_project_task_failure() -> None:
+    exc = VoicePrerequisiteError("项目解说人声线未配置")
+
+    message, payload, handled = _project_task_failure_for_exception(exc)
+
+    assert message == "项目解说人声线未配置"
+    assert payload == {"error_code": "voice_prereq_required"}
+    assert handled is True

--- a/tests/test_freezone_image_backend.py
+++ b/tests/test_freezone_image_backend.py
@@ -1044,8 +1044,19 @@ async def test_freezone_audio_generation_enqueues_two_feature_billings(
     tmp_path: Path,
 ) -> None:
     from novelvideo.config import INDEXTTS2_RECORD_MODEL
+    from novelvideo.project_config import set_narrator_reference_audio_in_state_dir
+    from novelvideo.seedance2_i2v.voice_clone import file_sha256
 
     _patch_freezone_project(monkeypatch, tmp_path)
+    ctx = _project_ctx(tmp_path)
+    narrator = ctx.output_dir / "assets" / "narrator" / "voice.wav"
+    narrator.parent.mkdir(parents=True, exist_ok=True)
+    narrator.write_bytes(b"narrator-voice")
+    set_narrator_reference_audio_in_state_dir(
+        ctx.state_dir,
+        relative_path=narrator.relative_to(ctx.output_dir).as_posix(),
+        sha256=file_sha256(narrator),
+    )
     captured: list[dict] = []
 
     async def fake_enqueue_project_task(_ctx: ProjectContext, **kwargs):


### PR DESCRIPTION
## Summary

- share speech voice resolution between API preflight and worker execution
- reject missing or unreadable voices with structured HTTP 409 before allocating a job
- classify worker-side voice races as handled business failures and gate speech generation in the canvas UI

## Test Plan

- [x] 26 focused Python tests
- [x] 6 focused Vitest tests
- [x] Ruff checks
- [x] TypeScript build check