### PR TITLE
fix: validate video prompt prerequisites before enqueue

### DIFF
--- a/frontend/src/__tests__/components/episode/beat-workbench/video-pane.test.tsx
+++ b/frontend/src/__tests__/components/episode/beat-workbench/video-pane.test.tsx
@@ -11,6 +11,7 @@ import {
   shouldDisableDialogueOnlyBackendForBeat,
   VideoPane,
 } from "@/components/episode/beat-workbench/video-pane";
+import { BackendStatusError } from "@/lib/api-errors";
 import { useAspectRatioStore } from "@/stores/aspect-ratio-store";
 import type { Beat } from "@/types/episode";
 
@@ -820,6 +821,27 @@ describe("VideoPane Seedance2 inspector", () => {
     expect(toast.error).not.toHaveBeenCalledWith(
       "本 Beat 视频提示词生成失败",
     );
+  });
+
+  it("shows a missing-media prerequisite without starting task tracking", async () => {
+    const user = userEvent.setup();
+    const message = "Beat 1 缺少草图或首帧，请先生成草图或预览";
+    generateBeatVideoPromptMock.mockRejectedValueOnce(
+      new BackendStatusError(message, 409, {
+        ok: false,
+        code: "VIDEO_PROMPT_PREREQUISITE_REQUIRED",
+        error: message,
+      }),
+    );
+    renderPane(
+      makeBeat({ video_mode: "first_frame", video_prompt: "" }),
+      { defaultBackend: "newapi_seedance-1.0-pro-fast" },
+    );
+
+    await user.click(screen.getByRole("button", { name: "生成本 Beat 提示词" }));
+
+    expect(toast.error).toHaveBeenCalledWith(message);
+    expect(taskStartMock).not.toHaveBeenCalled();
   });
 
   it("renders keyframe prompt editing for 1.x keyframe beats", () => {

--- a/frontend/src/__tests__/lib/queries/seedance2-prompt.test.tsx
+++ b/frontend/src/__tests__/lib/queries/seedance2-prompt.test.tsx
@@ -17,7 +17,10 @@ import {
   useGenerateBeatVideoPrompt,
   useGenerateSeedance2Prompt,
 } from "@/lib/queries/video";
-import { BillingRuleNotConfiguredError } from "@/lib/api-errors";
+import {
+  BackendStatusError,
+  BillingRuleNotConfiguredError,
+} from "@/lib/api-errors";
 import { useAppStore } from "@/stores/app-store";
 
 const server = setupServer();
@@ -212,5 +215,33 @@ describe("1.x beat video prompt generation query", () => {
 
     await waitFor(() => expect(result.current.error).toBeDefined());
     expect(result.current.error).toBeInstanceOf(BillingRuleNotConfiguredError);
+  });
+
+  it("preserves the structured prerequisite message from the 1.x endpoint", async () => {
+    server.use(
+      http.post(
+        "http://localhost:3000/api/v1/projects/demo/episodes/1/beats/2/video-prompt/generate",
+        () =>
+          HttpResponse.json(
+            {
+              ok: false,
+              code: "VIDEO_PROMPT_PREREQUISITE_REQUIRED",
+              error: "Beat 2 缺少草图或首帧，请先生成草图或预览",
+            },
+            { status: 409 },
+          ),
+      ),
+    );
+
+    const { result } = renderHook(() => useGenerateBeatVideoPrompt("demo", 1), {
+      wrapper,
+    });
+    result.current.mutate({ beatNum: 2 });
+
+    await waitFor(() => expect(result.current.error).toBeDefined());
+    expect(result.current.error).toBeInstanceOf(BackendStatusError);
+    expect(result.current.error?.message).toBe(
+      "Beat 2 缺少草图或首帧，请先生成草图或预览",
+    );
   });
 });

--- a/license-inventory.csv
+++ b/license-inventory.csv
@@ -1813,6 +1813,7 @@ src/novelvideo/verification/utils.py,Elastic-2.0,2026 SuperTale contributors,REU
 src/novelvideo/verification/version_hash.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 src/novelvideo/video_billing.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 src/novelvideo/video_duration.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
+src/novelvideo/video_prompt_prerequisite.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 src/novelvideo/video_request_usage.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 src/novelvideo/workflows/__init__.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 src/novelvideo/workflows/literal_script_writing.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation

--- a/src/novelvideo/api/routes/scripts.py
+++ b/src/novelvideo/api/routes/scripts.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException
+from fastapi.responses import JSONResponse
 
 logger = logging.getLogger("novelvideo.api.scripts")
 
