### PR TITLE
chore: release v2.0.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "supertale-ce"
-version = "2.0.0"
+version = "2.0.1"
 description = "SuperTale Community Edition API and video pipeline"
 readme = "README.md"
 requires-python = ">=3.11,<3.13"

--- a/src/novelvideo/release-notes.md
+++ b/src/novelvideo/release-notes.md
@@ -1,41 +1,30 @@
 ---
-version: 2.0.0
+version: 2.0.1
 attention: medium
 ---
-# v2.0.0
+# v2.0.1
 
 ## User-facing Highlights (zh)
 
-- **全新结构化创作流程**: 新项目默认从原文直接构建分集、角色和场景，不再依赖知识图谱或向量化处理，导入与规划更快、更稳定；已有项目继续兼容原流程。
-- **组织与渠道协作升级**: 增加组织品牌、模型可见范围、项目授权和任务并发控制能力，让多组织、多渠道环境下的权限、额度和任务归属更加清晰。
-- **虾画与资产库全面增强**: 画布支持标签页、元素大纲、文本生成、图生图风格墙和 HappyHorse 1.1，资产库支持按用途和文件夹管理，常用创作操作更集中。
-- **模型渠道配置更灵活**: 官方媒体目录支持独立更新，自定义模型配置可同步，并可按渠道能力管理文本、图片、视频和音频模型，媒体请求协议与诊断信息也更加一致。
-- **任务执行与大画布更可靠**: 完善项目级存储隔离、队列限流、授权重试、计费结算和失败回收，同时通过缩略图与按需加载降低大型画布和资产库的等待与卡顿。
+- **视频生成失败原因更明确**: 组织账号遇到参考图尺寸不合规、版权或敏感内容审核失败时会显示具体原因；Seedance 参考图会在任务提交前检查尺寸，避免无效排队和积分预扣。
+- **登录页与虾画交互更顺手**: 优化登录弹窗、公告中心、画布列表、资产库上传、风格图墙和搭子画廊，并恢复登录页公告的正常加载。
+- **大型资产库浏览更流畅**: 图片仅在真正进入可见区域后加载，减少大型项目打开画布和滚动资产列表时的图片请求与解码压力。
+- **画布与项目分享增加配额提示**: 单个用户在项目内最多创建 25 张画布，单个项目最多分享给 25 人；达到上限时会直接说明原因。
 
 ## User-facing Highlights (en)
 
-- **New structured creation workflow**: New projects now build episodes, characters, and scenes directly from source text without requiring knowledge-graph or embedding processing, improving import speed and reliability while keeping existing projects compatible with the legacy flow.
-- **Stronger organization and channel collaboration**: Organization branding, model visibility, project grants, and task concurrency controls make permissions, quotas, and task ownership clearer in multi-organization and multi-channel deployments.
-- **Major Canvas and asset library upgrades**: Canvas now includes tabs, an element outline, AI text generation, an image style wall, and HappyHorse 1.1 support, while the asset library organizes media by purpose and folder.
-- **More flexible model channel configuration**: The official media catalog can update independently, custom model settings stay synchronized, and channels can be managed by text, image, video, and audio capabilities with more consistent media request diagnostics.
-- **More reliable execution at scale**: Project-scoped storage, queue limits, authorization retries, credit settlement, and failure recovery are hardened, while thumbnail and on-demand loading reduce stalls on large canvases and asset libraries.
+- **Clearer video generation failures**: Organization users now receive specific reasons for invalid reference dimensions, copyright checks, or content moderation failures. Seedance reference dimensions are validated before queueing to avoid unnecessary task submission and credit reservation.
+- **Smoother login and Canvas interactions**: The login dialog, announcement center, canvas list, asset upload flow, style gallery, and companion gallery have been refined, and login-page announcements load correctly again.
+- **Faster browsing in large asset libraries**: Images now load only after they actually enter the visible viewport, reducing unnecessary requests and decoding work in large projects.
+- **Quota guidance for canvases and sharing**: A user can create up to 25 canvases per project, and a project can be shared with up to 25 people. The interface explains the limit when it is reached.
 
-## New Features
+## Fixes
 
