### PR TITLE
fix: summarize binary content in model call logs

### DIFF
--- a/src/novelvideo/llm_instrumentation.py
+++ b/src/novelvideo/llm_instrumentation.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import contextvars
 import logging
 import os
+from dataclasses import fields, is_dataclass
 from typing import Any, Optional
 
 logger = logging.getLogger("novelvideo.llm_instrumentation")
@@ -369,10 +370,23 @@ def _json_log_value(value: object, *, depth: int = 0) -> object:
     """Convert provider inputs/results to JSON-safe diagnostic values."""
     if value is None or isinstance(value, (str, int, float, bool)):
         return value
-    if isinstance(value, bytes):
-        return {"type": "bytes", "length": len(value)}
+    if isinstance(value, (bytes, bytearray, memoryview)):
+        size_bytes = value.nbytes if isinstance(value, memoryview) else len(value)
+        return {"type": "bytes", "size_bytes": size_bytes}
+    binary_data = getattr(value, "data", None)
+    if isinstance(binary_data, (bytes, bytearray, memoryview)):
+        size_bytes = (
+            binary_data.nbytes
+            if isinstance(binary_data, memoryview)
+            else len(binary_data)
+        )
+        return {
+            "type": type(value).__name__,
+            "media_type": str(getattr(value, "media_type", "") or ""),
+            "size_bytes": size_bytes,
+        }
     if depth >= 8:
-        return str(value)
+        return {"type": type(value).__name__, "truncated": True}
     if isinstance(value, dict):
         return {
             str(key): _json_log_value(item, depth=depth + 1)
@@ -380,16 +394,33 @@ def _json_log_value(value: object, *, depth: int = 0) -> object:
         }
     if isinstance(value, (list, tuple, set)):
         return [_json_log_value(item, depth=depth + 1) for item in value]
+    if is_dataclass(value) and not isinstance(value, type):
+        return {
+            "type": type(value).__name__,
+            "fields": {
+                field.name: _json_log_value(
+                    getattr(value, field.name), depth=depth + 1
+                )
+                for field in fields(value)
+            },
+        }
     model_dump = getattr(value, "model_dump", None)
     if callable(model_dump):
         try:
-            return _json_log_value(model_dump(mode="json"), depth=depth + 1)
+            return _json_log_value(model_dump(mode="python"), depth=depth + 1)
         except Exception:
             pass
     output = getattr(value, "output", None)
     if output is not None:
         return {"output": _json_log_value(output, depth=depth + 1)}
-    return str(value)
+    rendered = str(value)
+    if "BinaryContent(data=b" in rendered or "BinaryImage(data=b" in rendered:
+        return {
+            "type": type(value).__name__,
+            "omitted": True,
+            "reason": "nested_binary_repr",
+        }
+    return rendered
 
 
 def _provider_http_status(exc: BaseException) -> int | None:

--- a/tests/test_llm_instrumentation_logging.py
+++ b/tests/test_llm_instrumentation_logging.py
@@ -1,8 +1,13 @@
 from __future__ import annotations
 
+import base64
+import json
 from types import SimpleNamespace
 
 import pytest
+from pydantic import BaseModel, ConfigDict
+from pydantic_ai import BinaryContent, BinaryImage
+from pydantic_ai.messages import ModelRequest, UserPromptPart
 
 from novelvideo import llm_instrumentation
 from novelvideo import ports
@@ -12,7 +17,7 @@ from novelvideo.generators import video_generator
 def test_json_log_value_keeps_diagnostic_fields_json_safe() -> None:
     class Result:
         def model_dump(self, *, mode: str):
