### PR TITLE
fix(brainclaw): keep one project-scoped session per canvas

### DIFF
--- a/frontend/src/__tests__/features/freezone/canvas-agent-single-session-contract.test.ts
+++ b/frontend/src/__tests__/features/freezone/canvas-agent-single-session-contract.test.ts
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: Elastic-2.0
+// Copyright (c) 2026 ClaymoreLab
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+describe("Freezone canvas Agent session UI", () => {
+  it("keeps multi-session code but hides both creation actions", () => {
+    const shell = readFileSync(
+      resolve(process.cwd(), "src/features/freezone/FreezoneShell.tsx"),
+      "utf8",
+    );
+
+    expect(shell).toContain("const FREEZONE_MULTI_AGENT_SESSION_UI_ENABLED = false");
+    expect(shell).toContain("新建 Agent");
+    expect(shell).toContain("addFreezoneCanvasAgent");
+    expect(shell).toContain("initializeEmptyFreezoneAgentChat");
+    expect(shell).toContain("onAdd={handleAddAgent}");
+    expect(shell).toContain("selectFreezoneCanvasAgent(projectId, canvasId, DEFAULT_FREEZONE_AGENT_ID)");
+    expect(shell).toContain("const explicitAgentId = FREEZONE_MULTI_AGENT_SESSION_UI_ENABLED");
+    expect(shell).toContain("preferServerActive:");
+    expect(shell).toContain('aria-label={agentHistoryOpen ? "收起历史 Agent" : "打开历史 Agent"}');
+    expect(shell.match(/FREEZONE_MULTI_AGENT_SESSION_UI_ENABLED &&/g)?.length).toBeGreaterThanOrEqual(5);
+  });
+});