-- 新增结构化导入与双轨知识流水线，新项目默认使用结构化流程直接生成分集、角色和场景，同时兼容已有项目 (#352, #353, #354, #355, #367).
-- 增加组织品牌、组织模型可见范围和项目授权状态等多组织协作能力 (#274, #320, #345, #385, #389).
-- 支持官方媒体目录更新、自定义模型配置同步和按渠道能力管理模型 (#278, #308, #321).
-- 虾画新增标签页、元素大纲、文本生成、图生图风格墙与 HappyHorse 1.1，资产库增加用途分类和文件夹管理 (#276, #279, #288, #297, #318, #325).
-- 登录页增加可远程更新的公告入口 (#366, #379, #383).
-
-## Bug Fixes
-
-- 修复结构化项目中的章节映射、角色结果完整性、场景依赖、环境契约和解说配置等稳定性问题 (#351, #356, #359, #360, #362, #363, #364, #375).
-- 修复项目目录隔离、任务授权重试、队列限流、计费结算及 CE/EE 配置边界问题 (#309, #319, #324, #326, #327, #336, #339, #341).
-- 修复视频节点素材变化后模式未正确回退、视频编辑入口错误禁用及音频声线无效请求入队的问题 (#282, #338, #392).
+- 修复组织账号视频生成失败时只显示通用出口错误的问题，并增加 Seedance 参考图尺寸与宽高比预检 (#406).
+- 修复公告 JSON 域名未被前端 CSP 放行，导致登录页公告静默不显示的问题 (#395).
 
 ## Improvements
 
-- 统一媒体模型请求协议并补全模型调用诊断，减少渠道参数不一致导致的生成失败 (#292, #317).
-- 画布和资产库改用缩略图、聚合查询、视口附近加载和按需读取，降低大项目中的重复请求与媒体解码开销 (#329, #350, #380, #384, #386, #390).
-- 慢网络上传不再受固定 30 秒超时限制，并完善历史图片缩略图生成与缓存隔离 (#307, #344, #371, #376).
+- 优化登录页、公告中心、画布列表、资产库和搭子画廊的视觉与交互体验 (#405).
+- 增加画布与项目分享的前端配额提示，并让画布列表滚动时底部操作保持可见 (#391).
+- 资产图片改为进入真实可见区域后再加载，降低大项目浏览压力 (#396).

--- a/tests/test_release_feed.py
+++ b/tests/test_release_feed.py
@@ -114,7 +114,7 @@ def test_built_wheel_contains_parseable_release_notes_artifact(tmp_path: Path) -
 def test_project_version_is_single_source_of_truth() -> None:
     pyproject = tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))
 
-    assert pyproject["project"]["version"] == "2.0.0"
+    assert pyproject["project"]["version"] == "2.0.1"
     assert importlib.metadata.version("supertale-ce") == pyproject["project"]["version"]
     assert "__version__" not in Path("src/novelvideo/__init__.py").read_text(encoding="utf-8")
 

--- a/uv.lock
+++ b/uv.lock
@@ -3419,7 +3419,7 @@ wheels = [
 
 [[package]]
 name = "supertale-ce"
-version = "2.0.0"
+version = "2.0.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## PR 类型 / Type of PR
- [ ] 🐞 Bug 修复 / Bug fix
- [ ] ✨ 新功能 / Feature
- [x] 📝 文档 / Documentation
- [ ] 🧹 重构 / 清理 / Refactor or cleanup
- [x] ⚙️ 构建 / CI / Build or CI
- [ ] ⚠️ 破坏性变更 / Breaking change

## 改动说明 / What this PR does and why

准备 Dramaclaw v2.0.1 发布：

- 将项目版本和锁文件从 `2.0.0` 更新到 `2.0.1`
- 更新 Release Feed 版本真源测试
- 重写包内中英文发布说明，覆盖 v2.0.0 后合入的 5 个 PR
- 使用 `attention: medium` 提醒用户关注视频错误提示、公告恢复和交互体验修复

## 关联 issue / Linked issues

N/A

## 给 reviewer 的说明 / Notes for the reviewer

本 PR 仅修改版本元数据、锁文件、版本测试字面量和包内 release notes。合入后再创建 `v2.0.1` 标签和 GitHub Release；当前没有提前打标签。

验证结果：

- `UV_CACHE_DIR=/Users/newyue/claymorelab/.uv-cache uv lock --check`
- `UV_CACHE_DIR=/Users/newyue/claymorelab/.uv-cache uv run pytest tests/test_release_feed.py -q` (`12 passed`)
- `UV_CACHE_DIR=/Users/newyue/claymorelab/.uv-cache uv run pytest -n auto` (`3941 passed, 16 skipped`)
- `UV_CACHE_DIR=/Users/newyue/claymorelab/.uv-cache uv run python scripts/check_ce_port_closure.py`
- `UV_CACHE_DIR=/Users/newyue/claymorelab/.uv-cache uv run ruff check --output-format=concise .`
- `python3 scripts/lint_ce_imports.py`
- `python3 scripts/ce_allowlist.py`
- `python3 scripts/lint_ee_terms.py`
- `python3 scripts/lint_banned_words.py`
- `python3 scripts/check_dco.py origin/main..HEAD`
- `git diff --check`

## 面向用户的变更 / User-facing change

```release-note
v2.0.1 提供更明确的视频生成失败原因和 Seedance 参考图预检，恢复登录页公告，并优化登录、画布、资产库与大型项目图片加载体验。
```

## 自检 / Checklist
- [x] 已自测，`uv run pytest` 通过 / Self-tested, `uv run pytest` passes
- [x] 必要的文档已更新 / Docs updated where needed
- [x] 提交信息清晰（建议 Conventional Commits）/ Clear commits (Conventional Commits suggested)
- [x] 每个 commit 都已 `git commit -s` 附 DCO 签署 / Every commit signed off with `git commit -s` (DCO)
- [x] 我已阅读并同意[贡献者协议](../CONTRIBUTING.md#贡献者协议) / I have read and agree to the contributor terms
