### PR TITLE
refactor(codex): keep ephemeral files in runtime

### DIFF
--- a/src/novelvideo/chat/codex_app_server.py
+++ b/src/novelvideo/chat/codex_app_server.py
@@ -72,13 +72,14 @@ def _deny_unexpected_approval(method: str, _params: dict | None) -> dict:
 
 
 def _control_dir() -> Path:
-    """Return a short, private directory for the home-node control socket."""
+    """Return the short, private system root for node-local IPC files."""
 
     # macOS limits Unix-domain socket paths to roughly 104 bytes. CODEX_HOME is
-    # intentionally below the configured state root and can easily exceed that
-    # in a local checkout, so the transport endpoint cannot live below it.
+    # intentionally below the configured state root and can easily exceed that.
+    # These files are operating-system IPC state, not DramaClaw runtime data, so
+    # keep them under a fixed short path instead of following TMPDIR/runtime.
     uid = os.getuid() if hasattr(os, "getuid") else os.getpid()
-    path = Path("/tmp") / f"dramaclaw-codex-{uid}"
+    path = Path("/tmp") / f"claymore-{uid}"
     path.mkdir(mode=0o700, parents=True, exist_ok=True)
     mode = path.lstat().st_mode
     if stat.S_ISLNK(mode) or not stat.S_ISDIR(mode):
@@ -87,16 +88,41 @@ def _control_dir() -> Path:
     return path
 
 
+def _runtime_root() -> Path:
+    configured = str(os.environ.get("NOVELVIDEO_RUNTIME_DIR", "") or "").strip()
+    if configured:
+        return Path(configured).expanduser().resolve()
+    data_root = str(os.environ.get("NOVELVIDEO_DATA_ROOT", "") or "").strip()
+    if data_root:
+        return (Path(data_root).expanduser() / "runtime").resolve()
+    return Path(__file__).resolve().parents[3] / "runtime"
+
+
 def _control_paths(codex_home: Path) -> tuple[Path, Path, Path]:
     identity = hashlib.sha256(str(codex_home.resolve()).encode("utf-8")).hexdigest()[
-        :20
+        :16
     ]
-    control_dir = _control_dir()
+    control_dir = _control_dir() / identity
+    control_dir.mkdir(mode=0o700, exist_ok=True)
+    mode = control_dir.lstat().st_mode
+    if stat.S_ISLNK(mode) or not stat.S_ISDIR(mode):
+        raise RuntimeError(f"Unsafe Codex App Server node directory: {control_dir}")
+    control_dir.chmod(0o700)
     return (
-        control_dir / f"{identity}.sock",
-        control_dir / f"{identity}.lock",
-        control_dir / f"{identity}.signature",
+        control_dir / "app-server.sock",
+        control_dir / "node-runtime.lock",
+        control_dir / "app-server.signature",
     )
+
+
+def _app_server_log_path(codex_home: Path) -> Path:
+    identity = hashlib.sha256(str(codex_home.resolve()).encode("utf-8")).hexdigest()[
+        :16
+    ]
+    log_dir = _runtime_root() / "codex" / "logs"
+    log_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
+    log_dir.chmod(0o700)
+    return log_dir / f"app-server-{identity}.log"
 
 
 def _signature_digest(signature: tuple[object, ...]) -> str:
@@ -260,7 +286,9 @@ class _SharedCodexRuntime:
                 # to start Codex become ambient authority for every later project.
                 process_env = _node_process_env(env)
                 process_env["CODEX_HOME"] = str(codex_home)
