### PR TITLE
perf(auth): resolve static owner access by project id

### DIFF
--- a/license-inventory.csv
+++ b/license-inventory.csv
@@ -2075,6 +2075,7 @@ tests/test_project_dependencies.py,Elastic-2.0,2026 SuperTale contributors,REUSE
 tests/test_project_embedding_models.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_project_id_route_paths.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_project_spine_template.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
+tests/test_project_static_auth.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_project_static_media.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_project_task_routes.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_prompt_style_ethnicity_layering.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation

--- a/sbom.spdx.json
+++ b/sbom.spdx.json
@@ -7,7 +7,7 @@
     ]
   },
   "dataLicense": "CC0-1.0",
-  "documentNamespace": "https://supertale.local/spdx/supertale-ce/a8ebf133a3364a49",
+  "documentNamespace": "https://supertale.local/spdx/supertale-ce/bb2dd8180d0f7743",
   "name": "supertale-ce-p0b-sbom",
   "packages": [
     {
@@ -18,7 +18,7 @@
       "licenseConcluded": "Elastic-2.0",
       "licenseDeclared": "Elastic-2.0",
       "name": "supertale-ce",
-      "versionInfo": "1.3.2"
+      "versionInfo": "2.0.1"
     },
     {
       "SPDXID": "SPDXRef-Package-aiofiles",

--- a/src/novelvideo/api/routes/projects.py
+++ b/src/novelvideo/api/routes/projects.py
@@ -32,7 +32,7 @@ from novelvideo.knowledge_pipeline import KNOWLEDGE_PIPELINE_KEY, KNOWLEDGE_PIPE
 from novelvideo.novel_source import has_imported_novel
 from novelvideo.ports import get_project_access, get_project_registry
 from novelvideo.scene_prerequisites import scene_build_applies
-from novelvideo.ports.project import ProjectRecord
+from novelvideo.ports.project import ProjectRecord, require_role_value
 from novelvideo.project_config import (
     default_aspect_ratio_for_spine_template,
     load_effective_narration_style_for_voice_from_state_dir,
@@ -523,7 +523,11 @@ async def get_project(project: str, user: dict = Depends(get_api_user)):
 
 @router.get("/projects/{project}/static-auth", include_in_schema=False)
 async def authorize_project_static_media(project: str, user: dict = Depends(get_api_user)):
-    await resolve_project_context(user=user, project_id=project, required_role="viewer")
+    requester_user_id = await user_id_from_api_user(user)
+    access = get_project_access()
+    principals = await access.resolve_requester_principals(requester_user_id)
+    role = await access.effective_project_role_by_id(project, principals)
+    require_role_value(role, "viewer")
     return Response(status_code=204)
 
 

--- a/src/novelvideo/ports/local/project.py
+++ b/src/novelvideo/ports/local/project.py
@@ -312,6 +312,13 @@ class AllowAllProjectAccess:
     ) -> str | None:
         return "owner"
 
+    async def effective_project_role_by_id(
+        self,
+        project_id: str,
+        principals: list[Principal],
+    ) -> str | None:
+        return "owner"
+
     async def count_project_task_eligible_users(
         self,
         *,

--- a/src/novelvideo/ports/project.py
+++ b/src/novelvideo/ports/project.py
@@ -104,6 +104,12 @@ class ProjectAccess(Protocol):
         principals: list[Principal],
     ) -> str | None: ...
 
+    async def effective_project_role_by_id(
+        self,
+        project_id: str,
+        principals: list[Principal],
+    ) -> str | None: ...
+
     async def count_project_task_eligible_users(
         self,
         *,

--- a/tests/ports/test_access_local.py
+++ b/tests/ports/test_access_local.py
@@ -25,6 +25,7 @@ async def test_allow_all_project_access_returns_owner_semantics() -> None:
 
     principals = await access.resolve_requester_principals("u1")
     role = await access.effective_project_role(_project(), principals)
+    role_by_id = await access.effective_project_role_by_id("proj-1", principals)
     count = await access.count_project_task_eligible_users(
         project_id="proj-1",
         owner_type="user",
@@ -33,4 +34,5 @@ async def test_allow_all_project_access_returns_owner_semantics() -> None:
 
     assert principals == [Principal("user", "local")]
     assert role == "owner"
+    assert role_by_id == "owner"
     assert count == 1

--- a/tests/test_project_static_auth.py
+++ b/tests/test_project_static_auth.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import pytest
+
+from novelvideo.api.routes import projects
+from novelvideo.ports.project import Principal
+
+
+@pytest.mark.asyncio
+async def test_static_auth_uses_project_id_role_lookup(monkeypatch):
+    calls = []
+
+    class FakeAccess:
+        async def resolve_requester_principals(self, user_id: str):
+            calls.append(("principals", user_id))
+            return [Principal("user", user_id)]
+
+        async def effective_project_role_by_id(self, project_id: str, principals):
+            calls.append(("role", project_id, principals))
+            return "owner"
+
+    async def user_id_from_api_user(user):
+        assert user == {"username": "alice"}
+        return "user-1"
+
+    monkeypatch.setattr(projects, "get_project_access", lambda: FakeAccess())
+    monkeypatch.setattr(projects, "user_id_from_api_user", user_id_from_api_user)
+
+    response = await projects.authorize_project_static_media(
+        "project-1",
+        user={"username": "alice"},
+    )
+
+    assert response.status_code == 204
+    assert calls == [
+        ("principals", "user-1"),
+        ("role", "project-1", [Principal("user", "user-1")]),
+    ]


### PR DESCRIPTION
## Summary
- add a narrow `effective_project_role_by_id` project access port
- route `/projects/{project}/static-auth` through the project-id role lookup
- keep CE local mode owner semantics unchanged
- let EE cache only immutable project owner facts instead of mutable project records

## Companion
- Depends on claymorelab/SuperTale#130
- Deployment order: SuperTale first, then DramaClaw

## Verification
- targeted pytest: 2 passed
- Ruff passed
- git diff --check passed