### PR TITLE
fix(freezone): constrain workflow plan tool schema

### DIFF
--- a/.hermes/plugins/freezone/__init__.py
+++ b/.hermes/plugins/freezone/__init__.py
@@ -4662,6 +4662,187 @@ _SCOPE_PROPS = {
     "canvas_id": {"type": "string", "description": "Defaults to the current canvas context."},
 }
 
+_WORKFLOW_CATALOG_SCHEMA = {
+    "type": "object",
+    "description": (
+        "Catalog identity for this node. Executable nodes must name a Recipe allowed by "
+        "the plan's single Skill."
+    ),
+    "properties": {
+        "skillId": {"type": "string", "minLength": 1},
+        "skillVersion": {
+            "description": "Optional catalog Skill version, as a string or integer.",
+            "oneOf": [{"type": "string"}, {"type": "integer"}],
+        },
+        "recipeId": {"type": "string", "minLength": 1},
+        "recipeVersion": {
+            "description": "Optional catalog Recipe version, as a string or integer.",
+            "oneOf": [{"type": "string"}, {"type": "integer"}],
+        },
+        "recipePipeline": {
+            "type": "array",
+            "description": "Optional ordered follow-up Recipes from the same Skill.",
+            "items": {
+                "oneOf": [
+                    {"type": "string", "minLength": 1},
+                    {
+                        "type": "object",
+                        "properties": {
+                            "id": {"type": "string", "minLength": 1},
+                            "version": {
+                                "oneOf": [
+                                    {"type": "string"},
+                                    {"type": "integer"},
+                                ]
+                            },
+                        },
+                        "required": ["id"],
+                    },
+                ]
+            },
+        },
+    },
+}
+
+_WORKFLOW_NODE_PROPERTIES = {
+    "id": {"type": "string", "minLength": 1, "maxLength": 128},
+    "title": {"type": "string"},
+    "stage": {"type": "string"},
+    "content": {"type": "string"},
+    "prompt": {"type": "string"},
+    "data": {
+        "type": "object",
+        "properties": {"workflowCatalog": _WORKFLOW_CATALOG_SCHEMA},
+    },
+}
+
+_RECIPE_BACKED_WORKFLOW_NODE_SCHEMA = {
+    "type": "object",
+    "properties": {
+        **_WORKFLOW_NODE_PROPERTIES,
+        "node_type": {
+            "type": "string",
+            "enum": [
+                "textAnnotationNode",
+                "scriptNode",
+                "beatContextNode",
+                "imageGenNode",
+                "videoNode",
+                "audioNode",
+            ],
+        },
+        "data": {
+            "type": "object",
+            "properties": {
+                "workflowCatalog": {
+                    **_WORKFLOW_CATALOG_SCHEMA,
+                    "required": ["recipeId"],
+                }
+            },
+            "required": ["workflowCatalog"],
+        },
+    },
+    "required": ["id", "node_type", "data"],
+}
+
+_RESOURCE_TEXT_WORKFLOW_NODE_SCHEMA = {
+    "type": "object",
+    "properties": {
+        **_WORKFLOW_NODE_PROPERTIES,
+        "node_type": {"type": "string", "enum": ["textAnnotationNode"]},
+        "stage": {"type": "string", "enum": ["input", "resource", "asset"]},
+    },
+    "required": ["id", "node_type", "stage"],
+}
+
+_COMPOSE_WORKFLOW_NODE_SCHEMA = {
+    "type": "object",
+    "properties": {
+        **_WORKFLOW_NODE_PROPERTIES,
+        "node_type": {"type": "string", "enum": ["videoComposeNode"]},
+    },
+    "required": ["id", "node_type"],
+}
+
+_WORKFLOW_PLAN_OBJECT_SCHEMA = {
+    "type": "object",
+    "description": (
+        "Complete freezone_workflow_plan.v1 object. Send this as a JSON object, never as a "
+        "JSON-encoded string. It must reference exactly one valid Skill and explicit Recipes "
+        "for executable nodes."
+    ),
+    "properties": {
+        "schema_version": {
+            "type": "string",
+            "enum": ["freezone_workflow_plan.v1"],
+        },
+        "workflow_type": {"type": "string"},
+        "title": {"type": "string"},
+        "summary": {"type": "string"},
+        "inputs": {"type": "object"},
+        "skill": {
+            "type": "object",
+            "properties": {
+                "id": {"type": "string", "minLength": 1},
+                "version": {
+                    "description": "Optional catalog version, as a string or integer.",
+                },
+            },
+            "required": ["id"],
+        },
+        "nodes": {
+            "type": "array",
+            "minItems": 1,
+            "maxItems": 200,
+            "items": {
+                "anyOf": [
+                    _RECIPE_BACKED_WORKFLOW_NODE_SCHEMA,
+                    _RESOURCE_TEXT_WORKFLOW_NODE_SCHEMA,
+                    _COMPOSE_WORKFLOW_NODE_SCHEMA,
+                ]
+            },
+        },
+        "edges": {
+            "type": "array",
+            "description": (
+                "Dependency edges for one connected workflow graph. Multi-node plans must not "
+                "leave any node isolated."
+            ),
+            "maxItems": 400,
+            "items": {
+                "type": "object",
+                "properties": {
+                    "source": {"type": "string", "minLength": 1},
+                    "target": {"type": "string", "minLength": 1},
+                    "link_type": {
+                        "type": "string",
+                        "enum": [
+                            "context_for",
+                            "prompt_for",
+                            "dependency_for",
+                            "media_input_for",
+                            "derived_from",
+                            "composition_input_for",
+                        ],
+                    },
+                },
+                "required": ["source", "target", "link_type"],
+            },
+        },
+        "layout": {"type": "object"},
+    },
+    "required": ["schema_version", "skill", "nodes", "edges"],
+    "anyOf": [
+        {"properties": {"nodes": {"maxItems": 1}}},
+        {
+            "properties": {
+                "nodes": {"minItems": 2},
+                "edges": {"minItems": 1},
+            }
+        },
+    ],
+}
+
 _WORKFLOW_INTENT_OBJECT_SCHEMA = {
     "type": "object",
     "description": "Compact dynamic workflow decision. Do not send a full nodes/edges plan.",
@@ -6143,10 +6324,7 @@ TOOLS = (
             "Create one agent-authored dynamic Freezone WorkflowPlan in one frontend approval. A complete plan is required and strictly validated; fixed workflow_type/count/items template creation is disabled.",
             {
                 **_SCOPE_PROPS,
-                "plan": {
-                    "type": "object",
-                    "description": "Required complete freezone_workflow_plan.v1. It must reference exactly one valid Skill and explicit Recipes for executable nodes.",
-                },
+                "plan": _WORKFLOW_PLAN_OBJECT_SCHEMA,
                 "run_after_create": {
                     "type": "boolean",
                     "description": (

--- a/src/novelvideo/freezone/agent_workflows/graph.py
+++ b/src/novelvideo/freezone/agent_workflows/graph.py
@@ -469,6 +469,9 @@ def _node_data(
         result.setdefault("content", description.strip())
         result.setdefault("prompt", description.strip())
         result.setdefault("description", description.strip())
+    prompt = node.get("prompt")
+    if isinstance(prompt, str) and prompt.strip():
+        result.setdefault("prompt", prompt.strip())
     _normalize_model_alias(result, node_type)
     if node_type == "audioNode":
         result.setdefault("audioKind", "speech")

--- a/src/novelvideo/freezone/workflow_plan.py
+++ b/src/novelvideo/freezone/workflow_plan.py
@@ -171,7 +171,12 @@ def validate_workflow_plan(
         edges = []
     elif len(edges) > MAX_WORKFLOW_EDGES:
         errors.append(_issue("edges", f"must contain at most {MAX_WORKFLOW_EDGES} edges"))
+    elif len(node_types) > 1 and not edges:
+        errors.append(_issue("edges", "multi-node workflow must declare dependency edges"))
     adjacency: dict[str, list[str]] = {node_id: [] for node_id in node_types}
+    undirected_adjacency: dict[str, set[str]] = {
+        node_id: set() for node_id in node_types
+    }
     incoming_edges: dict[str, list[dict[str, Any]]] = {
         node_id: [] for node_id in node_types
     }
@@ -205,6 +210,9 @@ def validate_workflow_plan(
                         f"{link_type} is incompatible with {node_types[source]} -> {node_types[target]}",
                     )
                 )
+            else:
+                undirected_adjacency[source].add(target)
+                undirected_adjacency[target].add(source)
             adjacency[source].append(target)
             if (
                 link_type in {"media_input_for", "derived_from"}
@@ -301,6 +309,25 @@ def validate_workflow_plan(
                 _issue(
                     f"edges[{index}]",
                     "all videoComposeNode inputs must use composition_input_for",
+                )
+            )
+
+    if len(node_types) > 1 and edges:
+        first_node = next(iter(node_types))
+        connected = {first_node}
+        pending = [first_node]
+        while pending:
+            current = pending.pop()
+            for neighbor in undirected_adjacency[current] - connected:
+                connected.add(neighbor)
+                pending.append(neighbor)
+        disconnected = sorted(set(node_types) - connected)
+        if disconnected:
+            errors.append(
+                _issue(
+                    "edges",
+                    "workflow graph contains disconnected nodes: "
+                    + ", ".join(disconnected),
                 )
             )
 

--- a/tests/test_freezone_plugin.py
+++ b/tests/test_freezone_plugin.py
@@ -215,6 +215,13 @@ def _install_workflow_draft_api(monkeypatch, plugin, project_dir: Path) -> None:
 
 
 def test_freezone_plugin_registers_canvas_command_tools():
+    from novelvideo.freezone.workflow_plan import (
+        ALLOWED_LINK_TYPES,
+        ALLOWED_NODE_TYPES,
+        MAX_WORKFLOW_EDGES,
+        MAX_WORKFLOW_NODES,
+    )
+
     plugin = _load_plugin_module()
 
     names = {name for name, _schema, _handler in plugin.TOOLS}
@@ -251,6 +258,45 @@ def test_freezone_plugin_registers_canvas_command_tools():
     assert create_schema["required"] == ["plan"]
     assert "workflow_type" not in create_schema["properties"]
     assert "items" not in create_schema["properties"]
+    plan_schema = create_schema["properties"]["plan"]
+    assert plan_schema["type"] == "object"
+    assert plan_schema["required"] == ["schema_version", "skill", "nodes", "edges"]
+    assert plan_schema["properties"]["schema_version"]["enum"] == [
+        "freezone_workflow_plan.v1"
+    ]
+    assert plan_schema["properties"]["nodes"]["maxItems"] == MAX_WORKFLOW_NODES
+    node_variants = plan_schema["properties"]["nodes"]["items"]["anyOf"]
+    assert set(
+        node_type
+        for variant in node_variants
+        for node_type in variant["properties"]["node_type"]["enum"]
+    ) == ALLOWED_NODE_TYPES
+    recipe_variant = node_variants[0]
+    workflow_catalog = recipe_variant["properties"]["data"]["properties"][
+        "workflowCatalog"
+    ]
+    assert recipe_variant["required"] == ["id", "node_type", "data"]
+    assert workflow_catalog["required"] == ["recipeId"]
+    assert set(workflow_catalog["properties"]) >= {
+        "skillId",
+        "skillVersion",
+        "recipeId",
+        "recipeVersion",
+        "recipePipeline",
+    }
+    assert recipe_variant["properties"]["prompt"] == {"type": "string"}
+    assert plan_schema["properties"]["edges"]["items"]["required"] == [
+        "source",
+        "target",
+        "link_type",
+    ]
+    assert plan_schema["properties"]["edges"]["maxItems"] == MAX_WORKFLOW_EDGES
+    assert set(
+        plan_schema["properties"]["edges"]["items"]["properties"]["link_type"][
+            "enum"
+        ]
+    ) == ALLOWED_LINK_TYPES
+    assert plan_schema["properties"] != {}
     intent_schema = schemas["freezone_create_workflow_from_intent"]["parameters"]
     assert intent_schema["required"] == ["intent"]
     assert intent_schema["properties"]["intent"]["required"] == [
@@ -270,6 +316,74 @@ def test_freezone_plugin_registers_canvas_command_tools():
         "expected_revision",
         "changes",
     ]
+
+
+def test_workflow_graph_schema_rejects_missing_skill_and_executable_recipe():
+    from jsonschema import Draft202012Validator
+
+    plugin = _load_plugin_module()
+    schema = next(
+        schema
+        for name, schema, _handler in plugin.TOOLS
+        if name == "freezone_create_workflow_graph"
+    )["parameters"]["properties"]["plan"]
+    Draft202012Validator.check_schema(schema)
+    validator = Draft202012Validator(schema)
+    valid_plan = {
+        "schema_version": "freezone_workflow_plan.v1",
+        "skill": {"id": "ecommerce-product", "version": "1"},
+        "nodes": [
+            {
+                "id": "image-1",
+                "node_type": "imageGenNode",
+                "data": {
+                    "workflowCatalog": {
+                        "skillId": "ecommerce-product",
+                        "skillVersion": "1",
+                        "recipeId": "ecommerce-ad-image",
+                        "recipeVersion": "1",
+                        "recipePipeline": [
+                            {"id": "image-review", "version": "1"}
+                        ],
+                    }
+                },
+            }
+        ],
+        "edges": [],
+    }
+
+    assert validator.is_valid(valid_plan)
+    assert not validator.is_valid(
+        {key: value for key, value in valid_plan.items() if key != "skill"}
+    )
+    missing_recipe = copy.deepcopy(valid_plan)
+    missing_recipe["nodes"][0]["data"]["workflowCatalog"].pop("recipeId")
+    assert not validator.is_valid(missing_recipe)
+
+    disconnected_plan = copy.deepcopy(valid_plan)
+    second_node = copy.deepcopy(disconnected_plan["nodes"][0])
+    second_node["id"] = "image-2"
+    disconnected_plan["nodes"].append(second_node)
+    assert not validator.is_valid(disconnected_plan)
+    disconnected_plan["edges"] = [
+        {
+            "source": "image-1",
+            "target": "image-2",
+            "link_type": "dependency_for",
+        }
+    ]
+    assert validator.is_valid(disconnected_plan)
+
+    resource_plan = copy.deepcopy(valid_plan)
+    resource_plan["nodes"] = [
+        {
+            "id": "brief",
+            "node_type": "textAnnotationNode",
+            "stage": "input",
+            "data": {"content": "The user-provided brief."},
+        }
+    ]
+    assert validator.is_valid(resource_plan)
 
 
 def test_validation_payload_uses_only_the_declared_commands_contract():

--- a/tests/test_workflow_mcp.py
+++ b/tests/test_workflow_mcp.py
@@ -103,7 +103,12 @@ def test_graph_compiler_emits_one_grouped_canvas_batch():
                         "title": "测试提示词",
                         "content": "夜晚的未来城市",
                     },
-                    {"id": "frame", "node_type": "imageGenNode", "title": "测试首帧"},
+                    {
+                        "id": "frame",
+                        "node_type": "imageGenNode",
+                        "title": "测试首帧",
+                        "prompt": "霓虹灯下的未来城市首帧",
+                    },
                     {"id": "video", "node_type": "videoNode", "title": "测试视频"},
                 ],
                 "edges": [
@@ -127,3 +132,4 @@ def test_graph_compiler_emits_one_grouped_canvas_batch():
         "select_nodes",
     ]
     assert result["commands"][0]["data"]["title"] == "测试提示词"
+    assert result["commands"][1]["data"]["prompt"] == "霓虹灯下的未来城市首帧"

--- a/tests/test_workflow_plan.py
+++ b/tests/test_workflow_plan.py
@@ -1324,6 +1324,34 @@ def test_dynamic_workflow_plan_validates_skill_inputs(monkeypatch):
     assert valid["recommended_run_after_create"] is False
 
 
+def test_strict_workflow_plan_rejects_disconnected_multi_node_graph():
+    plan = _dynamic_plan(image_count=2)
+    plan["edges"] = []
+
+    result = validate_workflow_plan(plan)
+
+    assert result["ok"] is False
+    assert result["errors"] == [
+        {
+            "path": "edges",
+            "message": "multi-node workflow must declare dependency edges",
+        }
+    ]
+
+    partially_connected = _dynamic_plan(image_count=2)
+    partially_connected["edges"] = partially_connected["edges"][:1]
+
+    partial_result = validate_workflow_plan(partially_connected)
+
+    assert partial_result["ok"] is False
+    assert partial_result["errors"] == [
+        {
+            "path": "edges",
+            "message": "workflow graph contains disconnected nodes: product_image_2",
+        }
+    ]
+
+
 def test_strict_workflow_plan_rejects_unknown_node_bad_edge_and_cycle():
     plan = _dynamic_plan()
     plan["nodes"].append({"id": "invalid", "node_type": "inventedImageNode"})


### PR DESCRIPTION
## Summary
- publish the full `freezone_workflow_plan.v1` shape for `freezone_create_workflow_graph`
- require explicit Skill and Recipe identities for executable nodes
- reject empty or disconnected multi-node dependency graphs
- preserve top-level node prompts when compiling canvas commands
- pin node/link enums and limits to the runtime validator in tests

## Why
A malformed model-emitted workflow argument entered Responses history and caused BrainClaw to reject nine consecutive Evaluation Captures. The old model-visible plan schema exposed an empty properties object, providing no structural guidance. Partial graph validation could also allow disconnected work to execute in parallel, and top-level prompts were declared without reaching canvas node data.

## Verification
- `PYTHONPATH=/private/tmp/dramaclaw-workflow-schema-pr/src /Users/eric/Documents/GitHub/dramaclaw-brainclaw-routing-contract/.venv/bin/python -m pytest tests/test_freezone_plugin.py tests/test_workflow_plan.py tests/test_workflow_mcp.py -q`
- 136 passed
- Ruff passed for all changed Python files

## Compatibility
Single-node plans may still omit edges. Multi-node plans must form one weakly connected dependency graph, and top-level `nodes[].prompt` is normalized into `create_node.data.prompt`. These checks reject plans that previously reached the canvas with incomplete execution semantics.