-            assert mode == "json"
+            assert mode == "python"
             return {
                 "api_key": "hm-7neo-rDyL-example",
                 "prompt": "保留完整提示词",
@@ -22,8 +27,101 @@ def test_json_log_value_keeps_diagnostic_fields_json_safe() -> None:
     assert llm_instrumentation._json_log_value(Result()) == {
         "api_key": "hm-7neo-rDyL-example",
         "prompt": "保留完整提示词",
-        "binary": {"type": "bytes", "length": 19},
+        "binary": {"type": "bytes", "size_bytes": 19},
     }
+
+
+def test_json_log_value_summarizes_binary_content_without_image_bytes() -> None:
+    png_bytes = b"\x89PNG\r\n\x1a\n" + (b"frame-data" * 128)
+    frames = [BinaryContent(data=png_bytes, media_type="image/png") for _ in range(10)]
+
+    logged = llm_instrumentation._json_log_value(["分析这些视频关键帧", *frames])
+
+    assert logged[0] == "分析这些视频关键帧"
+    assert logged[1:] == [
+        {
+            "type": "BinaryContent",
+            "media_type": "image/png",
+            "size_bytes": len(png_bytes),
+        }
+        for _ in range(10)
+    ]
+    serialized = json.dumps(logged)
+    assert "frame-data" not in serialized
+    assert "BinaryContent(data=" not in serialized
+    assert llm_instrumentation._json_log_value(frames[0], depth=8) == logged[1]
+
+
+def test_json_log_value_summarizes_other_binary_data_wrappers() -> None:
+    image = BinaryImage(data=b"image-data", media_type="image/webp")
+
+    assert llm_instrumentation._json_log_value(image) == {
+        "type": "BinaryImage",
+        "media_type": "image/webp",
+        "size_bytes": 10,
+    }
+    assert llm_instrumentation._json_log_value(memoryview(b"audio")) == {
+        "type": "bytes",
+        "size_bytes": 5,
+    }
+
+
+def test_json_log_value_recurses_through_message_history_dataclasses() -> None:
+    png_bytes = b"\x89PNG\r\n\x1a\n" + (b"private-frame-data" * 128)
+    request = ModelRequest(
+        parts=[
+            UserPromptPart(
+                content=[
+                    "保留完整提示词",
+                    BinaryContent(data=png_bytes, media_type="image/png"),
+                ]
+            )
+        ]
+    )
+
+    logged = llm_instrumentation._json_log_value({"message_history": [request]})
+
+    content = logged["message_history"][0]["fields"]["parts"][0]["fields"][
+        "content"
+    ]
+    assert content == [
+        "保留完整提示词",
+        {
+            "type": "BinaryContent",
+            "media_type": "image/png",
+            "size_bytes": len(png_bytes),
+        },
+    ]
+    serialized = json.dumps(logged, ensure_ascii=False)
+    assert "保留完整提示词" in serialized
+    assert "private-frame-data" not in serialized
+    assert "BinaryContent(data=" not in serialized
+
+
+def test_json_log_value_summarizes_binary_nested_in_pydantic_model() -> None:
+    class RequestDeps(BaseModel):
+        model_config = ConfigDict(arbitrary_types_allowed=True)
+
+        prompt: str
+        attachment: BinaryContent
+
+    media_bytes = b"private-pydantic-media" * 256
+    deps = RequestDeps(
+        prompt="保留 Pydantic 提示词",
+        attachment=BinaryContent(data=media_bytes, media_type="image/png"),
+    )
+
+    logged = llm_instrumentation._json_log_value(deps)
+
+    assert logged["prompt"] == "保留 Pydantic 提示词"
+    assert logged["attachment"]["data"] == {
+        "type": "bytes",
+        "size_bytes": len(media_bytes),
+    }
+    assert logged["attachment"]["media_type"] == "image/png"
+    serialized = json.dumps(logged, ensure_ascii=False)
+    assert base64.b64encode(media_bytes).decode("ascii") not in serialized
+    assert "private-pydantic-media" not in serialized
 
 
 def test_failure_log_metadata_keeps_only_normalized_provider_http_status() -> None:


### PR DESCRIPTION
## Summary

- Summarize binary diagnostic values before model dumping or string conversion.
- Preserve attachment type, media type, and byte size without logging raw media bytes.
- Cover BinaryContent, BinaryImage, and future wrappers exposing binary data.

## Scope

This changes observability serialization only. Provider requests, model inputs, task execution, and billing are unchanged.

## Tests

- `pytest tests/test_llm_instrumentation_logging.py`
- `ruff check src/novelvideo/llm_instrumentation.py tests/test_llm_instrumentation_logging.py`

## Related

Companion database-side guard: claymorelab/SuperTale#125.