@@ -29,6 +30,10 @@ from novelvideo.api.schemas import (
 from novelvideo.models import sync_beat_asset_refs
 from novelvideo.ports import get_task_backend, get_usage_meter
 from novelvideo.task_identity import project_task_state_key
+from novelvideo.video_prompt_prerequisite import (
+    VideoPromptPrerequisiteError,
+    video_prompt_prerequisite_response,
+)
 
 router = APIRouter()
 
@@ -75,6 +80,41 @@ def _first_existing_path(*paths: Path) -> str:
     return ""
 
 
+def _require_beat_video_prompt_prerequisites(
+    *,
+    output_dir: str | Path,
+    episode: int,
+    beat: dict[str, Any],
+    next_beat: dict[str, Any] | None,
+    field: str,
+) -> None:
+    from novelvideo.utils.path_resolver import PathResolver
+
+    paths = PathResolver(str(output_dir), episode)
+    beat_num = int(beat.get("beat_number") or 0)
+    if field == "keyframe_prompt":
+        current_path = _first_existing_path(paths.frame(beat_num), paths.sketch(beat_num))
+        if not current_path:
+            raise VideoPromptPrerequisiteError(
+                f"Beat {beat_num} 缺少首帧或草图，请先生成预览或草图"
+            )
+        next_beat_num = int((next_beat or {}).get("beat_number") or beat_num + 1)
+        next_path = _first_existing_path(
+            paths.frame(next_beat_num), paths.sketch(next_beat_num)
+        )
+        if not next_path:
+            raise VideoPromptPrerequisiteError(
+                f"Beat {next_beat_num} 缺少首帧或草图，请先生成预览或草图"
+            )
+        return
+
+    current_path = _first_existing_path(paths.sketch(beat_num), paths.frame(beat_num))
+    if not current_path:
+        raise VideoPromptPrerequisiteError(
+            f"Beat {beat_num} 缺少草图或首帧，请先生成草图或预览"
+        )
+
+
 async def _generate_single_beat_video_prompt(
     *,
     store: Any | None = None,
@@ -98,7 +138,9 @@ async def _generate_single_beat_video_prompt(
     paths = PathResolver(str(output_dir), episode)
     sketch_image_path = _first_existing_path(paths.sketch(beat_num), paths.frame(beat_num))
     if not sketch_image_path:
-        raise ValueError(f"Beat {beat_num} 缺少草图或首帧，请先生成草图或预览")
+        raise VideoPromptPrerequisiteError(
+            f"Beat {beat_num} 缺少草图或首帧，请先生成草图或预览"
+        )
 
     beats = list(all_beats or [beat])
     characters = []
@@ -150,9 +192,13 @@ async def _generate_single_beat_keyframe_prompt(
         paths.frame(next_beat_num), paths.sketch(next_beat_num)
     )
     if not first_frame_path:
-        raise ValueError(f"Beat {beat_num} 缺少首帧或草图，请先生成预览或草图")
+        raise VideoPromptPrerequisiteError(
+            f"Beat {beat_num} 缺少首帧或草图，请先生成预览或草图"
+        )
     if not last_frame_path:
-        raise ValueError(f"Beat {next_beat_num} 缺少首帧或草图，请先生成预览或草图")
+        raise VideoPromptPrerequisiteError(
+            f"Beat {next_beat_num} 缺少首帧或草图，请先生成预览或草图"
+        )
 
     audio_type = str(beat.get("audio_type") or "narration")
     narration = str(beat.get("narration_segment") or "")
@@ -429,13 +475,25 @@ async def generate_beat_video_prompt(
     )
 
     try:
-        _, _, field = await _resolve_beat_video_prompt_target(
+        target, next_beat, field = await _resolve_beat_video_prompt_target(
             store=store,
             episode_num=episode_num,
             beat_num=beat_num,
         )
+        _require_beat_video_prompt_prerequisites(
+            output_dir=resolved.output_dir,
+            episode=episode_num,
+            beat=target,
+            next_beat=next_beat,
+            field=field,
+        )
     except LookupError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except VideoPromptPrerequisiteError as exc:
+        return JSONResponse(
+            status_code=409,
+            content=video_prompt_prerequisite_response(exc),
+        )
     except ValueError as exc:
         return {"ok": False, "error": str(exc)}
 

--- a/src/novelvideo/task_backend/run_core.py
+++ b/src/novelvideo/task_backend/run_core.py
@@ -555,6 +555,7 @@ def _project_task_failure_for_exception(
     from novelvideo.identity_prerequisites import IdentityPlanningPrerequisiteError
     from novelvideo.novel_source import NovelImportRequiredError
     from novelvideo.scene_prerequisites import ScenePlanningPrerequisiteError
+    from novelvideo.video_prompt_prerequisite import VideoPromptPrerequisiteError
 
     if isinstance(exc, VoicePrerequisiteError):
         return str(exc), {"error_code": exc.error_code}, True
@@ -566,6 +567,9 @@ def _project_task_failure_for_exception(
         return str(exc), {"error_code": exc.error_code}, True
 
     if isinstance(exc, NovelImportRequiredError):
+        return str(exc), {"error_code": exc.error_code}, True
+
+    if isinstance(exc, VideoPromptPrerequisiteError):
         return str(exc), {"error_code": exc.error_code}, True
 
     if isinstance(exc, TaskTimedOut):

--- a/src/novelvideo/video_prompt_prerequisite.py
+++ b/src/novelvideo/video_prompt_prerequisite.py
@@ -1,0 +1,20 @@
+"""Business errors for video-prompt media prerequisites."""
+
+from __future__ import annotations
+
+
+VIDEO_PROMPT_PREREQUISITE_REQUIRED_CODE = "VIDEO_PROMPT_PREREQUISITE_REQUIRED"
+
+
+class VideoPromptPrerequisiteError(ValueError):
+    error_code = VIDEO_PROMPT_PREREQUISITE_REQUIRED_CODE
+
+
+def video_prompt_prerequisite_response(
+    exc: VideoPromptPrerequisiteError,
+) -> dict[str, str | bool]:
+    return {
+        "ok": False,
+        "code": exc.error_code,
+        "error": str(exc),
+    }

--- a/tests/contract/test_m03_episodes_scripts_content.py
+++ b/tests/contract/test_m03_episodes_scripts_content.py
@@ -431,6 +431,12 @@ def test_m03_l2_covers_episodes_scripts_and_content_endpoints(m03_client):
     )
     assert missing_beat.status_code == 404
 
+    from novelvideo.utils.path_resolver import PathResolver
+
+    sketch_path = PathResolver(str(store.project_dir), 1).sketch(1)
+    sketch_path.parent.mkdir(parents=True, exist_ok=True)
+    sketch_path.write_bytes(b"sketch")
+
     video_prompt = client.post(
         "/api/v1/projects/demo/episodes/1/beats/1/video-prompt/generate",
         json={"language": "zh"},

--- a/tests/contract/test_m03_task_completion.py
+++ b/tests/contract/test_m03_task_completion.py
@@ -358,6 +358,12 @@ def test_script_and_video_prompt_tasks_complete_with_sorted_persisted_beats(m03_
         (20, 3),
     ]
 
+    from novelvideo.utils.path_resolver import PathResolver
+
+    sketch_path = PathResolver(str(ctx.output_dir), 1).sketch(1)
+    sketch_path.parent.mkdir(parents=True, exist_ok=True)
+    sketch_path.write_bytes(b"sketch")
+
     video_prompt_response = client.post(
         "/api/v1/projects/proj_m03_completion/episodes/1/beats/1/video-prompt/generate",
         json={},

--- a/tests/test_api_seedance2_prompt_route.py
+++ b/tests/test_api_seedance2_prompt_route.py
@@ -160,6 +160,11 @@ def _project_ctx(tmp_path: Path) -> ProjectContext:
     )
 
 
+def _write_test_image(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    Image.new("RGB", (8, 8), "white").save(path)
+
+
 def test_generate_seedance2_prompt_updates_config_json(monkeypatch, tmp_path):
     from novelvideo.seedance2_i2v import panel_service
 
@@ -424,6 +429,10 @@ def test_generate_beat_video_prompt_updates_first_frame_video_prompt(
         ],
     )
 
+    from novelvideo.utils.path_resolver import PathResolver
+
+    _write_test_image(PathResolver(str(tmp_path), 1).sketch(1))
+
     response = client.post(
         "/projects/demo/episodes/1/beats/1/video-prompt/generate",
         json={"language": "en"},
@@ -503,6 +512,10 @@ def test_generate_beat_video_prompt_enqueues_project_task_in_celery_mode(
     app.dependency_overrides[scripts.get_api_user] = lambda: {"username": "admin"}
     client = TestClient(app)
 
+    from novelvideo.utils.path_resolver import PathResolver
+
+    _write_test_image(PathResolver(str(tmp_path), 1).sketch(1))
+
     response = client.post(
         "/projects/demo/episodes/1/beats/1/video-prompt/generate",
         json={"language": "en"},
@@ -528,6 +541,82 @@ def test_generate_beat_video_prompt_enqueues_project_task_in_celery_mode(
         "display_name": "生成提示词 · EP1 / Beat 1",
     }
     assert store.updates == []
+
+
+def test_generate_beat_video_prompt_rejects_missing_media_before_enqueue(
+    monkeypatch, tmp_path
+):
+    from types import SimpleNamespace
+
+    from novelvideo.api.deps import ProjectResolution
+    from novelvideo.api.routes import scripts
+
+    ctx = _project_ctx(tmp_path)
+    store = DummySqliteStore(
+        [
+            {
+                "beat_number": 1,
+                "video_mode": "first_frame",
+                "video_prompt": "",
+            },
+            {"beat_number": 2},
+        ]
+    )
+    enqueue_calls = 0
+
+    async def fake_resolve_project_scope(project, user, *, required_role="viewer"):
+        return ProjectResolution(
+            ctx=ctx,
+            username="admin",
+            project_name="demo",
+            project_dir=tmp_path,
+            output_dir=str(tmp_path),
+            state_dir=str(tmp_path / "state"),
+            runtime_dir=str(tmp_path / "runtime"),
+        )
+
+    async def fake_make_sqlite_store_for_context(ctx_arg):
+        assert ctx_arg is ctx
+        return store
+
+    async def fake_enqueue_project_task(ctx_arg, **kwargs):
+        nonlocal enqueue_calls
+        enqueue_calls += 1
+        return SimpleNamespace(
+            task_state=SimpleNamespace(task_id="must_not_enqueue"),
+            backend="celery",
+            queue="queue:default",
+        )
+
+    monkeypatch.setattr(scripts, "resolve_project_scope", fake_resolve_project_scope)
+    monkeypatch.setattr(
+        scripts,
+        "make_sqlite_store_for_context",
+        fake_make_sqlite_store_for_context,
+    )
+    monkeypatch.setattr(
+        scripts,
+        "get_task_backend",
+        lambda: SimpleNamespace(enqueue_project_task=fake_enqueue_project_task),
+    )
+
+    app = FastAPI()
+    app.include_router(scripts.router)
+    app.dependency_overrides[scripts.get_api_user] = lambda: {"username": "admin"}
+    client = TestClient(app)
+
+    response = client.post(
+        "/projects/demo/episodes/1/beats/1/video-prompt/generate",
+        json={"language": "zh"},
+    )
+
+    assert response.status_code == 409
+    assert response.json() == {
+        "ok": False,
+        "code": "VIDEO_PROMPT_PREREQUISITE_REQUIRED",
+        "error": "Beat 1 缺少草图或首帧，请先生成草图或预览",
+    }
+    assert enqueue_calls == 0
 
 
 @pytest.mark.asyncio
@@ -703,6 +792,12 @@ def test_generate_beat_video_prompt_updates_keyframe_prompt(monkeypatch, tmp_pat
             {"beat_number": 2},
         ],
     )
+
+    from novelvideo.utils.path_resolver import PathResolver
+
+    paths = PathResolver(str(tmp_path), 1)
+    _write_test_image(paths.frame(1))
+    _write_test_image(paths.frame(2))
 
     response = client.post(
         "/projects/demo/episodes/1/beats/1/video-prompt/generate",

--- a/tests/test_task_credit_errors.py
+++ b/tests/test_task_credit_errors.py
@@ -32,6 +32,10 @@ from novelvideo.shared.provider_errors import (
     VIDEO_MEDIA_DIMENSIONS_INVALID_CODE,
     VIDEO_MEDIA_DIMENSIONS_INVALID_MESSAGE,
 )
+from novelvideo.video_prompt_prerequisite import (
+    VIDEO_PROMPT_PREREQUISITE_REQUIRED_CODE,
+    VideoPromptPrerequisiteError,
+)
 
 pytestmark = pytest.mark.m07
 
@@ -83,6 +87,19 @@ def test_task_failure_maps_novel_import_prerequisite(monkeypatch) -> None:
     assert handled is True
     assert error == NOVEL_IMPORT_REQUIRED_MESSAGE
     assert metadata == {"error_code": NOVEL_IMPORT_REQUIRED_CODE}
+
+
+def test_task_failure_maps_video_prompt_prerequisite(monkeypatch) -> None:
+    celery_tasks = _import_celery_tasks(monkeypatch)
+    message = "Beat 1 缺少草图或首帧，请先生成草图或预览"
+
+    error, metadata, handled = celery_tasks._project_task_failure_for_exception(
+        VideoPromptPrerequisiteError(message)
+    )
+
+    assert handled is True
+    assert error == message
+    assert metadata == {"error_code": VIDEO_PROMPT_PREREQUISITE_REQUIRED_CODE}
 
 
 def test_task_failure_maps_identity_character_prerequisite(monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- validate sketch or first-frame prerequisites before admitting beat video-prompt tasks
- return a structured HTTP 409 business error and classify the Worker fallback as expected
- preserve the prerequisite message in the UI without starting task tracking

## Test Plan
- [x] Backend focused suite: 31 passed
- [x] Frontend focused suite: 68 passed
- [x] TypeScript project check
- [x] Ruff and git diff checks