### PR TITLE
feat(video): support file and link references

### DIFF
--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -3863,6 +3863,17 @@
         "videoEdit": "Video Edit"
       },
       "placeholder": "Describe the video to generate.",
+      "referenceDocument": {
+        "file": "Reference file",
+        "removeFile": "Remove reference file",
+        "linkPlaceholder": "Public URL",
+        "unsupportedType": "Unsupported file type. Allowed: {{types}}",
+        "fileTooLarge": "Reference files must be 100MB or smaller (current: {{size}}MB)",
+        "fileUnsupported": "This model does not support file references",
+        "linkUnsupported": "This model does not support web link references",
+        "invalidLink": "Enter a valid public HTTP/HTTPS URL",
+        "fileLinkConflict": "A reference file and web link cannot be used together"
+      },
       "submit": "Submit",
       "submitBusy": "Generating, please wait",
       "partialBatchFailed": "Generated {{ok}}/{{total}}, the rest failed",
@@ -4575,6 +4586,9 @@
         "referenceImageMax": "Reference image limit",
         "referenceVideoMax": "Reference video limit",
         "referenceAudioMax": "Reference audio limit",
+        "referenceFileMax": "Reference file limit",
+        "referenceLinkMax": "Reference link limit",
+        "referenceFileTypes": "File types (comma-separated)",
         "referenceAudioMinSeconds": "Minimum per audio clip (seconds)",
         "referenceAudioMaxSeconds": "Maximum per audio clip (seconds)",
         "referenceAudioTotalMinSeconds": "Minimum total audio (seconds)",

--- a/frontend/public/locales/zh/translation.json
+++ b/frontend/public/locales/zh/translation.json
@@ -3863,6 +3863,17 @@
         "videoEdit": "视频编辑"
       },
       "placeholder": "根据文字描述生成视频。",
+      "referenceDocument": {
+        "file": "参考文件",
+        "removeFile": "移除参考文件",
+        "linkPlaceholder": "公网 URL",
+        "unsupportedType": "文件类型不受支持，可选：{{types}}",
+        "fileTooLarge": "参考文件不能超过 100MB（当前 {{size}}MB）",
+        "fileUnsupported": "该模型不支持文件参考",
+        "linkUnsupported": "该模型不支持网页链接参考",
+        "invalidLink": "请输入有效的 HTTP/HTTPS 公开网页链接",
+        "fileLinkConflict": "参考文件和网页链接不能同时使用"
+      },
       "submit": "提交",
       "submitBusy": "生成中，请稍候",
       "partialBatchFailed": "已生成 {{ok}}/{{total}} 条，其余生成失败",
@@ -4575,6 +4586,9 @@
         "referenceImageMax": "参考图片上限",
         "referenceVideoMax": "参考视频上限",
         "referenceAudioMax": "参考音频上限",
+        "referenceFileMax": "参考文件上限",
+        "referenceLinkMax": "参考链接上限",
+        "referenceFileTypes": "文件类型（逗号分隔）",
         "referenceAudioMinSeconds": "单条音频最短（秒）",
         "referenceAudioMaxSeconds": "单条音频最长（秒）",
         "referenceAudioTotalMinSeconds": "音频合计最短（秒）",