-                log_path = codex_home / "app-server.log"
+                log_path = _app_server_log_path(codex_home)
+                log_path.touch(mode=0o600, exist_ok=True)
+                log_path.chmod(0o600)
                 with log_path.open("ab") as log_file:
                     self._process = subprocess.Popen(
                         command,

--- a/src/novelvideo/chat/service.py
+++ b/src/novelvideo/chat/service.py
@@ -12,6 +12,7 @@ import os
 import re
 import shutil
 import sqlite3
+import stat
 import sys
 import threading
 import uuid
@@ -291,6 +292,16 @@ def _state_root() -> Path:
     if configured:
         return Path(configured).expanduser()
     return _repo_root() / "state"
+
+
+def _runtime_root() -> Path:
+    configured = os.environ.get("NOVELVIDEO_RUNTIME_DIR", "").strip()
+    if configured:
+        return Path(configured).expanduser()
+    data_root = os.environ.get("NOVELVIDEO_DATA_ROOT", "").strip()
+    if data_root:
+        return Path(data_root).expanduser() / "runtime"
+    return _repo_root() / "runtime"
 
 
 def _codex_node_home() -> Path:
@@ -4244,7 +4255,11 @@ def _write_codex_turn_token(
 ) -> Path:
     """Atomically create one credential file owned by exactly one Codex turn."""
 
-    token_root.mkdir(parents=True, exist_ok=True)
+    token_root.mkdir(mode=0o700, parents=True, exist_ok=True)
+    mode = token_root.lstat().st_mode
+    if stat.S_ISLNK(mode) or not stat.S_ISDIR(mode):
+        raise RuntimeError(f"Unsafe Codex turn-token directory: {token_root}")
+    token_root.chmod(0o700)
     scope_digest = hashlib.sha256(scope_key.encode("utf-8")).hexdigest()
     normalized_turn_id = str(business_turn_id or "").strip() or "turn"
     turn_slug = re.sub(r"[^A-Za-z0-9._-]+", "-", normalized_turn_id).strip("-._")
@@ -6258,23 +6273,10 @@ async def _stream_assistant_reply_codex(
             agent_kind="codex",
             ttl_seconds=CODEX_AGENT_SESSION_TTL_SECONDS,
         )
-        token_root = (
-            (
-                Path(project_state_dir)
-                if project_state_dir is not None
-                else (
-                    _project_state_dir(username, project)
-                    if project
-                    else _user_state_dir(username)
-                )
-            )
-            / "agents"
-            / "codex"
-            / "turn_tokens"
-        )
+        token_root = _runtime_root() / "codex" / "turn_tokens"
         token_file = _write_codex_turn_token(
             token_root,
-            scope_key=codex_scope_key,
+            scope_key=f"{username}\0{codex_scope_key}",
             business_turn_id=business_turn_id,
             token=agent_token,
         )

--- a/tests/test_chat_service_user_agent_scope.py
+++ b/tests/test_chat_service_user_agent_scope.py
@@ -1032,6 +1032,7 @@ async def test_codex_stream_passes_conversation_scope_to_thread_builder(
     expected_canvas,
 ):
     monkeypatch.setenv("NOVELVIDEO_STATE_DIR", str(tmp_path / "state"))
+    monkeypatch.setenv("NOVELVIDEO_RUNTIME_DIR", str(tmp_path / "runtime"))
     captured: dict[str, object] = {}
     revoked: list[str] = []
     history_sentinel = "CHATDB_HISTORY_MUST_NOT_REACH_CODEX"
@@ -1231,6 +1232,7 @@ async def test_codex_freezone_write_cannot_claim_success_without_tool_receipt(
     with_successful_tool,
 ):
     monkeypatch.setenv("NOVELVIDEO_STATE_DIR", str(tmp_path / "state"))
+    monkeypatch.setenv("NOVELVIDEO_RUNTIME_DIR", str(tmp_path / "runtime"))
     events = []
     revoked = []
 
@@ -1334,6 +1336,8 @@ async def test_codex_prompt_construction_failure_cleans_turn_credentials(
     tmp_path,
 ):
     project_state = tmp_path / "state" / "admin" / "project-a"
+    runtime_root = tmp_path / "runtime"
+    monkeypatch.setenv("NOVELVIDEO_RUNTIME_DIR", str(runtime_root))
     captured: dict[str, Path] = {}
     revoked: list[str] = []
     finished: list[str] = []
@@ -1393,7 +1397,10 @@ async def test_codex_prompt_construction_failure_cleans_turn_credentials(
     assert not captured["token_file"].exists()
     assert revoked == ["agent-token"]
     assert finished == ["failed"]
-    assert list((project_state / "agents" / "codex" / "turn_tokens").iterdir()) == []
+    token_root = runtime_root / "codex" / "turn_tokens"
+    assert list(token_root.iterdir()) == []
+    assert token_root.stat().st_mode & 0o777 == 0o700
+    assert not (project_state / "agents" / "codex" / "turn_tokens").exists()
 
 
 @pytest.mark.asyncio

--- a/tests/test_codex_app_server.py
+++ b/tests/test_codex_app_server.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 from contextlib import contextmanager
+import os
 import sqlite3
 import threading
 from types import SimpleNamespace
@@ -101,9 +102,34 @@ def test_control_socket_path_is_short_and_stable(monkeypatch, tmp_path):
     repeated = codex_app_server._control_paths(long_home)
 
     assert (socket_path, lock_path, signature_path) == repeated
-    assert socket_path.parent == control_dir
-    assert socket_path.suffix == ".sock"
-    assert len(socket_path.name) < 32
+    assert socket_path.parent.parent == control_dir
+    assert socket_path.name == "app-server.sock"
+    assert lock_path.name == "node-runtime.lock"
+    assert signature_path.name == "app-server.signature"
+    assert socket_path.parent.stat().st_mode & 0o777 == 0o700
+
+
+def test_control_files_use_system_tmp_while_logs_use_runtime(monkeypatch, tmp_path):
+    runtime_root = tmp_path / "runtime"
+    codex_home = tmp_path / "state" / ".codex-app-server"
+    monkeypatch.setenv("NOVELVIDEO_RUNTIME_DIR", str(runtime_root))
+
+    socket_path, lock_path, signature_path = codex_app_server._control_paths(
+        codex_home
+    )
+    log_path = codex_app_server._app_server_log_path(codex_home)
+
+    expected_control_root = Path("/tmp") / f"claymore-{os.getuid()}"
+    assert socket_path.parent.parent == expected_control_root
+    assert lock_path.parent == socket_path.parent
+    assert signature_path.parent == socket_path.parent
+    assert log_path.parent == runtime_root / "codex" / "logs"
+    assert not str(socket_path).startswith(str(codex_home))
+    assert not str(log_path).startswith(str(codex_home))
+    assert expected_control_root.stat().st_mode & 0o777 == 0o700
+    assert socket_path.parent.stat().st_mode & 0o777 == 0o700
+    assert len(os.fsencode(str(socket_path))) < 100
+    assert (runtime_root / "codex" / "logs").stat().st_mode & 0o777 == 0o700
 
 
 def test_control_socket_identity_changes_with_codex_home(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary

- keep durable Codex rollouts and SQLite under `state/.codex-app-server`
- keep node-local operating-system IPC under `/tmp/claymore-<uid>/<home-node-id>/`
- keep App Server logs under `NOVELVIDEO_RUNTIME_DIR/codex/logs`
- move per-turn gateway token files out of project state into `NOVELVIDEO_RUNTIME_DIR/codex/turn_tokens`
- enforce private `0700` directories and `0600` log/token files
- do not migrate legacy temporary files during the development phase

## Storage contract

- `output`: OSS-backed persistent project working set; unchanged
- `state`: node-local consistency state that cannot safely live on OSS; Codex home remains here
- `runtime`: disposable DramaClaw application logs and per-turn credentials
- `/tmp/claymore-<uid>/<home-node-id>/`: disposable operating-system process-control files (`node-runtime.lock`, `app-server.signature`, `app-server.sock`; future PID/token files belong here too)

The fixed `/tmp` control path is intentional: Unix-domain sockets have a short platform path limit, especially on macOS, so they must not inherit an arbitrarily long application runtime path.

## Verification

- `uv run ruff check src/novelvideo/chat/codex_app_server.py src/novelvideo/chat/service.py tests/test_codex_app_server.py tests/test_chat_service_user_agent_scope.py`
- `uv run pytest -q tests/test_docker_persistence_config.py tests/test_sandbox_roots.py tests/test_chat_service_user_agent_scope.py tests/test_codex_app_server.py` — 198 passed
- wheel release artifact test passed with network-enabled isolated build
- full backend run reached 4688 passed / 16 skipped; its only remaining code-independent failure was the staging license inventory omission for `canvas-agent-single-session-contract.test.ts`, which PR #410 now fixes
- `git diff --check`