--- a/frontend/src/features/freezone/FreezoneShell.tsx
+++ b/frontend/src/features/freezone/FreezoneShell.tsx
@@ -132,6 +132,7 @@ import {
 } from "@/features/freezone/canvasChatCommands";
 import {
   addFreezoneCanvasAgent,
+  DEFAULT_FREEZONE_AGENT_ID,
   loadFreezoneCanvasAgentsWithSource,
   mergeFreezoneCanvasAgentsFromServer,
   readFreezoneAgentIdFromUrl,
@@ -191,6 +192,9 @@ const FREEZONE_CHAT_WIDTH_MAX = 760;
 const FREEZONE_AGENT_HISTORY_WIDTH_DEFAULT = 220;
 const FREEZONE_AGENT_HISTORY_WIDTH_MIN = 180;
 const FREEZONE_AGENT_HISTORY_WIDTH_MAX = 360;
+// Keep the multi-session implementation available for a future product mode,
+// but Freezone currently defines one Agent session per canvas.
+const FREEZONE_MULTI_AGENT_SESSION_UI_ENABLED = false;
 /**
  * 抽屉最多能挤到只剩这么宽的左侧内容。
  * - 工作流（浮层）：画布可以任意窄，360 只是别让它彻底消失。
@@ -2218,7 +2222,9 @@ function FreezoneChatDock({
   const [agentState, setAgentState] = useState<FreezoneCanvasAgentState>(() => {
     const loaded = loadFreezoneCanvasAgentsWithSource(projectId, canvasId);
     localAgentSelectionRef.current = loaded.hadStoredState;
-    return loaded.state;
+    return FREEZONE_MULTI_AGENT_SESSION_UI_ENABLED
+      ? loaded.state
+      : selectFreezoneCanvasAgent(projectId, canvasId, DEFAULT_FREEZONE_AGENT_ID);
   });
   const [busyAgentIds, setBusyAgentIds] = useState<Set<string>>(() => new Set());
   const activeAgentId = agentState.activeAgentId;
@@ -2226,20 +2232,29 @@ function FreezoneChatDock({
   useEffect(() => {
     const loaded = loadFreezoneCanvasAgentsWithSource(projectId, canvasId);
     localAgentSelectionRef.current = loaded.hadStoredState;
-    setAgentState(loaded.state);
+    setAgentState(
+      FREEZONE_MULTI_AGENT_SESSION_UI_ENABLED
+        ? loaded.state
+        : selectFreezoneCanvasAgent(projectId, canvasId, DEFAULT_FREEZONE_AGENT_ID),
+    );
   }, [canvasId, projectId]);
 
   useEffect(() => {
     let cancelled = false;
     const hadLocalSelection = localAgentSelectionRef.current;
-    const explicitAgentId = readFreezoneAgentIdFromUrl();
+    const explicitAgentId = FREEZONE_MULTI_AGENT_SESSION_UI_ENABLED
+      ? readFreezoneAgentIdFromUrl()
+      : null;
     void listServerFreezoneCanvasAgents(projectId, canvasId)
       .then((serverAgents) => {
         if (cancelled || serverAgents.length === 0) return;
         setAgentState(
           mergeFreezoneCanvasAgentsFromServer(projectId, canvasId, serverAgents, {
             explicitAgentId,
-            preferServerActive: !hadLocalSelection && !explicitAgentId,
+            preferServerActive:
+              FREEZONE_MULTI_AGENT_SESSION_UI_ENABLED
+              && !hadLocalSelection
+              && !explicitAgentId,
           }),
         );
       })
@@ -2425,32 +2440,36 @@ function FreezoneChatDock({
 
   const agentHeaderActions = (
     <>
-      <Button
-        type="button"
-        variant="ghost"
-        size="icon-sm"
-        onClick={handleHeaderAddAgent}
-        aria-label="新建 Agent"
-        title="新建 Agent"
-        className="text-muted-foreground hover:bg-white/[0.08] hover:text-foreground"
-      >
-        <Plus className="size-4" />
-      </Button>
-      <Button
-        type="button"
-        variant="ghost"
-        size="icon-sm"
-        onClick={() => setAgentHistoryOpen((value) => !value)}
-        aria-pressed={agentHistoryOpen}
-        aria-label={agentHistoryOpen ? "收起历史 Agent" : "打开历史 Agent"}
-        title={agentHistoryOpen ? "收起历史 Agent" : "打开历史 Agent"}
-        className={cn(
-          "text-muted-foreground hover:bg-white/[0.08] hover:text-foreground",
-          agentHistoryOpen && "bg-white/[0.08] text-foreground",
-        )}
-      >
-        {agentHistoryOpen ? <PanelRightClose className="size-4" /> : <PanelRightOpen className="size-4" />}
-      </Button>
+      {FREEZONE_MULTI_AGENT_SESSION_UI_ENABLED && (
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-sm"
+          onClick={handleHeaderAddAgent}
+          aria-label="新建 Agent"
+          title="新建 Agent"
+          className="text-muted-foreground hover:bg-white/[0.08] hover:text-foreground"
+        >
+          <Plus className="size-4" />
+        </Button>
+      )}
+      {FREEZONE_MULTI_AGENT_SESSION_UI_ENABLED && (
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-sm"
+          onClick={() => setAgentHistoryOpen((value) => !value)}
+          aria-pressed={agentHistoryOpen}
+          aria-label={agentHistoryOpen ? "收起历史 Agent" : "打开历史 Agent"}
+          title={agentHistoryOpen ? "收起历史 Agent" : "打开历史 Agent"}
+          className={cn(
+            "text-muted-foreground hover:bg-white/[0.08] hover:text-foreground",
+            agentHistoryOpen && "bg-white/[0.08] text-foreground",
+          )}
+        >
+          {agentHistoryOpen ? <PanelRightClose className="size-4" /> : <PanelRightOpen className="size-4" />}
+        </Button>
+      )}
     </>
   );
 
@@ -2572,14 +2591,16 @@ function FreezoneChatDock({
             </SheetHeader>
             <div className="relative flex min-h-0 flex-1 overflow-hidden">
               <div className="min-h-0 flex-1">{agentPanels}</div>
-              <div
-                className={cn(
-                  "absolute inset-y-0 right-0 z-20 w-[220px] border-l border-white/[0.08] bg-[#212121] shadow-[-16px_0_32px_rgba(0,0,0,0.18)] transition-transform duration-200",
-                  agentHistoryOpen ? "translate-x-0" : "translate-x-full",
-                )}
-              >
-                {agentHistoryPanel}
-              </div>
+              {FREEZONE_MULTI_AGENT_SESSION_UI_ENABLED && (
+                <div
+                  className={cn(
+                    "absolute inset-y-0 right-0 z-20 w-[220px] border-l border-white/[0.08] bg-[#212121] shadow-[-16px_0_32px_rgba(0,0,0,0.18)] transition-transform duration-200",
+                    agentHistoryOpen ? "translate-x-0" : "translate-x-full",
+                  )}
+                >
+                  {agentHistoryPanel}
+                </div>
+              )}
             </div>
           </SheetContent>
         </Sheet>
@@ -2685,7 +2706,7 @@ function FreezoneChatDock({
           <div className="min-w-0 shrink-0" style={{ width: `var(${CHAT_PANE_WIDTH_VAR})` }}>
             {agentPanels}
           </div>
-          {agentHistoryOpen && (
+          {FREEZONE_MULTI_AGENT_SESSION_UI_ENABLED && agentHistoryOpen && (
             <div
               className="group relative z-20 flex w-2 shrink-0 cursor-col-resize touch-none items-stretch justify-center bg-white/[0.03] transition-colors hover:bg-white/[0.08]"
               role="separator"
@@ -2797,16 +2818,18 @@ function FreezoneAgentHistoryPanel({
           </div>
         )}
       </div>
-      <Button
-        type="button"
-        variant="secondary"
-        size="sm"
-        className="mt-3 h-9 shrink-0 rounded-lg bg-white/[0.10] text-sm text-zinc-100 hover:bg-white/[0.16]"
-        onClick={onAdd}
-      >
-        <Plus className="mr-1.5 size-4" />
-        新建 Agent
-      </Button>
+      {FREEZONE_MULTI_AGENT_SESSION_UI_ENABLED && (
+        <Button
+          type="button"
+          variant="secondary"
+          size="sm"
+          className="mt-3 h-9 shrink-0 rounded-lg bg-white/[0.10] text-sm text-zinc-100 hover:bg-white/[0.16]"
+          onClick={onAdd}
+        >
+          <Plus className="mr-1.5 size-4" />
+          新建 Agent
+        </Button>
+      )}
     </div>
   );
 }

--- a/license-inventory.csv
+++ b/license-inventory.csv
@@ -579,6 +579,7 @@ frontend/src/__tests__/features/freezone/canvas-outline-list.test.ts,Elastic-2.0
 frontend/src/__tests__/features/freezone/canvas-tool-results.test.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/__tests__/features/freezone/canvasSaveCoordinator.test.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/__tests__/features/freezone/canvasSyncCore.test.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
+frontend/src/__tests__/features/freezone/canvas-agent-single-session-contract.test.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/__tests__/features/freezone/canvases-tab-create-limit.test.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/__tests__/features/freezone/canvases-tab-query.test.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/__tests__/features/freezone/canvases-tab.test.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation

--- a/src/novelvideo/chat/service.py
+++ b/src/novelvideo/chat/service.py
@@ -1603,25 +1603,28 @@ def _turn_disposition_for(event: Any) -> str:
 def _evidence_identity(
     project: str | None, store_scope: Any | None, agent_profile: str
 ) -> dict[str, str]:
-    """Name the episode and project this turn belongs to.
+    """Name the trajectory and project this turn belongs to.
 
     ``project_group_id`` is the DramaClaw project, or the home sentinel when
     there is none — BrainClaw refuses to invent a grouping it cannot see, so the
     caller must say "no project" explicitly rather than omit it.
 
-    ``trajectory_id`` is the most specific conversation scope available: a Freezone
-    canvas when there is one, otherwise the project-and-profile conversation.
-    That deliberately over-groups — every turn of one long conversation lands in
-    one family — because over-grouping only costs statistical power, while
-    under-grouping manufactures independence that does not exist and silently
-    inflates any sign test built on it.
+    ``trajectory_id`` is the most specific conversation scope available within
+    the project: a Freezone canvas-and-Agent profile when there is one,
+    otherwise the project-and-profile conversation. Project is part of both
+    names so a reused canvas ID cannot merge evidence families across projects;
+    the profile keeps the identity correct if multi-session UI is enabled again.
+    Within that boundary this deliberately over-groups — every turn of one long
+    conversation lands in one family — because over-grouping only costs
+    statistical power, while under-grouping manufactures independence that
+    does not exist.
     """
     from novelvideo.chat.hermes_egress import HOME_SCOPE_EGRESS_PROJECT_ID
 
     project_id = (project or "").strip() or HOME_SCOPE_EGRESS_PROJECT_ID
     canvas_id = str(getattr(store_scope, "canvas_id", "") or "").strip()
     trajectory_id = (
-        f"canvas:{canvas_id}"
+        f"canvas:{project_id}:{canvas_id}:{agent_profile}"
         if canvas_id
         else f"conversation:{project_id}:{agent_profile}"
     )

--- a/tests/test_hermes_evidence_identity_passthrough.py
+++ b/tests/test_hermes_evidence_identity_passthrough.py
@@ -67,14 +67,14 @@ def test_home_scope_states_the_absence_of_a_project_explicitly() -> None:
     assert identity["trajectory_id"].startswith("conversation:")
 
 
-def test_a_canvas_is_its_own_episode_and_a_project_groups_them() -> None:
+def test_a_canvas_is_its_own_trajectory_within_a_project() -> None:
     class Scope:
         canvas_id = "canvas-7"
 
     canvas = service._evidence_identity("proj-a", Scope(), "freezone:main")
     plain = service._evidence_identity("proj-a", None, "main")
 
-    assert canvas["trajectory_id"] == "canvas:canvas-7"
+    assert canvas["trajectory_id"] == "canvas:proj-a:canvas-7:freezone:main"
     assert canvas["trajectory_id"] != plain["trajectory_id"], "a canvas is not the plain conversation"
     # The project is what groups distinct episodes for fold-splitting.
     assert canvas["project_id"] == plain["project_id"] == "proj-a"
@@ -96,6 +96,28 @@ def test_different_projects_never_share_a_group() -> None:
     b = service._evidence_identity("proj-b", None, "main")
     assert a["project_id"] != b["project_id"]
     assert a["trajectory_id"] != b["trajectory_id"]
+
+
+def test_the_same_canvas_id_never_spans_projects() -> None:
+    class Scope:
+        canvas_id = "canvas-7"
+
+    a = service._evidence_identity("proj-a", Scope(), "freezone:main")
+    b = service._evidence_identity("proj-b", Scope(), "freezone:main")
+    assert a["project_id"] != b["project_id"]
+    assert a["trajectory_id"] != b["trajectory_id"]
+
+
+def test_agent_profiles_on_the_same_canvas_never_share_a_trajectory() -> None:
+    class Scope:
+        canvas_id = "canvas-7"
+
+    main = service._evidence_identity("proj-a", Scope(), "freezone:main")
+    future_session = service._evidence_identity(
+        "proj-a", Scope(), "freezone:agent-future"
+    )
+    assert main["project_id"] == future_session["project_id"]
+    assert main["trajectory_id"] != future_session["trajectory_id"]
 
 
 def test_the_turn_key_reaches_the_worker_through_every_hop() -> None:


### PR DESCRIPTION
## Summary
- derive canvas trajectory identity from project + canvas + Agent profile
- prevent canvas IDs from merging evidence across projects and preserve future multi-session separation
- keep all multi-session creation/history implementations intact
- hide both creation actions and the history-session UI behind one explicitly disabled product flag

## Verification
- 50 focused BrainClaw/Control Context tests passed on the exact PR head
- same canvas ID across projects yields distinct trajectories
- different Agent profiles on one project/canvas yield distinct trajectories
- 12 focused frontend tests passed
- TypeScript build check and full frontend production build passed