--- a/frontend/src/api/ops.ts
+++ b/frontend/src/api/ops.ts
@@ -477,7 +477,7 @@ export async function submitFreezoneVideoEdit(
 
 // /freezone/video/omni-gen ------------------------------------------------ //
 
-export type FreezoneVideoReferenceType = "image" | "video" | "audio";
+export type FreezoneVideoReferenceType = "image" | "video" | "audio" | "file" | "link";
 
 export interface FreezoneVideoReferenceItem {
   type: FreezoneVideoReferenceType;
@@ -490,7 +490,7 @@ export interface FreezoneVideoOmniGenPayload extends FreezoneNodeContext {
   prompt: string;
   theme?: string;
   cameraTemplateId?: string | null;
-  /** mixed image/video/audio references. backend caps: image≤9, video≤3, audio≤3, total≤12. */
+  /** Mixed media references; file/link support and limits come from the model catalog. */
   references?: FreezoneVideoReferenceItem[];
   marks?: FreezoneVideoMark[];
   aspectRatio?: FreezoneVideoAspectRatio;
@@ -1137,6 +1137,9 @@ export interface FreezoneVideoModelInfo {
   referenceImageMax?: number | null;
   referenceVideoMax?: number | null;
   referenceAudioMax?: number | null;
+  referenceFileMax?: number | null;
+  referenceLinkMax?: number | null;
+  referenceFileTypes?: string[];
   referenceAudioMinSeconds?: number | null;
   referenceAudioMaxSeconds?: number | null;
   referenceAudioTotalMinSeconds?: number | null;
@@ -1223,6 +1226,9 @@ function videoModelEntryFromObject(
     referenceImageMax: pickNumber(entry, "referenceImageMax", "reference_image_max"),
     referenceVideoMax: pickNumber(entry, "referenceVideoMax", "reference_video_max"),
     referenceAudioMax: pickNumber(entry, "referenceAudioMax", "reference_audio_max"),
+    referenceFileMax: pickNumber(entry, "referenceFileMax", "reference_file_max"),
+    referenceLinkMax: pickNumber(entry, "referenceLinkMax", "reference_link_max"),
+    referenceFileTypes: pickStringArray(entry, "referenceFileTypes", "reference_file_types"),
     referenceAudioMinSeconds: pickNumber(
       entry,
       "referenceAudioMinSeconds",
@@ -2428,6 +2434,26 @@ export async function uploadFreezoneImage(
       method: "POST",
       body: fd,
       timeout: options?.timeoutMs ?? false,
+    },
+  ).json<{ ok: boolean; data?: FreezoneUploadResult; error?: string }>();
+  if (!resp.ok || !resp.data) {
+    throw new Error(resp.error ?? "upload failed");
+  }
+  return resp.data;
+}
+
+export async function uploadFreezoneReferenceFile(
+  project: string,
+  file: File,
+): Promise<FreezoneUploadResult> {
+  const fd = new FormData();
+  fd.append("file", file, file.name);
+  const resp = await apiClient(
+    `projects/${encodeURIComponent(project)}/freezone/reference-file-upload`,
+    {
+      method: "POST",
+      body: fd,
+      timeout: false,
     },
   ).json<{ ok: boolean; data?: FreezoneUploadResult; error?: string }>();
   if (!resp.ok || !resp.data) {

--- a/frontend/src/components/settings/settings-dialog.tsx
+++ b/frontend/src/components/settings/settings-dialog.tsx
@@ -4228,6 +4228,26 @@ function LocalMediaModelEditor({
                 min={0}
                 onChange={(value) => setCapability("referenceAudioMax", value)}
               />
+              <CatalogNumberField
+                label={t("settings.modelConfig.mediaModels.referenceFileMax")}
+                value={parsedConfig?.referenceFileMax}
+                min={0}
+                max={1}
+                onChange={(value) => setCapability("referenceFileMax", value)}
+              />
+              <CatalogNumberField
+                label={t("settings.modelConfig.mediaModels.referenceLinkMax")}
+                value={parsedConfig?.referenceLinkMax}
+                min={0}
+                max={1}
+                onChange={(value) => setCapability("referenceLinkMax", value)}
+              />
+              <CatalogListField
+                label={t("settings.modelConfig.mediaModels.referenceFileTypes")}
+                value={stringOptions("referenceFileTypes")}
+                onChange={(value) => setCapability("referenceFileTypes", value)}
+                placeholder="pdf, docx, xlsx, pptx, txt, md"
+              />
               {[
                 "referenceAudioMinSeconds",
                 "referenceAudioMaxSeconds",
@@ -4451,12 +4471,14 @@ function CatalogNumberField({
   label,
   value,
   min = 1,
+  max,
   step = 1,
   onChange,
 }: {
   label: string;
   value: unknown;
   min?: number;
+  max?: number;
   step?: number;
   onChange: (value: number | undefined) => void;
 }) {
@@ -4468,6 +4490,7 @@ function CatalogNumberField({
       <Input
         type="number"
         min={min}
+        max={max}
         step={step}
         value={typeof value === "number" ? value : ""}
         onChange={(event) =>

--- a/frontend/src/features/canvas/domain/canvasNodes.ts
+++ b/frontend/src/features/canvas/domain/canvasNodes.ts
@@ -164,6 +164,11 @@ export interface VideoNodeData extends NodeDisplayData {
    * (如新接入的)排在其后,按节点 y 坐标兜底。
    */
   referenceOrder?: string[];
+  /** Uploaded document reference for all-reference generation. */
+  referenceFileUrl?: string | null;
+  referenceFileName?: string | null;
+  /** Public HTTP(S) page reference for all-reference generation. */
+  referenceLink?: string | null;
   isGenerating?: boolean;
   generationStartedAt?: number | null;
   generationDurationMs?: number;

--- a/frontend/src/features/canvas/nodes/VideoNode.tsx
+++ b/frontend/src/features/canvas/nodes/VideoNode.tsx
@@ -436,6 +436,30 @@ function hasConfiguredReferenceCaps(model: ModelOption | null | undefined): bool
   );
 }
 
+function referenceFileExtension(value: string): string {
+  try {
+    const origin = typeof window === "undefined" ? "http://localhost" : window.location.origin;
+    const pathname = new URL(value, origin).pathname;
+    return pathname.split(".").pop()?.toLowerCase() ?? "";
+  } catch {
+    return "";
+  }
+}
+
+function isValidReferenceLink(value: string): boolean {
+  try {
+    const parsed = new URL(value);
+    return (
+      (parsed.protocol === "http:" || parsed.protocol === "https:") &&
+      Boolean(parsed.hostname) &&
+      !parsed.username &&
+      !parsed.password
+    );
+  } catch {
+    return false;
+  }
+}
+
 function sceneOptimizeOptionsForModel(
   model: {
     id?: string;
@@ -1938,7 +1962,8 @@ export const VideoNode = memo(
       genMode === "videoEdit"
         ? upstreamCounts.videos > 0
         : genMode === "allReference"
-          ? upstreamCounts.images + upstreamCounts.videos + upstreamCounts.audios > 0
+          ? upstreamCounts.images + upstreamCounts.videos + upstreamCounts.audios > 0 ||
+            Boolean(data.referenceFileUrl || data.referenceLink?.trim())
           : upstreamCounts.images > 0;
     // 提交前守卫：当前模型/模式无法消费已接入素材（视频/音频被静默丢、非 2.0 非
     // HappyHorse 多图会被后端 400）时给出理由并禁用提交，替代静默丢素材 / 提交 400。
@@ -1947,11 +1972,37 @@ export const VideoNode = memo(
       selectedVideoModel,
       upstreamCounts,
     );
-    const selectedModelReferenceError = selectedVideoModelReferenceDisabledReason(
+    const upstreamReferenceError = selectedVideoModelReferenceDisabledReason(
       selectedVideoModel,
       upstreamCounts,
       genMode,
     );
+    const selectedModelReferenceError = (() => {
+      if (upstreamReferenceError || genMode !== "allReference") return upstreamReferenceError;
+      const fileUrl = data.referenceFileUrl?.trim() ?? "";
+      const link = data.referenceLink?.trim() ?? "";
+      if (fileUrl && link) return t("node.videoNode.referenceDocument.fileLinkConflict");
+      if (fileUrl && (selectedVideoModel?.referenceFileMax ?? 0) < 1) {
+        return t("node.videoNode.referenceDocument.fileUnsupported");
+      }
+      if (link && (selectedVideoModel?.referenceLinkMax ?? 0) < 1) {
+        return t("node.videoNode.referenceDocument.linkUnsupported");
+      }
+      if (link && !isValidReferenceLink(link)) {
+        return t("node.videoNode.referenceDocument.invalidLink");
+      }
+      const allowedTypes = selectedVideoModel?.referenceFileTypes ?? [];
+      if (
+        fileUrl &&
+        allowedTypes.length > 0 &&
+        !allowedTypes.includes(referenceFileExtension(fileUrl))
+      ) {
+        return t("node.videoNode.referenceDocument.unsupportedType", {
+          types: allowedTypes.join(", "),
+        });
+      }
+      return null;
+    })();
     // 错误态重试的计费闸门。估价链随操作面板下沉后（选中才挂载、未选中不发请求），
     // 失败态的 RegenerateButton 成了唯一在未选中时也能提交的入口——若不在主体拦截，
     // 计费规则未配置时重试会放行一次注定被后端拒绝的请求。这里用一个仅错误态启用
@@ -2414,6 +2465,20 @@ export const VideoNode = memo(
               }
             }
           }
+          if (data.referenceFileUrl?.trim()) {
+            references.push({
+              type: "file",
+              url: data.referenceFileUrl.trim(),
+              role: "文件参考",
+              label: data.referenceFileName ?? "",
+            });
+          } else if (data.referenceLink?.trim()) {
+            references.push({
+              type: "link",
+              url: data.referenceLink.trim(),
+              role: "网页参考",
+            });
+          }
           if (references.length === 0) {
             console.warn("[video-node] omni-gen submit without any reference");
             updateNodeData(id, {
@@ -2644,6 +2709,11 @@ export const VideoNode = memo(
       cameraMovementId,
       cameraMovementPreset,
       count,
+      data.modelParams,
+      data.referenceFileName,
+      data.referenceFileUrl,
+      data.referenceLink,
+      data.referenceOrder,
       durationBounds,
       durationSec,
       generateAudio,

--- a/frontend/src/features/canvas/nodes/VideoOperationsPanel.tsx
+++ b/frontend/src/features/canvas/nodes/VideoOperationsPanel.tsx
@@ -3,6 +3,7 @@
 import {
   useCallback,
   useEffect,
+  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -15,16 +16,20 @@ import {
   ChevronDown,
   ChevronUp,
   Film,
+  FileText,
   Languages,
   Library,
+  Link as LinkIcon,
   Loader2,
   Music,
   Pause,
   Plus,
   Volume2,
   VolumeX,
+  X,
 } from "lucide-react";
 import { useTranslation } from "react-i18next";
+import { toast } from "sonner";
 
 import {
   CANVAS_NODE_TYPES,
@@ -97,6 +102,7 @@ import { useCanvasStore } from "@/stores/canvasStore";
 import {
   fetchFreezoneTextTranslateResult,
   submitFreezoneTextTranslate,
+  uploadFreezoneReferenceFile,
   type FreezoneVideoAspectRatio,
 } from "@/api/ops";
 import { awaitTaskCompletion } from "@/api/tasks";
@@ -286,6 +292,11 @@ export function VideoOperationsPanel({
     // 与 inputRef 分开:那个是「替换本节点自身的视频」(单选、只收视频),
     // 这个是「添加上游外部素材」(多选、收图片/视频/音频)。
     const externalAssetInputRef = useRef<HTMLInputElement>(null);
+    const referenceFileInputRef = useRef<HTMLInputElement>(null);
+    const toolbarContentRef = useRef<HTMLDivElement>(null);
+    const [isUploadingReferenceFile, setIsUploadingReferenceFile] = useState(false);
+    const [referenceLinkDraft, setReferenceLinkDraft] = useState(data.referenceLink ?? "");
+    const [referencePanelWidth, setReferencePanelWidth] = useState<number | null>(null);
     const [isTranslatingPrompt, setIsTranslatingPrompt] = useState(false);
     const [isCharacterLibraryOpen, setIsCharacterLibraryOpen] = useState(false);
     // Local draft + composition guard so IME (中文输入法) candidates stop being
@@ -298,6 +309,60 @@ export function VideoOperationsPanel({
       if (isComposingRef.current) return;
       setPromptDraft(prompt);
     }, [prompt]);
+    useEffect(() => {
+      setReferenceLinkDraft(data.referenceLink ?? "");
+    }, [data.referenceLink]);
+
+    const supportsReferenceFile = (selectedVideoModel?.referenceFileMax ?? 0) > 0;
+    const supportsReferenceLink = (selectedVideoModel?.referenceLinkMax ?? 0) > 0;
+    const referenceFileTypes = selectedVideoModel?.referenceFileTypes ?? [];
+    const referenceFileAccept = referenceFileTypes.length > 0
+      ? referenceFileTypes.map((extension) => `.${extension.replace(/^\./, "")}`).join(",")
+      : undefined;
+
+    const handleReferenceFile = useCallback(async (event: ChangeEvent<HTMLInputElement>) => {
+      const file = event.target.files?.[0];
+      event.target.value = "";
+      if (!file || isUploadingReferenceFile) return;
+      const maxReferenceFileBytes = 100 * 1024 * 1024;
+      if (file.size > maxReferenceFileBytes) {
+        toast.error(t("node.videoNode.referenceDocument.fileTooLarge", {
+          size: (file.size / 1024 / 1024).toFixed(1),
+        }));
+        return;
+      }
+      const extension = file.name.split(".").pop()?.toLowerCase() ?? "";
+      if (referenceFileTypes.length > 0 && !referenceFileTypes.includes(extension)) {
+        toast.error(t("node.videoNode.referenceDocument.unsupportedType", {
+          types: referenceFileTypes.join(", "),
+        }));
+        return;
+      }
+      const project = readUrl().project;
+      if (!project) return;
+      setIsUploadingReferenceFile(true);
+      try {
+        const uploaded = await uploadFreezoneReferenceFile(project, file);
+        updateNodeData(id, {
+          referenceFileUrl: uploaded.url,
+          referenceFileName: uploaded.filename || file.name,
+          referenceLink: null,
+        });
+        setReferenceLinkDraft("");
+      } catch (error) {
+        toast.error(error instanceof Error ? error.message : t("common.error"));
+      } finally {
+        setIsUploadingReferenceFile(false);
+      }
+    }, [id, isUploadingReferenceFile, referenceFileTypes, t, updateNodeData]);
+
+    const commitReferenceLink = useCallback(() => {
+      const value = referenceLinkDraft.trim();
+      updateNodeData(id, {
+        referenceLink: value || null,
+        ...(value ? { referenceFileUrl: null, referenceFileName: null } : {}),
+      });
+    }, [id, referenceLinkDraft, updateNodeData]);
     // 卸载前的 IME 合成兜底：合成进行中取消选中会直接卸载本面板，
     // onCompositionEnd 再也没有机会触发，最新草稿只存在于本地 state。
     // 用 ref 镜像 draft，卸载 cleanup 里发现仍在合成就把它落回 data.prompt。
@@ -600,6 +665,43 @@ export function VideoOperationsPanel({
     // 收起态浮动面板固定基础尺寸；放大用居中弹窗（见下方 OperationPanelShell）。
     const panelHeight = OPERATIONS_PANEL_HEIGHT;
     const panelOverhang = OPERATIONS_PANEL_OVERHANG;
+    const showReferenceDocumentControls =
+      genMode === "allReference" &&
+      (supportsReferenceFile ||
+        supportsReferenceLink ||
+        Boolean(data.referenceFileUrl) ||
+        Boolean(referenceLinkDraft.trim()));
+    useLayoutEffect(() => {
+      if (!showReferenceDocumentControls) {
+        setReferencePanelWidth(null);
+        return;
+      }
+      // The same toolbar is portalled into a constrained modal while expanded.
+      // Measuring there overwrites the inline panel's natural width with the
+      // modal layout width; on collapse that stale value can shrink the panel
+      // to only a few controls. Re-measure after it is back under the node.
+      if (expanded) return;
+      const content = toolbarContentRef.current;
+      if (!content) return;
+      const updateWidth = () => {
+        const contentWidth = content.scrollWidth;
+        if (contentWidth <= 0) return;
+        // Include toolbar padding plus a small buffer for borders and fractional
+        // canvas scaling, otherwise an exact fit can still show a scrollbar.
+        // scrollWidth is intentional: offsetWidth reports the width imposed by
+        // the current panel and can feed a collapsed width back into itself.
+        const nextWidth = Math.ceil(contentWidth + 76);
+        setReferencePanelWidth((current) => current === nextWidth ? current : nextWidth);
+      };
+      updateWidth();
+      if (typeof ResizeObserver === "undefined") return;
+      const observer = new ResizeObserver(updateWidth);
+      observer.observe(content);
+      return () => observer.disconnect();
+    }, [expanded, showReferenceDocumentControls]);
+    const adaptivePanelWidth = referencePanelWidth == null
+      ? "min(1040px, calc(100vw - 48px))"
+      : `min(${referencePanelWidth}px, calc(100vw - 48px))`;
 
     return (
       <>
@@ -609,8 +711,11 @@ export function VideoOperationsPanel({
               inlineClassName={`nodrag absolute z-30 flex flex-col rounded-[var(--node-radius)] ${CANVAS_NODE_OPS_PANEL_CLASS}`}
               inlineStyle={{
                 top: `calc(100% + ${OPERATIONS_PANEL_GAP}px)`,
-                left: -panelOverhang,
-                right: -panelOverhang,
+                left: showReferenceDocumentControls
+                  ? `calc((100% - ${adaptivePanelWidth}) / 2)`
+                  : -panelOverhang,
+                right: showReferenceDocumentControls ? "auto" : -panelOverhang,
+                width: showReferenceDocumentControls ? adaptivePanelWidth : undefined,
                 height: panelHeight,
               }}
               modalStyle={{
@@ -624,6 +729,7 @@ export function VideoOperationsPanel({
                 className="absolute right-2 top-2 z-20"
               />
               <div className="flex shrink-0 items-center overflow-x-auto px-3 pb-2 pr-10 pt-3">
+                <div ref={toolbarContentRef} className="flex w-max shrink-0 items-center">
                 <div className="flex shrink-0 items-center gap-2">
                   <CameraMovementChip
                     templates={cameraTemplates}
@@ -687,6 +793,78 @@ export function VideoOperationsPanel({
                     }
                   />
                 )}
+                {showReferenceDocumentControls && (
+                  <div className="ml-3 flex shrink-0 items-center gap-1.5">
+                    {(supportsReferenceFile || data.referenceFileUrl) && (
+                      <>
+                        <button
+                          type="button"
+                          title={t("node.videoNode.referenceDocument.file")}
+                          disabled={!supportsReferenceFile || isUploadingReferenceFile}
+                          onClick={() => referenceFileInputRef.current?.click()}
+                          className={NODE_CONTEXT_CONTROL_TRIGGER_CLASS}
+                        >
+                          {isUploadingReferenceFile ? (
+                            <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                          ) : (
+                            <FileText className="h-3.5 w-3.5" />
+                          )}
+                          <span className="max-w-32 truncate">
+                            {data.referenceFileName || t("node.videoNode.referenceDocument.file")}
+                          </span>
+                        </button>
+                        {data.referenceFileUrl && (
+                          <button
+                            type="button"
+                            title={t("node.videoNode.referenceDocument.removeFile")}
+                            onClick={() => updateNodeData(id, { referenceFileUrl: null, referenceFileName: null })}
+                            className={NODE_INLINE_ICON_BUTTON_CLASS}
+                          >
+                            <X className="h-3.5 w-3.5" />
+                          </button>
+                        )}
+                      </>
+                    )}
+                    {(supportsReferenceLink || referenceLinkDraft.trim()) && (
+                      <label className="flex h-7 w-44 items-center gap-1.5 rounded border border-white/15 bg-black/20 px-2 text-xs text-text-dark">
+                        <LinkIcon className="h-3.5 w-3.5 shrink-0 text-text-muted" />
+                        <input
+                          type="url"
+                          value={referenceLinkDraft}
+                          placeholder={t("node.videoNode.referenceDocument.linkPlaceholder")}
+                          onChange={(event) => {
+                            const value = event.target.value;
+                            setReferenceLinkDraft(value);
+                            updateNodeData(
+                              id,
+                              {
+                                referenceLink: value,
+                                ...(value.trim()
+                                  ? { referenceFileUrl: null, referenceFileName: null }
+                                  : {}),
+                              },
+                              { recordHistory: false },
+                            );
+                          }}
+                          onBlur={commitReferenceLink}
+                          onKeyDown={(event) => {
+                            event.stopPropagation();
+                            if (event.key === "Enter") event.currentTarget.blur();
+                          }}
+                          className="min-w-0 flex-1 bg-transparent outline-none placeholder:text-text-muted/60"
+                        />
+                      </label>
+                    )}
+                    <input
+                      ref={referenceFileInputRef}
+                      type="file"
+                      accept={referenceFileAccept}
+                      className="hidden"
+                      onChange={handleReferenceFile}
+                    />
+                  </div>
+                )}
+                </div>
               </div>
 
               <PromptMentionEditor

--- a/frontend/src/features/canvas/ui/ProviderModelPicker.tsx
+++ b/frontend/src/features/canvas/ui/ProviderModelPicker.tsx
@@ -63,6 +63,9 @@ export interface ModelOption {
   referenceImageMax?: number | null;
   referenceVideoMax?: number | null;
   referenceAudioMax?: number | null;
+  referenceFileMax?: number | null;
+  referenceLinkMax?: number | null;
+  referenceFileTypes?: string[];
   referenceAudioMinSeconds?: number | null;
   referenceAudioMaxSeconds?: number | null;
   referenceAudioTotalMinSeconds?: number | null;

--- a/license-inventory.csv
+++ b/license-inventory.csv
@@ -1899,6 +1899,7 @@ tests/test_api_novel_prerequisites.py,Elastic-2.0,2026 SuperTale contributors,RE
 tests/test_api_pipeline_manual_shots.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_api_project_resolution.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_api_project_summary_paths.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
+tests/test_api_request_body_limit.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_api_render_regenerate.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_api_render_settings.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_api_scripts.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
@@ -1998,6 +1999,7 @@ tests/test_freezone_mark_detect_egress.py,Elastic-2.0,2026 SuperTale contributor
 tests/test_freezone_multi_view_prompt.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_freezone_paths.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_freezone_projection_merge.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
+tests/test_freezone_reference_file_upload.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_freezone_relight_prompt.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_freezone_skill_parameters.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_freezone_text_backend.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation

--- a/src/novelvideo/api/app.py
+++ b/src/novelvideo/api/app.py
@@ -55,7 +55,10 @@ def _request_body_limit(request: Request) -> int:
     content_type = request.headers.get("content-type", "").lower()
     if (
         request.url.path.startswith("/api/v1/projects/")
-        and request.url.path.endswith("/upload")
+        and (
+            request.url.path.endswith("/upload")
+            or request.url.path.endswith("/reference-file-upload")
+        )
         and "multipart/form-data" in content_type
     ):
         return MAX_UPLOAD_REQUEST_BODY_BYTES

--- a/src/novelvideo/api/routes/freezone.py
+++ b/src/novelvideo/api/routes/freezone.py
@@ -4483,22 +4483,40 @@ async def freezone_skills(user: dict = Depends(get_api_user)):
 # 图片处理：上传
 # ============================================================
 
+REFERENCE_FILE_MAX_BYTES = 100 * 1024 * 1024
+_UPLOAD_READ_CHUNK_BYTES = 1024 * 1024
 
-@router.post("/projects/{project}/freezone/upload", tags=[TAG_FREEZONE_MEDIA])
-async def freezone_upload(
+
+async def _read_upload_contents(
+    file: UploadFile,
+    *,
+    max_bytes: int | None = None,
+) -> bytes:
+    chunks: list[bytes] = []
+    total = 0
+    while chunk := await file.read(_UPLOAD_READ_CHUNK_BYTES):
+        total += len(chunk)
+        if max_bytes is not None and total > max_bytes:
+            raise HTTPException(413, "reference file must be 100 MB or smaller")
+        chunks.append(chunk)
+    return b"".join(chunks)
+
+
+async def _save_freezone_upload(
     project: str,
-    file: Annotated[UploadFile, File()],
-    user: dict = Depends(get_api_user),
-):
-    """把外部资源上传保存到 `freezone/_uploads/`。"""
-    ctx, username, project_name, project_dir, _output_dir = await _resolve_freezone_project(
+    file: UploadFile,
+    user: dict,
+    *,
+    max_bytes: int | None = None,
+) -> dict[str, Any]:
+    ctx, _username, _project_name, project_dir, _output_dir = await _resolve_freezone_project(
         project, user
     )
     target_dir = uploads_dir(project_dir)
     target_dir.mkdir(parents=True, exist_ok=True)
     filename = safe_upload_filename(file.filename)
     target = target_dir / filename
-    contents = await file.read()
+    contents = await _read_upload_contents(file, max_bytes=max_bytes)
     target.write_bytes(contents)
     rel = target.relative_to(project_dir).as_posix()
     return {
@@ -4509,6 +4527,31 @@ async def freezone_upload(
             "size": len(contents),
         },
     }
+
+
+@router.post("/projects/{project}/freezone/upload", tags=[TAG_FREEZONE_MEDIA])
+async def freezone_upload(
+    project: str,
+    file: Annotated[UploadFile, File()],
+    user: dict = Depends(get_api_user),
+):
+    """把外部资源上传保存到 `freezone/_uploads/`。"""
+    return await _save_freezone_upload(project, file, user)
+
+
+@router.post("/projects/{project}/freezone/reference-file-upload", tags=[TAG_FREEZONE_MEDIA])
+async def freezone_reference_file_upload(
+    project: str,
+    file: Annotated[UploadFile, File()],
+    user: dict = Depends(get_api_user),
+):
+    """保存视频模型参考文件，并限制为不超过 100 MB。"""
+    return await _save_freezone_upload(
+        project,
+        file,
+        user,
+        max_bytes=REFERENCE_FILE_MAX_BYTES,
+    )
 
 
 @router.post("/projects/{project}/freezone/three-d-viewer/screenshot", tags=[TAG_FREEZONE_MEDIA])
@@ -7804,6 +7847,8 @@ def _catalog_reference_limits(
     image_default: int,
     video_default: int,
     audio_default: int,
+    file_default: int = 0,
+    link_default: int = 0,
 ) -> dict[str, int]:
     def _limit(key: str, default: int) -> int:
         value = capabilities.get(key) if capabilities else None
@@ -7813,6 +7858,8 @@ def _catalog_reference_limits(
         "image": _limit("referenceImageMax", image_default),
         "video": _limit("referenceVideoMax", video_default),
         "audio": _limit("referenceAudioMax", audio_default),
+        "file": _limit("referenceFileMax", file_default),
+        "link": _limit("referenceLinkMax", link_default),
     }
 
 
@@ -8901,7 +8948,7 @@ async def freezone_video_omni_gen(
 ):
     """视频处理：全能参考文生视频。
 
-    支持文本、图像、视频、音频混合输入，当前默认走 Seedance 2.0。
+    支持文本、图像、视频、音频、文件和公开网页链接混合输入。
     """
     ctx, username, project_name, project_dir, output_dir = await _resolve_freezone_project(
         project, user
@@ -8943,6 +8990,8 @@ async def freezone_video_omni_gen(
         image_default=9,
         video_default=3,
         audio_default=3,
+        file_default=0,
+        link_default=0,
     )
     try:
         validate_omni_reference_limits(
@@ -8950,6 +8999,8 @@ async def freezone_video_omni_gen(
             image_max=reference_limits["image"],
             video_max=reference_limits["video"],
             audio_max=reference_limits["audio"],
+            file_max=reference_limits["file"],
+            link_max=reference_limits["link"],
             total_max=(
                 sum(reference_limits.values())
                 if capabilities
@@ -8959,6 +9010,8 @@ async def freezone_video_omni_gen(
                         "referenceImageMax",
                         "referenceVideoMax",
                         "referenceAudioMax",
+                        "referenceFileMax",
+                        "referenceLinkMax",
                     )
                 )
                 else 12
@@ -8968,13 +9021,45 @@ async def freezone_video_omni_gen(
         raise HTTPException(400, str(exc)) from exc
     reference_items: list[dict[str, str]] = []
     for item in raw_reference_items:
-        path_list = _resolve_url_list(project_dir, [str(item.get("url") or "")])
-        if not path_list:
+        reference_type = str(item.get("type") or "image")
+        reference_url = str(item.get("url") or "").strip()
+        if not reference_url:
             raise HTTPException(400, "reference url is required")
+        if reference_type == "link":
+            parsed = urlsplit(reference_url)
+            if (
+                parsed.scheme not in {"http", "https"}
+                or not parsed.hostname
+                or parsed.username
+                or parsed.password
+            ):
+                raise HTTPException(400, "reference link must be a public HTTP/HTTPS URL")
+            resolved_reference = reference_url
+        elif reference_type == "file" and reference_url.startswith(("http://", "https://")):
+            resolved_reference = reference_url
+        else:
+            path_list = _resolve_url_list(project_dir, [reference_url])
+            if not path_list:
+                raise HTTPException(400, "reference url is required")
+            resolved_reference = path_list[0]
+
+        if reference_type == "file":
+            allowed_types = capabilities.get("referenceFileTypes") if capabilities else None
+            if isinstance(allowed_types, list) and allowed_types:
+                extension = Path(unquote(urlsplit(reference_url).path)).suffix.lower().lstrip(".")
+                normalized_types = {
+                    str(value).strip().lower().lstrip(".") for value in allowed_types
+                }
+                if extension not in normalized_types:
+                    raise HTTPException(
+                        400,
+                        "reference file type is not supported; expected one of: "
+                        + ", ".join(str(value) for value in allowed_types),
+                    )
         reference_items.append(
             {
-                "type": str(item.get("type") or "image"),
-                "path": path_list[0],
+                "type": reference_type,
+                "path": resolved_reference,
                 "role": str(item.get("role") or ""),
             }
         )

--- a/src/novelvideo/api/schemas.py
+++ b/src/novelvideo/api/schemas.py
@@ -1263,7 +1263,9 @@ class FreezoneVideoEditRequest(BaseModel):
 class FreezoneVideoReferenceItem(BaseModel):
     """全能参考单条素材。"""
 
-    type: Literal["image", "video", "audio"] = Field(description="素材类型")
+    type: Literal["image", "video", "audio", "file", "link"] = Field(
+        description="素材类型"
+    )
     url: str = Field(description="素材静态地址")
     role: str = Field(default="", description="素材角色，例如 角色参考 / 场景参考 / 配乐参考")
     label: str = Field(default="", description="前端展示标签，可为空")
@@ -1373,7 +1375,7 @@ class FreezoneImageReversePromptResponse(BaseModel):
 class FreezoneVideoOmniGenRequest(BaseModel):
     """全能参考视频请求。
 
-    支持文本、图像、视频、音频混合输入。
+    支持文本、图像、视频、音频、文件和公开网页链接混合输入。
     """
 
     prompt: str = Field(description="用户输入的视频内容描述")
@@ -1384,7 +1386,10 @@ class FreezoneVideoOmniGenRequest(BaseModel):
     )
     references: list[FreezoneVideoReferenceItem] = Field(
         default_factory=list,
-        description="混合参考素材列表。总数最多 12，图像≤9、视频≤3、音频≤3",
+        description=(
+            "混合参考素材列表。图像、视频、音频上限由模型目录控制；"
+            "文件和网页链接各最多 1 个且互斥"
+        ),
     )
     marks: list[FreezoneVideoMark] = Field(
         default_factory=list,

--- a/src/novelvideo/freezone/video_node.py
+++ b/src/novelvideo/freezone/video_node.py
@@ -538,7 +538,8 @@ def build_freezone_omni_video_prompt(
         parts.append(marks_block)
 
     parts.append(
-        "全能参考模式要求：综合文本、图像、视频和音频参考进行统一建模，优先保持主体身份、场景连续性、风格一致性和动作自然性。"
+        "全能参考模式要求：综合文本、图像、视频、音频、文件和网页链接参考进行统一建模，"
+        "优先保持主体身份、场景连续性、风格一致性和动作自然性。"
     )
     counts = summarize_omni_reference_counts(reference_items or [])
     single_video_reference_instruction = "这是视频参考生成新的视频，不是视频编辑。"
@@ -546,6 +547,8 @@ def build_freezone_omni_video_prompt(
         counts["video_count"] == 1
         and counts["image_count"] == 0
         and counts["audio_count"] == 0
+        and counts["file_count"] == 0
+        and counts["link_count"] == 0
         and single_video_reference_instruction not in "\n".join(parts)
     ):
         parts.append(single_video_reference_instruction)
@@ -559,11 +562,15 @@ def summarize_omni_reference_counts(items: list[dict[str, Any]]) -> dict[str, in
     image_count = sum(1 for item in items if str(item.get("type")) == "image")
     video_count = sum(1 for item in items if str(item.get("type")) == "video")
     audio_count = sum(1 for item in items if str(item.get("type")) == "audio")
+    file_count = sum(1 for item in items if str(item.get("type")) == "file")
+    link_count = sum(1 for item in items if str(item.get("type")) == "link")
     return {
         "image_count": image_count,
         "video_count": video_count,
         "audio_count": audio_count,
-        "total_count": image_count + video_count + audio_count,
+        "file_count": file_count,
+        "link_count": link_count,
+        "total_count": image_count + video_count + audio_count + file_count + link_count,
     }
 
 
@@ -573,6 +580,8 @@ def validate_omni_reference_limits(
     image_max: int = 9,
     video_max: int = 3,
     audio_max: int = 3,
+    file_max: int = 0,
+    link_max: int = 0,
     total_max: int = 12,
 ) -> None:
     counts = summarize_omni_reference_counts(items)
@@ -584,6 +593,12 @@ def validate_omni_reference_limits(
         raise ValueError(f"video references count must be <= {video_max}")
     if counts["audio_count"] > audio_max:
         raise ValueError(f"audio references count must be <= {audio_max}")
+    if counts["file_count"] > file_max:
+        raise ValueError(f"file references count must be <= {file_max}")
+    if counts["link_count"] > link_max:
+        raise ValueError(f"link references count must be <= {link_max}")
+    if counts["file_count"] and counts["link_count"]:
+        raise ValueError("reference_file and reference_link are mutually exclusive")
 
 
 # 火山 Seedance 对参考图的硬规则（从 400 报文里实测）：

--- a/src/novelvideo/generators/video_generator.py
+++ b/src/novelvideo/generators/video_generator.py
@@ -790,8 +790,8 @@ class SeedanceVideoGenerator(VideoGeneratorBase):
 class ShotReference:
     """Seedance 2.0 素材引用。"""
 
-    type: str  # "image" / "video" / "audio"
-    path: str  # 本地文件路径
+    type: str  # "image" / "video" / "audio" / "file" / "link"
+    path: str  # 本地文件路径或公开 URL
     role: str  # "首帧" / "角色参考" / "场景参考" / "配乐" / "音色参考"
 
 
@@ -2253,7 +2253,7 @@ class NewApiVideoGenerator(VideoGeneratorBase):
             media_type = str(getattr(ref, "type", "") or "image").strip().lower()
             path = str(getattr(ref, "path", "") or "").strip()
             role = str(getattr(ref, "role", "") or "").strip()
-            if path and media_type in {"image", "video", "audio"}:
+            if path and media_type in {"image", "video", "audio", "file", "link"}:
                 raw_items.append((media_type, path, role))
 
         seen: set[tuple[str, str]] = set()
@@ -2261,6 +2261,8 @@ class NewApiVideoGenerator(VideoGeneratorBase):
             "image": [],
             "video": [],
             "audio": [],
+            "file": [],
+            "link": [],
         }
         for media_type, path, role in raw_items:
             identity = (media_type, path)
@@ -2269,11 +2271,18 @@ class NewApiVideoGenerator(VideoGeneratorBase):
             seen.add(identity)
             if media_type == "image":
                 url = await self._relay_frame_input(path)
+            elif media_type == "link":
+                parsed = urllib.parse.urlsplit(path)
+                if parsed.scheme not in {"http", "https"} or not parsed.hostname:
+                    raise ValueError("reference link must be an HTTP/HTTPS URL")
+                url = path
             else:
                 url = await self._relay_media_input(
                     path,
-                    default_ext="mp4" if media_type == "video" else "mp3",
-                    resource_type="video",
+                    default_ext=(
+                        "mp4" if media_type == "video" else "mp3" if media_type == "audio" else "bin"
+                    ),
+                    resource_type="raw" if media_type == "file" else "video",
                 )
             if not path.startswith(("http://", "https://")):
                 log(f"{media_type} 参考素材已上传到媒体中转")
@@ -2282,6 +2291,11 @@ class NewApiVideoGenerator(VideoGeneratorBase):
         image_urls = [url for url, _role in relayed["image"]]
         video_urls = [url for url, _role in relayed["video"]]
         audio_urls = [url for url, _role in relayed["audio"]]
+        file_urls = [url for url, _role in relayed["file"]]
+        link_urls = [url for url, _role in relayed["link"]]
+
+        if file_urls and link_urls:
+            raise ValueError("reference_file and reference_link are mutually exclusive")
 
         if normalized_mode in {"image_reference", "all_reference", "video_edit"}:
             if image_urls:
@@ -2290,6 +2304,10 @@ class NewApiVideoGenerator(VideoGeneratorBase):
                 metadata["reference_videos"] = video_urls
             if audio_urls:
                 metadata["reference_audios"] = audio_urls
+            if file_urls:
+                metadata["reference_file"] = file_urls[0]
+            if link_urls:
+                metadata["reference_link"] = link_urls[0]
             return
 
         raise ValueError(f"unsupported video generation mode: {normalized_mode}")

--- a/src/novelvideo/media_model_request_schema.py
+++ b/src/novelvideo/media_model_request_schema.py
@@ -50,6 +50,7 @@ STRING_LIST_CONFIG_FIELDS = {
     "ratioOptions",
     "qualityOptions",
     "sceneOptimizeOptions",
+    "referenceFileTypes",
 }
 RESERVED_CATALOG_CONFIG_FIELDS = {
     "id",
@@ -116,6 +117,15 @@ def normalize_media_model_catalog_config(config: object) -> dict[str, Any]:
             seen_ratios.add(identity)
             canonical_ratios.append(value)
         normalized["ratioOptions"] = canonical_ratios
+    file_types = normalized.get("referenceFileTypes")
+    if isinstance(file_types, list):
+        normalized["referenceFileTypes"] = list(
+            dict.fromkeys(
+                str(item or "").strip().lower().lstrip(".")
+                for item in file_types
+                if str(item or "").strip().lstrip(".")
+            )
+        )
     return normalized
 
 
@@ -396,6 +406,9 @@ def validate_media_model_catalog_config(
             "supportedModes",
             "referenceVideoMax",
             "referenceAudioMax",
+            "referenceFileMax",
+            "referenceLinkMax",
+            "referenceFileTypes",
             "referenceAudioMinSeconds",
             "referenceAudioMaxSeconds",
             "referenceAudioTotalMinSeconds",
@@ -451,10 +464,29 @@ def validate_media_model_catalog_config(
     if minimum is not None and maximum is not None and minimum > maximum:
         raise MediaModelSchemaError("minDuration cannot exceed maxDuration")
 
-    for field in ("referenceImageMax", "referenceVideoMax", "referenceAudioMax"):
+    for field in (
+        "referenceImageMax",
+        "referenceVideoMax",
+        "referenceAudioMax",
+        "referenceFileMax",
+        "referenceLinkMax",
+    ):
         value = config.get(field)
         if value is not None and (type(value) is not int or value < 0):
             raise MediaModelSchemaError(f"{field} must be a non-negative integer")
+    for field in ("referenceFileMax", "referenceLinkMax"):
+        value = config.get(field)
+        if type(value) is int and value > 1:
+            raise MediaModelSchemaError(f"{field} cannot exceed 1")
+
+    reference_file_types = config.get("referenceFileTypes")
+    if reference_file_types is not None and any(
+        not re.fullmatch(r"[a-z0-9][a-z0-9_-]{0,15}", item)
+        for item in reference_file_types
+    ):
+        raise MediaModelSchemaError(
+            "referenceFileTypes must use lowercase extensions without dots"
+        )
 
     duration_fields = (
         "referenceAudioMinSeconds",
@@ -500,6 +532,17 @@ def validate_media_model_catalog_config(
         ):
             raise MediaModelSchemaError(
                 "referenceVideoMax requires all_reference or video_edit mode"
+            )
+        for field in ("referenceFileMax", "referenceLinkMax"):
+            limit = config.get(field)
+            if type(limit) is int and limit > 0 and "all_reference" not in configured_modes:
+                raise MediaModelSchemaError(f"{field} requires all_reference mode")
+        if reference_file_types and not (
+            type(config.get("referenceFileMax")) is int
+            and config["referenceFileMax"] > 0
+        ):
+            raise MediaModelSchemaError(
+                "referenceFileTypes requires a positive referenceFileMax"
             )
 
     min_pixels = config.get("minPixels")

--- a/src/novelvideo/official_media_models.json
+++ b/src/novelvideo/official_media_models.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "catalogVersion": "2026.08.14.1",
+  "catalogVersion": "2026.08.27.1",
   "name": "DramaClaw CE official media models",
   "mediaModels": {
     "LingShan-G2": {
@@ -92,6 +92,80 @@
         "request": {"endpoint": "images/generations", "parameters": []},
         "ratioOptions": ["1:1", "9:16", "16:9", "4:3", "3:4", "2:3", "3:2", "5:4", "4:5", "21:9"],
         "resolutionOptions": ["1K", "2K", "4K"]
+      }
+    },
+    "wan3.0-video-prime": {
+      "provider": "newapi",
+      "upstreamModel": "wan3.0-video-prime",
+      "mediaType": "video",
+      "label": "Wan 3.0 Video Prime",
+      "enabled": true,
+      "sortOrder": 5,
+      "aliases": [],
+      "config": {
+        "request": {
+          "endpoint": "video/generations",
+          "parameters": [
+            {"key": "prompt_extend", "label": "智能改写", "control": "switch", "default": true, "requestPath": "metadata.prompt_extend"},
+            {"key": "seed", "label": "随机种子", "control": "number", "min": 0, "max": 2147483647, "requestPath": "metadata.seed"},
+            {"key": "watermark", "label": "生成水印", "control": "switch", "default": false, "requestPath": "metadata.watermark"}
+          ]
+        },
+        "minDuration": 2,
+        "maxDuration": 30,
+        "ratioOptions": ["adaptive", "16:9", "4:3", "1:1", "3:4", "9:16"],
+        "resolutionOptions": ["480P", "720P", "1080P"],
+        "supportedModes": ["text_to_video", "image_to_video", "first_frame", "first_last_frame", "image_reference", "all_reference", "video_edit"],
+        "referenceImageMax": 10,
+        "referenceVideoMax": 5,
+        "referenceAudioMax": 5,
+        "referenceVideoMinSeconds": 1,
+        "referenceVideoMaxSeconds": 15,
+        "referenceVideoTotalMaxSeconds": 15,
+        "referenceAudioMinSeconds": 1,
+        "referenceAudioMaxSeconds": 15,
+        "referenceAudioTotalMaxSeconds": 15,
+        "referenceFileMax": 1,
+        "referenceLinkMax": 1,
+        "referenceFileTypes": ["docx", "doc", "xlsx", "xls", "pptx", "ppt", "pdf", "txt", "key", "pages", "numbers", "md"],
+        "supportsGenerateAudio": true
+      }
+    },
+    "wan3.0-video": {
+      "provider": "newapi",
+      "upstreamModel": "wan3.0-video",
+      "mediaType": "video",
+      "label": "Wan 3.0 Video",
+      "enabled": true,
+      "sortOrder": 6,
+      "aliases": [],
+      "config": {
+        "request": {
+          "endpoint": "video/generations",
+          "parameters": [
+            {"key": "prompt_extend", "label": "智能改写", "control": "switch", "default": true, "requestPath": "metadata.prompt_extend"},
+            {"key": "seed", "label": "随机种子", "control": "number", "min": 0, "max": 2147483647, "requestPath": "metadata.seed"},
+            {"key": "watermark", "label": "生成水印", "control": "switch", "default": false, "requestPath": "metadata.watermark"}
+          ]
+        },
+        "minDuration": 2,
+        "maxDuration": 30,
+        "ratioOptions": ["adaptive", "16:9", "4:3", "1:1", "3:4", "9:16"],
+        "resolutionOptions": ["480P", "720P", "1080P"],
+        "supportedModes": ["text_to_video", "image_to_video", "first_frame", "first_last_frame", "image_reference", "all_reference", "video_edit"],
+        "referenceImageMax": 10,
+        "referenceVideoMax": 5,
+        "referenceAudioMax": 5,
+        "referenceVideoMinSeconds": 1,
+        "referenceVideoMaxSeconds": 15,
+        "referenceVideoTotalMaxSeconds": 15,
+        "referenceAudioMinSeconds": 1,
+        "referenceAudioMaxSeconds": 15,
+        "referenceAudioTotalMaxSeconds": 15,
+        "referenceFileMax": 1,
+        "referenceLinkMax": 1,
+        "referenceFileTypes": ["docx", "doc", "xlsx", "xls", "pptx", "ppt", "pdf", "txt", "key", "pages", "numbers", "md"],
+        "supportsGenerateAudio": true
       }
     },
     "seedance-2.0-fast": {

--- a/src/novelvideo/storage/media_relay.py
+++ b/src/novelvideo/storage/media_relay.py
@@ -228,7 +228,7 @@ class CloudinaryRelay:
 
         ext = _normalize_ext(ext)
         resource_type = str(resource_type or "image").strip().lower()
-        if resource_type not in {"image", "video"}:
+        if resource_type not in {"image", "video", "raw"}:
             raise ValueError(f"unsupported Cloudinary resource type: {resource_type}")
         filename = f"{uuid.uuid4().hex}.{ext}"
         content_type = mimetypes.types_map.get(f".{ext}", "application/octet-stream")

--- a/tests/test_api_request_body_limit.py
+++ b/tests/test_api_request_body_limit.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from starlette.requests import Request
+
+from novelvideo.api.app import (
+    MAX_REQUEST_BODY_BYTES,
+    MAX_UPLOAD_REQUEST_BODY_BYTES,
+    _request_body_limit,
+)
+
+
+def _multipart_request(path: str) -> Request:
+    return Request(
+        {
+            "type": "http",
+            "method": "POST",
+            "scheme": "http",
+            "server": ("testserver", 80),
+            "client": ("testclient", 50000),
+            "path": path,
+            "raw_path": path.encode("ascii"),
+            "query_string": b"",
+            "headers": [(b"content-type", b"multipart/form-data; boundary=test")],
+        }
+    )
+
+
+def test_generic_freezone_upload_uses_upload_body_limit() -> None:
+    request = _multipart_request("/api/v1/projects/project-1/freezone/upload")
+
+    assert _request_body_limit(request) == MAX_UPLOAD_REQUEST_BODY_BYTES
+
+
+def test_reference_file_upload_uses_upload_body_limit() -> None:
+    request = _multipart_request(
+        "/api/v1/projects/project-1/freezone/reference-file-upload"
+    )
+
+    assert _request_body_limit(request) == MAX_UPLOAD_REQUEST_BODY_BYTES
+
+
+def test_non_upload_request_keeps_default_body_limit() -> None:
+    request = _multipart_request("/api/v1/projects/project-1/freezone/gen")
+
+    assert _request_body_limit(request) == MAX_REQUEST_BODY_BYTES

--- a/tests/test_freezone_canvas_route_home_node_guard.py
+++ b/tests/test_freezone_canvas_route_home_node_guard.py
@@ -259,8 +259,8 @@ def test_only_canvas_routes_opt_out_of_the_home_node_guard() -> None:
         and _opts_out_of_the_guard(call)
     }
 
-    # 取证口径（`TCP-P60`）：freezone 78 条路由全过同一个解析器，画布只占 14 条。
-    assert router_decorators == 78
+    # 取证口径（`TCP-P60`）：freezone 79 条路由全过同一个解析器，画布只占 14 条。
+    assert router_decorators == 79
     assert len(canvas_routes) == 14
 
     # 正向：14 条画布路由必须全部、且每一处调用都 opt-out。

--- a/tests/test_freezone_reference_file_upload.py
+++ b/tests/test_freezone_reference_file_upload.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from io import BytesIO
+
+import pytest
+from fastapi import HTTPException, UploadFile
+
+from novelvideo.api.routes.freezone import _read_upload_contents
+
+
+@pytest.mark.asyncio
+async def test_read_reference_file_accepts_exact_limit() -> None:
+    upload = UploadFile(filename="reference.pdf", file=BytesIO(b"1234"))
+
+    assert await _read_upload_contents(upload, max_bytes=4) == b"1234"
+
+
+@pytest.mark.asyncio
+async def test_read_reference_file_rejects_over_limit() -> None:
+    upload = UploadFile(filename="reference.pdf", file=BytesIO(b"12345"))
+
+    with pytest.raises(HTTPException) as exc_info:
+        await _read_upload_contents(upload, max_bytes=4)
+
+    assert exc_info.value.status_code == 413
+    assert exc_info.value.detail == "reference file must be 100 MB or smaller"

--- a/tests/test_freezone_video_backend.py
+++ b/tests/test_freezone_video_backend.py
@@ -681,6 +681,8 @@ def test_validate_omni_reference_limits_and_summary() -> None:
         "image_count": 9,
         "video_count": 3,
         "audio_count": 0,
+        "file_count": 0,
+        "link_count": 0,
         "total_count": 12,
     }
 
@@ -709,6 +711,32 @@ def test_validate_omni_reference_limits_and_summary() -> None:
             image_max=1,
             video_max=0,
             audio_max=0,
+            total_max=2,
+        )
+
+    validate_omni_reference_limits(
+        [
+            {"type": "image", "url": "/static/a.png"},
+            {"type": "file", "url": "/static/brief.pdf"},
+        ],
+        image_max=1,
+        video_max=0,
+        audio_max=0,
+        file_max=1,
+        link_max=1,
+        total_max=2,
+    )
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        validate_omni_reference_limits(
+            [
+                {"type": "file", "url": "/static/brief.pdf"},
+                {"type": "link", "url": "https://example.com/brief"},
+            ],
+            image_max=0,
+            video_max=0,
+            audio_max=0,
+            file_max=1,
+            link_max=1,
             total_max=2,
         )
 

--- a/tests/test_freezone_video_route_modes.py
+++ b/tests/test_freezone_video_route_modes.py
@@ -28,6 +28,22 @@ def _catalog(*modes: str) -> dict:
     }
 
 
+def _wan_catalog() -> dict:
+    catalog = _catalog("all_reference")
+    catalog.update(
+        {
+            "referenceImageMax": 10,
+            "referenceVideoMax": 5,
+            "referenceAudioMax": 5,
+            "referenceFileMax": 1,
+            "referenceLinkMax": 1,
+            "referenceFileTypes": ["pdf", "docx", "md"],
+            "maxDuration": 30,
+        }
+    )
+    return catalog
+
+
 async def _install_route_fakes(monkeypatch, tmp_path: Path, capabilities: dict) -> dict:
     captured: dict = {}
 
@@ -129,6 +145,92 @@ async def test_video_edit_forwards_configured_independent_audio(
         },
     ]
     assert captured["validated_audio_items"] == captured["start"]["reference_items"]
+
+
+@pytest.mark.asyncio
+async def test_omni_video_forwards_document_reference(
+    monkeypatch, tmp_path: Path
+) -> None:
+    captured = await _install_route_fakes(monkeypatch, tmp_path, _wan_catalog())
+
+    await freezone_routes.freezone_video_omni_gen(
+        "project",
+        FreezoneVideoOmniGenRequest(
+            prompt="根据产品说明生成广告",
+            references=[
+                {
+                    "type": "file",
+                    "url": "https://example.com/product.PDF?download=1",
+                    "role": "产品说明",
+                }
+            ],
+            model="catalog-video",
+            duration_seconds=30,
+        ),
+        {"username": "admin"},
+    )
+
+    assert captured["request_mode"] == "allReference"
+    assert captured["start"]["duration_seconds"] == 30
+    assert captured["start"]["reference_items"] == [
+        {
+            "type": "file",
+            "path": "https://example.com/product.PDF?download=1",
+            "role": "产品说明",
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_omni_video_forwards_public_link_reference(
+    monkeypatch, tmp_path: Path
+) -> None:
+    captured = await _install_route_fakes(monkeypatch, tmp_path, _wan_catalog())
+
+    await freezone_routes.freezone_video_omni_gen(
+        "project",
+        FreezoneVideoOmniGenRequest(
+            prompt="根据页面内容生成新闻短片",
+            references=[
+                {
+                    "type": "link",
+                    "url": "https://example.com/news/wan-3",
+                    "role": "网页参考",
+                }
+            ],
+            model="catalog-video",
+        ),
+        {"username": "admin"},
+    )
+
+    assert captured["start"]["reference_items"] == [
+        {
+            "type": "link",
+            "path": "https://example.com/news/wan-3",
+            "role": "网页参考",
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_omni_video_rejects_file_and_link_together(
+    monkeypatch, tmp_path: Path
+) -> None:
+    await _install_route_fakes(monkeypatch, tmp_path, _wan_catalog())
+
+    with pytest.raises(HTTPException, match="mutually exclusive"):
+        await freezone_routes.freezone_video_omni_gen(
+            "project",
+            FreezoneVideoOmniGenRequest(
+                prompt="生成介绍视频",
+                references=[
+                    {"type": "file", "url": "https://example.com/brief.pdf"},
+                    {"type": "link", "url": "https://example.com/brief"},
+                ],
+                model="catalog-video",
+            ),
+            {"username": "admin"},
+        )
 
 
 @pytest.mark.asyncio

--- a/tests/test_media_model_request_schema.py
+++ b/tests/test_media_model_request_schema.py
@@ -440,6 +440,9 @@ def test_validates_media_catalog_capabilities():
         "referenceImageMax": 4,
         "referenceVideoMax": 1,
         "referenceAudioMax": 0,
+        "referenceFileMax": 1,
+        "referenceLinkMax": 1,
+        "referenceFileTypes": ["pdf", "docx", "md"],
         "humanReview": True,
         "supportsGenerateAudio": True,
         "request": {"endpoint": "video/generations", "parameters": []},
@@ -466,6 +469,37 @@ def test_validates_media_catalog_capabilities():
             {**valid, "supportedModes": ["text_to_video"]},
             "video",
         )
+
+
+def test_validates_file_and_link_reference_capabilities():
+    base = {
+        "supportedModes": ["all_reference"],
+        "referenceFileMax": 1,
+        "referenceLinkMax": 1,
+        "referenceFileTypes": ["pdf", "docx", "md"],
+        "request": {"endpoint": "video/generations", "parameters": []},
+    }
+    assert validate_media_model_catalog_config(base, "video") is base
+
+    for field in ("referenceFileMax", "referenceLinkMax"):
+        with pytest.raises(MediaModelSchemaError, match=f"{field} cannot exceed 1"):
+            validate_media_model_catalog_config({**base, field: 2}, "video")
+
+    with pytest.raises(MediaModelSchemaError, match="referenceFileMax requires"):
+        validate_media_model_catalog_config(
+            {**base, "supportedModes": ["text_to_video"]}, "video"
+        )
+    with pytest.raises(MediaModelSchemaError, match="lowercase extensions"):
+        validate_media_model_catalog_config(
+            {**base, "referenceFileTypes": [".PDF"]}, "video"
+        )
+
+
+def test_normalizes_reference_file_extensions():
+    normalized = normalize_media_model_catalog_config(
+        {"referenceFileTypes": [".PDF", " docx ", "pdf", "MD"]}
+    )
+    assert normalized["referenceFileTypes"] == ["pdf", "docx", "md"]
 
 
 def test_validates_video_native_audio_capabilities():

--- a/tests/test_media_relay.py
+++ b/tests/test_media_relay.py
@@ -154,6 +154,7 @@ def test_get_media_relay_uses_saved_runtime_cloudinary_config(monkeypatch, tmp_p
         ("PNG", "image", "/image/upload", "image/png"),
         ("mp3", "video", "/video/upload", "audio/mpeg"),
         ("mp4", "video", "/video/upload", "video/mp4"),
+        ("pdf", "raw", "/raw/upload", "application/pdf"),
     ],
 )
 def test_cloudinary_relay_uploads_bytes_with_basic_auth(

--- a/tests/test_model_gateway_settings.py
+++ b/tests/test_model_gateway_settings.py
@@ -66,6 +66,17 @@ from novelvideo.newapi_provisioner import (
 )
 
 
+def _newer_bundled_catalog_version(offset: int = 1) -> str:
+    bundled = json.loads(
+        Path(model_gateway_settings.__file__)
+        .with_name("official_media_models.json")
+        .read_text(encoding="utf-8")
+    )
+    parts = str(bundled["catalogVersion"]).split(".")
+    parts[-1] = str(int(parts[-1]) + offset)
+    return ".".join(parts)
+
+
 def test_generic_comfyui_i2v_defaults_to_widescreen():
     config = model_gateway._default_comfyui_media_model_config("wan-i2v")
 
@@ -1739,9 +1750,10 @@ def test_official_media_catalog_preferences_and_remote_update(monkeypatch, tmp_p
     _isolate_settings_db(monkeypatch, tmp_path)
     source_url = "https://catalog.example.test/official_media_models.json"
     monkeypatch.setenv("OFFICIAL_MEDIA_CATALOG_URL", source_url)
+    remote_version = _newer_bundled_catalog_version()
     payload = {
         "version": 1,
-        "catalogVersion": "2026.08.14.2",
+        "catalogVersion": remote_version,
         "name": "Test official media models",
         "mediaModels": {
             "test-video": {
@@ -1781,7 +1793,7 @@ def test_official_media_catalog_preferences_and_remote_update(monkeypatch, tmp_p
     assert checked.status_code == 200, checked.text
     assert checked.json()["data"]["updated"] is True
     assert current.json()["data"]["source"] == "remote"
-    assert current.json()["data"]["catalogVersion"] == "2026.08.14.2"
+    assert current.json()["data"]["catalogVersion"] == remote_version
     assert current.json()["data"]["modelCount"] == 1
 
 
@@ -1804,7 +1816,7 @@ def test_official_media_catalog_manifest_verifies_hash_and_revalidates_etag(
     monkeypatch.setenv("OFFICIAL_MEDIA_CATALOG_MANIFEST_URL", manifest_url)
     payload = {
         "version": 1,
-        "catalogVersion": "2026.08.14.3",
+        "catalogVersion": _newer_bundled_catalog_version(2),
         "name": "Test official media models",
         "mediaModels": {
             "test-video": {
@@ -3312,11 +3324,15 @@ def test_official_media_model_catalog_uses_ce_export_shape():
     videos = get_official_media_model_catalog("video")
 
     assert len(images) == 6
-    assert len(videos) == 8
+    assert len(videos) == 10
     assert [entry["id"] for entry in videos[:2]] == [
-        "seedance-2.0-fast",
-        "seedance-2.0",
+        "wan3.0-video-prime",
+        "wan3.0-video",
     ]
+    wan = videos[0]
+    assert wan["referenceFileMax"] == 1
+    assert wan["referenceLinkMax"] == 1
+    assert "pdf" in wan["referenceFileTypes"]
     seedream = next(entry for entry in images if entry["id"] == "seedream-5.0-pro")
     assert seedream["gatewayModel"] == "seedream-5.0-pro"
     assert seedream["resolutionOptions"] == ["1k", "2k"]

--- a/tests/test_seedance2_request.py
+++ b/tests/test_seedance2_request.py
@@ -1274,6 +1274,45 @@ async def test_newapi_catalog_model_builds_huimeng_protocol_multimedia_reference
     }
 
 
+@pytest.mark.parametrize(
+    ("reference_type", "reference_url", "expected"),
+    [
+        (
+            "file",
+            "https://example.com/brief.pdf",
+            {"reference_file": "https://example.com/brief.pdf"},
+        ),
+        (
+            "link",
+            "https://example.com/article",
+            {"reference_link": "https://example.com/article"},
+        ),
+    ],
+)
+async def test_newapi_catalog_model_builds_file_and_link_references(
+    reference_type, reference_url, expected
+):
+    from novelvideo.generators.video_generator import NewApiVideoGenerator, ShotReference
+
+    generator = NewApiVideoGenerator(
+        api_key="test-key",
+        endpoint="https://newapi.example",
+        model="wan3.0-video",
+    )
+    metadata: dict[str, object] = {}
+
+    await generator._apply_huimeng_protocol_media_inputs(
+        metadata,
+        mode="all_reference",
+        image_path="",
+        last_frame_path=None,
+        references=[ShotReference(reference_type, reference_url, "参考素材")],
+        log=lambda _message: None,
+    )
+
+    assert metadata == expected
+
+
 async def test_newapi_video_edit_keeps_independent_audio_reference():
     from novelvideo.generators.video_generator import NewApiVideoGenerator, ShotReference
 


### PR DESCRIPTION
## PR 类型 / Type of PR
- [ ] 🐞 Bug 修复 / Bug fix
- [x] ✨ 新功能 / Feature
- [ ] 📝 文档 / Documentation
- [ ] 🧹 重构 / 清理 / Refactor or cleanup
- [ ] ⚙️ 构建 / CI / Build or CI
- [ ] ⚠️ 破坏性变更 / Breaking change

## 改动说明 / What this PR does and why
为视频全能参考模式增加文件和公开网页链接输入，支持通过媒体模型目录配置数量与文件类型。新增 Wan 3.0 官方媒体模型配置，并将文件/链接按 DC-Media 协议写入 `metadata.reference_file` 或 `metadata.reference_link`。

The video all-reference flow now accepts document files and public web links. Model catalog capabilities control availability, limits, and file extensions, and the request is mapped to the DC-Media metadata contract.

## 关联 issue / Linked issues
N/A

## 给 reviewer 的说明 / Notes for the reviewer
- 文件与链接互斥，且各自最多一个。
- 文件上传限制为 100 MB；前后端均有校验。
- 本地调试用官方网关地址未包含在此 PR。
- 验证：`UV_CACHE_DIR=/Users/newyue/claymorelab/.uv-cache uv run pytest tests/test_api_request_body_limit.py tests/test_freezone_reference_file_upload.py tests/test_freezone_video_backend.py tests/test_freezone_video_route_modes.py tests/test_media_model_request_schema.py tests/test_media_relay.py tests/test_seedance2_request.py`（207 passed）；`uv run pytest tests/test_p0b_compliance_generator.py::test_license_inventory_covers_current_git_index`；`cd frontend && pnpm build`。
- 前端完整测试结果为 2800 passed / 6 failed；失败集中在当前 Node 环境的既有 localStorage/FormData 测试，本 PR 未修改对应实现。

## 面向用户的变更 / User-facing change
```release-note
视频节点的全能参考模式现支持文件和公开网页链接，并新增 Wan 3.0 视频模型配置。
```

## 自检 / Checklist
- [ ] 已自测，`uv run pytest` 通过 / Self-tested, `uv run pytest` passes
- [ ] 必要的文档已更新 / Docs updated where needed
- [x] 提交信息清晰（建议 Conventional Commits）/ Clear commits (Conventional Commits suggested)
- [x] 每个 commit 都已 `git commit -s` 附 DCO 签署 / Every commit signed off with `git commit -s` (DCO)
- [x] 我已阅读并同意[贡献者协议](../CONTRIBUTING.md#贡献者协议) / I have read and agree to the contributor terms