### PR TITLE
fix(freezone): 组织账号视频失败透出 VIDEO_* 厂商码，参考图尺寸入队前预检

### DIFF
--- a/src/novelvideo/api/routes/freezone.py
+++ b/src/novelvideo/api/routes/freezone.py
@@ -469,7 +469,10 @@ async def _start_or_enqueue_freezone_video_gen(
             and str(item.get("path") or "").strip()
         ]
         if last_frame_path:
-            image_input_paths.append(str(last_frame_path))
+            image_input_paths.append(str(last_frame_path).strip())
+        # 关键帧路由把尾帧同时放进 reference_items 和 last_frame_path，去重后
+        # 同一文件只读一次头、报错也只列一次。
+        image_input_paths = list(dict.fromkeys(path for path in image_input_paths if path))
         if image_input_paths:
             try:
                 # 读文件头走线程：/data/output 在 s3fs 上，同步 IO 会卡住事件循环。

--- a/src/novelvideo/api/routes/freezone.py
+++ b/src/novelvideo/api/routes/freezone.py
@@ -275,6 +275,7 @@ from novelvideo.freezone.video_node import (
     get_video_camera_templates,
     is_freezone_happyhorse_backend,
     is_freezone_seedance2_backend,
+    is_freezone_seedance_backend,
     library_folder_keys,
     load_video_character_folders,
     load_video_character_library,
@@ -288,6 +289,7 @@ from novelvideo.freezone.video_node import (
     summarize_omni_reference_counts,
     update_video_character_folder,
     validate_omni_reference_audio_durations,
+    validate_omni_reference_image_dimensions,
     validate_omni_reference_limits,
     MAX_OMNI_REFERENCE_AUDIO_SECONDS,
     MAX_OMNI_REFERENCE_AUDIO_TOTAL_SECONDS,
@@ -456,6 +458,27 @@ async def _start_or_enqueue_freezone_video_gen(
             )
         except ValueError as exc:
             raise HTTPException(400, str(exc)) from exc
+    # 参考图尺寸在入队前就拦：厂商必拒的图没必要先预扣积分、上传 relay 再退款。
+    # 组织账号的出口路径会把厂商原文抹成 EGRESS_OPERATION_UNKNOWN，这里是用户唯一
+    # 能看懂原因的地方（3060 2026-08-26：338x191 被 HeightTooSmall 连拒 8 次）。
+    if is_freezone_seedance_backend(backend):
+        image_input_paths = [
+            str(item.get("path") or "").strip()
+            for item in reference_items
+            if str(item.get("type") or "image").strip().lower() == "image"
+            and str(item.get("path") or "").strip()
+        ]
+        if last_frame_path:
+            image_input_paths.append(str(last_frame_path))
+        if image_input_paths:
+            try:
+                # 读文件头走线程：/data/output 在 s3fs 上，同步 IO 会卡住事件循环。
+                await asyncio.to_thread(
+                    validate_omni_reference_image_dimensions, image_input_paths
+                )
+            except ValueError as exc:
+                raise HTTPException(400, str(exc)) from exc
+
     normalized_mode = str(gen_mode or "").strip()
     if normalized_mode == "video_edit":
         if not video_input_paths or input_video_duration_seconds <= 0:

--- a/src/novelvideo/freezone/video_node.py
+++ b/src/novelvideo/freezone/video_node.py
@@ -349,6 +349,19 @@ def is_freezone_seedance2_backend(backend: str | None) -> bool:
     return bool(model and model.startswith("seedance-2.0"))
 
 
+def is_freezone_seedance_backend(backend: str | None) -> bool:
+    """任何代际的 Seedance（1.0/1.5/2.x）——参考图尺寸规则只对它们成立。"""
+    text = str(backend or "").strip()
+    if text in {"seedance_2", "seedance_fast"}:
+        return True
+
+    from novelvideo.generators.huimengi import parse_huimeng_video_backend
+    from novelvideo.generators.video_generator import parse_newapi_video_backend
+
+    model = parse_newapi_video_backend(text) or parse_huimeng_video_backend(text)
+    return bool(model and model.startswith("seedance"))
+
+
 def is_freezone_happyhorse_backend(backend: str | None) -> bool:
     from novelvideo.generators.video_generator import parse_newapi_video_backend
 
@@ -571,6 +584,72 @@ def validate_omni_reference_limits(
         raise ValueError(f"video references count must be <= {video_max}")
     if counts["audio_count"] > audio_max:
         raise ValueError(f"audio references count must be <= {audio_max}")
+
+
+# 火山 Seedance 对参考图的硬规则（从 400 报文里实测）：
+#   `[InvalidParameter.HeightTooSmall] Height must be between 300px and 6000px.`
+# 宽高比 0.4~2.5 与 seedance2_i2v/assets.py 里分镜路径用的同一组数字。
+MIN_OMNI_REFERENCE_IMAGE_PX = 300
+MAX_OMNI_REFERENCE_IMAGE_PX = 6000
+MIN_OMNI_REFERENCE_IMAGE_ASPECT = 0.4
+MAX_OMNI_REFERENCE_IMAGE_ASPECT = 2.5
+
+
+def _read_reference_image_size(path: Path) -> tuple[int, int] | None:
+    """只读文件头拿尺寸；读不出（文件不存在 / 不是图片）返回 None 交给厂商判。"""
+    try:
+        from PIL import Image
+
+        with Image.open(path) as img:
+            width, height = img.size
+    except Exception:  # noqa: BLE001 - 任何读取失败都不该替厂商拦请求
+        return None
+    if width <= 0 or height <= 0:
+        return None
+    return int(width), int(height)
+
+
+def validate_omni_reference_image_dimensions(
+    paths: list[str | Path | None],
+    *,
+    min_px: int = MIN_OMNI_REFERENCE_IMAGE_PX,
+    max_px: int = MAX_OMNI_REFERENCE_IMAGE_PX,
+    min_aspect: float = MIN_OMNI_REFERENCE_IMAGE_ASPECT,
+    max_aspect: float = MAX_OMNI_REFERENCE_IMAGE_ASPECT,
+) -> None:
+    """参考图尺寸兜底校验，入队前拦住厂商必拒的图，省掉一次预扣 + 上传 + 退款。
+
+    与 `validate_omni_reference_audio_durations` 同一口径：读不出尺寸的条目**不参与判定**。
+    先报边长越界，再报宽高比，两类同时出现时只报前者。
+    """
+    out_of_range: list[str] = []
+    bad_aspect: list[str] = []
+    for raw in paths:
+        text = str(raw or "").strip()
+        if not text:
+            continue
+        path = Path(text)
+        size = _read_reference_image_size(path)
+        if size is None:
+            continue
+        width, height = size
+        label = path.name or text
+        if not (min_px <= width <= max_px and min_px <= height <= max_px):
+            out_of_range.append(f"{label} ({width}x{height})")
+            continue
+        aspect = width / height
+        if not (min_aspect <= aspect <= max_aspect):
+            bad_aspect.append(f"{label} ({width}x{height}, {aspect:.2f})")
+    if out_of_range:
+        raise ValueError(
+            f"参考图尺寸不符合要求，宽度和高度需在 {min_px} 至 {max_px} 像素之间: "
+            + ", ".join(out_of_range)
+        )
+    if bad_aspect:
+        raise ValueError(
+            f"参考图宽高比需在 {min_aspect:g} 至 {max_aspect:g} 之间: "
+            + ", ".join(bad_aspect)
+        )
 
 
 async def run_trusted_freezone_video_gen(

--- a/src/novelvideo/generators/video_generator.py
+++ b/src/novelvideo/generators/video_generator.py
@@ -21,6 +21,11 @@ from enum import Enum
 from pathlib import Path
 from typing import Any, Callable, Optional
 
+from novelvideo.shared.provider_errors import (
+    classify_provider_video_task_error,
+    provider_video_error_code_from_text,
+)
+
 import aiohttp
 import websockets
 from dotenv import load_dotenv
@@ -115,6 +120,10 @@ def _safe_video_error_code(exc: BaseException, fallback: str) -> str:
         "EGRESS_OPERATION_REPLAYED",
     }:
         return code
+    # 网关用 VIDEO_* 枚举码打回（尺寸/审核）时放行该码；原文本身不回传。
+    provider_code = provider_video_error_code_from_text(str(exc))
+    if provider_code:
+        return provider_code
     return fallback
 
 
@@ -3579,7 +3588,10 @@ class NewApiVideoGenerator(VideoGeneratorBase):
                         or "DramaClawAPI video task failed"
                     )
                     safe_task_error = (
-                        "EGRESS_OPERATION_UNKNOWN"
+                        (
+                            classify_provider_video_task_error(task)
+                            or "EGRESS_OPERATION_UNKNOWN"
+                        )
                         if organization_request
                         else str(error)
                     )

--- a/src/novelvideo/shared/provider_errors.py
+++ b/src/novelvideo/shared/provider_errors.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import re
+from collections.abc import Mapping
 from typing import Any
 
 CONTENT_MODERATION_FAILED_CODE = "CONTENT_MODERATION_FAILED"
@@ -12,6 +14,57 @@ OUTPUT_VIDEO_POLICY_FAILED_MESSAGE = (
 )
 COPYRIGHT_POLICY_FAILED_MESSAGE = (
     "生成内容可能涉及版权限制，未通过平台审核。请调整提示词或更换参考素材后重试。"
+)
+OUTPUT_AUDIO_POLICY_FAILED_MESSAGE = (
+    "生成音频可能包含敏感内容，未通过平台审核。请更换音频或调整描述后重试。"
+)
+
+# DramaClawAPI（视频网关）在任务失败报文里给的枚举码。组织账号的出口路径会把厂商
+# 原文整个抹掉（原文里可能带签名的 relay URL），但这些枚举码本身不含秘密，必须放行，
+# 否则用户只能看到 `EGRESS_OPERATION_UNKNOWN`——2026-08-26 3060 上 338x191 的参考图
+# 被火山 HeightTooSmall 连拒 8 次，用户就是这么被蒙住的。
+VIDEO_MEDIA_DIMENSIONS_INVALID_CODE = "VIDEO_MEDIA_DIMENSIONS_INVALID"
+VIDEO_MEDIA_DIMENSIONS_INVALID_MESSAGE = (
+    "参考素材尺寸不符合要求：图片宽度和高度需在 300 至 6000 像素之间，"
+    "请更换参考图后重试。"
+)
+VIDEO_CONTENT_COPYRIGHT_RESTRICTED_CODE = "VIDEO_CONTENT_COPYRIGHT_RESTRICTED"
+VIDEO_OUTPUT_AUDIO_SENSITIVE_CODE = "VIDEO_OUTPUT_AUDIO_SENSITIVE"
+
+# 只认「全大写枚举」形态的 VIDEO_* 码；任何带空格/小写/标点的东西都当自由文本拒掉。
+_PROVIDER_VIDEO_ERROR_CODE_RE = re.compile(r"VIDEO_[A-Z0-9]+(?:_[A-Z0-9]+)*")
+# 网关 HTTP 错误体（JSON）或 Python repr 里的 `"code": "VIDEO_*"`。
+_PROVIDER_VIDEO_ERROR_BODY_CODE_RE = re.compile(
+    r"[\"']code[\"']\s*:\s*[\"'](VIDEO_[A-Z0-9_]+)[\"']"
+)
+# 网关只给自由文本（`error_message`）时，按厂商原话里的关键字归类。
+_PROVIDER_VIDEO_ERROR_TEXT_MARKERS: tuple[tuple[str, str], ...] = (
+    ("heighttoosmall", VIDEO_MEDIA_DIMENSIONS_INVALID_CODE),
+    ("widthtoosmall", VIDEO_MEDIA_DIMENSIONS_INVALID_CODE),
+    ("heighttoolarge", VIDEO_MEDIA_DIMENSIONS_INVALID_CODE),
+    ("widthtoolarge", VIDEO_MEDIA_DIMENSIONS_INVALID_CODE),
+    ("must be between 300px and 6000px", VIDEO_MEDIA_DIMENSIONS_INVALID_CODE),
+    ("copyright restrictions", VIDEO_CONTENT_COPYRIGHT_RESTRICTED_CODE),
+    ("output audio may contain sensitive", VIDEO_OUTPUT_AUDIO_SENSITIVE_CODE),
+)
+# 已知码 → 给用户看的 (error_code, message)。版权/敏感沿用前端已经认识的
+# CONTENT_MODERATION_FAILED，尺寸问题单独一个码，方便前端以后做针对性引导。
+_PROVIDER_VIDEO_ERROR_PRESENTATION: dict[str, tuple[str, str]] = {
+    VIDEO_MEDIA_DIMENSIONS_INVALID_CODE: (
+        VIDEO_MEDIA_DIMENSIONS_INVALID_CODE,
+        VIDEO_MEDIA_DIMENSIONS_INVALID_MESSAGE,
+    ),
+    VIDEO_CONTENT_COPYRIGHT_RESTRICTED_CODE: (
+        CONTENT_MODERATION_FAILED_CODE,
+        COPYRIGHT_POLICY_FAILED_MESSAGE,
+    ),
+    VIDEO_OUTPUT_AUDIO_SENSITIVE_CODE: (
+        CONTENT_MODERATION_FAILED_CODE,
+        OUTPUT_AUDIO_POLICY_FAILED_MESSAGE,
+    ),
+}
+_KNOWN_PROVIDER_VIDEO_ERROR_RE = re.compile(
+    r"\b(" + "|".join(re.escape(code) for code in _PROVIDER_VIDEO_ERROR_PRESENTATION) + r")\b"
 )
 
 _CONTENT_MODERATION_MARKERS = (
@@ -51,13 +104,81 @@ def content_moderation_payload(exc: BaseException | None = None) -> dict[str, An
     return payload
 
 
+def safe_provider_video_error_code(code: object) -> str:
+    """网关给的 `code` 字段是纯枚举的 VIDEO_* 才原样返回，否则返回空串。"""
+    text = str(code or "").strip()
+    if len(text) > 64 or not _PROVIDER_VIDEO_ERROR_CODE_RE.fullmatch(text):
+        return ""
+    return text
+
+
+def provider_video_error_code_from_text(text: str) -> str:
+    """从厂商/网关自由文本里提取安全的 VIDEO_* 码；认不出返回空串，原文绝不回传。"""
+    if not text:
+        return ""
+    match = _PROVIDER_VIDEO_ERROR_BODY_CODE_RE.search(text)
+    if match:
+        code = safe_provider_video_error_code(match.group(1))
+        if code:
+            return code
+    lowered = text.lower()
+    for marker, code in _PROVIDER_VIDEO_ERROR_TEXT_MARKERS:
+        if marker in lowered:
+            return code
+    return ""
+
+
+def classify_provider_video_task_error(task: Mapping[str, Any]) -> str:
+    """把网关「任务失败」报文归成安全的 VIDEO_* 码，认不出返回空串。
+
+    报文有两种形态：`error: {code, message}`，或只有 `error_message` 自由文本
+    （里面可能带签名的 relay URL）。只有枚举码会被返回，文本只用来识别关键字。
+    """
+    error = task.get("error")
+    if isinstance(error, Mapping):
+        code = safe_provider_video_error_code(error.get("code"))
+        if code:
+            return code
+        message = error.get("message")
+    else:
+        message = error
+    text = " ".join(
+        str(part)
+        for part in (message, task.get("fail_reason"), task.get("error_message"))
+        if part
+    )
+    return provider_video_error_code_from_text(text)
+
+
+def provider_video_error_payload(exc: BaseException) -> dict[str, Any] | None:
+    """异常文本里带已知 VIDEO_* 码时，给出结构化的用户可读失败；否则 None。"""
+    match = _KNOWN_PROVIDER_VIDEO_ERROR_RE.search(str(exc))
+    if not match:
+        return None
+    error_code, message = _PROVIDER_VIDEO_ERROR_PRESENTATION[match.group(1)]
+    return {
+        "error_code": error_code,
+        "message": message,
+        "provider_error": str(exc)[:2000],
+    }
+
+
 __all__ = [
     "CONTENT_MODERATION_FAILED_CODE",
     "CONTENT_MODERATION_FAILED_MESSAGE",
     "COPYRIGHT_POLICY_FAILED_MESSAGE",
     "INPUT_IMAGE_POLICY_FAILED_MESSAGE",
+    "OUTPUT_AUDIO_POLICY_FAILED_MESSAGE",
     "OUTPUT_VIDEO_POLICY_FAILED_MESSAGE",
+    "VIDEO_CONTENT_COPYRIGHT_RESTRICTED_CODE",
+    "VIDEO_MEDIA_DIMENSIONS_INVALID_CODE",
+    "VIDEO_MEDIA_DIMENSIONS_INVALID_MESSAGE",
+    "VIDEO_OUTPUT_AUDIO_SENSITIVE_CODE",
+    "classify_provider_video_task_error",
     "content_moderation_message",
     "content_moderation_payload",
     "is_content_moderation_error",
+    "provider_video_error_code_from_text",
+    "provider_video_error_payload",
+    "safe_provider_video_error_code",
 ]

--- a/src/novelvideo/task_backend/run_core.py
+++ b/src/novelvideo/task_backend/run_core.py
@@ -633,6 +633,19 @@ def _project_task_failure_for_exception(
     except Exception:
         pass
 
+    try:
+        from novelvideo.shared.provider_errors import provider_video_error_payload
+
+        provider_payload = provider_video_error_payload(exc)
+        if provider_payload is not None:
+            return (
+                str(provider_payload.get("message") or ""),
+                provider_payload,
+                True,
+            )
+    except Exception:
+        pass
+
     if not isinstance(exc, Exception):
         raise exc
     from novelvideo.utils.error_redaction import safe_exception_message

--- a/tests/contract/test_m06_route_contracts.py
+++ b/tests/contract/test_m06_route_contracts.py
@@ -34,7 +34,9 @@ def _png_bytes() -> bytes:
     from PIL import Image
 
     buf = io.BytesIO()
-    Image.new("RGB", (4, 4), color=(90, 120, 150)).save(buf, format="PNG")
+    # 占位图要满足厂商真实约束（Seedance 参考图边长 >= 300px），否则入队前的
+    # 尺寸校验会先于本测试关心的响应形状把请求 400 掉。
+    Image.new("RGB", (320, 320), color=(90, 120, 150)).save(buf, format="PNG")
     return buf.getvalue()
 
 

--- a/tests/test_freezone_image_backend.py
+++ b/tests/test_freezone_image_backend.py
@@ -9514,3 +9514,47 @@ async def test_freezone_video_generation_skips_dimension_gate_for_non_seedance_b
 
     assert result["data"]["task_type"] == "freezone_video_gen"
     assert captured["task_type"] == "freezone_video_gen"
+
+
+@pytest.mark.asyncio
+async def test_freezone_video_generation_reports_duplicate_last_frame_once(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """关键帧路由会把尾帧同时放进 reference_items 和 last_frame_path，预检要去重。"""
+
+    async def unexpected_enqueue(*_args, **_kwargs):
+        raise AssertionError("image validation must happen before enqueue")
+
+    monkeypatch.setattr(
+        freezone_routes,
+        "get_task_backend",
+        lambda: SimpleNamespace(enqueue_project_task=unexpected_enqueue),
+    )
+    small = tmp_path / "last.png"
+    Image.new("RGB", (338, 191), (255, 255, 255)).save(small, format="PNG")
+
+    with pytest.raises(HTTPException) as exc:
+        await freezone_routes._start_or_enqueue_freezone_video_gen(
+            ctx=_project_ctx(tmp_path),
+            username="admin",
+            project="demo",
+            project_dir=tmp_path / "project",
+            output_dir=str(tmp_path / "output"),
+            job_id="job_dup_last_frame",
+            prompt="首尾帧生成",
+            reference_items=[{"type": "image", "path": str(small), "role": "尾帧"}],
+            aspect_ratio="16:9",
+            resolution="720p",
+            duration_seconds=6,
+            generate_audio=False,
+            human_review=False,
+            scene_optimize=None,
+            backend="newapi_seedance-2.0",
+            last_frame_path=str(small),
+            gen_mode="keyframe",
+            capabilities={},
+        )
+
+    assert exc.value.status_code == 400
+    assert str(exc.value.detail).count("last.png (338x191)") == 1

--- a/tests/test_freezone_image_backend.py
+++ b/tests/test_freezone_image_backend.py
@@ -9415,3 +9415,102 @@ async def test_reverse_prompt_uses_shared_freezone_vision_model(
         captured["timeout_seconds"]
         == image_node.FREEZONE_IMAGE_REVERSE_PROMPT_TIMEOUT_SECONDS
     )
+
+
+@pytest.mark.asyncio
+async def test_freezone_video_generation_rejects_small_reference_image_before_billing(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """参考图小于 300px 在入队前就 400，不预扣积分、不送厂商（3060 2026-08-26 实例）。"""
+
+    async def unexpected_enqueue(*_args, **_kwargs):
+        raise AssertionError("image validation must happen before enqueue")
+
+    monkeypatch.setattr(
+        freezone_routes,
+        "get_task_backend",
+        lambda: SimpleNamespace(enqueue_project_task=unexpected_enqueue),
+    )
+    small = tmp_path / "logo.png"
+    Image.new("RGB", (338, 191), (255, 255, 255)).save(small, format="PNG")
+    ok = tmp_path / "frame.png"
+    Image.new("RGB", (1280, 720), (255, 255, 255)).save(ok, format="PNG")
+
+    with pytest.raises(HTTPException) as exc:
+        await freezone_routes._start_or_enqueue_freezone_video_gen(
+            ctx=_project_ctx(tmp_path),
+            username="admin",
+            project="demo",
+            project_dir=tmp_path / "project",
+            output_dir=str(tmp_path / "output"),
+            job_id="job_small_image",
+            prompt="参考图生成",
+            reference_items=[
+                {"type": "image", "path": str(ok), "role": "图片1"},
+                {"type": "image", "path": str(small), "role": "图片2"},
+            ],
+            aspect_ratio="16:9",
+            resolution="720p",
+            duration_seconds=6,
+            generate_audio=False,
+            human_review=False,
+            scene_optimize=None,
+            backend="newapi_seedance-2.0",
+            gen_mode="allReference",
+            capabilities={},
+        )
+
+    assert exc.value.status_code == 400
+    detail = str(exc.value.detail)
+    assert "logo.png" in detail
+    assert "338x191" in detail
+    assert "300" in detail
+
+
+@pytest.mark.asyncio
+async def test_freezone_video_generation_skips_dimension_gate_for_non_seedance_backend(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """300~6000px 是火山 Seedance 的规则，别的模型不能拿它凭空 400。"""
+    captured: dict[str, object] = {}
+
+    async def fake_enqueue_project_task(_ctx: ProjectContext, **kwargs):
+        captured.update(kwargs)
+        return SimpleNamespace(
+            task_state=SimpleNamespace(task_id="task_video"),
+            backend="celery",
+            queue="node.node_a.video",
+        )
+
+    monkeypatch.setattr(
+        freezone_routes,
+        "get_task_backend",
+        lambda: SimpleNamespace(enqueue_project_task=fake_enqueue_project_task),
+    )
+    small = tmp_path / "logo.png"
+    Image.new("RGB", (338, 191), (255, 255, 255)).save(small, format="PNG")
+
+    result = await freezone_routes._start_or_enqueue_freezone_video_gen(
+        ctx=_project_ctx(tmp_path),
+        username="admin",
+        project="demo",
+        project_dir=tmp_path / "project",
+        output_dir=str(tmp_path / "output"),
+        job_id="job_other_model",
+        prompt="参考图生成",
+        reference_items=[{"type": "image", "path": str(small), "role": "图片1"}],
+        aspect_ratio="16:9",
+        resolution="720p",
+        duration_seconds=6,
+        generate_audio=False,
+        human_review=False,
+        scene_optimize=None,
+        backend="newapi_happyhorse-1.0",
+        gen_mode="allReference",
+        capabilities={},
+    )
+
+    assert result["data"]["task_type"] == "freezone_video_gen"
+    assert captured["task_type"] == "freezone_video_gen"

--- a/tests/test_freezone_video_backend.py
+++ b/tests/test_freezone_video_backend.py
@@ -40,6 +40,7 @@ from novelvideo.freezone.video_node import (
     summarize_omni_reference_counts,
     sync_mainline_assets_into_library,
     validate_omni_reference_audio_durations,
+    validate_omni_reference_image_dimensions,
     validate_omni_reference_limits,
 )
 
@@ -800,3 +801,52 @@ def test_validate_reference_duration_uses_video_label() -> None:
             total_max_seconds=None,
             media_label="video",
         )
+
+
+def _write_png(path: Path, width: int, height: int) -> Path:
+    from PIL import Image
+
+    Image.new("RGB", (width, height), (255, 255, 255)).save(path, format="PNG")
+    return path
+
+
+def test_validate_omni_reference_image_dimensions_rejects_small_image(
+    tmp_path: Path,
+) -> None:
+    """3060 实例：338x191 的参考图被火山 HeightTooSmall 打回，要在入队前拦住。"""
+    small = _write_png(tmp_path / "logo.png", 338, 191)
+    ok = _write_png(tmp_path / "frame.png", 1280, 720)
+
+    with pytest.raises(ValueError) as exc:
+        validate_omni_reference_image_dimensions([str(ok), str(small)])
+
+    message = str(exc.value)
+    assert "logo.png" in message
+    assert "338x191" in message
+    assert "300" in message
+    assert "frame.png" not in message
+
+
+def test_validate_omni_reference_image_dimensions_accepts_valid_and_skips_unreadable(
+    tmp_path: Path,
+) -> None:
+    ok = _write_png(tmp_path / "frame.png", 1280, 720)
+    missing = tmp_path / "missing.png"
+    not_an_image = tmp_path / "notes.txt"
+    not_an_image.write_text("hello", encoding="utf-8")
+
+    validate_omni_reference_image_dimensions(
+        [str(ok), str(missing), str(not_an_image), ""]
+    )
+
+
+def test_validate_omni_reference_image_dimensions_rejects_extreme_aspect_ratio(
+    tmp_path: Path,
+) -> None:
+    banner = _write_png(tmp_path / "banner.png", 3000, 400)
+
+    with pytest.raises(ValueError) as exc:
+        validate_omni_reference_image_dimensions([str(banner)])
+
+    assert "banner.png" in str(exc.value)
+    assert "0.4" in str(exc.value) and "2.5" in str(exc.value)

--- a/tests/test_p0g4c_video_egress.py
+++ b/tests/test_p0g4c_video_egress.py
@@ -1463,3 +1463,150 @@ async def test_freezone_platform_context_preserves_legacy_leaf(
 
     assert len(calls) == 1
     assert "egress_context" not in calls[0]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("poll_response", "expected_error"),
+    [
+        (
+            {
+                "status": "failed",
+                "error": {
+                    "code": "VIDEO_MEDIA_DIMENSIONS_INVALID",
+                    "message": "素材尺寸不符合要求 secret-canary",
+                },
+            },
+            "VIDEO_MEDIA_DIMENSIONS_INVALID",
+        ),
+        (
+            {
+                "status": "failed",
+                "error_message": (
+                    "素材审核失败（共 1 个素材）：\n\n[1] 素材：https://relay.example/"
+                    "a.jpg?OSSAccessKeyId=secret-canary\n    原因：[InvalidParameter."
+                    "HeightTooSmall] Height must be between 300px and 6000px."
+                ),
+            },
+            "VIDEO_MEDIA_DIMENSIONS_INVALID",
+        ),
+        (
+            {
+                "status": "failed",
+                "error": {"code": "weird secret-canary", "message": "x"},
+            },
+            "EGRESS_OPERATION_UNKNOWN",
+        ),
+    ],
+)
+async def test_newapi_organization_failures_keep_safe_provider_error_codes(
+    monkeypatch,
+    tmp_path: Path,
+    poll_response: dict,
+    expected_error: str,
+) -> None:
+    """厂商明确打回（尺寸/审核）时，组织账号要拿到可读的错误码而不是一律 UNKNOWN。
+
+    2026-08-26 3060 上 creator02-zhu 的参考图 338x191 被火山 HeightTooSmall 拒了 8 次，
+    用户只看到 `EGRESS_OPERATION_UNKNOWN`。放行的只能是 `VIDEO_*` 这种枚举码，
+    厂商原文（含带签名的 relay URL）依旧不能进 result。
+    """
+    from novelvideo.generators.video_generator import (
+        NewApiVideoGenerator,
+        VideoGenStatus,
+    )
+
+    context = _context()
+    operation_port = _OperationPort()
+    events: list[str] = []
+    _install_newapi_ports(monkeypatch, context, operation_port, events)
+    generator = NewApiVideoGenerator(
+        model="seedance-2.0", egress_context=context
+    )
+    refund_errors: list[str] = []
+
+    async def post(*_args, **_kwargs):
+        return {"id": "provider-job-1"}
+
+    async def poll(*_args, **_kwargs):
+        return poll_response
+
+    async def capture_refund(*_args, **kwargs):
+        refund_errors.append(str(kwargs.get("error") or ""))
+
+    monkeypatch.setattr(generator, "_post_json", post)
+    monkeypatch.setattr(generator, "_get_json", poll)
+    monkeypatch.setattr(
+        generator, "_revalidate_organization", lambda _context: _async_none()
+    )
+    monkeypatch.setattr(
+        "novelvideo.generators.video_generator._refund_video_model_call",
+        capture_refund,
+    )
+
+    result = await generator.generate(
+        image_path=None,
+        prompt="prompt",
+        output_path=str(tmp_path / "video.mp4"),
+        episode=1,
+        beat_num=2,
+        scope="beat",
+        task_type="single_video",
+        max_polls=1,
+    )
+
+    assert result.status is VideoGenStatus.FAILED
+    assert result.error == expected_error
+    assert "secret-canary" not in repr(result)
+    assert refund_errors == [expected_error]
+    assert [name for name, _ in operation_port.events] == [
+        "claim",
+        "accepted",
+        "unknown",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_newapi_organization_submit_rejection_keeps_safe_provider_error_code(
+    monkeypatch, tmp_path: Path
+) -> None:
+    """网关在提交阶段就用 `VIDEO_*` 码打回时，组织账号同样拿到该码，不泄漏响应原文。"""
+    from novelvideo.generators.video_generator import (
+        NewApiVideoError,
+        NewApiVideoGenerator,
+        VideoGenStatus,
+    )
+
+    context = _context()
+    operation_port = _OperationPort()
+    events: list[str] = []
+    _install_newapi_ports(monkeypatch, context, operation_port, events)
+    generator = NewApiVideoGenerator(model="seedance-2.0", egress_context=context)
+
+    async def rejected(*_args, **_kwargs):
+        raise NewApiVideoError(
+            'DramaClawAPI submit failed: HTTP 400 - {"error": {"code": '
+            '"VIDEO_MEDIA_DIMENSIONS_INVALID", "message": "secret-canary"}}',
+            request_id="req-1",
+            status_code=400,
+        )
+
+    monkeypatch.setattr(generator, "_post_json", rejected)
+    monkeypatch.setattr(
+        generator, "_revalidate_organization", lambda _context: _async_none()
+    )
+
+    result = await generator.generate(
+        image_path=None,
+        prompt="prompt",
+        output_path=str(tmp_path / "video.mp4"),
+        episode=1,
+        beat_num=2,
+        scope="beat",
+        task_type="single_video",
+    )
+
+    assert result.status is VideoGenStatus.FAILED
+    assert result.error == "VIDEO_MEDIA_DIMENSIONS_INVALID"
+    assert "secret-canary" not in repr(result)
+    assert [name for name, _ in operation_port.events] == ["claim", "unknown"]

--- a/tests/test_task_credit_errors.py
+++ b/tests/test_task_credit_errors.py
@@ -26,8 +26,11 @@ from novelvideo.shared.billing_errors import (
 from novelvideo.shared.provider_errors import (
     CONTENT_MODERATION_FAILED_CODE,
     CONTENT_MODERATION_FAILED_MESSAGE,
+    COPYRIGHT_POLICY_FAILED_MESSAGE,
     INPUT_IMAGE_POLICY_FAILED_MESSAGE,
     OUTPUT_VIDEO_POLICY_FAILED_MESSAGE,
+    VIDEO_MEDIA_DIMENSIONS_INVALID_CODE,
+    VIDEO_MEDIA_DIMENSIONS_INVALID_MESSAGE,
 )
 
 pytestmark = pytest.mark.m07
@@ -198,3 +201,56 @@ def test_celery_task_failure_reraises_non_business_base_exception(monkeypatch) -
 
     with pytest.raises(KeyboardInterrupt):
         celery_tasks._project_task_failure_for_exception(KeyboardInterrupt())
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "freezone video generation failed: VIDEO_MEDIA_DIMENSIONS_INVALID",
+        (
+            "freezone video generation failed: {'code': 'VIDEO_MEDIA_DIMENSIONS_INVALID', "
+            "'message': '素材尺寸不符合要求，宽度和高度需在 300 至 6000 像素之间。'}"
+        ),
+    ],
+)
+def test_celery_task_failure_maps_video_media_dimensions_invalid(
+    monkeypatch, text: str
+) -> None:
+    celery_tasks = _import_celery_tasks(monkeypatch)
+
+    error, metadata, handled = celery_tasks._project_task_failure_for_exception(
+        RuntimeError(text)
+    )
+
+    assert handled is True
+    assert error == VIDEO_MEDIA_DIMENSIONS_INVALID_MESSAGE
+    assert metadata["error_code"] == VIDEO_MEDIA_DIMENSIONS_INVALID_CODE
+    assert metadata["message"] == VIDEO_MEDIA_DIMENSIONS_INVALID_MESSAGE
+    assert "VIDEO_MEDIA_DIMENSIONS_INVALID" in metadata["provider_error"]
+
+
+def test_celery_task_failure_maps_provider_copyright_code_to_moderation(
+    monkeypatch,
+) -> None:
+    celery_tasks = _import_celery_tasks(monkeypatch)
+
+    error, metadata, handled = celery_tasks._project_task_failure_for_exception(
+        RuntimeError("freezone video generation failed: VIDEO_CONTENT_COPYRIGHT_RESTRICTED")
+    )
+
+    assert handled is True
+    assert error == COPYRIGHT_POLICY_FAILED_MESSAGE
+    assert metadata["error_code"] == CONTENT_MODERATION_FAILED_CODE
+    assert metadata["message"] == COPYRIGHT_POLICY_FAILED_MESSAGE
+
+
+def test_celery_task_failure_leaves_unknown_egress_code_unmapped(monkeypatch) -> None:
+    celery_tasks = _import_celery_tasks(monkeypatch)
+
+    error, metadata, handled = celery_tasks._project_task_failure_for_exception(
+        RuntimeError("freezone video generation failed: EGRESS_OPERATION_UNKNOWN")
+    )
+
+    assert handled is False
+    assert metadata == {}
+    assert "EGRESS_OPERATION_UNKNOWN" in error


### PR DESCRIPTION
## PR 类型 / Type of PR
- [x] 🐞 Bug 修复 / Bug fix
- [ ] ✨ 新功能 / Feature
- [ ] 📝 文档 / Documentation
- [ ] 🧹 重构 / 清理 / Refactor or cleanup
- [ ] ⚙️ 构建 / CI / Build or CI
- [ ] ⚠️ 破坏性变更 / Breaking change

## 改动说明 / What this PR does and why

**现象**：2026-08-26 14:30–14:43 CST，3060 上组织 `creator02-zhu` 的用户连点 8 次"重新生成"，全部报 `freezone video generation failed: EGRESS_OPERATION_UNKNOWN`。同时段其他用户视频正常。

**根因**：参考图 338×191，火山 Seedance 打回 `[InvalidParameter.HeightTooSmall] Height must be between 300px and 6000px.`（`model_call_logs.response_payload` 里 8 条都是它）。但组织账号的出口路径（`_safe_video_error_code`）为了防泄漏带签名的 relay URL，把厂商任何失败都抹成 `EGRESS_OPERATION_UNKNOWN`；同样的错误换成非组织用户能直接看到中文原因。积分每次都已 `feature_refund`，没有多扣。

**两处修复**：
1. **组织账号透出安全的厂商码**
   - `shared/provider_errors.py`：只放行 `VIDEO_[A-Z0-9_]+` 形态的枚举码，厂商原文绝不回传；网关 `error.code` 与只有 `error_message` 自由文本（带签名 URL 的那种）两种报文都能归类
   - `generators/video_generator.py`：轮询到 `failed` / 提交阶段 400 两条组织路径先归类，认不出才兜底 UNKNOWN
   - `task_backend/run_core.py`：`VIDEO_MEDIA_DIMENSIONS_INVALID` → 中文结构化失败；版权/音频敏感沿用前端已认识的 `CONTENT_MODERATION_FAILED`
2. **参考图尺寸入队前预检**（`freezone/video_node.py` + `api/routes/freezone.py`）
   - Seedance 系列在计费/入队**之前**校验 300~6000px、宽高比 0.4~2.5，命中直接 400 并点名文件：`参考图尺寸不符合要求，宽度和高度需在 300 至 6000 像素之间: logo.png (338x191)`
   - 不再走"预扣积分 → 上传 relay → 厂商拒 → 退款"一圈；happyhorse 等非 Seedance 模型不受影响
   - 读文件头走 `asyncio.to_thread`，避免 s3fs 上的同步 IO 卡住 API 事件循环

## 关联 issue / Linked issues
N/A

## 给 reviewer 的说明 / Notes for the reviewer
- **安全边界**：只有全大写枚举形态的 `VIDEO_*` 会穿过组织脱敏层；测试里用 `secret-canary` 断言了 `error.message` / `error_message`（含 `OSSAccessKeyId=`）/ 非枚举 `code` 三种情况都不进 `result`。
- **egress_operations 状态机不动**：厂商明确 failed 仍标 `unknown`，只改用户看到的错误码；如果觉得该单独一个终态，另开 PR 讨论。
- `tests/contract/test_m06_route_contracts.py` 的占位图从 4×4 改成 320×320——它只关心响应形状同构，占位图不该违反厂商真实约束。
- 全量 `pytest -n auto`：3939 passed / 16 skipped / 1 failed；那 1 条 `test_release_feed::test_project_version_is_single_source_of_truth` 是本地 `.venv` 可编辑安装元数据停在 1.3.2（pyproject 已 2.0.0），`uv sync` 即可，与本 PR 无关。
- `ruff check` 全过；`ruff format --check` 对 `provider_errors.py` / `video_node.py` 提示的重排是 main 上就有的漂移，没碰。

## 面向用户的变更 / User-facing change
```release-note
组织账号的视频生成被厂商拒绝时（参考图尺寸不合规、版权/敏感审核未过）现在会显示具体原因，不再是 EGRESS_OPERATION_UNKNOWN；Seedance 参考图小于 300px 或宽高比超出 0.4~2.5 会在提交时直接提示，不再预扣积分。
```

## 自检 / Checklist
- [x] 已自测，`uv run pytest` 通过 / Self-tested, `uv run pytest` passes
- [x] 必要的文档已更新 / Docs updated where needed（N/A，无文档变更）
- [x] 提交信息清晰（建议 Conventional Commits）/ Clear commits (Conventional Commits suggested)
- [x] 每个 commit 都已 `git commit -s` 附 DCO 签署 / Every commit signed off with `git commit -s` (DCO)
- [x] 我已阅读并同意[贡献者协议](../CONTRIBUTING.md#贡献者协议) / I've read and agree to the [contributor terms](../CONTRIBUTING.md#贡献者协议)

https://claude.ai/code/session_01GSUicJVVF6XE128iHLm68H
