### PR TITLE
fix: move blocking route work off event loop

### DIFF
--- a/license-inventory.csv
+++ b/license-inventory.csv
@@ -1496,6 +1496,7 @@ src/novelvideo/api/routes/styles.py,Elastic-2.0,2026 SuperTale contributors,REUS
 src/novelvideo/api/routes/tasks.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 src/novelvideo/api/schemas.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 src/novelvideo/api/task_start_errors.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
+src/novelvideo/api/upload_workers.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 src/novelvideo/api/viewer_manifests.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 src/novelvideo/api/wsgi.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 src/novelvideo/assets/__init__.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
@@ -1890,6 +1891,7 @@ tests/support/egress_ledger.py,Elastic-2.0,2026 SuperTale contributors,REUSE.tom
 tests/test_acceptance_run_script.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_ai_identity_detector.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_api_assets.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
+tests/test_api_asset_upload_offload.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_api_audio_indextts2_cutover.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_api_audio_prereq.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_api_auth_ports.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
@@ -2127,6 +2129,7 @@ tests/test_seedance2_config_persistence.py,Elastic-2.0,2026 SuperTale contributo
 tests/test_seedance2_fast_demo.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_seedance2_models.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_seedance2_panel_service_narration_audio.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
+tests/test_seedance2_panel_voice_offload.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_seedance2_prompt.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_seedance2_request.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_seedance2_status_returned_last_frame.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
@@ -2162,6 +2165,7 @@ tests/test_task_envelope_producer.py,Elastic-2.0,2026 SuperTale contributors,REU
 tests/test_task_envelope_signing_config.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_task_payload_projection.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_task_payload_projection_guardrails.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
+tests/test_task_route_threading.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_task_runner_cancel_checkpoints.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_task_runner_home_node_placement.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_task_runner_state_dir.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation

--- a/src/novelvideo/api/app.py
+++ b/src/novelvideo/api/app.py
@@ -37,6 +37,7 @@ from novelvideo.task_backend.limits import (
     ProjectUserTaskLimitExceeded,
     UserTaskLimitExceeded,
 )
+from novelvideo.utils.upload_safety import MAX_PROJECT_UPLOAD_BYTES
 
 logger = logging.getLogger("novelvideo.api.app")
 
@@ -45,7 +46,7 @@ logger = logging.getLogger("novelvideo.api.app")
 # (50k nodes × ~80 bytes JSON each) with comfortable headroom; anything
 # bigger is almost certainly a runaway client / DoS attempt.
 MAX_REQUEST_BODY_BYTES = 5 * 1024 * 1024
-MAX_UPLOAD_REQUEST_BODY_BYTES = 200 * 1024 * 1024
+MAX_UPLOAD_REQUEST_BODY_BYTES = MAX_PROJECT_UPLOAD_BYTES
 _RESOURCE_REQUEST_COUNTS: Counter[str] = Counter()
 _RESOURCE_REQUEST_TOTAL = 0
 _RESOURCE_REQUEST_LOCK = threading.Lock()

--- a/src/novelvideo/api/routes/characters.py
+++ b/src/novelvideo/api/routes/characters.py
@@ -1,10 +1,10 @@
 """角色列表 & 肖像/身份图生成端点。"""
 
 import asyncio
-import io
 import logging
 import re
 import shutil
+import tempfile
 from contextlib import asynccontextmanager
 from datetime import datetime
 from pathlib import Path
@@ -18,6 +18,7 @@ logger = logging.getLogger("novelvideo.api.characters")
 
 from novelvideo.api.asset_metadata import newest_updated_at, tree_updated_at
 from novelvideo.api.auth import get_api_user
+from novelvideo.api.upload_workers import run_asset_upload_operation
 from novelvideo.api.deps import (
     may_run_asset_repair,
     make_sqlite_store,
@@ -73,10 +74,13 @@ from novelvideo.seedance2_i2v.character_voice_storage import (
     AGE_GROUP_SLOTS as VOICE_AGE_GROUP_SLOTS,
     ALL_SLOTS as VOICE_SAMPLE_SLOTS,
     DEFAULT_SLOT as VOICE_DEFAULT_SLOT,
+    character_voice_resource_key,
     clear_character_voice_file,
     decode_recorded_audio_data_url,
     persist_character_voice_file,
+    run_voice_media_operation,
     trim_existing_character_voice_file,
+    voice_resource_lock,
 )
 from novelvideo.sqlite_store import SQLiteStore
 
@@ -271,6 +275,78 @@ def _backup_character_asset(path: Path) -> Path | None:
     backup = path.with_name(f"{path.stem}_{ts}{path.suffix}")
     shutil.copy2(path, backup)
     return backup
+
+
+def _persist_uploaded_character_image(file: UploadFile, target: Path) -> None:
+    """Decode and atomically publish one uploaded character image."""
+
+    from PIL import Image
+
+    tmp_path: Path | None = None
+    converted = None
+    try:
+        try:
+            file.file.seek(0)
+        except (AttributeError, OSError):
+            pass
+        with Image.open(file.file) as source:
+            converted = source.convert("RGB")
+        target.parent.mkdir(parents=True, exist_ok=True)
+        with tempfile.NamedTemporaryFile(
+            prefix=f".{target.stem}_",
+            suffix=target.suffix,
+            dir=target.parent,
+            delete=False,
+        ) as tmp:
+            tmp_path = Path(tmp.name)
+        converted.save(tmp_path, format="PNG")
+        _backup_character_asset(target)
+        tmp_path.replace(target)
+        tmp_path = None
+    finally:
+        if converted is not None:
+            converted.close()
+        if tmp_path is not None:
+            tmp_path.unlink(missing_ok=True)
+
+
+def _persist_uploaded_character_voice(
+    file: UploadFile,
+    *,
+    project_dir: Path,
+    character_name: str,
+    slot: str,
+    filename: str,
+) -> tuple[str, str, str]:
+    try:
+        file.file.seek(0)
+    except (AttributeError, OSError):
+        pass
+    content = file.file.read()
+    return persist_character_voice_file(
+        project_dir=project_dir,
+        character_name=character_name,
+        slot=slot,
+        filename=filename,
+        content=content,
+    )
+
+
+def _persist_recorded_character_voice(
+    data_url: str,
+    *,
+    project_dir: Path,
+    character_name: str,
+    slot: str,
+) -> tuple[str, str, str]:
+    content, extension = decode_recorded_audio_data_url(data_url)
+    return persist_character_voice_file(
+        project_dir=project_dir,
+        character_name=character_name,
+        slot=slot,
+        filename=f"recorded{extension}",
+        content=content,
+    )
 
 
 def _resolve_character_asset_path(
@@ -1291,21 +1367,10 @@ async def upload_character_voice_sample(
         return {"ok": False, "error": f"Unsupported voice slot: {slot}"}
 
     filename = file.filename or ""
-    content = await file.read()
-    try:
-        rel_path, sha256, updated_at = persist_character_voice_file(
-            project_dir=project_dir,
-            character_name=name,
-            slot=slot,
-            filename=filename,
-            content=content,
-        )
-    except ValueError as exc:
-        return {"ok": False, "error": str(exc)}
 
-    return {
-        "ok": True,
-        "data": await _apply_character_voice_update(
+    async def finalize_voice_update(result):
+        rel_path, sha256, updated_at = result
+        return await _apply_character_voice_update(
             ctx=ctx,
             project_dir=project_dir,
             character=character,
@@ -1314,8 +1379,26 @@ async def upload_character_voice_sample(
             path=rel_path,
             sha256=sha256,
             updated_at=updated_at,
-        ),
-    }
+        )
+
+    try:
+        key = character_voice_resource_key(
+            project_dir=project_dir, character_name=name, slot=slot
+        )
+        async with voice_resource_lock(key):
+            data = await run_voice_media_operation(
+                _persist_uploaded_character_voice,
+                file,
+                project_dir=project_dir,
+                character_name=name,
+                slot=slot,
+                filename=filename,
+                finalize=finalize_voice_update,
+            )
+    except ValueError as exc:
+        return {"ok": False, "error": str(exc)}
+
+    return {"ok": True, "data": data}
 
 
 @router.post("/projects/{project}/characters/{name}/voice-samples/{slot}/record")
@@ -1336,21 +1419,9 @@ async def record_character_voice_sample(
     if slot not in VOICE_SAMPLE_SLOTS:
         return {"ok": False, "error": f"Unsupported voice slot: {slot}"}
 
-    try:
-        content, extension = decode_recorded_audio_data_url(body.data_url)
-        rel_path, sha256, updated_at = persist_character_voice_file(
-            project_dir=project_dir,
-            character_name=name,
-            slot=slot,
-            filename=f"recorded{extension}",
-            content=content,
-        )
-    except ValueError as exc:
-        return {"ok": False, "error": str(exc)}
-
-    return {
-        "ok": True,
-        "data": await _apply_character_voice_update(
+    async def finalize_voice_update(result):
+        rel_path, sha256, updated_at = result
+        return await _apply_character_voice_update(
             ctx=ctx,
             project_dir=project_dir,
             character=character,
@@ -1359,8 +1430,25 @@ async def record_character_voice_sample(
             path=rel_path,
             sha256=sha256,
             updated_at=updated_at,
-        ),
-    }
+        )
+
+    try:
+        key = character_voice_resource_key(
+            project_dir=project_dir, character_name=name, slot=slot
+        )
+        async with voice_resource_lock(key):
+            data = await run_voice_media_operation(
+                _persist_recorded_character_voice,
+                body.data_url,
+                project_dir=project_dir,
+                character_name=name,
+                slot=slot,
+                finalize=finalize_voice_update,
+            )
+    except ValueError as exc:
+        return {"ok": False, "error": str(exc)}
+
+    return {"ok": True, "data": data}
 
 
 @router.post("/projects/{project}/characters/{name}/voice-samples/{slot}/trim")
@@ -1381,21 +1469,9 @@ async def trim_character_voice_sample(
     if slot not in VOICE_SAMPLE_SLOTS:
         return {"ok": False, "error": f"Unsupported voice slot: {slot}"}
 
-    try:
-        rel_path, sha256, updated_at = trim_existing_character_voice_file(
-            project_dir=project_dir,
-            character_name=name,
-            slot=slot,
-            source_path=body.source_path,
-            start_seconds=body.start_seconds,
-            duration_seconds=body.duration_seconds,
-        )
-    except ValueError as exc:
-        return {"ok": False, "error": str(exc)}
-
-    return {
-        "ok": True,
-        "data": await _apply_character_voice_update(
+    async def finalize_voice_update(result):
+        rel_path, sha256, updated_at = result
+        return await _apply_character_voice_update(
             ctx=ctx,
             project_dir=project_dir,
             character=character,
@@ -1404,8 +1480,27 @@ async def trim_character_voice_sample(
             path=rel_path,
             sha256=sha256,
             updated_at=updated_at,
-        ),
-    }
+        )
+
+    try:
+        key = character_voice_resource_key(
+            project_dir=project_dir, character_name=name, slot=slot
+        )
+        async with voice_resource_lock(key):
+            data = await run_voice_media_operation(
+                trim_existing_character_voice_file,
+                project_dir=project_dir,
+                character_name=name,
+                slot=slot,
+                source_path=body.source_path,
+                start_seconds=body.start_seconds,
+                duration_seconds=body.duration_seconds,
+                finalize=finalize_voice_update,
+            )
+    except ValueError as exc:
+        return {"ok": False, "error": str(exc)}
+
+    return {"ok": True, "data": data}
 
 
 @router.post("/projects/{project}/characters/{name}/voice-samples/{slot}/delete")
@@ -1425,14 +1520,8 @@ async def delete_character_voice_sample(
     if slot not in VOICE_SAMPLE_SLOTS:
         return {"ok": False, "error": f"Unsupported voice slot: {slot}"}
 
-    clear_character_voice_file(
-        project_dir=project_dir,
-        character_name=name,
-        slot=slot,
-    )
-    return {
-        "ok": True,
-        "data": await _apply_character_voice_update(
+    async def finalize_voice_delete(_removed):
+        return await _apply_character_voice_update(
             ctx=ctx,
             project_dir=project_dir,
             character=character,
@@ -1441,8 +1530,20 @@ async def delete_character_voice_sample(
             path="",
             sha256="",
             updated_at="",
-        ),
-    }
+        )
+
+    key = character_voice_resource_key(
+        project_dir=project_dir, character_name=name, slot=slot
+    )
+    async with voice_resource_lock(key):
+        data = await run_voice_media_operation(
+            clear_character_voice_file,
+            project_dir=project_dir,
+            character_name=name,
+            slot=slot,
+            finalize=finalize_voice_delete,
+        )
+    return {"ok": True, "data": data}
 
 
 @router.post("/projects/{project}/characters/{name}/identities")
@@ -1667,23 +1768,18 @@ async def upload_portrait(
     if character is None:
         return {"ok": False, "error": f"Character '{name}' not found"}
 
-    from PIL import Image
-
-    content = await file.read()
-    img = Image.open(io.BytesIO(content)).convert("RGB")
-
     char_dir = project_dir / "assets" / "characters" / name
-    char_dir.mkdir(parents=True, exist_ok=True)
-
-    # 备份旧肖像
     portrait_path = char_dir / "portrait.png"
-    if portrait_path.exists():
-        ts = datetime.now().strftime("%Y%m%d%H%M%S")
-        backup = char_dir / f"portrait_{ts}.png"
-        shutil.copy(portrait_path, backup)
 
-    img.save(str(portrait_path), format="PNG")
-    await store.touch_character_asset(name)
+    async def touch_portrait(_result):
+        await store.touch_character_asset(name)
+
+    await run_asset_upload_operation(
+        _persist_uploaded_character_image,
+        file,
+        portrait_path,
+        finalize=touch_portrait,
+    )
 
     portrait_url = _asset_url(ctx, project_dir, portrait_path)
 
@@ -1708,17 +1804,9 @@ async def upload_identity_image(
     if character is None:
         return {"ok": False, "error": f"Character '{name}' not found"}
 
-    from PIL import Image
-
-    content = await file.read()
-    img = Image.open(io.BytesIO(content)).convert("RGB")
-
     identities_dir = project_dir / "assets" / "characters" / name / "identities"
-    identities_dir.mkdir(parents=True, exist_ok=True)
-
     img_path = identities_dir / f"{identity_name}.png"
-    _backup_character_asset(img_path)
-    img.save(str(img_path), format="PNG")
+    await run_asset_upload_operation(_persist_uploaded_character_image, file, img_path)
 
     image_url = _asset_url(ctx, project_dir, img_path)
 
@@ -1761,21 +1849,21 @@ async def upload_identity_costume(
     if identity is None:
         return {"ok": False, "error": f"Identity '{identity_id}' not found"}
 
-    from PIL import Image
-
-    content = await file.read()
-    img = Image.open(io.BytesIO(content)).convert("RGB")
     safe_name = _safe_asset_name(identity.identity_name)
     identities_dir = project_dir / "assets" / "characters" / name / "identities"
-    identities_dir.mkdir(parents=True, exist_ok=True)
     target = identities_dir / f"{safe_name}_costume.png"
-    if target.exists():
-        backup = (
-            identities_dir / f"{safe_name}_costume_{datetime.now():%Y%m%d%H%M%S}.png"
+
+    async def update_costume_path(_result):
+        await store.update_character_identity(
+            name, identity_id, costume_image=str(target)
         )
-        shutil.copy(target, backup)
-    img.save(str(target), format="PNG")
-    await store.update_character_identity(name, identity_id, costume_image=str(target))
+
+    await run_asset_upload_operation(
+        _persist_uploaded_character_image,
+        file,
+        target,
+        finalize=update_costume_path,
+    )
     return {
         "ok": True,
         "data": {"costume_image_url": _asset_url(ctx, project_dir, target)},
@@ -1845,22 +1933,21 @@ async def upload_identity_portrait(
     if identity is None:
         return {"ok": False, "error": f"Identity '{identity_id}' not found"}
 
-    from PIL import Image
-
-    content = await file.read()
-    img = Image.open(io.BytesIO(content)).convert("RGB")
     safe_name = _safe_asset_name(identity.identity_name)
     identities_dir = project_dir / "assets" / "characters" / name / "identities"
-    identities_dir.mkdir(parents=True, exist_ok=True)
     target = identities_dir / f"{name}_{safe_name}_portrait.png"
-    if target.exists():
-        backup = (
-            identities_dir
-            / f"{name}_{safe_name}_portrait_{datetime.now():%Y%m%d%H%M%S}.png"
+
+    async def update_portrait_path(_result):
+        await store.update_character_identity(
+            name, identity_id, portrait_image=str(target)
         )
-        shutil.copy(target, backup)
-    img.save(str(target), format="PNG")
-    await store.update_character_identity(name, identity_id, portrait_image=str(target))
+
+    await run_asset_upload_operation(
+        _persist_uploaded_character_image,
+        file,
+        target,
+        finalize=update_portrait_path,
+    )
     return {
         "ok": True,
         "data": {"portrait_image_url": _asset_url(ctx, project_dir, target)},

--- a/src/novelvideo/api/routes/characters.py
+++ b/src/novelvideo/api/routes/characters.py
@@ -4,7 +4,6 @@ import asyncio
 import logging
 import re
 import shutil
-import tempfile
 from contextlib import asynccontextmanager
 from datetime import datetime
 from pathlib import Path
@@ -70,6 +69,8 @@ from novelvideo.utils.path_resolver import (
     canonical_identity_portrait_path,
 )
 from novelvideo.utils.static_urls import project_static_url
+from novelvideo.utils.async_ops import metadata_io_limiter
+from novelvideo.utils.upload_safety import create_staged_upload_file
 from novelvideo.seedance2_i2v.character_voice_storage import (
     AGE_GROUP_SLOTS as VOICE_AGE_GROUP_SLOTS,
     ALL_SLOTS as VOICE_SAMPLE_SLOTS,
@@ -292,13 +293,12 @@ def _persist_uploaded_character_image(file: UploadFile, target: Path) -> None:
         with Image.open(file.file) as source:
             converted = source.convert("RGB")
         target.parent.mkdir(parents=True, exist_ok=True)
-        with tempfile.NamedTemporaryFile(
+        tmp_path = create_staged_upload_file(
+            target.parent,
             prefix=f".{target.stem}_",
             suffix=target.suffix,
-            dir=target.parent,
-            delete=False,
-        ) as tmp:
-            tmp_path = Path(tmp.name)
+            destination=target,
+        )
         converted.save(tmp_path, format="PNG")
         _backup_character_asset(target)
         tmp_path.replace(target)
@@ -1542,6 +1542,7 @@ async def delete_character_voice_sample(
             character_name=name,
             slot=slot,
             finalize=finalize_voice_delete,
+            worker_limiter=metadata_io_limiter(),
         )
     return {"ok": True, "data": data}
 
@@ -2171,7 +2172,11 @@ async def get_identity_attempts(
             if not p.name.endswith("_costume.png") and "_portrait" not in p.stem
         ]
     )
-    portrait_attempts = len(list(identities_dir.glob(f"*{safe_name}_portrait*.png")))
+    portrait_attempts = sum(
+        1
+        for path in identities_dir.glob(f"*{safe_name}_portrait*.png")
+        if path.is_file() and not path.name.startswith(".")
+    )
     return {
         "ok": True,
         "data": {

--- a/src/novelvideo/api/routes/episodes.py
+++ b/src/novelvideo/api/routes/episodes.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import Literal
 
 from fastapi import APIRouter, Depends
+from starlette.concurrency import run_in_threadpool
 
 from novelvideo.api.auth import get_api_user
 from novelvideo.api.chapter_preview import build_chapter_preview
@@ -214,8 +215,11 @@ async def _enqueue_episode_asset_planner(
             user=user,
         )
     if asset_kind == "scene":
-        build_task = get_task_manager().get_task_for_project(
-            resolved.ctx, "build_scenes", 0
+        build_task = await run_in_threadpool(
+            get_task_manager().get_task_for_project,
+            resolved.ctx,
+            "build_scenes",
+            0,
         )
         if build_task is not None and build_task.status in ACTIVE_PROJECT_TASK_STATUSES:
             return scene_prerequisite_response(SceneCatalogBuildingError())
@@ -558,8 +562,11 @@ async def plan_episode_identities(
     resolved = await resolve_project_scope(project, user, required_role="editor")
     if resolved.ctx is not None:
         try:
-            build_task = get_task_manager().get_task_for_project(
-                resolved.ctx, "build_characters", 0
+            build_task = await run_in_threadpool(
+                get_task_manager().get_task_for_project,
+                resolved.ctx,
+                "build_characters",
+                0,
             )
             if (
                 build_task is not None

--- a/src/novelvideo/api/routes/freezone.py
+++ b/src/novelvideo/api/routes/freezone.py
@@ -26,6 +26,7 @@ from fastapi import (
     APIRouter, Body, Depends, File, Form, HTTPException, Query, UploadFile,
 )
 from fastapi.responses import FileResponse, JSONResponse
+from starlette.concurrency import run_in_threadpool
 
 from novelvideo.api.auth import get_api_user
 from novelvideo.api.deps import (
@@ -9853,11 +9854,18 @@ async def freezone_job_result(
     ctx, username, project_name, project_dir, _output_dir = await _resolve_freezone_project(
         project, user, required_role="viewer"
     )
-    task = (
-        get_task_manager().get_task_for_project(ctx, task_type, 0, scope=job_id)
-        if ctx is not None
-        else get_task_manager().get_task(task_type, username, project_name, 0, scope=job_id)
-    )
+    if ctx is not None:
+        task = await run_in_threadpool(
+            get_task_manager().get_task_for_project,
+            ctx,
+            task_type,
+            0,
+            scope=job_id,
+        )
+    else:
+        task = get_task_manager().get_task(
+            task_type, username, project_name, 0, scope=job_id
+        )
     if task_type == "freezone_image_to_3gs":
         if task is not None:
             if task.status == "failed":
@@ -10108,16 +10116,17 @@ async def freezone_skill_run_result(
         task_beat_num = int(task_beat_num_raw) if task_beat_num_raw is not None else None
     except (TypeError, ValueError):
         task_beat_num = None
-    task = (
-        get_task_manager().get_task_for_project(
+    if ctx is not None:
+        task = await run_in_threadpool(
+            get_task_manager().get_task_for_project,
             ctx,
             task_type,
             task_episode,
             beat_num=task_beat_num,
             scope=task_scope,
         )
-        if ctx is not None
-        else get_task_manager().get_task(
+    else:
+        task = get_task_manager().get_task(
             task_type,
             username,
             project_name,
@@ -10125,7 +10134,6 @@ async def freezone_skill_run_result(
             beat_num=task_beat_num,
             scope=task_scope,
         )
-    )
     task_status = getattr(task, "status", None)
     if task is not None and task_status == "failed":
         return SkillRunResult(

--- a/src/novelvideo/api/routes/freezone.py
+++ b/src/novelvideo/api/routes/freezone.py
@@ -9863,8 +9863,13 @@ async def freezone_job_result(
             scope=job_id,
         )
     else:
-        task = get_task_manager().get_task(
-            task_type, username, project_name, 0, scope=job_id
+        task = await run_in_threadpool(
+            get_task_manager().get_task,
+            task_type,
+            username,
+            project_name,
+            0,
+            scope=job_id,
         )
     if task_type == "freezone_image_to_3gs":
         if task is not None:
@@ -10126,7 +10131,8 @@ async def freezone_skill_run_result(
             scope=task_scope,
         )
     else:
-        task = get_task_manager().get_task(
+        task = await run_in_threadpool(
+            get_task_manager().get_task,
             task_type,
             username,
             project_name,

--- a/src/novelvideo/api/routes/generation.py
+++ b/src/novelvideo/api/routes/generation.py
@@ -5,11 +5,12 @@ import io
 import logging
 import os
 import re
+from contextlib import suppress
 from pathlib import Path
 from typing import Any
 
 from fastapi import APIRouter, Depends, File, Form, HTTPException, Query, UploadFile, status
-from fastapi.responses import JSONResponse
+from fastapi.responses import FileResponse, JSONResponse
 
 from novelvideo.api.auth import get_api_user, require_scope
 from novelvideo.api.deps import (
@@ -88,6 +89,17 @@ from novelvideo.services.background_anchor_service import (
     select_background_anchor,
 )
 from novelvideo.utils.path_resolver import PathResolver, compute_identity_path, compute_portrait_path
+
+
+class _TemporaryFileResponse(FileResponse):
+    """Delete the response file after ASGI delivery, including failed or cancelled sends."""
+
+    async def __call__(self, scope, receive, send) -> None:
+        try:
+            await super().__call__(scope, receive, send)
+        finally:
+            with suppress(OSError):
+                Path(self.path).unlink(missing_ok=True)
 
 router = APIRouter()
 
@@ -1498,17 +1510,16 @@ async def upload_seedance2_asset(
         user=user,
     )
     from novelvideo.seedance2_i2v.panel_service import (
-        save_seedance2_uploaded_asset,
+        save_seedance2_uploaded_file,
     )
 
-    content = await file.read()
-    target = await save_seedance2_uploaded_asset(
+    target = await save_seedance2_uploaded_file(
         store=ctx["store"],
         episode=episode_num,
         beat=ctx["beat"],
         project_dir=ctx["output_dir"],
         filename=file.filename or "seedance2_asset",
-        content=content,
+        upload_stream=file.file,
         content_type=file.content_type or "",
     )
     if target is None:
@@ -1544,6 +1555,7 @@ async def delete_seedance2_asset(
         store=ctx["store"],
         episode=episode_num,
         beat=ctx["beat"],
+        project_dir=ctx["output_dir"],
         media_kind=body.media_kind,
         path=body.path,
     )
@@ -5893,11 +5905,14 @@ async def cut_grid(
 @router.post("/projects/{project}/episodes/{episode_num}/export/zip")
 async def export_zip(project: str, episode_num: int, user: dict = Depends(get_api_user)):
     """打包指定集的所有资源为 ZIP 文件下载。"""
+    import asyncio
+    import anyio
     import zipfile
     import tempfile
 
-    from fastapi.responses import FileResponse
+    from starlette.background import BackgroundTask
     from novelvideo.export.episode_export import build_srt_content
+    from novelvideo.utils.async_ops import call_blocking
     from novelvideo.utils.path_resolver import PathResolver
 
     resolved = await _resolve_generation_project(project, user, required_role="viewer")
@@ -5944,21 +5959,55 @@ async def export_zip(project: str, episode_num: int, user: dict = Depends(get_ap
 
     srt_content = await build_srt_content(project_dir, episode_num, beats)
 
-    # 创建临时 ZIP 文件
-    tmp = tempfile.NamedTemporaryFile(delete=False, suffix=".zip")
-    tmp.close()
+    def build_zip_file() -> str:
+        tmp_path = ""
+        try:
+            tmp = tempfile.NamedTemporaryFile(delete=False, suffix=".zip")
+            tmp_path = tmp.name
+            tmp.close()
+            with zipfile.ZipFile(tmp_path, "w", zipfile.ZIP_STORED) as zf:
+                for file_path, arc_name in files_to_pack:
+                    zf.write(file_path, arc_name)
+                if srt_content:
+                    zf.writestr(
+                        f"{ep_tag}.srt",
+                        srt_content,
+                        compress_type=zipfile.ZIP_DEFLATED,
+                    )
+            return tmp_path
+        except Exception:
+            if tmp_path:
+                Path(tmp_path).unlink(missing_ok=True)
+            raise
 
-    with zipfile.ZipFile(tmp.name, "w", zipfile.ZIP_DEFLATED) as zf:
-        for file_path, arc_name in files_to_pack:
-            zf.write(file_path, arc_name)
-        if srt_content:
-            zf.writestr(f"{ep_tag}.srt", srt_content)
-
-    return FileResponse(
-        path=tmp.name,
-        filename=f"{project_name}_{ep_tag}.zip",
-        media_type="application/zip",
-    )
+    build_task = asyncio.create_task(call_blocking(build_zip_file))
+    try:
+        tmp_path = await asyncio.shield(build_task)
+    except asyncio.CancelledError as cancellation:
+        while not build_task.done():
+            try:
+                with anyio.CancelScope(shield=True):
+                    await asyncio.shield(build_task)
+            except asyncio.CancelledError:
+                continue
+            except BaseException:
+                break
+        try:
+            cancelled_tmp_path = build_task.result()
+        except BaseException:
+            raise
+        Path(cancelled_tmp_path).unlink(missing_ok=True)
+        raise cancellation
+    try:
+        return _TemporaryFileResponse(
+            path=tmp_path,
+            filename=f"{project_name}_{ep_tag}.zip",
+            media_type="application/zip",
+            background=BackgroundTask(Path(tmp_path).unlink, missing_ok=True),
+        )
+    except Exception:
+        Path(tmp_path).unlink(missing_ok=True)
+        raise
 
 
 # ---------------------------------------------------------------------------

--- a/src/novelvideo/api/routes/generation.py
+++ b/src/novelvideo/api/routes/generation.py
@@ -5906,13 +5906,11 @@ async def cut_grid(
 async def export_zip(project: str, episode_num: int, user: dict = Depends(get_api_user)):
     """打包指定集的所有资源为 ZIP 文件下载。"""
     import asyncio
-    import anyio
     import zipfile
     import tempfile
 
-    from starlette.background import BackgroundTask
     from novelvideo.export.episode_export import build_srt_content
-    from novelvideo.utils.async_ops import call_blocking
+    from novelvideo.utils.async_ops import call_blocking, wait_for_task_completion
     from novelvideo.utils.path_resolver import PathResolver
 
     resolved = await _resolve_generation_project(project, user, required_role="viewer")
@@ -5981,29 +5979,15 @@ async def export_zip(project: str, episode_num: int, user: dict = Depends(get_ap
             raise
 
     build_task = asyncio.create_task(call_blocking(build_zip_file))
-    try:
-        tmp_path = await asyncio.shield(build_task)
-    except asyncio.CancelledError as cancellation:
-        while not build_task.done():
-            try:
-                with anyio.CancelScope(shield=True):
-                    await asyncio.shield(build_task)
-            except asyncio.CancelledError:
-                continue
-            except BaseException:
-                break
-        try:
-            cancelled_tmp_path = build_task.result()
-        except BaseException:
-            raise
-        Path(cancelled_tmp_path).unlink(missing_ok=True)
+    tmp_path, cancellation = await wait_for_task_completion(build_task)
+    if cancellation is not None:
+        Path(tmp_path).unlink(missing_ok=True)
         raise cancellation
     try:
         return _TemporaryFileResponse(
             path=tmp_path,
             filename=f"{project_name}_{ep_tag}.zip",
             media_type="application/zip",
-            background=BackgroundTask(Path(tmp_path).unlink, missing_ok=True),
         )
     except Exception:
         Path(tmp_path).unlink(missing_ok=True)

--- a/src/novelvideo/api/routes/ingest.py
+++ b/src/novelvideo/api/routes/ingest.py
@@ -1,13 +1,18 @@
 """小说上传 & 导入端点。"""
 
+import asyncio
+import functools
 import logging
 import os
 import secrets
 import shutil
 import stat
+from collections.abc import Callable
 from pathlib import Path
-from typing import Annotated
+from typing import Annotated, Any
 
+import anyio
+from anyio.lowlevel import RunVar
 from fastapi import APIRouter, Depends, File, Form, UploadFile
 
 from novelvideo.api.auth import get_api_user, require_scope
@@ -48,6 +53,48 @@ from novelvideo.utils.upload_safety import (
 
 logger = logging.getLogger("novelvideo.api.ingest")
 router = APIRouter()
+_INGEST_UPLOAD_CONCURRENCY = 2
+_ingest_upload_limiter_var: RunVar[anyio.CapacityLimiter] = RunVar(
+    "ingest_upload_limiter"
+)
+
+
+def _ingest_upload_limiter() -> anyio.CapacityLimiter:
+    """Return the upload-processing gate scoped to the current async run."""
+
+    limiter = _ingest_upload_limiter_var.get(None)
+    if limiter is None:
+        limiter = anyio.CapacityLimiter(_INGEST_UPLOAD_CONCURRENCY)
+        _ingest_upload_limiter_var.set(limiter)
+    return limiter
+
+
+async def _run_ingest_upload_operation(
+    operation: Callable[..., Any], /, *args: Any, **kwargs: Any
+) -> Any:
+    """Run blocking upload work off-loop without abandoning its limiter token."""
+
+    bound = functools.partial(operation, *args, **kwargs)
+    worker_task = asyncio.create_task(
+        anyio.to_thread.run_sync(
+            bound,
+            abandon_on_cancel=False,
+            limiter=_ingest_upload_limiter(),
+        )
+    )
+    try:
+        return await asyncio.shield(worker_task)
+    except asyncio.CancelledError as cancellation:
+        with anyio.CancelScope(shield=True):
+            try:
+                await asyncio.shield(worker_task)
+            except BaseException:
+                pass
+        try:
+            worker_task.result()
+        except BaseException:
+            pass
+        raise cancellation
 
 
 @router.get("/projects/{project}/ingest/graph")
@@ -154,21 +201,21 @@ def _create_staged_upload(staging_dir: Path, suffix: str) -> Path:
     raise OSError("failed to allocate upload staging file")
 
 
-@router.post("/projects/{project}/ingest/upload")
-async def upload_novel(
+def _upload_novel_sync(
+    *,
     project: str,
-    file: UploadFile = File(...),
-    spine_template: Annotated[str | None, Form()] = None,
-    user: dict = Depends(get_api_user),
-):
-    """上传小说文件到项目的 uploads/ 目录。"""
-    logger.info("[%s] upload_novel: %s", project, file.filename)
-    resolved = await resolve_project_scope(project, user, required_role="editor")
-    project_dir = resolved.project_dir
+    upload_stream: Any,
+    filename: str | None,
+    project_dir: Path,
+    state_dir: str | Path,
+    spine_template: str | None,
+) -> dict:
+    """Stage, parse, preview, and atomically persist one novel upload."""
+
     uploads_dir = project_dir / "uploads"
     uploads_dir.mkdir(parents=True, exist_ok=True)
 
-    safe_name = sanitize_upload_filename(file.filename)
+    safe_name = sanitize_upload_filename(filename)
     if not is_safe_upload_target(uploads_dir, safe_name):
         return {"ok": False, "error": "非法文件名"}
     if not is_supported_novel_path(safe_name):
@@ -179,7 +226,7 @@ async def upload_novel(
     staged_path = _create_staged_upload(staging_dir, Path(safe_name).suffix)
     try:
         try:
-            size = stream_to_file_with_limit(file.file, staged_path)
+            size = stream_to_file_with_limit(upload_stream, staged_path)
         except UploadTooLargeError:
             return _file_too_large_response()
 
@@ -189,9 +236,7 @@ async def upload_novel(
             billable_chars = count_billable_novel_chars(content)
             if billable_chars > MAX_NOVEL_IMPORT_CHARS:
                 return _text_too_large_response(billable_chars)
-            project_config = load_project_config_file_from_state_dir(
-                resolved.state_dir
-            )
+            project_config = load_project_config_file_from_state_dir(state_dir)
             requested_spine_template = str(
                 spine_template
                 or project_config.get("spine_template")
@@ -216,7 +261,9 @@ async def upload_novel(
                 "detail": str(exc),
             }
         except Exception:
-            logger.warning("[%s] failed to build chapter preview", project, exc_info=True)
+            logger.warning(
+                "[%s] failed to build chapter preview", project, exc_info=True
+            )
             return {"ok": False, "error": "解析章节失败"}
 
         has_chapters = bool(preview.get("chapters"))
@@ -244,7 +291,9 @@ async def upload_novel(
                 staged_path.chmod(destination_mode)
             os.replace(staged_path, dest)
         except OSError:
-            logger.exception("[%s] failed to persist uploaded novel: %s", project, safe_name)
+            logger.exception(
+                "[%s] failed to persist uploaded novel: %s", project, safe_name
+            )
             return {"ok": False, "error": "保存上传文件失败"}
 
         data.update(preview)
@@ -260,6 +309,27 @@ async def upload_novel(
                 staged_path.name,
                 exc_info=True,
             )
+
+
+@router.post("/projects/{project}/ingest/upload")
+async def upload_novel(
+    project: str,
+    file: UploadFile = File(...),
+    spine_template: Annotated[str | None, Form()] = None,
+    user: dict = Depends(get_api_user),
+):
+    """上传小说文件到项目的 uploads/ 目录。"""
+    logger.info("[%s] upload_novel: %s", project, file.filename)
+    resolved = await resolve_project_scope(project, user, required_role="editor")
+    return await _run_ingest_upload_operation(
+        _upload_novel_sync,
+        project=project,
+        upload_stream=file.file,
+        filename=file.filename,
+        project_dir=Path(resolved.project_dir),
+        state_dir=resolved.state_dir,
+        spine_template=spine_template,
+    )
 
 
 @router.post("/projects/{project}/ingest/start")

--- a/src/novelvideo/api/routes/ingest.py
+++ b/src/novelvideo/api/routes/ingest.py
@@ -1,12 +1,8 @@
 """小说上传 & 导入端点。"""
 
-import asyncio
-import functools
 import logging
 import os
-import secrets
 import shutil
-import stat
 from collections.abc import Callable
 from pathlib import Path
 from typing import Annotated, Any
@@ -42,10 +38,12 @@ from novelvideo.utils.document_parsers import (
     supported_novel_extensions_label,
 )
 from novelvideo.utils.screenplay_quality import build_import_format_check
+from novelvideo.utils.async_ops import run_sync_bounded
 from novelvideo.utils.upload_safety import (
     MAX_NOVEL_IMPORT_BYTES,
     MAX_NOVEL_UPLOAD_BYTES,
     UploadTooLargeError,
+    create_staged_upload_file,
     is_safe_upload_target,
     sanitize_upload_filename,
     stream_to_file_with_limit,
@@ -74,27 +72,12 @@ async def _run_ingest_upload_operation(
 ) -> Any:
     """Run blocking upload work off-loop without abandoning its limiter token."""
 
-    bound = functools.partial(operation, *args, **kwargs)
-    worker_task = asyncio.create_task(
-        anyio.to_thread.run_sync(
-            bound,
-            abandon_on_cancel=False,
-            limiter=_ingest_upload_limiter(),
-        )
+    return await run_sync_bounded(
+        operation,
+        *args,
+        limiter=_ingest_upload_limiter(),
+        **kwargs,
     )
-    try:
-        return await asyncio.shield(worker_task)
-    except asyncio.CancelledError as cancellation:
-        with anyio.CancelScope(shield=True):
-            try:
-                await asyncio.shield(worker_task)
-            except BaseException:
-                pass
-        try:
-            worker_task.result()
-        except BaseException:
-            pass
-        raise cancellation
 
 
 @router.get("/projects/{project}/ingest/graph")
@@ -183,24 +166,6 @@ def _text_too_large_response(actual_chars: int) -> dict:
     }
 
 
-def _create_staged_upload(staging_dir: Path, suffix: str) -> Path:
-    """Create a unique staging file whose mode respects the process umask."""
-
-    for _ in range(10):
-        staged_path = staging_dir / f"upload-{secrets.token_hex(16)}{suffix}"
-        try:
-            fd = os.open(
-                staged_path,
-                os.O_WRONLY | os.O_CREAT | os.O_EXCL,
-                0o666,
-            )
-        except FileExistsError:
-            continue
-        os.close(fd)
-        return staged_path
-    raise OSError("failed to allocate upload staging file")
-
-
 def _upload_novel_sync(
     *,
     project: str,
@@ -223,7 +188,11 @@ def _upload_novel_sync(
     dest = uploads_dir / safe_name
     staging_dir = uploads_dir / ".staging"
     staging_dir.mkdir(exist_ok=True)
-    staged_path = _create_staged_upload(staging_dir, Path(safe_name).suffix)
+    staged_path = create_staged_upload_file(
+        staging_dir,
+        suffix=Path(safe_name).suffix,
+        destination=dest,
+    )
     try:
         try:
             size = stream_to_file_with_limit(upload_stream, staged_path)
@@ -280,15 +249,6 @@ def _upload_novel_sync(
             }
 
         try:
-            # Replacements preserve their existing mode. New staging files were
-            # created with mode 0666 filtered through the process umask, matching
-            # the historical ``open(path, "wb")`` behavior.
-            try:
-                destination_mode = stat.S_IMODE(dest.stat().st_mode)
-            except FileNotFoundError:
-                pass
-            else:
-                staged_path.chmod(destination_mode)
             os.replace(staged_path, dest)
         except OSError:
             logger.exception(

--- a/src/novelvideo/api/routes/projects.py
+++ b/src/novelvideo/api/routes/projects.py
@@ -1,7 +1,6 @@
 """项目 CRUD 端点。"""
 
 import asyncio
-import functools
 import logging
 import shutil
 import sqlite3
@@ -69,6 +68,7 @@ from novelvideo.seedance2_i2v.voice_clone import (
     NARRATION_STYLES,
     resolve_narrator_source,
 )
+from novelvideo.utils.async_ops import metadata_io_limiter, run_sync_bounded
 
 logger = logging.getLogger("novelvideo.api.projects")
 
@@ -187,27 +187,12 @@ async def _summary_for_record(
 ) -> ProjectSummary:
     """Build one project summary off-loop without abandoning its limiter token."""
 
-    operation = functools.partial(
+    return await run_sync_bounded(
         _summary_for_record_sync,
         record,
         effective_role=effective_role,
+        limiter=_project_summary_limiter(),
     )
-    worker_task = asyncio.create_task(
-        anyio.to_thread.run_sync(
-            operation,
-            abandon_on_cancel=False,
-            limiter=_project_summary_limiter(),
-        )
-    )
-    try:
-        return await asyncio.shield(worker_task)
-    except asyncio.CancelledError as cancellation:
-        with anyio.CancelScope(shield=True):
-            try:
-                await worker_task
-            except BaseException:
-                pass
-        raise cancellation
 
 
 def _project_relative_path(project_dir: str | Path, path: str | Path) -> str:
@@ -435,6 +420,7 @@ async def _run_narrator_voice_update(
     store,
     operation,
     /,
+    worker_limiter: anyio.CapacityLimiter | None = None,
     **operation_kwargs,
 ) -> dict:
     """Serialize one narrator mutation through its final response snapshot."""
@@ -444,9 +430,16 @@ async def _run_narrator_voice_update(
         state_dir=project_context.state_dir,
     )
     async with voice_resource_lock(key):
-        await run_voice_media_operation(operation, **operation_kwargs)
+        await run_voice_media_operation(
+            operation,
+            worker_limiter=worker_limiter,
+            **operation_kwargs,
+        )
         return await run_voice_media_operation(
-            _narrator_voice_payload, project_context, store
+            _narrator_voice_payload,
+            project_context,
+            store,
+            worker_limiter=metadata_io_limiter(),
         )
 
 
@@ -889,7 +882,11 @@ async def delete_narrator_voice(
     ctx = await resolve_project_context(user=user, project_id=project, required_role="editor")
     store = await make_sqlite_store_for_context(ctx)
     payload = await _run_narrator_voice_update(
-        ctx, store, _delete_narrator_voice_content, ctx=ctx
+        ctx,
+        store,
+        _delete_narrator_voice_content,
+        ctx=ctx,
+        worker_limiter=metadata_io_limiter(),
     )
     return {
         "ok": True,

--- a/src/novelvideo/api/routes/projects.py
+++ b/src/novelvideo/api/routes/projects.py
@@ -1,5 +1,7 @@
 """项目 CRUD 端点。"""
 
+import asyncio
+import functools
 import logging
 import shutil
 import sqlite3
@@ -8,6 +10,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 import asyncpg
+import anyio
+from anyio.lowlevel import RunVar
 from fastapi import APIRouter, Depends, File, HTTPException, Query, Response, UploadFile
 from fastapi.responses import JSONResponse
 
@@ -53,8 +57,11 @@ from novelvideo.seedance2_i2v.character_voice_storage import (
     VOICE_SAMPLE_EXTENSIONS,
     decode_recorded_audio_data_url,
     is_supported_voice_sample,
+    narrator_voice_resource_key,
+    run_voice_media_operation,
     trim_voice_sample_content,
     voice_content_sha256,
+    voice_resource_lock,
     voice_sample_extension,
 )
 from novelvideo.seedance2_i2v.voice_clone import (
@@ -69,6 +76,10 @@ router = APIRouter()
 VOICE_SOURCE_ROOTS = ("audio", "seedance2_uploads", "assets", "uploads")
 NARRATOR_VOICE_MODE_EXPLANATION = "第一人称解说使用解说主角声线；第三人称解说使用项目解说声线。"
 SUPPORTED_VOICE_SAMPLE_COPY = "仅支持 mp3 / wav / m4a / aac / ogg"
+_PROJECT_SUMMARY_CONCURRENCY = 2
+_project_summary_limiter_var: RunVar[anyio.CapacityLimiter] = RunVar(
+    "project_summary_limiter"
+)
 
 
 def _now_iso() -> str:
@@ -113,7 +124,15 @@ def _project_counts(paths, status: str) -> tuple[int | None, int | None]:
         return None, None
 
 
-async def _summary_for_record(
+def _project_summary_limiter() -> anyio.CapacityLimiter:
+    limiter = _project_summary_limiter_var.get(None)
+    if limiter is None:
+        limiter = anyio.CapacityLimiter(_PROJECT_SUMMARY_CONCURRENCY)
+        _project_summary_limiter_var.set(limiter)
+    return limiter
+
+
+def _summary_for_record_sync(
     record: ProjectRecord,
     *,
     effective_role: str = "",
@@ -159,6 +178,36 @@ async def _summary_for_record(
         episode_count=episode_count,
         beat_count=beat_count,
     )
+
+
+async def _summary_for_record(
+    record: ProjectRecord,
+    *,
+    effective_role: str = "",
+) -> ProjectSummary:
+    """Build one project summary off-loop without abandoning its limiter token."""
+
+    operation = functools.partial(
+        _summary_for_record_sync,
+        record,
+        effective_role=effective_role,
+    )
+    worker_task = asyncio.create_task(
+        anyio.to_thread.run_sync(
+            operation,
+            abandon_on_cancel=False,
+            limiter=_project_summary_limiter(),
+        )
+    )
+    try:
+        return await asyncio.shield(worker_task)
+    except asyncio.CancelledError as cancellation:
+        with anyio.CancelScope(shield=True):
+            try:
+                await worker_task
+            except BaseException:
+                pass
+        raise cancellation
 
 
 def _project_relative_path(project_dir: str | Path, path: str | Path) -> str:
@@ -293,6 +342,114 @@ def _persist_narrator_voice_content(
     return target
 
 
+def _record_narrator_voice_content(*, ctx: ProjectContext, data_url: str) -> Path:
+    """Decode and publish one browser recording as a single worker transaction."""
+
+    _ensure_third_person_narrator(ctx)
+    content, extension = decode_recorded_audio_data_url(data_url)
+    return _persist_narrator_voice_content(
+        state_dir=ctx.state_dir,
+        project_dir=ctx.output_dir,
+        filename=f"recorded{extension}",
+        content=content,
+    )
+
+
+def _upload_narrator_voice_content(
+    *, ctx: ProjectContext, filename: str, content: bytes
+) -> Path:
+    _ensure_third_person_narrator(ctx)
+    return _persist_narrator_voice_content(
+        state_dir=ctx.state_dir,
+        project_dir=ctx.output_dir,
+        filename=filename,
+        content=content,
+    )
+
+
+def _upload_narrator_voice_file(
+    *, ctx: ProjectContext, filename: str, upload_stream
+) -> Path:
+    """Read and publish an upload in one bounded voice-worker transaction."""
+
+    return _upload_narrator_voice_content(
+        ctx=ctx,
+        filename=filename,
+        content=upload_stream.read(),
+    )
+
+
+def _trim_narrator_voice_transaction(
+    *, ctx: ProjectContext, start_seconds: float, duration_seconds: float
+) -> Path:
+    _ensure_third_person_narrator(ctx)
+    return _trim_narrator_voice_content(
+        state_dir=ctx.state_dir,
+        project_dir=ctx.output_dir,
+        start_seconds=start_seconds,
+        duration_seconds=duration_seconds,
+    )
+
+
+def _copy_narrator_voice_content(*, ctx: ProjectContext, source_path: str) -> Path:
+    """Validate, read, and publish project audio in one worker transaction."""
+
+    _ensure_third_person_narrator(ctx)
+    raw_path = Path(source_path)
+    source = raw_path if raw_path.is_absolute() else ctx.output_dir / raw_path
+    source = source.resolve()
+    source.relative_to(ctx.output_dir.resolve())
+    if (
+        not source.exists()
+        or not source.is_file()
+        or source.suffix.lower() not in VOICE_SAMPLE_EXTENSIONS
+    ):
+        raise ValueError("请选择项目内有效的音频文件")
+    return _persist_narrator_voice_content(
+        state_dir=ctx.state_dir,
+        project_dir=ctx.output_dir,
+        filename=source.name,
+        content=source.read_bytes(),
+    )
+
+
+def _delete_narrator_voice_content(*, ctx: ProjectContext) -> None:
+    """Archive the current sample and clear its config in one worker transaction."""
+
+    stored = load_narrator_reference_audio_from_state_dir(ctx.state_dir)
+    target = Path(stored.get("path", ""))
+    if str(target):
+        if not target.is_absolute():
+            target = ctx.output_dir / target
+        if target.exists():
+            target.replace(
+                target.with_name(f"{target.stem}_{int(time.time())}{target.suffix}")
+            )
+    set_narrator_reference_audio_in_state_dir(
+        ctx.state_dir, relative_path="", sha256=""
+    )
+
+
+async def _run_narrator_voice_update(
+    project_context: ProjectContext,
+    store,
+    operation,
+    /,
+    **operation_kwargs,
+) -> dict:
+    """Serialize one narrator mutation through its final response snapshot."""
+
+    key = narrator_voice_resource_key(
+        project_dir=project_context.output_dir,
+        state_dir=project_context.state_dir,
+    )
+    async with voice_resource_lock(key):
+        await run_voice_media_operation(operation, **operation_kwargs)
+        return await run_voice_media_operation(
+            _narrator_voice_payload, project_context, store
+        )
+
+
 def _trim_narrator_voice_content(
     *,
     state_dir: str | Path,
@@ -415,10 +572,16 @@ async def list_project_summaries(
     principals = await access.resolve_requester_principals(user_id)
     records = await registry.list_accessible_projects([(p.type, p.id) for p in principals])
     records = [record for record in records if not record.purged_at]
-    summaries = []
+    roles: list[str] = []
     for record in records:
         role = await access.effective_project_role(record, principals)
-        summaries.append(await _summary_for_record(record, effective_role=role or ""))
+        roles.append(role or "")
+    summaries = await asyncio.gather(
+        *(
+            _summary_for_record(record, effective_role=role)
+            for record, role in zip(records, roles, strict=True)
+        )
+    )
     if status == "visible":
         summaries = [s for s in summaries if s.status != "deleted"]
     elif status != "all":
@@ -629,19 +792,19 @@ async def upload_narrator_voice(
     ctx = await resolve_project_context(user=user, project_id=project, required_role="editor")
     store = await make_sqlite_store_for_context(ctx)
     try:
-        _ensure_third_person_narrator(ctx)
-        content = await file.read()
-        _persist_narrator_voice_content(
-            state_dir=ctx.state_dir,
-            project_dir=ctx.output_dir,
+        payload = await _run_narrator_voice_update(
+            ctx,
+            store,
+            _upload_narrator_voice_file,
+            ctx=ctx,
             filename=file.filename or "",
-            content=content,
+            upload_stream=file.file,
         )
     except ValueError as exc:
         return {"ok": False, "error": str(exc)}
     return {
         "ok": True,
-        "data": _narrator_voice_payload(ctx, store),
+        "data": payload,
     }
 
 
@@ -655,19 +818,16 @@ async def record_narrator_voice(
     ctx = await resolve_project_context(user=user, project_id=project, required_role="editor")
     store = await make_sqlite_store_for_context(ctx)
     try:
-        _ensure_third_person_narrator(ctx)
-        content, extension = decode_recorded_audio_data_url(body.data_url)
-        _persist_narrator_voice_content(
-            state_dir=ctx.state_dir,
-            project_dir=ctx.output_dir,
-            filename=f"recorded{extension}",
-            content=content,
+        payload = await _run_narrator_voice_update(
+            ctx,
+            store,
+            _record_narrator_voice_content, ctx=ctx, data_url=body.data_url
         )
     except ValueError as exc:
         return {"ok": False, "error": str(exc)}
     return {
         "ok": True,
-        "data": _narrator_voice_payload(ctx, store),
+        "data": payload,
     }
 
 
@@ -681,24 +841,16 @@ async def copy_project_audio_as_narrator_voice(
     ctx = await resolve_project_context(user=user, project_id=project, required_role="editor")
     store = await make_sqlite_store_for_context(ctx)
     try:
-        _ensure_third_person_narrator(ctx)
-        raw_path = Path(body.source_path)
-        source_path = raw_path if raw_path.is_absolute() else ctx.output_dir / raw_path
-        source_path = source_path.resolve()
-        source_path.relative_to(ctx.output_dir.resolve())
-        if not source_path.exists() or source_path.suffix.lower() not in VOICE_SAMPLE_EXTENSIONS:
-            return {"ok": False, "error": "请选择项目内有效的音频文件"}
-        _persist_narrator_voice_content(
-            state_dir=ctx.state_dir,
-            project_dir=ctx.output_dir,
-            filename=source_path.name,
-            content=source_path.read_bytes(),
+        payload = await _run_narrator_voice_update(
+            ctx,
+            store,
+            _copy_narrator_voice_content, ctx=ctx, source_path=body.source_path
         )
     except (ValueError, OSError) as exc:
         return {"ok": False, "error": str(exc)}
     return {
         "ok": True,
-        "data": _narrator_voice_payload(ctx, store),
+        "data": payload,
     }
 
 
@@ -712,10 +864,11 @@ async def trim_narrator_voice(
     ctx = await resolve_project_context(user=user, project_id=project, required_role="editor")
     store = await make_sqlite_store_for_context(ctx)
     try:
-        _ensure_third_person_narrator(ctx)
-        _trim_narrator_voice_content(
-            state_dir=ctx.state_dir,
-            project_dir=ctx.output_dir,
+        payload = await _run_narrator_voice_update(
+            ctx,
+            store,
+            _trim_narrator_voice_transaction,
+            ctx=ctx,
             start_seconds=body.start_seconds,
             duration_seconds=body.duration_seconds,
         )
@@ -723,7 +876,7 @@ async def trim_narrator_voice(
         return {"ok": False, "error": str(exc)}
     return {
         "ok": True,
-        "data": _narrator_voice_payload(ctx, store),
+        "data": payload,
     }
 
 
@@ -735,17 +888,12 @@ async def delete_narrator_voice(
     """移除第三人称项目解说声线。"""
     ctx = await resolve_project_context(user=user, project_id=project, required_role="editor")
     store = await make_sqlite_store_for_context(ctx)
-    stored = load_narrator_reference_audio_from_state_dir(ctx.state_dir)
-    target = Path(stored.get("path", ""))
-    if str(target):
-        if not target.is_absolute():
-            target = ctx.output_dir / target
-        if target.exists():
-            target.replace(target.with_name(f"{target.stem}_{int(time.time())}{target.suffix}"))
-    set_narrator_reference_audio_in_state_dir(ctx.state_dir, relative_path="", sha256="")
+    payload = await _run_narrator_voice_update(
+        ctx, store, _delete_narrator_voice_content, ctx=ctx
+    )
     return {
         "ok": True,
-        "data": _narrator_voice_payload(ctx, store),
+        "data": payload,
     }
 
 

--- a/src/novelvideo/api/routes/scenes.py
+++ b/src/novelvideo/api/routes/scenes.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import asyncio
-import io
 import logging
 import shutil
 import tempfile
@@ -13,9 +12,15 @@ from urllib.parse import quote
 from typing import Annotated, Any
 
 from fastapi import APIRouter, Depends, File, Query, UploadFile
+from starlette.concurrency import run_in_threadpool
 
 from novelvideo.api.asset_metadata import newest_updated_at, tree_updated_at
 from novelvideo.api.auth import get_api_user
+from novelvideo.api.upload_workers import (
+    run_asset_upload_operation,
+    scene_ply_upload_limiter,
+    scene_upload_lock,
+)
 from novelvideo.api.deps import (
     may_run_asset_repair,
     make_sqlite_store_for_context,
@@ -65,9 +70,27 @@ from novelvideo.utils.path_resolver import (
     compute_scene_reverse_master_path,
 )
 from novelvideo.utils.static_urls import project_static_url
+from novelvideo.utils.upload_safety import (
+    MAX_PROJECT_UPLOAD_BYTES,
+    UploadTooLargeError,
+    stream_to_file_with_limit,
+)
 
 router = APIRouter()
 logger = logging.getLogger("novelvideo.api.scenes")
+
+
+class _InvalidSceneImageError(ValueError):
+    pass
+
+
+class _InvalidScenePanoRatioError(ValueError):
+    pass
+
+
+class _EmptyScenePackageError(ValueError):
+    pass
+
 
 _SCENE_TIME_TOKENS = {
     "清晨",
@@ -400,7 +423,12 @@ def _stage_3gs_payload(
     }
 
 
-def _copy_upload_to_temp_file(file: UploadFile, *, suffix: str) -> tuple[Path, int]:
+def _copy_upload_to_temp_file(
+    file: UploadFile,
+    *,
+    suffix: str,
+    max_bytes: int = MAX_PROJECT_UPLOAD_BYTES,
+) -> tuple[Path, int]:
     tmp_path: Path | None = None
     try:
         with tempfile.NamedTemporaryFile(suffix=suffix, delete=False) as tmp:
@@ -409,13 +437,165 @@ def _copy_upload_to_temp_file(file: UploadFile, *, suffix: str) -> tuple[Path, i
                 file.file.seek(0)
             except (AttributeError, OSError):
                 pass
-            shutil.copyfileobj(file.file, tmp)
-            size = tmp.tell()
+        size = stream_to_file_with_limit(file.file, tmp_path, max_bytes=max_bytes)
     except Exception:
         if tmp_path is not None:
             tmp_path.unlink(missing_ok=True)
         raise
     return tmp_path, size
+
+
+def _persist_custom_scene_upload(
+    file: UploadFile,
+    *,
+    suffix: str,
+    project_dir: Path,
+    scene_name: str,
+) -> None:
+    from novelvideo import stage_asset_tasks
+
+    tmp_path: Path | None = None
+    try:
+        tmp_path, size = _copy_upload_to_temp_file(
+            file,
+            suffix=suffix,
+            max_bytes=MAX_PROJECT_UPLOAD_BYTES,
+        )
+        if size == 0:
+            raise _EmptyScenePackageError("Custom scene package is empty")
+        stage_asset_tasks.upload_scene_package(project_dir, scene_name, tmp_path)
+    finally:
+        if tmp_path is not None:
+            tmp_path.unlink(missing_ok=True)
+
+
+def _load_scene_upload_image(file: UploadFile):
+    from PIL import Image
+
+    try:
+        try:
+            file.file.seek(0)
+        except (AttributeError, OSError):
+            pass
+        with Image.open(file.file) as source:
+            return source.convert("RGB")
+    except Exception as exc:
+        raise _InvalidSceneImageError(str(exc)) from exc
+
+
+def _publish_scene_image(image, target: Path, archive_stem: str) -> None:
+    tmp_path: Path | None = None
+    try:
+        target.parent.mkdir(parents=True, exist_ok=True)
+        with tempfile.NamedTemporaryFile(
+            prefix=f".{target.stem}_",
+            suffix=target.suffix,
+            dir=target.parent,
+            delete=False,
+        ) as tmp:
+            tmp_path = Path(tmp.name)
+        image.save(tmp_path, format="PNG")
+        if target.exists():
+            target.replace(target.parent / f"{archive_stem}_{int(time.time())}.png")
+        tmp_path.replace(target)
+        tmp_path = None
+    finally:
+        image.close()
+        if tmp_path is not None:
+            tmp_path.unlink(missing_ok=True)
+
+
+def _persist_scene_master_upload(file: UploadFile, target: Path) -> None:
+    image = _load_scene_upload_image(file)
+    _publish_scene_image(image, target, "master")
+
+
+def _persist_scene_pano_upload(
+    file: UploadFile,
+    *,
+    project_dir: Path,
+    scene_name: str,
+) -> None:
+    image = _load_scene_upload_image(file)
+    width, height = image.size
+    if height <= 0 or abs((width / height) - 2.0) > 0.08:
+        image.close()
+        raise _InvalidScenePanoRatioError(
+            f"360 panorama must be close to 2:1 equirectangular; got {width}x{height}"
+        )
+    out_dir = stage_manifest.stage_dir(project_dir, scene_name)
+    pano_path = out_dir / "pano_360.png"
+    _publish_scene_image(image, pano_path, "pano_360")
+    stage_manifest.update_manifest(
+        project_dir,
+        scene_name,
+        clear_fields=[
+            "ply_path",
+            "collision_glb_path",
+            "voxel_json_path",
+            "pano_sharp_args",
+            "splat_transform_args",
+        ],
+        pano_path=pano_path.name,
+        source="uploaded_360",
+    )
+
+
+def _scene_upload_lock_key(project_dir: Path, scene_name: str) -> tuple[str, str]:
+    stage_dir = stage_manifest.stage_dir(project_dir, scene_name)
+    return "scene-stage", str(stage_dir.resolve())
+
+
+def _delete_scene_pano_files(project_dir: Path, scene_name: str) -> bool:
+    pano_path = stage_manifest.resolve_pano_path(project_dir, scene_name)
+    deleted = False
+    if pano_path is not None:
+        pano_path.unlink(missing_ok=True)
+        deleted = True
+    stage_manifest.update_manifest(
+        project_dir,
+        scene_name,
+        clear_fields=[
+            "source",
+            "pano_path",
+            "ply_path",
+            "collision_glb_path",
+            "voxel_json_path",
+            "pano_sharp_args",
+            "splat_transform_args",
+        ],
+    )
+    return deleted
+
+
+def _delete_scene_custom_files(project_dir: Path, scene_name: str) -> bool:
+    custom_scene_path = stage_manifest.resolve_ply_path(
+        project_dir, scene_name, ply_kind="custom"
+    )
+    active_ply_path = stage_manifest.resolve_ply_path(project_dir, scene_name)
+    deleted = False
+    if custom_scene_path is not None:
+        custom_scene_path.unlink(missing_ok=True)
+        deleted = True
+
+    clear_fields = ["custom_scene_path"]
+    manifest = stage_manifest.load_manifest(project_dir, scene_name) or {}
+    if manifest.get("source") == "custom_scene" or (
+        custom_scene_path is not None
+        and active_ply_path is not None
+        and custom_scene_path.resolve() == active_ply_path.resolve()
+    ):
+        clear_fields.extend(
+            [
+                "source",
+                "ply_path",
+                "collision_glb_path",
+                "voxel_json_path",
+                "splat_transform_args",
+            ]
+        )
+    stage_manifest.update_manifest(project_dir, scene_name, clear_fields=clear_fields)
+    return deleted
 
 
 def _move_dir_if_exists(old_dir: Path, new_dir: Path) -> None:
@@ -1140,7 +1320,11 @@ async def build_scenes(project: str, user: dict = Depends(get_api_user)):
         # The other half of the exclusion. Both write the scenes table, so a
         # build landing on top of a running planner leaves a catalogue whose
         # contents depend on which writer got there first.
-        if running_scene_planner(get_task_manager().list_tasks_for_project(ctx)):
+        tasks = await run_in_threadpool(
+            get_task_manager().list_tasks_for_project,
+            ctx,
+        )
+        if running_scene_planner(tasks):
             return scene_prerequisite_response(ScenePlanningRunningError())
         queued = await get_task_backend().enqueue_project_task(
             ctx,
@@ -1177,20 +1361,21 @@ async def upload_scene_master(
     if scene is None:
         return {"ok": False, "error": f"Scene '{name}' not found"}
 
-    try:
-        from PIL import Image
-
-        img = Image.open(io.BytesIO(await file.read())).convert("RGB")
-    except Exception as exc:
-        return {"ok": False, "error": f"Invalid image file: {exc}"}
-
     master_path = canonical_scene_master_path(project_dir, scene.name)
-    master_path.parent.mkdir(parents=True, exist_ok=True)
-    if master_path.exists():
-        master_path.replace(master_path.parent / f"master_{int(time.time())}.png")
-    img.save(master_path, format="PNG")
-    await store.touch_scene_asset(scene.name)
-    scene = await _require_scene(store, scene.name) or scene
+
+    async def touch_master(_result):
+        await store.touch_scene_asset(scene.name)
+        return await _require_scene(store, scene.name) or scene
+
+    try:
+        scene = await run_asset_upload_operation(
+            _persist_scene_master_upload,
+            file,
+            master_path,
+            finalize=touch_master,
+        )
+    except _InvalidSceneImageError as exc:
+        return {"ok": False, "error": f"Invalid image file: {exc}"}
 
     return {
         "ok": True,
@@ -1327,38 +1512,19 @@ async def upload_scene_pano(
         return {"ok": False, "error": f"Scene '{name}' not found"}
 
     try:
-        from PIL import Image
-
-        img = Image.open(io.BytesIO(await file.read())).convert("RGB")
-    except Exception as exc:
+        async with scene_upload_lock(
+            _scene_upload_lock_key(project_dir, scene.name)
+        ):
+            await run_asset_upload_operation(
+                _persist_scene_pano_upload,
+                file,
+                project_dir=project_dir,
+                scene_name=scene.name,
+            )
+    except _InvalidSceneImageError as exc:
         return {"ok": False, "error": f"Invalid image file: {exc}"}
-
-    width, height = img.size
-    if height <= 0 or abs((width / height) - 2.0) > 0.08:
-        return {
-            "ok": False,
-            "error": f"360 panorama must be close to 2:1 equirectangular; got {width}x{height}",
-        }
-
-    out_dir = stage_manifest.stage_dir(project_dir, scene.name)
-    out_dir.mkdir(parents=True, exist_ok=True)
-    pano_path = out_dir / "pano_360.png"
-    if pano_path.exists():
-        pano_path.replace(out_dir / f"pano_360_{int(time.time())}.png")
-    img.save(pano_path, format="PNG")
-    stage_manifest.update_manifest(
-        project_dir,
-        scene.name,
-        clear_fields=[
-            "ply_path",
-            "collision_glb_path",
-            "voxel_json_path",
-            "pano_sharp_args",
-            "splat_transform_args",
-        ],
-        pano_path=pano_path.name,
-        source="uploaded_360",
-    )
+    except _InvalidScenePanoRatioError as exc:
+        return {"ok": False, "error": str(exc)}
 
     return {
         "ok": True,
@@ -1382,24 +1548,12 @@ async def delete_scene_pano(
     scene = await _require_scene(store, name)
     if scene is None:
         return {"ok": False, "error": f"Scene '{name}' not found"}
-    pano_path = stage_manifest.resolve_pano_path(project_dir, scene.name)
-    deleted = False
-    if pano_path is not None:
-        pano_path.unlink(missing_ok=True)
-        deleted = True
-    stage_manifest.update_manifest(
-        project_dir,
-        scene.name,
-        clear_fields=[
-            "source",
-            "pano_path",
-            "ply_path",
-            "collision_glb_path",
-            "voxel_json_path",
-            "pano_sharp_args",
-            "splat_transform_args",
-        ],
-    )
+    async with scene_upload_lock(_scene_upload_lock_key(project_dir, scene.name)):
+        deleted = await run_asset_upload_operation(
+            _delete_scene_pano_files,
+            project_dir,
+            scene.name,
+        )
     return {"ok": True, "data": {"deleted": deleted}}
 
 
@@ -1423,20 +1577,30 @@ async def upload_scene_custom_package(
             "error": "Custom scene package must be .ply, .sog, .splat, or .ksplat",
         }
 
-    tmp_path, size = _copy_upload_to_temp_file(file, suffix=suffix)
-    if size == 0:
-        tmp_path.unlink(missing_ok=True)
-        return {"ok": False, "error": "Custom scene package is empty"}
-
-    from novelvideo import stage_asset_tasks
-
     try:
-        stage_asset_tasks.upload_scene_package(project_dir, scene.name, tmp_path)
-    finally:
-        try:
-            tmp_path.unlink()
-        except OSError:
-            pass
+        async with scene_upload_lock(
+            _scene_upload_lock_key(project_dir, scene.name)
+        ):
+            await run_asset_upload_operation(
+                _persist_custom_scene_upload,
+                file,
+                suffix=suffix,
+                project_dir=project_dir,
+                scene_name=scene.name,
+                worker_limiter=(
+                    scene_ply_upload_limiter() if suffix == ".ply" else None
+                ),
+            )
+    except _EmptyScenePackageError as exc:
+        return {"ok": False, "error": str(exc)}
+    except UploadTooLargeError:
+        return {
+            "ok": False,
+            "error": (
+                "Custom scene package exceeds "
+                f"{MAX_PROJECT_UPLOAD_BYTES // (1024 * 1024)}MB limit"
+            ),
+        }
 
     return {
         "ok": True,
@@ -1461,32 +1625,12 @@ async def delete_scene_custom_package(
     if scene is None:
         return {"ok": False, "error": f"Scene '{name}' not found"}
 
-    custom_scene_path = stage_manifest.resolve_ply_path(
-        project_dir, scene.name, ply_kind="custom"
-    )
-    active_ply_path = stage_manifest.resolve_ply_path(project_dir, scene.name)
-    deleted = False
-    if custom_scene_path is not None:
-        custom_scene_path.unlink(missing_ok=True)
-        deleted = True
-
-    clear_fields = ["custom_scene_path"]
-    manifest = stage_manifest.load_manifest(project_dir, scene.name) or {}
-    if manifest.get("source") == "custom_scene" or (
-        custom_scene_path is not None
-        and active_ply_path is not None
-        and custom_scene_path.resolve() == active_ply_path.resolve()
-    ):
-        clear_fields.extend(
-            [
-                "source",
-                "ply_path",
-                "collision_glb_path",
-                "voxel_json_path",
-                "splat_transform_args",
-            ]
+    async with scene_upload_lock(_scene_upload_lock_key(project_dir, scene.name)):
+        deleted = await run_asset_upload_operation(
+            _delete_scene_custom_files,
+            project_dir,
+            scene.name,
         )
-    stage_manifest.update_manifest(project_dir, scene.name, clear_fields=clear_fields)
 
     return {"ok": True, "data": {"deleted": deleted}}
 

--- a/src/novelvideo/api/routes/scenes.py
+++ b/src/novelvideo/api/routes/scenes.py
@@ -61,6 +61,7 @@ from novelvideo.task_identity import project_task_state_key
 from novelvideo.task_state import get_task_manager
 from novelvideo.task_scopes import scene_reference_asset_scope, stage_asset_scope
 from novelvideo.utils.asset_names import move_asset_dir, path_safe_asset_name
+from novelvideo.utils.async_ops import metadata_io_limiter
 from novelvideo.utils.derived_scenes import (
     compose_derived_scene_name,
 )
@@ -69,6 +70,7 @@ from novelvideo.utils.path_resolver import (
     compute_scene_master_path,
     compute_scene_reverse_master_path,
 )
+from novelvideo.utils.upload_safety import create_staged_upload_file
 from novelvideo.utils.static_urls import project_static_url
 from novelvideo.utils.upload_safety import (
     MAX_PROJECT_UPLOAD_BYTES,
@@ -487,16 +489,15 @@ def _publish_scene_image(image, target: Path, archive_stem: str) -> None:
     tmp_path: Path | None = None
     try:
         target.parent.mkdir(parents=True, exist_ok=True)
-        with tempfile.NamedTemporaryFile(
+        tmp_path = create_staged_upload_file(
+            target.parent,
             prefix=f".{target.stem}_",
             suffix=target.suffix,
-            dir=target.parent,
-            delete=False,
-        ) as tmp:
-            tmp_path = Path(tmp.name)
+            destination=target,
+        )
         image.save(tmp_path, format="PNG")
         if target.exists():
-            target.replace(target.parent / f"{archive_stem}_{int(time.time())}.png")
+            target.replace(target.parent / f"{archive_stem}_{time.time_ns()}.png")
         tmp_path.replace(target)
         tmp_path = None
     finally:
@@ -1553,6 +1554,7 @@ async def delete_scene_pano(
             _delete_scene_pano_files,
             project_dir,
             scene.name,
+            worker_limiter=metadata_io_limiter(),
         )
     return {"ok": True, "data": {"deleted": deleted}}
 
@@ -1630,6 +1632,7 @@ async def delete_scene_custom_package(
             _delete_scene_custom_files,
             project_dir,
             scene.name,
+            worker_limiter=metadata_io_limiter(),
         )
 
     return {"ok": True, "data": {"deleted": deleted}}

--- a/src/novelvideo/api/upload_workers.py
+++ b/src/novelvideo/api/upload_workers.py
@@ -1,0 +1,121 @@
+"""Bounded worker adapter for blocking upload processing."""
+
+from __future__ import annotations
+
+import asyncio
+import functools
+import weakref
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+import anyio
+from anyio.lowlevel import RunVar
+
+ASSET_UPLOAD_CONCURRENCY = 2
+SCENE_PLY_UPLOAD_CONCURRENCY = 1
+_asset_upload_limiter_var: RunVar[anyio.CapacityLimiter] = RunVar(
+    "asset_upload_limiter"
+)
+_scene_ply_upload_limiter_var: RunVar[anyio.CapacityLimiter] = RunVar(
+    "scene_ply_upload_limiter"
+)
+_scene_upload_locks_var: RunVar[
+    weakref.WeakValueDictionary[tuple[str, str], asyncio.Lock]
+] = RunVar("scene_upload_locks")
+
+
+def asset_upload_limiter() -> anyio.CapacityLimiter:
+    """Return the small upload-processing gate scoped to this async run."""
+
+    limiter = _asset_upload_limiter_var.get(None)
+    if limiter is None:
+        limiter = anyio.CapacityLimiter(ASSET_UPLOAD_CONCURRENCY)
+        _asset_upload_limiter_var.set(limiter)
+    return limiter
+
+
+def scene_ply_upload_limiter() -> anyio.CapacityLimiter:
+    """Return the single-slot PLY conversion gate for this async run."""
+
+    limiter = _scene_ply_upload_limiter_var.get(None)
+    if limiter is None:
+        limiter = anyio.CapacityLimiter(SCENE_PLY_UPLOAD_CONCURRENCY)
+        _scene_ply_upload_limiter_var.set(limiter)
+    return limiter
+
+
+def scene_upload_lock(key: tuple[str, str]) -> asyncio.Lock:
+    """Return a per-run lock serializing manifest writes for one scene."""
+
+    locks = _scene_upload_locks_var.get(None)
+    if locks is None:
+        locks = weakref.WeakValueDictionary()
+        _scene_upload_locks_var.set(locks)
+    lock = locks.get(key)
+    if lock is None:
+        lock = asyncio.Lock()
+        locks[key] = lock
+    return lock
+
+
+async def _wait_for_task_completion(
+    task: asyncio.Task,
+    cancellation: asyncio.CancelledError | None = None,
+) -> tuple[Any, asyncio.CancelledError | None]:
+    """Wait until *task* is done despite repeated direct or level cancellation."""
+
+    while not task.done():
+        try:
+            if cancellation is None:
+                await asyncio.shield(task)
+            else:
+                with anyio.CancelScope(shield=True):
+                    await asyncio.shield(task)
+        except asyncio.CancelledError as exc:
+            if cancellation is None:
+                cancellation = exc
+        except BaseException:
+            if cancellation is not None:
+                raise cancellation
+            raise
+
+    try:
+        return task.result(), cancellation
+    except BaseException:
+        if cancellation is not None:
+            raise cancellation
+        raise
+
+
+async def run_asset_upload_operation(
+    operation: Callable[..., Any],
+    /,
+    *args: Any,
+    finalize: Callable[[Any], Awaitable[Any]] | None = None,
+    worker_limiter: anyio.CapacityLimiter | None = None,
+    **kwargs: Any,
+) -> Any:
+    """Run a blocking publish and optional async metadata commit as one transaction."""
+
+    bound = functools.partial(operation, *args, **kwargs)
+    limiter = (
+        worker_limiter if worker_limiter is not None else asset_upload_limiter()
+    )
+    worker_task = asyncio.create_task(
+        anyio.to_thread.run_sync(
+            bound,
+            abandon_on_cancel=False,
+            limiter=limiter,
+        )
+    )
+    result, cancellation = await _wait_for_task_completion(worker_task)
+
+    if finalize is not None:
+        finalize_task = asyncio.create_task(finalize(result))
+        result, cancellation = await _wait_for_task_completion(
+            finalize_task, cancellation
+        )
+
+    if cancellation is not None:
+        raise cancellation
+    return result

--- a/src/novelvideo/api/upload_workers.py
+++ b/src/novelvideo/api/upload_workers.py
@@ -3,13 +3,14 @@
 from __future__ import annotations
 
 import asyncio
-import functools
 import weakref
 from collections.abc import Awaitable, Callable
 from typing import Any
 
 import anyio
 from anyio.lowlevel import RunVar
+
+from novelvideo.utils.async_ops import run_sync_bounded
 
 ASSET_UPLOAD_CONCURRENCY = 2
 SCENE_PLY_UPLOAD_CONCURRENCY = 1
@@ -58,35 +59,6 @@ def scene_upload_lock(key: tuple[str, str]) -> asyncio.Lock:
     return lock
 
 
-async def _wait_for_task_completion(
-    task: asyncio.Task,
-    cancellation: asyncio.CancelledError | None = None,
-) -> tuple[Any, asyncio.CancelledError | None]:
-    """Wait until *task* is done despite repeated direct or level cancellation."""
-
-    while not task.done():
-        try:
-            if cancellation is None:
-                await asyncio.shield(task)
-            else:
-                with anyio.CancelScope(shield=True):
-                    await asyncio.shield(task)
-        except asyncio.CancelledError as exc:
-            if cancellation is None:
-                cancellation = exc
-        except BaseException:
-            if cancellation is not None:
-                raise cancellation
-            raise
-
-    try:
-        return task.result(), cancellation
-    except BaseException:
-        if cancellation is not None:
-            raise cancellation
-        raise
-
-
 async def run_asset_upload_operation(
     operation: Callable[..., Any],
     /,
@@ -97,25 +69,13 @@ async def run_asset_upload_operation(
 ) -> Any:
     """Run a blocking publish and optional async metadata commit as one transaction."""
 
-    bound = functools.partial(operation, *args, **kwargs)
     limiter = (
         worker_limiter if worker_limiter is not None else asset_upload_limiter()
     )
-    worker_task = asyncio.create_task(
-        anyio.to_thread.run_sync(
-            bound,
-            abandon_on_cancel=False,
-            limiter=limiter,
-        )
+    return await run_sync_bounded(
+        operation,
+        *args,
+        finalize=finalize,
+        limiter=limiter,
+        **kwargs,
     )
-    result, cancellation = await _wait_for_task_completion(worker_task)
-
-    if finalize is not None:
-        finalize_task = asyncio.create_task(finalize(result))
-        result, cancellation = await _wait_for_task_completion(
-            finalize_task, cancellation
-        )
-
-    if cancellation is not None:
-        raise cancellation
-    return result

--- a/src/novelvideo/seedance2_i2v/character_voice_storage.py
+++ b/src/novelvideo/seedance2_i2v/character_voice_storage.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 import asyncio
 import base64
 import binascii
-import functools
 import hashlib
 import json
 import re
@@ -25,6 +24,8 @@ from typing import Any
 
 import anyio
 from anyio.lowlevel import RunVar
+
+from novelvideo.utils.async_ops import run_sync_bounded
 
 VOICE_SAMPLE_EXTENSIONS = (".mp3", ".wav", ".m4a", ".aac", ".ogg")
 DEFAULT_SLOT = "default"
@@ -94,10 +95,14 @@ def narrator_voice_resource_key(
 ) -> tuple[Any, ...]:
     """Canonical key covering a project's narrator files and config metadata."""
 
+    normalized_state_dir = str(state_dir).strip()
+    if normalized_state_dir in {"", "."}:
+        raise ValueError("state_dir is required for narrator voice locking")
+
     return (
         "narrator-voice",
         str(Path(project_dir).resolve()),
-        str(Path(state_dir).resolve()),
+        str(Path(normalized_state_dir).resolve()),
     )
 
 
@@ -119,6 +124,7 @@ async def run_voice_media_operation(
     /,
     *args: Any,
     finalize: Callable[[Any], Awaitable[Any]] | None = None,
+    worker_limiter: anyio.CapacityLimiter | None = None,
     **kwargs: Any,
 ) -> Any:
     """Run a blocking voice operation and optional async metadata commit atomically.
@@ -128,47 +134,14 @@ async def run_voice_media_operation(
     prevents a published voice file from being left without its async metadata.
     """
 
-    bound = functools.partial(operation, *args, **kwargs)
-    worker_task = asyncio.create_task(
-        anyio.to_thread.run_sync(
-            bound,
-            abandon_on_cancel=False,
-            limiter=_voice_media_limiter(),
-        )
+    limiter = worker_limiter if worker_limiter is not None else _voice_media_limiter()
+    return await run_sync_bounded(
+        operation,
+        *args,
+        finalize=finalize,
+        limiter=limiter,
+        **kwargs,
     )
-    result, cancellation = await _wait_for_voice_task_completion(worker_task)
-    if finalize is not None:
-        finalize_task = asyncio.create_task(finalize(result))
-        result, cancellation = await _wait_for_voice_task_completion(
-            finalize_task, cancellation
-        )
-    if cancellation is not None:
-        raise cancellation
-    return result
-
-
-async def _wait_for_voice_task_completion(
-    task: asyncio.Task,
-    cancellation: asyncio.CancelledError | None = None,
-) -> tuple[Any, asyncio.CancelledError | None]:
-    """Wait through direct, repeated, or AnyIO level cancellation."""
-
-    while not task.done():
-        try:
-            if cancellation is None:
-                await asyncio.shield(task)
-            else:
-                with anyio.CancelScope(shield=True):
-                    await asyncio.shield(task)
-        except asyncio.CancelledError as exc:
-            if cancellation is None:
-                cancellation = exc
-        except BaseException:
-            raise
-    try:
-        return task.result(), cancellation
-    except BaseException:
-        raise
 
 
 def decode_recorded_audio_data_url(data_url: str) -> tuple[bytes, str]:

--- a/src/novelvideo/seedance2_i2v/character_voice_storage.py
+++ b/src/novelvideo/seedance2_i2v/character_voice_storage.py
@@ -7,16 +7,24 @@ the metadata required by ``NovelCharacter.reference_audio_*`` /
 
 from __future__ import annotations
 
+import asyncio
 import base64
 import binascii
+import functools
 import hashlib
 import json
 import re
 import shutil
 import subprocess
 import tempfile
+import weakref
+from collections.abc import Awaitable, Callable
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import Any
+
+import anyio
+from anyio.lowlevel import RunVar
 
 VOICE_SAMPLE_EXTENSIONS = (".mp3", ".wav", ".m4a", ".aac", ".ogg")
 DEFAULT_SLOT = "default"
@@ -33,6 +41,134 @@ RECORDED_AUDIO_EXTENSION_BY_MIME = {
     "audio/wav": ".wav",
     "audio/x-wav": ".wav",
 }
+
+FFMPEG_TIMEOUT_SECONDS = 60.0
+"""Hard wall-clock limit for user-provided audio conversion and trimming."""
+
+_VOICE_MEDIA_CONCURRENCY = 2
+_voice_media_limiter_var: RunVar[anyio.CapacityLimiter] = RunVar("voice_media_limiter")
+_voice_resource_locks_var: RunVar[
+    weakref.WeakValueDictionary[tuple[Any, ...], asyncio.Lock]
+] = RunVar("voice_resource_locks")
+
+
+def _voice_media_limiter() -> anyio.CapacityLimiter:
+    """Return the small media-process gate scoped to the current async run."""
+
+    limiter = _voice_media_limiter_var.get(None)
+    if limiter is None:
+        limiter = anyio.CapacityLimiter(_VOICE_MEDIA_CONCURRENCY)
+        _voice_media_limiter_var.set(limiter)
+    return limiter
+
+
+def voice_resource_lock(key: tuple[Any, ...]) -> asyncio.Lock:
+    """Return a per-async-run lock for one canonical voice resource."""
+
+    locks = _voice_resource_locks_var.get(None)
+    if locks is None:
+        locks = weakref.WeakValueDictionary()
+        _voice_resource_locks_var.set(locks)
+    lock = locks.get(key)
+    if lock is None:
+        lock = asyncio.Lock()
+        locks[key] = lock
+    return lock
+
+
+def character_voice_resource_key(
+    *, project_dir: str | Path, character_name: str, slot: str
+) -> tuple[Any, ...]:
+    """Canonical key covering one character voice slot and its metadata."""
+
+    return (
+        "character-voice",
+        str(Path(project_dir).resolve()),
+        _safe_asset_name(character_name),
+        str(slot).strip().lower(),
+    )
+
+
+def narrator_voice_resource_key(
+    *, project_dir: str | Path, state_dir: str | Path
+) -> tuple[Any, ...]:
+    """Canonical key covering a project's narrator files and config metadata."""
+
+    return (
+        "narrator-voice",
+        str(Path(project_dir).resolve()),
+        str(Path(state_dir).resolve()),
+    )
+
+
+def seedance2_asset_resource_key(
+    *, project_dir: str | Path, episode: int, beat_number: int
+) -> tuple[Any, ...]:
+    """Canonical key for one beat's shared upload naming/config domain."""
+
+    return (
+        "seedance2-assets",
+        str(Path(project_dir).resolve()),
+        int(episode),
+        int(beat_number),
+    )
+
+
+async def run_voice_media_operation(
+    operation: Callable[..., Any],
+    /,
+    *args: Any,
+    finalize: Callable[[Any], Awaitable[Any]] | None = None,
+    **kwargs: Any,
+) -> Any:
+    """Run a blocking voice operation and optional async metadata commit atomically.
+
+    Cancellation is delayed until the worker and metadata finalizer have both
+    completed.  This keeps the limiter token held while the thread is alive and
+    prevents a published voice file from being left without its async metadata.
+    """
+
+    bound = functools.partial(operation, *args, **kwargs)
+    worker_task = asyncio.create_task(
+        anyio.to_thread.run_sync(
+            bound,
+            abandon_on_cancel=False,
+            limiter=_voice_media_limiter(),
+        )
+    )
+    result, cancellation = await _wait_for_voice_task_completion(worker_task)
+    if finalize is not None:
+        finalize_task = asyncio.create_task(finalize(result))
+        result, cancellation = await _wait_for_voice_task_completion(
+            finalize_task, cancellation
+        )
+    if cancellation is not None:
+        raise cancellation
+    return result
+
+
+async def _wait_for_voice_task_completion(
+    task: asyncio.Task,
+    cancellation: asyncio.CancelledError | None = None,
+) -> tuple[Any, asyncio.CancelledError | None]:
+    """Wait through direct, repeated, or AnyIO level cancellation."""
+
+    while not task.done():
+        try:
+            if cancellation is None:
+                await asyncio.shield(task)
+            else:
+                with anyio.CancelScope(shield=True):
+                    await asyncio.shield(task)
+        except asyncio.CancelledError as exc:
+            if cancellation is None:
+                cancellation = exc
+        except BaseException:
+            raise
+    try:
+        return task.result(), cancellation
+    except BaseException:
+        raise
 
 
 def decode_recorded_audio_data_url(data_url: str) -> tuple[bytes, str]:
@@ -85,7 +221,10 @@ def _transcode_to_mp3(content: bytes) -> bytes:
             input=content,
             capture_output=True,
             check=True,
+            timeout=FFMPEG_TIMEOUT_SECONDS,
         )
+    except subprocess.TimeoutExpired as exc:
+        raise ValueError(f"ffmpeg 转码超时（>{FFMPEG_TIMEOUT_SECONDS:g}s）") from exc
     except subprocess.CalledProcessError as exc:
         stderr = (exc.stderr or b"").decode("utf-8", "ignore").strip()
         raise ValueError(f"ffmpeg 转码失败：{stderr or exc}") from exc
@@ -200,7 +339,12 @@ def trim_voice_sample_content(
                 ],
                 capture_output=True,
                 check=True,
+                timeout=FFMPEG_TIMEOUT_SECONDS,
             )
+        except subprocess.TimeoutExpired as exc:
+            raise ValueError(
+                f"ffmpeg 裁剪超时（>{FFMPEG_TIMEOUT_SECONDS:g}s）"
+            ) from exc
         except subprocess.CalledProcessError as exc:
             stderr = (exc.stderr or b"").decode("utf-8", "ignore").strip()
             raise ValueError(f"ffmpeg 裁剪失败：{stderr or exc}") from exc

--- a/src/novelvideo/seedance2_i2v/panel_service.py
+++ b/src/novelvideo/seedance2_i2v/panel_service.py
@@ -20,7 +20,11 @@ from novelvideo.seedance2_i2v.assets import (
 )
 from novelvideo.seedance2_i2v.character_voice_storage import (
     VOICE_SAMPLE_EXTENSIONS,
+    narrator_voice_resource_key,
+    run_voice_media_operation,
+    seedance2_asset_resource_key,
     trim_voice_sample_content,
+    voice_resource_lock,
     voice_content_sha256,
 )
 from novelvideo.seedance2_i2v.models import (
@@ -34,7 +38,7 @@ from novelvideo.seedance2_i2v.prompt import (
     generate_seedance2_prompt,
 )
 from novelvideo.seedance2_i2v.voice_clone import normalize_seedance2_audio_type
-from novelvideo.utils.media_io import crop_image_to_path, get_audio_duration
+from novelvideo.utils.media_io import get_audio_duration
 from novelvideo.utils.path_resolver import PathResolver
 
 
@@ -89,6 +93,69 @@ async def save_seedance2_video_panel_config(
     next_beat: dict[str, Any] | None = None,
     prop_menu: list[Any] | None = None,
 ) -> str:
+    beat_num = int(beat.get("beat_number") or 0)
+    root = _seedance2_panel_project_dir(
+        project_dir=project_dir,
+        store=store,
+        fallback=state_dir,
+    )
+    resource_key = seedance2_asset_resource_key(
+        project_dir=root,
+        episode=episode,
+        beat_number=beat_num,
+    )
+
+    async def finalize(saved_json: str) -> str:
+        await store.update_beat_asset(
+            episode_number=episode,
+            beat_number=beat_num,
+            seedance2_config_json=saved_json,
+        )
+        beat["seedance2_config_json"] = saved_json
+        return saved_json
+
+    async with voice_resource_lock(resource_key):
+        return await run_voice_media_operation(
+            _prepare_seedance2_video_panel_config,
+            state_dir=state_dir,
+            episode=episode,
+            beat=beat,
+            mode=mode,
+            duration=duration,
+            resolution=resolution,
+            ratio=ratio,
+            generate_audio=generate_audio,
+            return_last_frame=return_last_frame,
+            human_review=human_review,
+            prompt_guidance=prompt_guidance,
+            final_prompt=final_prompt,
+            text_overlay=text_overlay,
+            project_dir=project_dir,
+            next_beat=next_beat,
+            prop_menu=prop_menu,
+            finalize=finalize,
+        )
+
+
+def _prepare_seedance2_video_panel_config(
+    *,
+    state_dir: str | Path,
+    episode: int,
+    beat: dict[str, Any],
+    mode: str | None,
+    duration: int | float | None,
+    resolution: str | None,
+    ratio: str | None,
+    generate_audio: bool | None,
+    return_last_frame: bool | None,
+    human_review: bool | None,
+    prompt_guidance: str | None,
+    final_prompt: str | None,
+    text_overlay: dict[str, Any] | None,
+    project_dir: Path | None,
+    next_beat: dict[str, Any] | None,
+    prop_menu: list[Any] | None,
+) -> str:
     config = parse_seedance2_config(beat.get("seedance2_config_json"))
     if mode is not None:
         config.mode = Seedance2I2VMode(mode)
@@ -127,12 +194,6 @@ async def save_seedance2_video_panel_config(
         )
 
     saved_json = dump_seedance2_config(config)
-    beat["seedance2_config_json"] = saved_json
-    await store.update_beat_asset(
-        episode_number=episode,
-        beat_number=int(beat.get("beat_number") or 0),
-        seedance2_config_json=saved_json,
-    )
     return saved_json
 
 
@@ -143,6 +204,44 @@ async def append_seedance2_prompt_guidance_template(
     beat: dict[str, Any],
     label: str,
     prompt_guidance: str | None = None,
+    project_dir: Path | None = None,
+) -> str:
+    beat_num = int(beat.get("beat_number") or 0)
+    root = _seedance2_panel_project_dir(
+        project_dir=project_dir,
+        store=store,
+    )
+    resource_key = seedance2_asset_resource_key(
+        project_dir=root,
+        episode=episode,
+        beat_number=beat_num,
+    )
+
+    async def finalize(saved_json: str) -> str:
+        if store is not None:
+            await store.update_beat_asset(
+                episode_number=episode,
+                beat_number=beat_num,
+                seedance2_config_json=saved_json,
+            )
+        beat["seedance2_config_json"] = saved_json
+        return saved_json
+
+    async with voice_resource_lock(resource_key):
+        return await run_voice_media_operation(
+            _prepare_seedance2_prompt_guidance_template,
+            beat=beat,
+            label=label,
+            prompt_guidance=prompt_guidance,
+            finalize=finalize,
+        )
+
+
+def _prepare_seedance2_prompt_guidance_template(
+    *,
+    beat: dict[str, Any],
+    label: str,
+    prompt_guidance: str | None,
 ) -> str:
     template = SEEDANCE2_PROMPT_GUIDANCE_TEMPLATES.get(str(label or "").strip())
     config = parse_seedance2_config(beat.get("seedance2_config_json"))
@@ -153,13 +252,6 @@ async def append_seedance2_prompt_guidance_template(
         config.prompt_guidance = "\n".join(parts)
 
     saved_json = dump_seedance2_config(config)
-    beat["seedance2_config_json"] = saved_json
-    if store is not None:
-        await store.update_beat_asset(
-            episode_number=episode,
-            beat_number=int(beat.get("beat_number") or 0),
-            seedance2_config_json=saved_json,
-        )
     return saved_json
 
 
@@ -242,6 +334,115 @@ async def save_seedance2_uploaded_asset(
     media_kind = _seedance2_uploaded_media_kind(filename, content_type)
     if not media_kind or not content:
         return None
+    beat_num = int(beat.get("beat_number") or 0)
+    resource_key = seedance2_asset_resource_key(
+        project_dir=project_dir,
+        episode=episode,
+        beat_number=beat_num,
+    )
+
+    async def finalize(prepared: tuple[Path, int, str] | None) -> Path | None:
+        if prepared is None:
+            return None
+        target, beat_num, saved_json = prepared
+        await store.update_beat_asset(
+            episode_number=episode,
+            beat_number=beat_num,
+            seedance2_config_json=saved_json,
+        )
+        beat["seedance2_config_json"] = saved_json
+        return target
+
+    async with voice_resource_lock(resource_key):
+        return await run_voice_media_operation(
+            _prepare_seedance2_uploaded_asset,
+            episode=episode,
+            beat=beat,
+            project_dir=project_dir,
+            filename=filename,
+            content=content,
+            content_type=content_type,
+            finalize=finalize,
+        )
+
+
+async def save_seedance2_uploaded_file(
+    *,
+    store: Any,
+    episode: int,
+    beat: dict[str, Any],
+    project_dir: Path,
+    filename: str,
+    upload_stream: Any,
+    content_type: str = "",
+) -> Path | None:
+    """Read and publish an upload in one bounded voice-worker transaction."""
+
+    beat_num = int(beat.get("beat_number") or 0)
+    resource_key = seedance2_asset_resource_key(
+        project_dir=project_dir,
+        episode=episode,
+        beat_number=beat_num,
+    )
+
+    async def finalize(prepared: tuple[Path, int, str] | None) -> Path | None:
+        if prepared is None:
+            return None
+        target, prepared_beat_num, saved_json = prepared
+        await store.update_beat_asset(
+            episode_number=episode,
+            beat_number=prepared_beat_num,
+            seedance2_config_json=saved_json,
+        )
+        beat["seedance2_config_json"] = saved_json
+        return target
+
+    async with voice_resource_lock(resource_key):
+        return await run_voice_media_operation(
+            _read_and_prepare_seedance2_uploaded_asset,
+            upload_stream=upload_stream,
+            episode=episode,
+            beat=beat,
+            project_dir=project_dir,
+            filename=filename,
+            content_type=content_type,
+            finalize=finalize,
+        )
+
+
+def _read_and_prepare_seedance2_uploaded_asset(
+    *,
+    upload_stream: Any,
+    episode: int,
+    beat: dict[str, Any],
+    project_dir: Path,
+    filename: str,
+    content_type: str,
+) -> tuple[Path, int, str] | None:
+    return _prepare_seedance2_uploaded_asset(
+        episode=episode,
+        beat=beat,
+        project_dir=project_dir,
+        filename=filename,
+        content=upload_stream.read(),
+        content_type=content_type,
+    )
+
+
+def _prepare_seedance2_uploaded_asset(
+    *,
+    episode: int,
+    beat: dict[str, Any],
+    project_dir: Path,
+    filename: str,
+    content: bytes,
+    content_type: str,
+) -> tuple[Path, int, str] | None:
+    """Publish an upload and prepare its metadata entirely in a voice worker."""
+
+    media_kind = _seedance2_uploaded_media_kind(filename, content_type)
+    if not media_kind or not content:
+        return None
 
     beat_num = int(beat.get("beat_number") or 0)
     upload_dir = (
@@ -253,7 +454,6 @@ async def save_seedance2_uploaded_asset(
     )
     upload_dir.mkdir(parents=True, exist_ok=True)
     target = _next_available_upload_path(upload_dir, filename)
-    target.write_bytes(bytes(content))
 
     config = parse_seedance2_config(beat.get("seedance2_config_json"))
     path_value = str(target)
@@ -267,13 +467,8 @@ async def save_seedance2_uploaded_asset(
         )
 
     saved_json = dump_seedance2_config(config)
-    beat["seedance2_config_json"] = saved_json
-    await store.update_beat_asset(
-        episode_number=episode,
-        beat_number=beat_num,
-        seedance2_config_json=saved_json,
-    )
-    return target
+    target.write_bytes(bytes(content))
+    return target, beat_num, saved_json
 
 
 async def crop_seedance2_asset_to_reference(
@@ -286,19 +481,64 @@ async def crop_seedance2_asset_to_reference(
     source_path: str | Path,
     crop_data: dict[str, Any],
 ) -> Path | None:
+    beat_num = int(beat.get("beat_number") or 0)
+    resource_key = seedance2_asset_resource_key(
+        project_dir=project_dir,
+        episode=episode,
+        beat_number=beat_num,
+    )
+
+    async def finalize(
+        prepared: tuple[Path | None, str | None]
+    ) -> Path | None:
+        output_path, saved_json = prepared
+        if output_path is None:
+            return None
+        if saved_json is not None:
+            await store.update_beat_asset(
+                episode_number=episode,
+                beat_number=beat_num,
+                seedance2_config_json=saved_json,
+            )
+            beat["seedance2_config_json"] = saved_json
+        return output_path
+
+    async with voice_resource_lock(resource_key):
+        return await run_voice_media_operation(
+            _prepare_cropped_seedance2_asset,
+            episode=episode,
+            beat=beat,
+            project_dir=project_dir,
+            asset_key=asset_key,
+            source_path=source_path,
+            crop_data=crop_data,
+            finalize=finalize,
+        )
+
+
+def _prepare_cropped_seedance2_asset(
+    *,
+    episode: int,
+    beat: dict[str, Any],
+    project_dir: Path,
+    asset_key: str,
+    source_path: str | Path,
+    crop_data: dict[str, Any],
+) -> tuple[Path | None, str | None]:
     source = Path(source_path)
     if not source.exists():
-        return None
+        return None, None
     width = int(crop_data.get("width") or 0)
     height = int(crop_data.get("height") or 0)
     if width <= 0 or height <= 0:
-        return None
+        return None, None
 
     beat_num = int(beat.get("beat_number") or 0)
     target = str(crop_data.get("target") or "reference_image")
     if target in {"first_frame", "last_frame"}:
         paths = PathResolver(project_dir, episode)
         output_path = paths.video_input_frame(beat_num, slot=target)
+        saved_json = None
     else:
         output_path = (
             Path(project_dir)
@@ -307,7 +547,13 @@ async def crop_seedance2_asset_to_reference(
             / f"beat_{beat_num:02d}"
             / f"{_seedance2_safe_asset_key(str(asset_key or 'asset'))}.png"
         )
-    await crop_image_to_path(
+        config = parse_seedance2_config(beat.get("seedance2_config_json"))
+        config.reference_image_paths = _unique_paths(
+            list(config.reference_image_paths) + [str(output_path)]
+        )
+        saved_json = dump_seedance2_config(config)
+
+    _crop_image_to_path_sync(
         source,
         x=int(crop_data.get("x") or 0),
         y=int(crop_data.get("y") or 0),
@@ -316,24 +562,34 @@ async def crop_seedance2_asset_to_reference(
         output_path=output_path,
     )
     if validate_seedance2_reference_image(output_path):
-        return None
+        return None, None
     if target in {"first_frame", "last_frame"}:
         paths.write_video_input_frame_meta(beat_num, slot=target, source_path=source)
-        return output_path
+    return output_path, saved_json
 
-    config = parse_seedance2_config(beat.get("seedance2_config_json"))
-    output_value = str(output_path)
-    config.reference_image_paths = _unique_paths(
-        list(config.reference_image_paths) + [output_value]
-    )
-    saved_json = dump_seedance2_config(config)
-    beat["seedance2_config_json"] = saved_json
-    await store.update_beat_asset(
-        episode_number=episode,
-        beat_number=beat_num,
-        seedance2_config_json=saved_json,
-    )
-    return output_path
+
+def _crop_image_to_path_sync(
+    image_path: str | Path,
+    *,
+    x: int,
+    y: int,
+    width: int,
+    height: int,
+    output_path: str | Path,
+) -> tuple[int, int]:
+    from PIL import Image
+
+    source = Path(image_path)
+    target = Path(output_path)
+    with Image.open(source) as img:
+        crop_x = max(0, min(int(x), img.width - 1))
+        crop_y = max(0, min(int(y), img.height - 1))
+        right = min(crop_x + max(1, int(width)), img.width)
+        bottom = min(crop_y + max(1, int(height)), img.height)
+        cropped = img.crop((crop_x, crop_y, right, bottom))
+        target.parent.mkdir(parents=True, exist_ok=True)
+        cropped.save(target)
+        return cropped.width, cropped.height
 
 
 def _project_relative_path(project_dir: Path, path: Path) -> str:
@@ -376,6 +632,58 @@ async def trim_seedance2_audio_to_reference(
     start_seconds: float = 0.0,
     duration_seconds: float = 4.0,
 ) -> Path | None:
+    beat_num = int(beat.get("beat_number") or 0)
+    if str(asset_key or "").strip() == "voice:narrator":
+        resource_key = narrator_voice_resource_key(
+            project_dir=project_dir,
+            state_dir=str(getattr(store, "state_dir", "") or ""),
+        )
+    else:
+        resource_key = seedance2_asset_resource_key(
+            project_dir=project_dir,
+            episode=episode,
+            beat_number=beat_num,
+        )
+
+    async def finalize(prepared: tuple[Path, int | None, str | None]) -> Path:
+        target, beat_num, saved_json = prepared
+        if beat_num is not None and saved_json is not None:
+            await store.update_beat_asset(
+                episode_number=episode,
+                beat_number=beat_num,
+                seedance2_config_json=saved_json,
+            )
+            beat["seedance2_config_json"] = saved_json
+        return target
+
+    async with voice_resource_lock(resource_key):
+        return await run_voice_media_operation(
+            _prepare_trimmed_seedance2_audio,
+            store=store,
+            episode=episode,
+            beat=beat,
+            project_dir=project_dir,
+            asset_key=asset_key,
+            source_path=source_path,
+            start_seconds=start_seconds,
+            duration_seconds=duration_seconds,
+            finalize=finalize,
+        )
+
+
+def _prepare_trimmed_seedance2_audio(
+    *,
+    store: Any,
+    episode: int,
+    beat: dict[str, Any],
+    project_dir: Path,
+    asset_key: str,
+    source_path: str | Path,
+    start_seconds: float,
+    duration_seconds: float,
+) -> tuple[Path, int | None, str | None]:
+    """Read, trim, publish, and prepare config in one bounded worker."""
+
     source = _resolve_project_audio_source(Path(project_dir), source_path)
     content, _filename = trim_voice_sample_content(
         source.read_bytes(),
@@ -397,7 +705,7 @@ async def trim_seedance2_audio_to_reference(
             relative_path=_project_relative_path(Path(project_dir), target),
             sha256=voice_content_sha256(content),
         )
-        return target
+        return target, None, None
 
     beat_num = int(beat.get("beat_number") or 0)
     output_path = (
@@ -407,22 +715,16 @@ async def trim_seedance2_audio_to_reference(
         / f"beat_{beat_num:02d}"
         / f"{_seedance2_safe_asset_key(str(asset_key or 'audio'))}_trimmed.mp3"
     )
-    output_path.parent.mkdir(parents=True, exist_ok=True)
-    output_path.write_bytes(content)
 
     config = parse_seedance2_config(beat.get("seedance2_config_json"))
-    output_value = str(output_path)
     config.reference_audio_paths = _unique_paths(
-        list(config.reference_audio_paths) + [output_value]
+        list(config.reference_audio_paths) + [str(output_path)]
     )
     saved_json = dump_seedance2_config(config)
-    beat["seedance2_config_json"] = saved_json
-    await store.update_beat_asset(
-        episode_number=episode,
-        beat_number=beat_num,
-        seedance2_config_json=saved_json,
-    )
-    return output_path
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_bytes(content)
+    return output_path, beat_num, saved_json
 
 
 async def remove_seedance2_uploaded_asset(
@@ -432,22 +734,86 @@ async def remove_seedance2_uploaded_asset(
     beat: dict[str, Any],
     media_kind: str,
     path: str,
+    project_dir: Path | None = None,
 ) -> bool:
+    beat_num = int(beat.get("beat_number") or 0)
+    root = _seedance2_asset_project_dir(
+        project_dir=project_dir,
+        store=store,
+        asset_path=path,
+    )
+    resource_key = seedance2_asset_resource_key(
+        project_dir=root,
+        episode=episode,
+        beat_number=beat_num,
+    )
+
+    async def finalize(prepared: tuple[bool, str | None]) -> bool:
+        removed, saved_json = prepared
+        if not removed or saved_json is None:
+            return False
+        await store.update_beat_asset(
+            episode_number=episode,
+            beat_number=beat_num,
+            seedance2_config_json=saved_json,
+        )
+        beat["seedance2_config_json"] = saved_json
+        return True
+
+    async with voice_resource_lock(resource_key):
+        return await run_voice_media_operation(
+            _prepare_removed_seedance2_asset,
+            beat=beat,
+            media_kind=media_kind,
+            path=path,
+            finalize=finalize,
+        )
+
+
+def _prepare_removed_seedance2_asset(
+    *, beat: dict[str, Any], media_kind: str, path: str
+) -> tuple[bool, str | None]:
     config = parse_seedance2_config(beat.get("seedance2_config_json"))
     paths = config.reference_image_paths if media_kind == "images" else config.reference_audio_paths
     path_value = str(path)
     if path_value not in paths:
-        return False
+        return False, None
     paths[:] = [existing for existing in paths if existing != path_value]
     _seedance2_unlink_user_reference_file(path_value)
-    saved_json = dump_seedance2_config(config)
-    beat["seedance2_config_json"] = saved_json
-    await store.update_beat_asset(
-        episode_number=episode,
-        beat_number=int(beat.get("beat_number") or 0),
-        seedance2_config_json=saved_json,
-    )
-    return True
+    return True, dump_seedance2_config(config)
+
+
+def _seedance2_asset_project_dir(
+    *, project_dir: Path | None, store: Any, asset_path: str | Path
+) -> Path:
+    if project_dir is not None:
+        return Path(project_dir)
+    stored_project_dir = str(getattr(store, "project_dir", "") or "")
+    if stored_project_dir:
+        return Path(stored_project_dir)
+    candidate = Path(asset_path)
+    for parent in candidate.parents:
+        if parent.name in {"seedance2_uploads", "seedance2_crops"}:
+            return parent.parent
+    return candidate.parent
+
+
+def _seedance2_panel_project_dir(
+    *,
+    project_dir: Path | None,
+    store: Any,
+    fallback: str | Path | None = None,
+) -> Path:
+    """Resolve the canonical project root used by all per-beat asset writers."""
+
+    if project_dir is not None:
+        return Path(project_dir)
+    stored_project_dir = str(getattr(store, "project_dir", "") or "")
+    if stored_project_dir:
+        return Path(stored_project_dir)
+    if fallback is not None:
+        return Path(fallback)
+    return Path(".")
 
 
 def build_seedance2_video_panel_state(

--- a/src/novelvideo/seedance2_i2v/panel_service.py
+++ b/src/novelvideo/seedance2_i2v/panel_service.py
@@ -9,6 +9,9 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any
 
+import anyio
+from anyio.lowlevel import RunVar
+
 from novelvideo.manual_shots import resolve_target_video_duration
 from novelvideo.project_config import set_narrator_reference_audio_in_state_dir
 from novelvideo.seedance2_i2v.assets import (
@@ -38,7 +41,11 @@ from novelvideo.seedance2_i2v.prompt import (
     generate_seedance2_prompt,
 )
 from novelvideo.seedance2_i2v.voice_clone import normalize_seedance2_audio_type
-from novelvideo.utils.media_io import get_audio_duration
+from novelvideo.utils.async_ops import metadata_io_limiter
+from novelvideo.utils.media_io import (
+    crop_image_to_path_sync as _crop_image_to_path_sync,
+    get_audio_duration,
+)
 from novelvideo.utils.path_resolver import PathResolver
 
 
@@ -50,6 +57,18 @@ SEEDANCE2_PROMPT_GUIDANCE_TEMPLATES: dict[str, str] = {
     "风格": "风格：限定画面质感、时代感、色彩倾向和真实度，避免风格漂移。",
     "无字幕": "无字幕：避免生成任何文字或字幕，保持画面纯净。",
 }
+_SEEDANCE2_ASSET_CONCURRENCY = 2
+_seedance2_asset_limiter_var: RunVar[anyio.CapacityLimiter] = RunVar(
+    "seedance2_asset_limiter"
+)
+
+
+def _seedance2_asset_limiter() -> anyio.CapacityLimiter:
+    limiter = _seedance2_asset_limiter_var.get(None)
+    if limiter is None:
+        limiter = anyio.CapacityLimiter(_SEEDANCE2_ASSET_CONCURRENCY)
+        _seedance2_asset_limiter_var.set(limiter)
+    return limiter
 
 
 @dataclass(frozen=True)
@@ -133,6 +152,7 @@ async def save_seedance2_video_panel_config(
             project_dir=project_dir,
             next_beat=next_beat,
             prop_menu=prop_menu,
+            worker_limiter=metadata_io_limiter(),
             finalize=finalize,
         )
 
@@ -233,6 +253,7 @@ async def append_seedance2_prompt_guidance_template(
             beat=beat,
             label=label,
             prompt_guidance=prompt_guidance,
+            worker_limiter=metadata_io_limiter(),
             finalize=finalize,
         )
 
@@ -362,6 +383,7 @@ async def save_seedance2_uploaded_asset(
             filename=filename,
             content=content,
             content_type=content_type,
+            worker_limiter=_seedance2_asset_limiter(),
             finalize=finalize,
         )
 
@@ -406,6 +428,7 @@ async def save_seedance2_uploaded_file(
             project_dir=project_dir,
             filename=filename,
             content_type=content_type,
+            worker_limiter=_seedance2_asset_limiter(),
             finalize=finalize,
         )
 
@@ -512,6 +535,7 @@ async def crop_seedance2_asset_to_reference(
             asset_key=asset_key,
             source_path=source_path,
             crop_data=crop_data,
+            worker_limiter=_seedance2_asset_limiter(),
             finalize=finalize,
         )
 
@@ -566,30 +590,6 @@ def _prepare_cropped_seedance2_asset(
     if target in {"first_frame", "last_frame"}:
         paths.write_video_input_frame_meta(beat_num, slot=target, source_path=source)
     return output_path, saved_json
-
-
-def _crop_image_to_path_sync(
-    image_path: str | Path,
-    *,
-    x: int,
-    y: int,
-    width: int,
-    height: int,
-    output_path: str | Path,
-) -> tuple[int, int]:
-    from PIL import Image
-
-    source = Path(image_path)
-    target = Path(output_path)
-    with Image.open(source) as img:
-        crop_x = max(0, min(int(x), img.width - 1))
-        crop_y = max(0, min(int(y), img.height - 1))
-        right = min(crop_x + max(1, int(width)), img.width)
-        bottom = min(crop_y + max(1, int(height)), img.height)
-        cropped = img.crop((crop_x, crop_y, right, bottom))
-        target.parent.mkdir(parents=True, exist_ok=True)
-        cropped.save(target)
-        return cropped.width, cropped.height
 
 
 def _project_relative_path(project_dir: Path, path: Path) -> str:
@@ -766,6 +766,7 @@ async def remove_seedance2_uploaded_asset(
             beat=beat,
             media_kind=media_kind,
             path=path,
+            worker_limiter=metadata_io_limiter(),
             finalize=finalize,
         )
 

--- a/src/novelvideo/utils/async_ops.py
+++ b/src/novelvideo/utils/async_ops.py
@@ -1,6 +1,107 @@
 import asyncio
 import functools
-from typing import Any, Callable
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+import anyio
+from anyio.lowlevel import RunVar
+
+
+METADATA_IO_CONCURRENCY = 4
+_metadata_io_limiter_var: RunVar[anyio.CapacityLimiter] = RunVar(
+    "metadata_io_limiter"
+)
+
+
+def metadata_io_limiter() -> anyio.CapacityLimiter:
+    """Return the lightweight metadata/file-operation gate for this async run."""
+
+    limiter = _metadata_io_limiter_var.get(None)
+    if limiter is None:
+        limiter = anyio.CapacityLimiter(METADATA_IO_CONCURRENCY)
+        _metadata_io_limiter_var.set(limiter)
+    return limiter
+
+
+async def wait_for_task_completion(
+    task: asyncio.Task,
+    cancellation: asyncio.CancelledError | None = None,
+) -> tuple[Any, asyncio.CancelledError | None]:
+    """Wait through repeated cancellation, preserving the first cancellation."""
+
+    while not task.done():
+        try:
+            if cancellation is None:
+                await asyncio.shield(task)
+            else:
+                with anyio.CancelScope(shield=True):
+                    await asyncio.shield(task)
+        except asyncio.CancelledError as exc:
+            if cancellation is None:
+                cancellation = exc
+        except BaseException:
+            if cancellation is not None:
+                raise cancellation
+            raise
+    try:
+        return task.result(), cancellation
+    except BaseException:
+        if cancellation is not None:
+            raise cancellation
+        raise
+
+
+async def run_sync_bounded(
+    function: Callable[..., Any],
+    /,
+    *args: Any,
+    limiter: anyio.CapacityLimiter,
+    finalize: Callable[[Any], Awaitable[Any]] | None = None,
+    shield: bool = True,
+    **kwargs: Any,
+) -> Any:
+    """Run bounded blocking work with optional transactional cancellation shielding.
+
+    When ``shield`` is true, cancellation is delayed while waiting for capacity
+    and until the worker and optional finalizer complete. When false, waiting
+    for capacity is cancellable; once admitted, the operation retains its
+    limiter token until the worker and optional finalizer finish. If a finalizer
+    is supplied, its return value is the operation result.
+    """
+
+    bound = functools.partial(function, *args, **kwargs)
+    if shield:
+        worker_task = asyncio.create_task(
+            anyio.to_thread.run_sync(
+                bound,
+                abandon_on_cancel=False,
+                limiter=limiter,
+            )
+        )
+        result, cancellation = await wait_for_task_completion(worker_task)
+    else:
+        await limiter.acquire()
+        try:
+            worker_task = asyncio.create_task(asyncio.to_thread(bound))
+            result, cancellation = await wait_for_task_completion(worker_task)
+            if finalize is not None:
+                finalize_task = asyncio.create_task(finalize(result))
+                result, cancellation = await wait_for_task_completion(
+                    finalize_task, cancellation
+                )
+        finally:
+            limiter.release()
+        if cancellation is not None:
+            raise cancellation
+        return result
+    if finalize is not None:
+        finalize_task = asyncio.create_task(finalize(result))
+        result, cancellation = await wait_for_task_completion(
+            finalize_task, cancellation
+        )
+    if cancellation is not None:
+        raise cancellation
+    return result
 
 
 async def call_blocking(func: Callable[..., Any], /, *args, **kwargs) -> Any:

--- a/src/novelvideo/utils/media_io.py
+++ b/src/novelvideo/utils/media_io.py
@@ -109,6 +109,32 @@ async def get_audio_durations_async(paths: "Sequence[str]") -> "list[float | Non
     return list(await asyncio.gather(*(probe(path) for path in paths)))
 
 
+def crop_image_to_path_sync(
+    image_path: str | Path,
+    *,
+    x: int,
+    y: int,
+    width: int,
+    height: int,
+    output_path: str | Path | None = None,
+) -> tuple[int, int]:
+    """Synchronously crop an image with bounds clamping and save it to disk."""
+
+    from PIL import Image
+
+    source = Path(image_path)
+    target = Path(output_path) if output_path is not None else source
+    with Image.open(source) as img:
+        crop_x = max(0, min(int(x), img.width - 1))
+        crop_y = max(0, min(int(y), img.height - 1))
+        right = min(crop_x + max(1, int(width)), img.width)
+        bottom = min(crop_y + max(1, int(height)), img.height)
+        cropped = img.crop((crop_x, crop_y, right, bottom))
+        target.parent.mkdir(parents=True, exist_ok=True)
+        cropped.save(target)
+        return cropped.width, cropped.height
+
+
 async def crop_image_to_path(
     image_path: str | Path,
     *,
@@ -118,24 +144,22 @@ async def crop_image_to_path(
     height: int,
     output_path: str | Path | None = None,
 ) -> tuple[int, int]:
-    """Crop an image with bounds clamping and save it to disk."""
+    """Crop an image off the event loop."""
 
-    def _crop() -> tuple[int, int]:
-        from PIL import Image
-
-        source = Path(image_path)
-        target = Path(output_path) if output_path is not None else source
-        with Image.open(source) as img:
-            crop_x = max(0, min(int(x), img.width - 1))
-            crop_y = max(0, min(int(y), img.height - 1))
-            right = min(crop_x + max(1, int(width)), img.width)
-            bottom = min(crop_y + max(1, int(height)), img.height)
-            cropped = img.crop((crop_x, crop_y, right, bottom))
-            target.parent.mkdir(parents=True, exist_ok=True)
-            cropped.save(target)
-            return cropped.width, cropped.height
-
-    return await call_blocking(_crop)
+    return await call_blocking(
+        crop_image_to_path_sync,
+        image_path,
+        x=x,
+        y=y,
+        width=width,
+        height=height,
+        output_path=output_path,
+    )
 
 
-__all__ = ["crop_image_to_path", "get_audio_duration", "get_audio_duration_async"]
+__all__ = [
+    "crop_image_to_path",
+    "crop_image_to_path_sync",
+    "get_audio_duration",
+    "get_audio_duration_async",
+]

--- a/src/novelvideo/utils/upload_safety.py
+++ b/src/novelvideo/utils/upload_safety.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+import os
 import re
+import secrets
+import stat
 from pathlib import Path, PurePosixPath
 from typing import BinaryIO
 
@@ -13,6 +16,39 @@ MAX_PROJECT_UPLOAD_BYTES = 200 * 1024 * 1024
 
 class UploadTooLargeError(ValueError):
     """Raised when an upload exceeds its raw file-size limit."""
+
+
+def create_staged_upload_file(
+    staging_dir: Path,
+    *,
+    suffix: str,
+    prefix: str = "upload-",
+    destination: Path | None = None,
+) -> Path:
+    """Create a unique staging file with publish-compatible permissions."""
+
+    for _ in range(10):
+        staged_path = staging_dir / f"{prefix}{secrets.token_hex(16)}{suffix}"
+        try:
+            fd = os.open(
+                staged_path,
+                os.O_WRONLY | os.O_CREAT | os.O_EXCL,
+                0o666,
+            )
+        except FileExistsError:
+            continue
+        os.close(fd)
+        try:
+            if destination is not None:
+                destination_mode = stat.S_IMODE(destination.stat().st_mode)
+                staged_path.chmod(destination_mode)
+        except FileNotFoundError:
+            pass
+        except BaseException:
+            staged_path.unlink(missing_ok=True)
+            raise
+        return staged_path
+    raise OSError("failed to allocate upload staging file")
 
 
 def sanitize_upload_filename(raw_name: str | None, *, fallback: str = "upload.txt") -> str:

--- a/src/novelvideo/utils/upload_safety.py
+++ b/src/novelvideo/utils/upload_safety.py
@@ -8,10 +8,11 @@ from typing import BinaryIO
 
 MAX_NOVEL_UPLOAD_BYTES = 512 * 1024
 MAX_NOVEL_IMPORT_BYTES = 1 * 1024 * 1024
+MAX_PROJECT_UPLOAD_BYTES = 200 * 1024 * 1024
 
 
 class UploadTooLargeError(ValueError):
-    """Raised when a novel upload exceeds its raw file-size limit."""
+    """Raised when an upload exceeds its raw file-size limit."""
 
 
 def sanitize_upload_filename(raw_name: str | None, *, fallback: str = "upload.txt") -> str:

--- a/tests/test_api_asset_upload_offload.py
+++ b/tests/test_api_asset_upload_offload.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import asyncio
 import gc
 import io
+import os
+import stat
 import threading
 import weakref
 from pathlib import Path
@@ -22,6 +24,65 @@ def _png_upload(size: tuple[int, int] = (4, 4)) -> UploadFile:
     Image.new("RGB", size, color=(120, 80, 40)).save(payload, format="PNG")
     payload.seek(0)
     return UploadFile(filename="upload.png", file=payload)
+
+
+@pytest.mark.parametrize("publisher", ["character", "scene"])
+def test_published_images_respect_umask_for_new_targets(tmp_path, publisher):
+    from PIL import Image
+
+    from novelvideo.api.routes import characters, scenes
+
+    target = tmp_path / "portrait.png"
+    previous_umask = os.umask(0o022)
+    try:
+        if publisher == "character":
+            characters._persist_uploaded_character_image(_png_upload(), target)
+        else:
+            scenes._publish_scene_image(
+                Image.new("RGB", (4, 4), color="red"), target, "master"
+            )
+    finally:
+        os.umask(previous_umask)
+
+    assert stat.S_IMODE(target.stat().st_mode) == 0o644
+
+
+@pytest.mark.parametrize("publisher", ["character", "scene"])
+def test_published_images_preserve_existing_target_mode(tmp_path, publisher):
+    from PIL import Image
+
+    from novelvideo.api.routes import characters, scenes
+
+    target = tmp_path / "portrait.png"
+    Image.new("RGB", (2, 2), color="blue").save(target)
+    target.chmod(0o640)
+
+    if publisher == "character":
+        characters._persist_uploaded_character_image(_png_upload(), target)
+    else:
+        scenes._publish_scene_image(
+            Image.new("RGB", (4, 4), color="red"), target, "master"
+        )
+
+    assert stat.S_IMODE(target.stat().st_mode) == 0o640
+
+
+def test_scene_image_archives_do_not_collide_within_one_second(tmp_path, monkeypatch):
+    from PIL import Image
+
+    from novelvideo.api.routes import scenes
+
+    target = tmp_path / "master.png"
+    monkeypatch.setattr(scenes.time, "time", lambda: 1_700_000_000.0)
+    stamps = iter((1_700_000_000_000_000_001, 1_700_000_000_000_000_002))
+    monkeypatch.setattr(scenes.time, "time_ns", lambda: next(stamps))
+
+    for color in ("red", "green", "blue"):
+        scenes._publish_scene_image(
+            Image.new("RGB", (4, 4), color=color), target, "master"
+        )
+
+    assert len(list(tmp_path.glob("master_*.png"))) == 2
 
 
 class _CharacterStore:
@@ -60,6 +121,42 @@ class _SceneStore:
     async def touch_scene_asset(self, _name: str) -> bool:
         self.touched.append(_name)
         return True
+
+
+@pytest.mark.asyncio
+async def test_identity_attempts_ignore_hidden_staging_files(tmp_path, monkeypatch):
+    from novelvideo.api.routes import characters
+
+    store = _CharacterStore()
+
+    async def resolve_project(*_args, **_kwargs):
+        return (
+            SimpleNamespace(project_id="proj_demo"),
+            "admin",
+            "demo",
+            tmp_path,
+            str(tmp_path),
+            store,
+        )
+
+    monkeypatch.setattr(characters, "_resolve_character_project", resolve_project)
+    identities_dir = tmp_path / "assets" / "characters" / "秦" / "identities"
+    identities_dir.mkdir(parents=True)
+    for filename in (
+        "秦_少年_portrait.png",
+        "秦_少年_portrait_20260831.png",
+        ".秦_少年_portrait_deadbeef.png",
+    ):
+        (identities_dir / filename).write_bytes(b"png")
+
+    response = await characters.get_identity_attempts(
+        project="demo",
+        name="秦",
+        identity_id="秦_少年",
+        user={"username": "admin"},
+    )
+
+    assert response["data"]["portrait_attempts"] == 2
 
 
 @pytest.mark.asyncio
@@ -594,6 +691,68 @@ async def test_scene_delete_waits_for_matching_upload_transaction(
             stage_manifest.resolve_ply_path(tmp_path, "Hall", ply_kind="custom")
             is None
         )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("kind", ["pano", "custom"])
+async def test_scene_metadata_delete_does_not_wait_for_upload_capacity(
+    tmp_path, monkeypatch, kind
+):
+    from novelvideo.api.routes import scenes
+    from novelvideo.api.upload_workers import run_asset_upload_operation
+
+    store = _SceneStore()
+    ctx = SimpleNamespace(project_id="proj_demo")
+
+    async def resolve_project(*_args, **_kwargs):
+        return ctx, "admin", "demo", tmp_path, str(tmp_path), store
+
+    monkeypatch.setattr(scenes, "_resolve_scene_project", resolve_project)
+    upload_capacity_full = threading.Event()
+    release_uploads = threading.Event()
+    started_count = 0
+    started_lock = threading.Lock()
+
+    def blocking_upload() -> None:
+        nonlocal started_count
+        with started_lock:
+            started_count += 1
+            if started_count == 2:
+                upload_capacity_full.set()
+        assert release_uploads.wait(timeout=5)
+
+    delete_started = threading.Event()
+
+    def delete_files(*_args) -> bool:
+        delete_started.set()
+        return True
+
+    if kind == "pano":
+        monkeypatch.setattr(scenes, "_delete_scene_pano_files", delete_files)
+        delete_call = scenes.delete_scene_pano(
+            project="demo", name="Hall", user={"username": "admin"}
+        )
+    else:
+        monkeypatch.setattr(scenes, "_delete_scene_custom_files", delete_files)
+        delete_call = scenes.delete_scene_custom_package(
+            project="demo", name="Hall", user={"username": "admin"}
+        )
+
+    blockers = [
+        asyncio.create_task(run_asset_upload_operation(blocking_upload))
+        for _ in range(2)
+    ]
+    delete_task = None
+    try:
+        assert await asyncio.to_thread(upload_capacity_full.wait, 1)
+        delete_task = asyncio.create_task(delete_call)
+        assert await asyncio.to_thread(delete_started.wait, 1)
+        assert (await delete_task)["ok"] is True
+    finally:
+        release_uploads.set()
+        await asyncio.gather(*blockers, return_exceptions=True)
+        if delete_task is not None and not delete_task.done():
+            await asyncio.gather(delete_task, return_exceptions=True)
 
 
 @pytest.mark.asyncio
@@ -1157,6 +1316,121 @@ async def test_cancelled_upload_finishes_metadata_before_reraising(tmp_path):
     assert raised.value.args == ("publish-cancel",)
     assert target.exists()
     assert metadata == [target]
+
+
+@pytest.mark.asyncio
+async def test_cancelled_asset_worker_preserves_cancellation_precedence():
+    from novelvideo.api.upload_workers import run_asset_upload_operation
+
+    started = threading.Event()
+    release = threading.Event()
+
+    def failing_worker() -> None:
+        started.set()
+        release.wait(timeout=3)
+        raise RuntimeError("asset worker failed after cancellation")
+
+    task = asyncio.create_task(run_asset_upload_operation(failing_worker))
+    assert await asyncio.to_thread(started.wait, 1)
+    task.cancel("cancel-asset-worker")
+    release.set()
+
+    with pytest.raises(asyncio.CancelledError) as raised:
+        await task
+    assert raised.value.args == ("cancel-asset-worker",)
+
+
+@pytest.mark.asyncio
+async def test_unshielded_bounded_worker_cancels_while_waiting_for_capacity():
+    from novelvideo.utils.async_ops import run_sync_bounded
+
+    limiter = anyio.CapacityLimiter(1)
+    holder_started = threading.Event()
+    release_holder = threading.Event()
+    queued_started = threading.Event()
+
+    def hold_capacity() -> None:
+        holder_started.set()
+        assert release_holder.wait(timeout=5)
+
+    holder = asyncio.create_task(
+        run_sync_bounded(hold_capacity, limiter=limiter, shield=False)
+    )
+    queued = None
+    try:
+        assert await asyncio.to_thread(holder_started.wait, 1)
+        queued = asyncio.create_task(
+            run_sync_bounded(
+                queued_started.set,
+                limiter=limiter,
+                shield=False,
+            )
+        )
+        while limiter.statistics().tasks_waiting != 1:
+            await asyncio.sleep(0)
+
+        queued.cancel("drop-queued-work")
+        done, _pending = await asyncio.wait({queued}, timeout=1)
+        assert queued in done
+        with pytest.raises(asyncio.CancelledError) as raised:
+            await queued
+        assert raised.value.args == ("drop-queued-work",)
+        assert not queued_started.is_set()
+        assert limiter.statistics().tasks_waiting == 0
+    finally:
+        release_holder.set()
+        await asyncio.gather(holder, return_exceptions=True)
+        if queued is not None and not queued.done():
+            await asyncio.gather(queued, return_exceptions=True)
+
+
+@pytest.mark.asyncio
+async def test_unshielded_bounded_worker_keeps_capacity_after_admission():
+    from novelvideo.utils.async_ops import run_sync_bounded
+
+    limiter = anyio.CapacityLimiter(1)
+    worker_started = threading.Event()
+    release_worker = threading.Event()
+
+    def hold_capacity() -> str:
+        worker_started.set()
+        assert release_worker.wait(timeout=5)
+        return "worker-result"
+
+    task = asyncio.create_task(
+        run_sync_bounded(hold_capacity, limiter=limiter, shield=False)
+    )
+    try:
+        assert await asyncio.to_thread(worker_started.wait, 1)
+        task.cancel("cancel-admitted-work")
+        await asyncio.sleep(0)
+
+        assert not task.done()
+        assert limiter.borrowed_tokens == 1
+    finally:
+        release_worker.set()
+
+    with pytest.raises(asyncio.CancelledError) as raised:
+        await task
+    assert raised.value.args == ("cancel-admitted-work",)
+    assert limiter.borrowed_tokens == 0
+
+
+@pytest.mark.asyncio
+async def test_bounded_worker_returns_finalizer_result():
+    from novelvideo.utils.async_ops import run_sync_bounded
+
+    async def finalize(worker_result: str) -> str:
+        assert worker_result == "worker-result"
+        return "finalizer-result"
+
+    result = await run_sync_bounded(
+        lambda: "worker-result",
+        limiter=anyio.CapacityLimiter(1),
+        finalize=finalize,
+    )
+
+    assert result == "finalizer-result"
 
 
 @pytest.mark.asyncio

--- a/tests/test_api_asset_upload_offload.py
+++ b/tests/test_api_asset_upload_offload.py
@@ -1,0 +1,1352 @@
+from __future__ import annotations
+
+import asyncio
+import gc
+import io
+import threading
+import weakref
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+import anyio
+from fastapi import UploadFile
+
+from novelvideo.models import CharacterIdentity, NovelCharacter, NovelScene
+
+
+def _png_upload(size: tuple[int, int] = (4, 4)) -> UploadFile:
+    from PIL import Image
+
+    payload = io.BytesIO()
+    Image.new("RGB", size, color=(120, 80, 40)).save(payload, format="PNG")
+    payload.seek(0)
+    return UploadFile(filename="upload.png", file=payload)
+
+
+class _CharacterStore:
+    def __init__(self) -> None:
+        self.character = NovelCharacter(name="秦")
+        self.character.identities = [
+            CharacterIdentity(
+                identity_id="秦_少年",
+                character_name="秦",
+                identity_name="少年",
+            )
+        ]
+        self.touched: list[str] = []
+        self.identity_updates: list[tuple[str, str, dict]] = []
+
+    def get_character(self, name: str):
+        return self.character if name == self.character.name else None
+
+    async def touch_character_asset(self, _name: str) -> bool:
+        self.touched.append(_name)
+        return True
+
+    async def update_character_identity(self, name: str, identity_id: str, **updates):
+        self.identity_updates.append((name, identity_id, updates))
+        return True
+
+
+class _SceneStore:
+    def __init__(self, names: tuple[str, ...] = ("Hall",)) -> None:
+        self.scenes = {name: NovelScene(name=name) for name in names}
+        self.touched: list[str] = []
+
+    async def get_scene(self, name: str):
+        return self.scenes.get(name)
+
+    async def touch_scene_asset(self, _name: str) -> bool:
+        self.touched.append(_name)
+        return True
+
+
+@pytest.mark.asyncio
+async def test_character_image_upload_encodes_off_event_loop(tmp_path, monkeypatch):
+    from PIL import Image
+
+    from novelvideo.api.routes import characters
+
+    store = _CharacterStore()
+    ctx = SimpleNamespace(project_id="proj_demo")
+
+    async def resolve_project(*_args, **_kwargs):
+        return ctx, "admin", "demo", tmp_path, str(tmp_path), store
+
+    monkeypatch.setattr(characters, "_resolve_character_project", resolve_project)
+    monkeypatch.setattr(
+        characters,
+        "make_static_url_for_context",
+        lambda _ctx, rel, local_path=None: f"/static/{rel}",
+    )
+    upload = _png_upload()
+    event_loop_thread = threading.get_ident()
+    encoder_threads: list[int] = []
+    original_save = Image.Image.save
+
+    def recording_save(self, fp, format=None, **params):
+        encoder_threads.append(threading.get_ident())
+        return original_save(self, fp, format=format, **params)
+
+    monkeypatch.setattr(Image.Image, "save", recording_save)
+
+    response = await characters.upload_portrait(
+        project="demo",
+        name="秦",
+        file=upload,
+        user={"username": "admin"},
+    )
+
+    assert response["ok"] is True
+    assert encoder_threads
+    assert all(thread_id != event_loop_thread for thread_id in encoder_threads)
+    assert (tmp_path / "assets" / "characters" / "秦" / "portrait.png").exists()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("route_name", "route_kwargs", "expected_metadata"),
+    [
+        ("upload_portrait", {}, ("touch", "秦")),
+        ("upload_identity_image", {"identity_name": "少年"}, None),
+        (
+            "upload_identity_costume",
+            {"identity_id": "秦_少年"},
+            ("identity", "costume_image"),
+        ),
+        (
+            "upload_identity_portrait",
+            {"identity_id": "秦_少年"},
+            ("identity", "portrait_image"),
+        ),
+    ],
+)
+async def test_cancelled_character_image_upload_finishes_required_metadata(
+    tmp_path, monkeypatch, route_name, route_kwargs, expected_metadata
+):
+    from novelvideo.api.routes import characters
+
+    store = _CharacterStore()
+    ctx = SimpleNamespace(project_id="proj_demo")
+
+    async def resolve_project(*_args, **_kwargs):
+        return ctx, "admin", "demo", tmp_path, str(tmp_path), store
+
+    monkeypatch.setattr(characters, "_resolve_character_project", resolve_project)
+    monkeypatch.setattr(
+        characters,
+        "make_static_url_for_context",
+        lambda _ctx, rel, local_path=None: f"/static/{rel}",
+    )
+    loop = asyncio.get_running_loop()
+    published = asyncio.Event()
+    release = threading.Event()
+    worker_threads: list[int] = []
+    published_paths: list[Path] = []
+
+    def publish(_file: UploadFile, target: Path) -> None:
+        worker_threads.append(threading.get_ident())
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(b"image")
+        published_paths.append(target)
+        loop.call_soon_threadsafe(published.set)
+        assert release.wait(timeout=5)
+
+    monkeypatch.setattr(characters, "_persist_uploaded_character_image", publish)
+    route = getattr(characters, route_name)
+    task = asyncio.create_task(
+        route(
+            project="demo",
+            name="秦",
+            file=_png_upload(),
+            user={"username": "admin"},
+            **route_kwargs,
+        )
+    )
+    try:
+        await asyncio.wait_for(published.wait(), timeout=1)
+        task.cancel(f"cancel-{route_name}")
+        await asyncio.sleep(0)
+    finally:
+        release.set()
+
+    with pytest.raises(asyncio.CancelledError) as raised:
+        await task
+
+    assert raised.value.args == (f"cancel-{route_name}",)
+    assert worker_threads[0] != threading.get_ident()
+    assert published_paths[0].exists()
+    if expected_metadata is None:
+        assert store.touched == []
+        assert store.identity_updates == []
+    elif expected_metadata[0] == "touch":
+        assert store.touched == [expected_metadata[1]]
+    else:
+        assert len(store.identity_updates) == 1
+        assert expected_metadata[1] in store.identity_updates[0][2]
+
+
+@pytest.mark.asyncio
+async def test_scene_image_upload_encodes_off_event_loop(tmp_path, monkeypatch):
+    from PIL import Image
+
+    from novelvideo.api.routes import scenes
+
+    store = _SceneStore()
+    ctx = SimpleNamespace(project_id="proj_demo")
+
+    async def resolve_project(*_args, **_kwargs):
+        return ctx, "admin", "demo", tmp_path, str(tmp_path), store
+
+    monkeypatch.setattr(scenes, "_resolve_scene_project", resolve_project)
+    monkeypatch.setattr(
+        scenes,
+        "make_static_url_for_context",
+        lambda _ctx, rel, local_path=None: f"/static/{rel}",
+    )
+    upload = _png_upload()
+    event_loop_thread = threading.get_ident()
+    encoder_threads: list[int] = []
+    original_save = Image.Image.save
+
+    def recording_save(self, fp, format=None, **params):
+        encoder_threads.append(threading.get_ident())
+        return original_save(self, fp, format=format, **params)
+
+    monkeypatch.setattr(Image.Image, "save", recording_save)
+
+    response = await scenes.upload_scene_master(
+        project="demo",
+        name="Hall",
+        file=upload,
+        user={"username": "admin"},
+    )
+
+    assert response["ok"] is True
+    assert encoder_threads
+    assert all(thread_id != event_loop_thread for thread_id in encoder_threads)
+
+
+@pytest.mark.asyncio
+async def test_cancelled_scene_master_finishes_asset_version_metadata(
+    tmp_path, monkeypatch
+):
+    from novelvideo.api.routes import scenes
+
+    store = _SceneStore()
+    ctx = SimpleNamespace(project_id="proj_demo")
+
+    async def resolve_project(*_args, **_kwargs):
+        return ctx, "admin", "demo", tmp_path, str(tmp_path), store
+
+    monkeypatch.setattr(scenes, "_resolve_scene_project", resolve_project)
+    loop = asyncio.get_running_loop()
+    published = asyncio.Event()
+    release = threading.Event()
+
+    def publish(_file: UploadFile, target: Path) -> None:
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(b"image")
+        loop.call_soon_threadsafe(published.set)
+        assert release.wait(timeout=5)
+
+    monkeypatch.setattr(scenes, "_persist_scene_master_upload", publish)
+    task = asyncio.create_task(
+        scenes.upload_scene_master(
+            project="demo",
+            name="Hall",
+            file=_png_upload(),
+            user={"username": "admin"},
+        )
+    )
+    try:
+        await asyncio.wait_for(published.wait(), timeout=1)
+        task.cancel("cancel-scene-master")
+        await asyncio.sleep(0)
+    finally:
+        release.set()
+
+    with pytest.raises(asyncio.CancelledError) as raised:
+        await task
+
+    assert raised.value.args == ("cancel-scene-master",)
+    assert store.touched == ["Hall"]
+
+
+@pytest.mark.asyncio
+async def test_cancelled_scene_pano_keeps_published_manifest(tmp_path, monkeypatch):
+    from novelvideo.api.routes import scenes
+    from novelvideo.director_world import stage_manifest
+
+    store = _SceneStore()
+    ctx = SimpleNamespace(project_id="proj_demo")
+
+    async def resolve_project(*_args, **_kwargs):
+        return ctx, "admin", "demo", tmp_path, str(tmp_path), store
+
+    monkeypatch.setattr(scenes, "_resolve_scene_project", resolve_project)
+    loop = asyncio.get_running_loop()
+    published = asyncio.Event()
+    release = threading.Event()
+    worker_threads: list[int] = []
+    original_update = stage_manifest.update_manifest
+
+    def update_manifest(*args, **kwargs):
+        result = original_update(*args, **kwargs)
+        worker_threads.append(threading.get_ident())
+        loop.call_soon_threadsafe(published.set)
+        assert release.wait(timeout=5)
+        return result
+
+    monkeypatch.setattr(stage_manifest, "update_manifest", update_manifest)
+    task = asyncio.create_task(
+        scenes.upload_scene_pano(
+            project="demo",
+            name="Hall",
+            file=_png_upload((4, 2)),
+            user={"username": "admin"},
+        )
+    )
+    try:
+        await asyncio.wait_for(published.wait(), timeout=1)
+        task.cancel("cancel-scene-pano")
+        await asyncio.sleep(0)
+    finally:
+        release.set()
+
+    with pytest.raises(asyncio.CancelledError) as raised:
+        await task
+
+    manifest = stage_manifest.load_manifest(tmp_path, "Hall")
+    assert raised.value.args == ("cancel-scene-pano",)
+    assert worker_threads[0] != threading.get_ident()
+    assert manifest["pano_path"] == "pano_360.png"
+    assert manifest["source"] == "uploaded_360"
+
+
+@pytest.mark.asyncio
+async def test_same_scene_pano_and_custom_uploads_serialize_manifest_transaction(
+    tmp_path, monkeypatch
+):
+    from novelvideo.api.routes import scenes
+    from novelvideo.director_world import stage_manifest
+
+    store = _SceneStore()
+    ctx = SimpleNamespace(project_id="proj_demo")
+
+    async def resolve_project(*_args, **_kwargs):
+        return ctx, "admin", "demo", tmp_path, str(tmp_path), store
+
+    monkeypatch.setattr(scenes, "_resolve_scene_project", resolve_project)
+    loop = asyncio.get_running_loop()
+    pano_manifest_written = asyncio.Event()
+    custom_entered = asyncio.Event()
+    release_pano = threading.Event()
+    original_update = stage_manifest.update_manifest
+    original_custom = scenes._persist_custom_scene_upload
+
+    def update_manifest(*args, **kwargs):
+        result = original_update(*args, **kwargs)
+        if kwargs.get("source") == "uploaded_360":
+            loop.call_soon_threadsafe(pano_manifest_written.set)
+            assert release_pano.wait(timeout=5)
+        return result
+
+    def custom_upload(*args, **kwargs):
+        loop.call_soon_threadsafe(custom_entered.set)
+        return original_custom(*args, **kwargs)
+
+    monkeypatch.setattr(stage_manifest, "update_manifest", update_manifest)
+    monkeypatch.setattr(scenes, "_persist_custom_scene_upload", custom_upload)
+    stage_dir = stage_manifest.stage_dir(tmp_path, "Hall")
+    stage_dir.mkdir(parents=True, exist_ok=True)
+    (stage_dir / "pano_360.png").write_bytes(b"old pano")
+
+    pano_task = asyncio.create_task(
+        scenes.upload_scene_pano(
+            project="demo",
+            name="Hall",
+            file=_png_upload((4, 2)),
+            user={"username": "admin"},
+        )
+    )
+    await asyncio.wait_for(pano_manifest_written.wait(), timeout=1)
+    custom_task = asyncio.create_task(
+        scenes.upload_scene_custom_package(
+            project="demo",
+            name="Hall",
+            file=UploadFile(file=io.BytesIO(b"sog"), filename="scene.sog"),
+            user={"username": "admin"},
+        )
+    )
+    try:
+        await asyncio.sleep(0)
+        assert not custom_entered.is_set()
+    finally:
+        release_pano.set()
+
+    pano_response, custom_response = await asyncio.gather(pano_task, custom_task)
+    manifest = stage_manifest.load_manifest(tmp_path, "Hall")
+    backups = list(stage_dir.glob("pano_360_*.png"))
+    assert pano_response["ok"] is True
+    assert custom_response["ok"] is True
+    assert custom_entered.is_set()
+    assert manifest["pano_path"] == "pano_360.png"
+    assert manifest["custom_scene_path"] == "custom.sog"
+    assert (stage_dir / "custom.sog").read_bytes() == b"sog"
+    assert len(backups) == 1
+    assert backups[0].read_bytes() == b"old pano"
+
+
+@pytest.mark.asyncio
+async def test_different_scene_upload_locks_allow_parallel_pano_work(
+    tmp_path, monkeypatch
+):
+    from novelvideo.api.routes import scenes
+
+    store = _SceneStore(("Hall", "Yard"))
+    ctx = SimpleNamespace(project_id="proj_demo")
+
+    async def resolve_project(*_args, **_kwargs):
+        return ctx, "admin", "demo", tmp_path, str(tmp_path), store
+
+    monkeypatch.setattr(scenes, "_resolve_scene_project", resolve_project)
+    loop = asyncio.get_running_loop()
+    started: asyncio.Queue[str] = asyncio.Queue()
+    release = threading.Event()
+
+    def pano_upload(_file, *, project_dir, scene_name):
+        loop.call_soon_threadsafe(started.put_nowait, scene_name)
+        assert release.wait(timeout=5)
+
+    monkeypatch.setattr(scenes, "_persist_scene_pano_upload", pano_upload)
+    tasks = [
+        asyncio.create_task(
+            scenes.upload_scene_pano(
+                project="demo",
+                name=name,
+                file=_png_upload((4, 2)),
+                user={"username": "admin"},
+            )
+        )
+        for name in ("Hall", "Yard")
+    ]
+    try:
+        entered = {
+            await asyncio.wait_for(started.get(), timeout=1),
+            await asyncio.wait_for(started.get(), timeout=1),
+        }
+        assert entered == {"Hall", "Yard"}
+    finally:
+        release.set()
+
+    assert all(response["ok"] for response in await asyncio.gather(*tasks))
+
+
+@pytest.mark.asyncio
+async def test_cancellation_while_waiting_for_scene_lock_does_not_start_upload(
+    tmp_path, monkeypatch
+):
+    from novelvideo.api.routes import scenes
+
+    store = _SceneStore()
+    ctx = SimpleNamespace(project_id="proj_demo")
+
+    async def resolve_project(*_args, **_kwargs):
+        return ctx, "admin", "demo", tmp_path, str(tmp_path), store
+
+    monkeypatch.setattr(scenes, "_resolve_scene_project", resolve_project)
+    loop = asyncio.get_running_loop()
+    custom_started = asyncio.Event()
+    release_custom = threading.Event()
+    pano_calls: list[str] = []
+
+    def custom_upload(*_args, **_kwargs):
+        loop.call_soon_threadsafe(custom_started.set)
+        assert release_custom.wait(timeout=5)
+
+    def pano_upload(_file, *, project_dir, scene_name):
+        pano_calls.append(scene_name)
+
+    monkeypatch.setattr(scenes, "_persist_custom_scene_upload", custom_upload)
+    monkeypatch.setattr(scenes, "_persist_scene_pano_upload", pano_upload)
+    custom_task = asyncio.create_task(
+        scenes.upload_scene_custom_package(
+            project="demo",
+            name="Hall",
+            file=UploadFile(file=io.BytesIO(b"sog"), filename="scene.sog"),
+            user={"username": "admin"},
+        )
+    )
+    await asyncio.wait_for(custom_started.wait(), timeout=1)
+    pano_task = asyncio.create_task(
+        scenes.upload_scene_pano(
+            project="demo",
+            name="Hall",
+            file=_png_upload((4, 2)),
+            user={"username": "admin"},
+        )
+    )
+    try:
+        await asyncio.sleep(0)
+        pano_task.cancel("waiting-lock-cancel")
+        with pytest.raises(asyncio.CancelledError) as raised:
+            await pano_task
+        assert raised.value.args == ("waiting-lock-cancel",)
+        assert pano_calls == []
+    finally:
+        release_custom.set()
+
+    assert (await custom_task)["ok"] is True
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("kind", ["pano", "custom"])
+async def test_scene_delete_waits_for_matching_upload_transaction(
+    tmp_path, monkeypatch, kind
+):
+    from novelvideo.api.routes import scenes
+    from novelvideo.director_world import stage_manifest
+
+    store = _SceneStore()
+    ctx = SimpleNamespace(project_id="proj_demo")
+
+    async def resolve_project(*_args, **_kwargs):
+        return ctx, "admin", "demo", tmp_path, str(tmp_path), store
+
+    monkeypatch.setattr(scenes, "_resolve_scene_project", resolve_project)
+    loop = asyncio.get_running_loop()
+    published = asyncio.Event()
+    release_upload = threading.Event()
+    event_loop_thread = threading.get_ident()
+    delete_threads: list[int] = []
+
+    if kind == "pano":
+        original_upload = scenes._persist_scene_pano_upload
+
+        def held_upload(*args, **kwargs):
+            original_upload(*args, **kwargs)
+            loop.call_soon_threadsafe(published.set)
+            assert release_upload.wait(timeout=5)
+
+        monkeypatch.setattr(scenes, "_persist_scene_pano_upload", held_upload)
+        upload_call = scenes.upload_scene_pano(
+            project="demo",
+            name="Hall",
+            file=_png_upload((4, 2)),
+            user={"username": "admin"},
+        )
+        delete_call = scenes.delete_scene_pano(
+            project="demo", name="Hall", user={"username": "admin"}
+        )
+    else:
+        original_upload = scenes._persist_custom_scene_upload
+
+        def held_upload(*args, **kwargs):
+            original_upload(*args, **kwargs)
+            loop.call_soon_threadsafe(published.set)
+            assert release_upload.wait(timeout=5)
+
+        monkeypatch.setattr(scenes, "_persist_custom_scene_upload", held_upload)
+        upload_call = scenes.upload_scene_custom_package(
+            project="demo",
+            name="Hall",
+            file=UploadFile(file=io.BytesIO(b"sog"), filename="scene.sog"),
+            user={"username": "admin"},
+        )
+        delete_call = scenes.delete_scene_custom_package(
+            project="demo", name="Hall", user={"username": "admin"}
+        )
+
+    original_update = stage_manifest.update_manifest
+
+    def record_delete_update(*args, **kwargs):
+        clear_fields = set(kwargs.get("clear_fields") or [])
+        if (kind == "pano" and "pano_path" in clear_fields) or (
+            kind == "custom" and "custom_scene_path" in clear_fields
+        ):
+            delete_threads.append(threading.get_ident())
+        return original_update(*args, **kwargs)
+
+    monkeypatch.setattr(stage_manifest, "update_manifest", record_delete_update)
+    upload_task = asyncio.create_task(upload_call)
+    await asyncio.wait_for(published.wait(), timeout=1)
+    delete_task = asyncio.create_task(delete_call)
+    try:
+        await asyncio.sleep(0)
+        assert not delete_task.done()
+        assert delete_threads == []
+    finally:
+        release_upload.set()
+
+    upload_response, delete_response = await asyncio.gather(upload_task, delete_task)
+    manifest = stage_manifest.load_manifest(tmp_path, "Hall")
+    assert upload_response["ok"] is True
+    assert delete_response == {"ok": True, "data": {"deleted": True}}
+    assert delete_threads and delete_threads[0] != event_loop_thread
+    if kind == "pano":
+        assert not manifest.get("pano_path")
+        assert stage_manifest.resolve_pano_path(tmp_path, "Hall") is None
+    else:
+        assert not manifest.get("custom_scene_path")
+        assert (
+            stage_manifest.resolve_ply_path(tmp_path, "Hall", ply_kind="custom")
+            is None
+        )
+
+
+@pytest.mark.asyncio
+async def test_cancelled_scene_delete_waiting_for_upload_lock_does_not_delete(
+    tmp_path, monkeypatch
+):
+    from novelvideo.api.routes import scenes
+    from novelvideo.director_world import stage_manifest
+
+    store = _SceneStore()
+    ctx = SimpleNamespace(project_id="proj_demo")
+
+    async def resolve_project(*_args, **_kwargs):
+        return ctx, "admin", "demo", tmp_path, str(tmp_path), store
+
+    monkeypatch.setattr(scenes, "_resolve_scene_project", resolve_project)
+    loop = asyncio.get_running_loop()
+    published = asyncio.Event()
+    release_upload = threading.Event()
+    original_upload = scenes._persist_custom_scene_upload
+
+    def held_upload(*args, **kwargs):
+        original_upload(*args, **kwargs)
+        loop.call_soon_threadsafe(published.set)
+        assert release_upload.wait(timeout=5)
+
+    monkeypatch.setattr(scenes, "_persist_custom_scene_upload", held_upload)
+    upload_task = asyncio.create_task(
+        scenes.upload_scene_custom_package(
+            project="demo",
+            name="Hall",
+            file=UploadFile(file=io.BytesIO(b"sog"), filename="scene.sog"),
+            user={"username": "admin"},
+        )
+    )
+    await asyncio.wait_for(published.wait(), timeout=1)
+    delete_task = asyncio.create_task(
+        scenes.delete_scene_custom_package(
+            project="demo", name="Hall", user={"username": "admin"}
+        )
+    )
+    try:
+        await asyncio.sleep(0)
+        delete_task.cancel("delete-lock-cancel")
+        with pytest.raises(asyncio.CancelledError) as raised:
+            await delete_task
+        assert raised.value.args == ("delete-lock-cancel",)
+    finally:
+        release_upload.set()
+
+    assert (await upload_task)["ok"] is True
+    custom_path = stage_manifest.resolve_ply_path(
+        tmp_path, "Hall", ply_kind="custom"
+    )
+    assert custom_path is not None and custom_path.exists()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("kind", ["pano", "custom"])
+async def test_scene_upload_waits_for_matching_delete_transaction(
+    tmp_path, monkeypatch, kind
+):
+    from novelvideo.api.routes import scenes
+    from novelvideo.director_world import stage_manifest
+
+    store = _SceneStore()
+    ctx = SimpleNamespace(project_id="proj_demo")
+
+    async def resolve_project(*_args, **_kwargs):
+        return ctx, "admin", "demo", tmp_path, str(tmp_path), store
+
+    monkeypatch.setattr(scenes, "_resolve_scene_project", resolve_project)
+    loop = asyncio.get_running_loop()
+    delete_applied = asyncio.Event()
+    upload_entered = asyncio.Event()
+    release_delete = threading.Event()
+
+    if kind == "pano":
+        scenes._persist_scene_pano_upload(
+            _png_upload((4, 2)), project_dir=tmp_path, scene_name="Hall"
+        )
+        original_delete = scenes._delete_scene_pano_files
+        original_upload = scenes._persist_scene_pano_upload
+
+        def held_delete(*args, **kwargs):
+            result = original_delete(*args, **kwargs)
+            loop.call_soon_threadsafe(delete_applied.set)
+            assert release_delete.wait(timeout=5)
+            return result
+
+        def tracked_upload(*args, **kwargs):
+            loop.call_soon_threadsafe(upload_entered.set)
+            return original_upload(*args, **kwargs)
+
+        monkeypatch.setattr(scenes, "_delete_scene_pano_files", held_delete)
+        monkeypatch.setattr(scenes, "_persist_scene_pano_upload", tracked_upload)
+        delete_call = scenes.delete_scene_pano(
+            project="demo", name="Hall", user={"username": "admin"}
+        )
+        upload_call = scenes.upload_scene_pano(
+            project="demo",
+            name="Hall",
+            file=_png_upload((4, 2)),
+            user={"username": "admin"},
+        )
+    else:
+        scenes._persist_custom_scene_upload(
+            UploadFile(file=io.BytesIO(b"old sog"), filename="scene.sog"),
+            suffix=".sog",
+            project_dir=tmp_path,
+            scene_name="Hall",
+        )
+        original_delete = scenes._delete_scene_custom_files
+        original_upload = scenes._persist_custom_scene_upload
+
+        def held_delete(*args, **kwargs):
+            result = original_delete(*args, **kwargs)
+            loop.call_soon_threadsafe(delete_applied.set)
+            assert release_delete.wait(timeout=5)
+            return result
+
+        def tracked_upload(*args, **kwargs):
+            loop.call_soon_threadsafe(upload_entered.set)
+            return original_upload(*args, **kwargs)
+
+        monkeypatch.setattr(scenes, "_delete_scene_custom_files", held_delete)
+        monkeypatch.setattr(scenes, "_persist_custom_scene_upload", tracked_upload)
+        delete_call = scenes.delete_scene_custom_package(
+            project="demo", name="Hall", user={"username": "admin"}
+        )
+        upload_call = scenes.upload_scene_custom_package(
+            project="demo",
+            name="Hall",
+            file=UploadFile(file=io.BytesIO(b"new sog"), filename="scene.sog"),
+            user={"username": "admin"},
+        )
+
+    delete_task = asyncio.create_task(delete_call)
+    await asyncio.wait_for(delete_applied.wait(), timeout=1)
+    upload_task = asyncio.create_task(upload_call)
+    try:
+        await asyncio.sleep(0)
+        assert not upload_entered.is_set()
+    finally:
+        release_delete.set()
+
+    delete_response, upload_response = await asyncio.gather(delete_task, upload_task)
+    manifest = stage_manifest.load_manifest(tmp_path, "Hall")
+    assert delete_response == {"ok": True, "data": {"deleted": True}}
+    assert upload_response["ok"] is True
+    assert upload_entered.is_set()
+    if kind == "pano":
+        pano_path = stage_manifest.resolve_pano_path(tmp_path, "Hall")
+        assert pano_path is not None and pano_path.exists()
+        assert manifest["pano_path"] == "pano_360.png"
+    else:
+        custom_path = stage_manifest.resolve_ply_path(
+            tmp_path, "Hall", ply_kind="custom"
+        )
+        assert custom_path is not None and custom_path.read_bytes() == b"new sog"
+        assert manifest["custom_scene_path"] == "custom.sog"
+
+
+def test_scene_upload_lock_key_uses_canonical_stage_path(tmp_path):
+    from novelvideo.api.routes import scenes
+
+    project_dir = tmp_path / "project"
+    project_dir.mkdir()
+    alias_dir = tmp_path / "project-alias"
+    alias_dir.symlink_to(project_dir, target_is_directory=True)
+
+    assert scenes._scene_upload_lock_key(
+        project_dir, "Hall/Room"
+    ) == scenes._scene_upload_lock_key(alias_dir, "Hall:Room")
+
+
+@pytest.mark.asyncio
+async def test_scene_upload_lock_is_stable_while_held_and_waited_on():
+    from novelvideo.api import upload_workers
+
+    key = ("project", "Hall")
+    holder_lock = upload_workers.scene_upload_lock(key)
+    waiter_ready = asyncio.Event()
+    waiter_release = asyncio.Event()
+    waiter_locks: list[asyncio.Lock] = []
+
+    async def waiter() -> None:
+        lock = upload_workers.scene_upload_lock(key)
+        waiter_locks.append(lock)
+        waiter_ready.set()
+        async with lock:
+            await waiter_release.wait()
+
+    async with holder_lock:
+        task = asyncio.create_task(waiter())
+        await waiter_ready.wait()
+        await asyncio.sleep(0)
+        assert waiter_locks == [holder_lock]
+        assert upload_workers.scene_upload_lock(key) is holder_lock
+
+    await asyncio.sleep(0)
+    assert not task.done()
+    waiter_release.set()
+    await task
+
+
+@pytest.mark.asyncio
+async def test_scene_upload_lock_registry_releases_unused_locks():
+    from novelvideo.api import upload_workers
+
+    key = ("gc-project", "Hall")
+    lock = upload_workers.scene_upload_lock(key)
+    lock_ref = weakref.ref(lock)
+    registry = upload_workers._scene_upload_locks_var.get()
+    assert registry[key] is lock
+
+    del lock
+    gc.collect()
+
+    assert lock_ref() is None
+    assert key not in registry
+
+
+def test_scene_upload_lock_registry_is_isolated_between_async_runs():
+    from novelvideo.api import upload_workers
+
+    async def registry_identity():
+        lock = upload_workers.scene_upload_lock(("loop", "isolated"))
+        assert lock is upload_workers.scene_upload_lock(("loop", "isolated"))
+        return upload_workers._scene_upload_locks_var.get()
+
+    first = asyncio.run(registry_identity())
+    second = asyncio.run(registry_identity())
+
+    assert first is not second
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("suffix", [".sog", ".splat", ".ksplat"])
+async def test_custom_scene_package_staging_and_publish_run_off_event_loop(
+    tmp_path, monkeypatch, suffix
+):
+    from novelvideo import stage_asset_tasks
+    from novelvideo.api.routes import scenes
+    from novelvideo.director_world import stage_manifest
+
+    store = _SceneStore()
+    ctx = SimpleNamespace(project_id="proj_demo")
+
+    async def resolve_project(*_args, **_kwargs):
+        return ctx, "admin", "demo", tmp_path, str(tmp_path), store
+
+    monkeypatch.setattr(scenes, "_resolve_scene_project", resolve_project)
+    monkeypatch.setattr(
+        scenes,
+        "make_static_url_for_context",
+        lambda _ctx, rel, local_path=None: f"/static/{rel}",
+    )
+    event_loop_thread = threading.get_ident()
+    copy_threads: list[int] = []
+    original_copy = stage_asset_tasks.shutil.copy2
+
+    def copy_in_worker(source, target, *args, **kwargs):
+        copy_threads.append(threading.get_ident())
+        assert Path(source).read_bytes() == b"sog package"
+        return original_copy(source, target, *args, **kwargs)
+
+    monkeypatch.setattr(stage_asset_tasks.shutil, "copy2", copy_in_worker)
+
+    response = await scenes.upload_scene_custom_package(
+        project="demo",
+        name="Hall",
+        file=UploadFile(
+            file=io.BytesIO(b"sog package"), filename=f"scene{suffix}"
+        ),
+        user={"username": "admin"},
+    )
+
+    assert response["ok"] is True
+    custom_path = stage_manifest.stage_dir(tmp_path, "Hall") / f"custom{suffix}"
+    manifest = stage_manifest.load_manifest(tmp_path, "Hall")
+    assert copy_threads and copy_threads[0] != event_loop_thread
+    assert custom_path.read_bytes() == b"sog package"
+    assert manifest["custom_scene_path"] == f"custom{suffix}"
+
+
+@pytest.mark.asyncio
+async def test_custom_ply_copy_and_compression_run_in_worker(tmp_path, monkeypatch):
+    from novelvideo import stage_asset_tasks
+    from novelvideo.api.routes import scenes
+    from novelvideo.director_world import stage_manifest
+
+    store = _SceneStore()
+    ctx = SimpleNamespace(project_id="proj_demo")
+
+    async def resolve_project(*_args, **_kwargs):
+        return ctx, "admin", "demo", tmp_path, str(tmp_path), store
+
+    monkeypatch.setattr(scenes, "_resolve_scene_project", resolve_project)
+    monkeypatch.setattr(
+        scenes,
+        "make_static_url_for_context",
+        lambda _ctx, rel, local_path=None: f"/static/{rel}",
+    )
+    event_loop_thread = threading.get_ident()
+    compression_threads: list[int] = []
+
+    def compress(ply_path: Path, sog_path: Path, **_kwargs) -> Path:
+        compression_threads.append(threading.get_ident())
+        assert ply_path.read_bytes() == b"ply package"
+        sog_path.write_bytes(b"compressed sog")
+        return sog_path
+
+    monkeypatch.setattr(stage_asset_tasks, "_compress_ply_to_sog", compress)
+
+    response = await scenes.upload_scene_custom_package(
+        project="demo",
+        name="Hall",
+        file=UploadFile(file=io.BytesIO(b"ply package"), filename="scene.ply"),
+        user={"username": "admin"},
+    )
+
+    manifest = stage_manifest.load_manifest(tmp_path, "Hall")
+    custom_path = stage_manifest.stage_dir(tmp_path, "Hall") / "custom.sog"
+    assert response["ok"] is True
+    assert len(compression_threads) == 1
+    assert compression_threads[0] != event_loop_thread
+    assert custom_path.read_bytes() == b"compressed sog"
+    assert manifest["custom_scene_path"] == "custom.sog"
+
+
+@pytest.mark.asyncio
+async def test_concurrent_ply_uploads_use_single_conversion_slot(tmp_path, monkeypatch):
+    from novelvideo.api.routes import scenes
+    from novelvideo.api.upload_workers import scene_ply_upload_limiter
+
+    store = _SceneStore(("Hall", "Yard"))
+    ctx = SimpleNamespace(project_id="proj_demo")
+
+    async def resolve_project(*_args, **_kwargs):
+        return ctx, "admin", "demo", tmp_path, str(tmp_path), store
+
+    monkeypatch.setattr(scenes, "_resolve_scene_project", resolve_project)
+    loop = asyncio.get_running_loop()
+    started: asyncio.Queue[str] = asyncio.Queue()
+    releases = {name: threading.Event() for name in ("Hall", "Yard")}
+    state_lock = threading.Lock()
+    active = 0
+    peak = 0
+
+    def convert(_file, *, suffix, project_dir, scene_name):
+        nonlocal active, peak
+        assert suffix == ".ply"
+        with state_lock:
+            active += 1
+            peak = max(peak, active)
+        loop.call_soon_threadsafe(started.put_nowait, scene_name)
+        try:
+            assert releases[scene_name].wait(timeout=5)
+        finally:
+            with state_lock:
+                active -= 1
+
+    monkeypatch.setattr(scenes, "_persist_custom_scene_upload", convert)
+    tasks = [
+        asyncio.create_task(
+            scenes.upload_scene_custom_package(
+                project="demo",
+                name=name,
+                file=UploadFile(file=io.BytesIO(b"ply"), filename="scene.ply"),
+                user={"username": "admin"},
+            )
+        )
+        for name in ("Hall", "Yard")
+    ]
+    first = await asyncio.wait_for(started.get(), timeout=1)
+    try:
+        await asyncio.sleep(0)
+        assert started.empty()
+        assert scene_ply_upload_limiter().borrowed_tokens == 1
+        releases[first].set()
+        second = await asyncio.wait_for(started.get(), timeout=1)
+        assert second != first
+    finally:
+        for release in releases.values():
+            release.set()
+
+    responses = await asyncio.gather(*tasks)
+    assert all(response["ok"] for response in responses)
+    assert peak == 1
+    assert scene_ply_upload_limiter().borrowed_tokens == 0
+
+
+@pytest.mark.asyncio
+async def test_cancelled_ply_upload_keeps_single_slot_until_worker_finishes(
+    tmp_path, monkeypatch
+):
+    from novelvideo.api.routes import scenes
+    from novelvideo.api.upload_workers import scene_ply_upload_limiter
+
+    store = _SceneStore(("Hall", "Yard"))
+    ctx = SimpleNamespace(project_id="proj_demo")
+
+    async def resolve_project(*_args, **_kwargs):
+        return ctx, "admin", "demo", tmp_path, str(tmp_path), store
+
+    monkeypatch.setattr(scenes, "_resolve_scene_project", resolve_project)
+    loop = asyncio.get_running_loop()
+    started: asyncio.Queue[str] = asyncio.Queue()
+    releases = {name: threading.Event() for name in ("Hall", "Yard")}
+
+    def convert(_file, *, suffix, project_dir, scene_name):
+        assert suffix == ".ply"
+        loop.call_soon_threadsafe(started.put_nowait, scene_name)
+        assert releases[scene_name].wait(timeout=5)
+
+    monkeypatch.setattr(scenes, "_persist_custom_scene_upload", convert)
+    first_task = asyncio.create_task(
+        scenes.upload_scene_custom_package(
+            project="demo",
+            name="Hall",
+            file=UploadFile(file=io.BytesIO(b"ply"), filename="scene.ply"),
+            user={"username": "admin"},
+        )
+    )
+    assert await asyncio.wait_for(started.get(), timeout=1) == "Hall"
+    first_task.cancel("first-ply-cancel")
+    await asyncio.sleep(0)
+    first_task.cancel("second-ply-cancel")
+    second_task = asyncio.create_task(
+        scenes.upload_scene_custom_package(
+            project="demo",
+            name="Yard",
+            file=UploadFile(file=io.BytesIO(b"ply"), filename="scene.ply"),
+            user={"username": "admin"},
+        )
+    )
+    try:
+        await asyncio.sleep(0)
+        assert started.empty()
+        assert scene_ply_upload_limiter().borrowed_tokens == 1
+        releases["Hall"].set()
+        assert await asyncio.wait_for(started.get(), timeout=1) == "Yard"
+    finally:
+        releases["Hall"].set()
+        releases["Yard"].set()
+
+    with pytest.raises(asyncio.CancelledError) as raised:
+        await first_task
+    assert raised.value.args == ("first-ply-cancel",)
+    assert (await second_task)["ok"] is True
+    assert scene_ply_upload_limiter().borrowed_tokens == 0
+
+
+@pytest.mark.asyncio
+async def test_asset_upload_workers_are_bounded_to_two():
+    from novelvideo.api.upload_workers import (
+        asset_upload_limiter,
+        run_asset_upload_operation,
+    )
+
+    loop = asyncio.get_running_loop()
+    started: asyncio.Queue[int] = asyncio.Queue()
+    release = threading.Event()
+
+    def blocking_upload(index: int) -> int:
+        loop.call_soon_threadsafe(started.put_nowait, index)
+        assert release.wait(timeout=5)
+        return index
+
+    tasks = [
+        asyncio.create_task(run_asset_upload_operation(blocking_upload, index))
+        for index in range(3)
+    ]
+    try:
+        first_two = {await started.get(), await started.get()}
+
+        assert len(first_two) == 2
+        assert asset_upload_limiter().borrowed_tokens == 2
+        assert started.empty()
+    finally:
+        release.set()
+    assert sorted(await asyncio.gather(*tasks)) == [0, 1, 2]
+
+
+@pytest.mark.asyncio
+async def test_asset_upload_cancellation_waits_for_cleanup_and_preserves_error(
+    tmp_path,
+):
+    from novelvideo.api.upload_workers import (
+        asset_upload_limiter,
+        run_asset_upload_operation,
+    )
+
+    loop = asyncio.get_running_loop()
+    started = asyncio.Event()
+    release = threading.Event()
+    staged_path = tmp_path / "staged-upload.sog"
+
+    def blocking_upload() -> None:
+        staged_path.write_bytes(b"staged")
+        loop.call_soon_threadsafe(started.set)
+        try:
+            assert release.wait(timeout=5)
+        finally:
+            staged_path.unlink(missing_ok=True)
+
+    task = asyncio.create_task(run_asset_upload_operation(blocking_upload))
+    try:
+        await started.wait()
+        task.cancel("asset-upload-cancel")
+        await asyncio.sleep(0)
+
+        assert not task.done()
+        assert asset_upload_limiter().borrowed_tokens == 1
+        assert staged_path.exists()
+    finally:
+        release.set()
+    with pytest.raises(asyncio.CancelledError) as raised:
+        await task
+
+    assert raised.value.args == ("asset-upload-cancel",)
+    assert not staged_path.exists()
+    assert asset_upload_limiter().borrowed_tokens == 0
+
+
+@pytest.mark.asyncio
+async def test_cancelled_upload_finishes_metadata_before_reraising(tmp_path):
+    from novelvideo.api.upload_workers import run_asset_upload_operation
+
+    loop = asyncio.get_running_loop()
+    published = asyncio.Event()
+    release = threading.Event()
+    target = tmp_path / "portrait.png"
+    metadata: list[Path] = []
+
+    def publish() -> Path:
+        target.write_bytes(b"image")
+        loop.call_soon_threadsafe(published.set)
+        assert release.wait(timeout=5)
+        return target
+
+    async def finalize(path: Path) -> Path:
+        metadata.append(path)
+        return path
+
+    task = asyncio.create_task(
+        run_asset_upload_operation(publish, finalize=finalize)
+    )
+    try:
+        await asyncio.wait_for(published.wait(), timeout=1)
+        task.cancel("publish-cancel")
+        await asyncio.sleep(0)
+        assert not metadata
+    finally:
+        release.set()
+
+    with pytest.raises(asyncio.CancelledError) as raised:
+        await task
+
+    assert raised.value.args == ("publish-cancel",)
+    assert target.exists()
+    assert metadata == [target]
+
+
+@pytest.mark.asyncio
+async def test_repeated_cancellation_waits_for_worker_then_finishes_route_metadata(
+    tmp_path, monkeypatch
+):
+    from novelvideo.api.routes import characters
+    from novelvideo.api.upload_workers import asset_upload_limiter
+
+    store = _CharacterStore()
+    ctx = SimpleNamespace(project_id="proj_demo")
+
+    async def resolve_project(*_args, **_kwargs):
+        return ctx, "admin", "demo", tmp_path, str(tmp_path), store
+
+    monkeypatch.setattr(characters, "_resolve_character_project", resolve_project)
+    loop = asyncio.get_running_loop()
+    published = asyncio.Event()
+    release = threading.Event()
+
+    def publish(_file: UploadFile, target: Path) -> None:
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(b"image")
+        loop.call_soon_threadsafe(published.set)
+        assert release.wait(timeout=5)
+
+    monkeypatch.setattr(characters, "_persist_uploaded_character_image", publish)
+    task = asyncio.create_task(
+        characters.upload_portrait(
+            project="demo",
+            name="秦",
+            file=_png_upload(),
+            user={"username": "admin"},
+        )
+    )
+    try:
+        await asyncio.wait_for(published.wait(), timeout=1)
+        task.cancel("first-worker-cancel")
+        await asyncio.sleep(0)
+        task.cancel("second-worker-cancel")
+        await asyncio.sleep(0)
+        assert not task.done()
+        assert asset_upload_limiter().borrowed_tokens == 1
+        assert store.touched == []
+    finally:
+        release.set()
+
+    with pytest.raises(asyncio.CancelledError) as raised:
+        await task
+
+    assert raised.value.args == ("first-worker-cancel",)
+    assert store.touched == ["秦"]
+    assert asset_upload_limiter().borrowed_tokens == 0
+
+
+@pytest.mark.asyncio
+async def test_repeated_cancellation_waits_for_route_metadata_finalize(
+    tmp_path, monkeypatch
+):
+    from novelvideo.api.routes import characters
+
+    store = _CharacterStore()
+    ctx = SimpleNamespace(project_id="proj_demo")
+    finalize_started = asyncio.Event()
+    finalize_release = asyncio.Event()
+
+    async def touch_character_asset(name: str) -> bool:
+        finalize_started.set()
+        await finalize_release.wait()
+        store.touched.append(name)
+        return True
+
+    async def resolve_project(*_args, **_kwargs):
+        return ctx, "admin", "demo", tmp_path, str(tmp_path), store
+
+    def publish(_file: UploadFile, target: Path) -> None:
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(b"image")
+
+    monkeypatch.setattr(store, "touch_character_asset", touch_character_asset)
+    monkeypatch.setattr(characters, "_resolve_character_project", resolve_project)
+    monkeypatch.setattr(characters, "_persist_uploaded_character_image", publish)
+    task = asyncio.create_task(
+        characters.upload_portrait(
+            project="demo",
+            name="秦",
+            file=_png_upload(),
+            user={"username": "admin"},
+        )
+    )
+    try:
+        await asyncio.wait_for(finalize_started.wait(), timeout=1)
+        task.cancel("first-finalize-cancel")
+        await asyncio.sleep(0)
+        task.cancel("second-finalize-cancel")
+        await asyncio.sleep(0)
+        assert not task.done()
+        assert store.touched == []
+    finally:
+        finalize_release.set()
+
+    with pytest.raises(asyncio.CancelledError) as raised:
+        await task
+
+    assert raised.value.args == ("first-finalize-cancel",)
+    assert store.touched == ["秦"]
+
+
+@pytest.mark.asyncio
+async def test_asset_upload_preserves_anyio_cancel_scope_marker():
+    from novelvideo.api.upload_workers import (
+        asset_upload_limiter,
+        run_asset_upload_operation,
+    )
+
+    loop = asyncio.get_running_loop()
+    started = asyncio.Event()
+    release = threading.Event()
+    scope = anyio.CancelScope()
+    outcome: dict[str, bool] = {}
+
+    def blocking_upload() -> None:
+        loop.call_soon_threadsafe(started.set)
+        assert release.wait(timeout=5)
+
+    async def run_in_scope() -> None:
+        with scope:
+            await run_asset_upload_operation(blocking_upload)
+        outcome["cancelled_caught"] = scope.cancelled_caught
+
+    async with anyio.create_task_group() as task_group:
+        task_group.start_soon(run_in_scope)
+        try:
+            await asyncio.wait_for(started.wait(), timeout=1)
+            scope.cancel()
+            await anyio.sleep(0)
+            assert asset_upload_limiter().borrowed_tokens == 1
+        finally:
+            release.set()
+
+    assert outcome == {"cancelled_caught": True}
+
+
+def test_custom_scene_package_size_guard_removes_partial_temp(tmp_path, monkeypatch):
+    from novelvideo.api.routes import scenes
+    from novelvideo.utils.upload_safety import UploadTooLargeError
+
+    monkeypatch.setattr(scenes.tempfile, "tempdir", str(tmp_path))
+    upload = UploadFile(file=io.BytesIO(b"12345"), filename="scene.sog")
+
+    with pytest.raises(UploadTooLargeError):
+        scenes._copy_upload_to_temp_file(upload, suffix=".sog", max_bytes=4)
+
+    assert list(tmp_path.iterdir()) == []
+
+
+@pytest.mark.asyncio
+async def test_custom_scene_route_enforces_stream_limit_without_content_length(
+    tmp_path, monkeypatch
+):
+    from novelvideo.api.routes import scenes
+    from novelvideo.utils.upload_safety import UploadTooLargeError
+
+    store = _SceneStore()
+    ctx = SimpleNamespace(project_id="proj_demo")
+
+    async def resolve_project(*_args, **_kwargs):
+        return ctx, "admin", "demo", tmp_path, str(tmp_path), store
+
+    monkeypatch.setattr(scenes, "_resolve_scene_project", resolve_project)
+    monkeypatch.setattr(scenes.tempfile, "tempdir", str(tmp_path))
+    seen_limits: list[int] = []
+
+    def reject_oversize(_file, *, suffix, max_bytes):
+        assert suffix == ".sog"
+        seen_limits.append(max_bytes)
+        raise UploadTooLargeError("oversize")
+
+    monkeypatch.setattr(scenes, "_copy_upload_to_temp_file", reject_oversize)
+
+    response = await scenes.upload_scene_custom_package(
+        project="demo",
+        name="Hall",
+        file=UploadFile(file=io.BytesIO(b"12345"), filename="scene.sog"),
+        user={"username": "admin"},
+    )
+
+    assert response == {
+        "ok": False,
+        "error": "Custom scene package exceeds 200MB limit",
+    }
+    assert seen_limits == [200 * 1024 * 1024]
+    assert list(tmp_path.iterdir()) == []

--- a/tests/test_api_character_voice_samples.py
+++ b/tests/test_api_character_voice_samples.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
+import asyncio
 import base64
+import hashlib
 import io
+import threading
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -262,6 +265,37 @@ async def test_upload_character_voice_sample_persists_default_slot(tmp_path, mon
 
 
 @pytest.mark.asyncio
+async def test_upload_character_voice_sample_reads_and_writes_off_event_loop(
+    tmp_path, monkeypatch
+):
+    from novelvideo.api.routes import characters
+
+    character = NovelCharacter(name="秦")
+    store = _CharacterStore([character])
+    _patch_project(monkeypatch, characters, tmp_path, store)
+    event_loop_thread = threading.get_ident()
+    worker_threads: list[int] = []
+    original_persist = characters.persist_character_voice_file
+
+    def recording_persist(**kwargs):
+        worker_threads.append(threading.get_ident())
+        return original_persist(**kwargs)
+
+    monkeypatch.setattr(characters, "persist_character_voice_file", recording_persist)
+
+    response = await characters.upload_character_voice_sample(
+        project="demo",
+        name="秦",
+        slot="default",
+        file=UploadFile(file=io.BytesIO(b"default voice"), filename="voice.wav"),
+        user={"username": "admin"},
+    )
+
+    assert response["ok"] is True
+    assert worker_threads and worker_threads[0] != event_loop_thread
+
+
+@pytest.mark.asyncio
 async def test_upload_character_voice_sample_rejects_unsupported_format(tmp_path, monkeypatch):
     from novelvideo.api.routes import characters
 
@@ -290,8 +324,23 @@ async def test_record_character_voice_sample_persists_age_slot(tmp_path, monkeyp
     character = NovelCharacter(name="秦")
     store = _CharacterStore([character])
     _patch_project(monkeypatch, characters, tmp_path, store)
+    event_loop_thread_id = threading.get_ident()
+    worker_thread_ids: list[int] = []
     payload = base64.b64encode(b"recorded voice").decode("ascii")
     body = SimpleNamespace(data_url=f"data:audio/wav;base64,{payload}")
+
+    def fake_decode(_data_url):
+        worker_thread_ids.append(threading.get_ident())
+        return b"recorded voice", ".wav"
+
+    original_persist = characters.persist_character_voice_file
+
+    def recording_persist(**kwargs):
+        worker_thread_ids.append(threading.get_ident())
+        return original_persist(**kwargs)
+
+    monkeypatch.setattr(characters, "decode_recorded_audio_data_url", fake_decode)
+    monkeypatch.setattr(characters, "persist_character_voice_file", recording_persist)
 
     response = await characters.record_character_voice_sample(
         project="demo",
@@ -307,6 +356,9 @@ async def test_record_character_voice_sample_persists_age_slot(tmp_path, monkeyp
     assert data["path"].endswith("voice_youth.wav")
     assert data["sha256"]
     assert (tmp_path / data["path"]).exists()
+    assert len(worker_thread_ids) == 2
+    assert len(set(worker_thread_ids)) == 1
+    assert event_loop_thread_id not in worker_thread_ids
     assert store.updates[-1][1]["voice_samples_by_age_group"]["youth"]["path"] == data["path"]
     assert store.updates[-1][1]["voice_samples_by_age_group"]["youth"]["sha256"] == data["sha256"]
 
@@ -326,9 +378,12 @@ async def test_trim_character_voice_sample_updates_default_slot(tmp_path, monkey
     )
     store = _CharacterStore([character])
     _patch_project(monkeypatch, characters, tmp_path, store)
+    event_loop_thread_id = threading.get_ident()
     calls: list[dict] = []
+    worker_thread_ids: list[int] = []
 
     def fake_trim_existing_character_voice_file(**kwargs):
+        worker_thread_ids.append(threading.get_ident())
         calls.append(kwargs)
         rel_path = "assets/characters/秦/voices/voice_default.wav"
         (tmp_path / rel_path).write_bytes(b"trimmed voice")
@@ -370,8 +425,86 @@ async def test_trim_character_voice_sample_updates_default_slot(tmp_path, monkey
             "duration_seconds": 4.0,
         }
     ]
+    assert worker_thread_ids
+    assert event_loop_thread_id not in worker_thread_ids
     assert store.updates[-1][1]["reference_audio_sha256"] == "trimmed-sha"
     assert store.updates[-1][1]["reference_audio_updated_at"] == "2026-05-13T00:00:03+00:00"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("operation", ["upload", "record", "trim"])
+async def test_cancelled_voice_publish_finishes_sqlite_metadata(
+    tmp_path, monkeypatch, operation
+):
+    import asyncio
+
+    from novelvideo.api.routes import characters
+
+    character = NovelCharacter(name="秦")
+    store = _CharacterStore([character])
+    _patch_project(monkeypatch, characters, tmp_path, store)
+    loop = asyncio.get_running_loop()
+    published = asyncio.Event()
+    release = threading.Event()
+    rel_path = "assets/characters/秦/voices/voice_default.wav"
+
+    def publish(*_args, **_kwargs):
+        target = tmp_path / rel_path
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(b"voice")
+        loop.call_soon_threadsafe(published.set)
+        assert release.wait(timeout=5)
+        return rel_path, "voice-sha", "2026-08-28T00:00:00+00:00"
+
+    if operation == "upload":
+        monkeypatch.setattr(characters, "_persist_uploaded_character_voice", publish)
+        route_call = characters.upload_character_voice_sample(
+            project="demo",
+            name="秦",
+            slot="default",
+            file=UploadFile(file=io.BytesIO(b"voice"), filename="voice.wav"),
+            user={"username": "admin"},
+        )
+    elif operation == "record":
+        monkeypatch.setattr(characters, "_persist_recorded_character_voice", publish)
+        route_call = characters.record_character_voice_sample(
+            project="demo",
+            name="秦",
+            slot="default",
+            body=SimpleNamespace(data_url="data:audio/wav;base64,dm9pY2U="),
+            user={"username": "admin"},
+        )
+    else:
+        monkeypatch.setattr(
+            characters, "trim_existing_character_voice_file", publish
+        )
+        route_call = characters.trim_character_voice_sample(
+            project="demo",
+            name="秦",
+            slot="default",
+            body=SimpleNamespace(
+                source_path=rel_path,
+                start_seconds=0.0,
+                duration_seconds=1.0,
+            ),
+            user={"username": "admin"},
+        )
+
+    task = asyncio.create_task(route_call)
+    try:
+        await asyncio.wait_for(published.wait(), timeout=1)
+        task.cancel(f"cancel-voice-{operation}")
+        await asyncio.sleep(0)
+    finally:
+        release.set()
+
+    with pytest.raises(asyncio.CancelledError) as raised:
+        await task
+
+    assert raised.value.args == (f"cancel-voice-{operation}",)
+    assert (tmp_path / rel_path).exists()
+    assert store.updates[-1][1]["reference_audio_path"] == rel_path
+    assert store.updates[-1][1]["reference_audio_sha256"] == "voice-sha"
 
 
 @pytest.mark.asyncio
@@ -408,3 +541,240 @@ async def test_delete_character_voice_sample_clears_age_slot(tmp_path, monkeypat
     assert response["data"]["slot"] == "child"
     assert response["data"]["path"] == ""
     assert "child" not in store.updates[-1][1]["voice_samples_by_age_group"]
+
+
+@pytest.mark.asyncio
+async def test_upload_then_delete_same_voice_slot_cannot_resurrect_file(
+    tmp_path, monkeypatch
+):
+    from novelvideo.api.routes import characters
+
+    character = NovelCharacter(name="秦")
+    store = _CharacterStore([character])
+    _patch_project(monkeypatch, characters, tmp_path, store)
+    upload_started = threading.Event()
+    release_upload = threading.Event()
+    delete_started = threading.Event()
+    real_upload = characters._persist_uploaded_character_voice
+    real_clear = characters.clear_character_voice_file
+
+    def blocking_upload(*args, **kwargs):
+        upload_started.set()
+        assert release_upload.wait(timeout=3)
+        return real_upload(*args, **kwargs)
+
+    def tracking_clear(**kwargs):
+        delete_started.set()
+        return real_clear(**kwargs)
+
+    monkeypatch.setattr(characters, "_persist_uploaded_character_voice", blocking_upload)
+    monkeypatch.setattr(characters, "clear_character_voice_file", tracking_clear)
+    upload = asyncio.create_task(
+        characters.upload_character_voice_sample(
+            project="demo",
+            name="秦",
+            slot="default",
+            file=UploadFile(file=io.BytesIO(b"new voice"), filename="voice.wav"),
+            user={"username": "admin"},
+        )
+    )
+    assert await asyncio.to_thread(upload_started.wait, 1)
+    delete = asyncio.create_task(
+        characters.delete_character_voice_sample(
+            project="demo",
+            name="秦",
+            slot="default",
+            user={"username": "admin"},
+        )
+    )
+    await asyncio.sleep(0)
+    assert not delete_started.is_set()
+
+    release_upload.set()
+    upload_response, delete_response = await asyncio.gather(upload, delete)
+
+    assert upload_response["ok"] is True
+    assert delete_response["ok"] is True
+    assert delete_started.is_set()
+    assert character.reference_audio_path == ""
+    assert character.reference_audio_sha256 == ""
+    assert not (tmp_path / "assets/characters/秦/voices/voice_default.wav").exists()
+
+
+@pytest.mark.asyncio
+async def test_cancelled_character_voice_delete_finishes_file_and_metadata(
+    tmp_path, monkeypatch
+):
+    from novelvideo.api.routes import characters
+
+    rel_path = "assets/characters/秦/voices/voice_default.wav"
+    target = tmp_path / rel_path
+    target.parent.mkdir(parents=True)
+    target.write_bytes(b"voice")
+    character = NovelCharacter(
+        name="秦",
+        reference_audio_path=rel_path,
+        reference_audio_sha256="old-sha",
+        reference_audio_updated_at="2026-08-28T00:00:00+00:00",
+    )
+    store = _CharacterStore([character])
+    _patch_project(monkeypatch, characters, tmp_path, store)
+    clear_started = threading.Event()
+    release_clear = threading.Event()
+    real_clear = characters.clear_character_voice_file
+
+    def blocking_clear(**kwargs):
+        clear_started.set()
+        assert release_clear.wait(timeout=3)
+        return real_clear(**kwargs)
+
+    monkeypatch.setattr(characters, "clear_character_voice_file", blocking_clear)
+    task = asyncio.create_task(
+        characters.delete_character_voice_sample(
+            project="demo",
+            name="秦",
+            slot="default",
+            user={"username": "admin"},
+        )
+    )
+    assert await asyncio.to_thread(clear_started.wait, 1)
+    task.cancel("cancel-delete")
+    release_clear.set()
+
+    with pytest.raises(asyncio.CancelledError) as raised:
+        await task
+
+    assert raised.value.args == ("cancel-delete",)
+    assert not target.exists()
+    assert character.reference_audio_path == ""
+    assert character.reference_audio_sha256 == ""
+
+
+@pytest.mark.asyncio
+async def test_two_uploads_same_voice_slot_publish_in_request_order(
+    tmp_path, monkeypatch
+):
+    from novelvideo.api.routes import characters
+
+    character = NovelCharacter(name="秦")
+    store = _CharacterStore([character])
+    _patch_project(monkeypatch, characters, tmp_path, store)
+    first_started = threading.Event()
+    release_first = threading.Event()
+    second_started = threading.Event()
+    real_upload = characters._persist_uploaded_character_voice
+    calls = 0
+    calls_guard = threading.Lock()
+
+    def ordered_upload(*args, **kwargs):
+        nonlocal calls
+        with calls_guard:
+            calls += 1
+            call_number = calls
+        if call_number == 1:
+            first_started.set()
+            assert release_first.wait(timeout=3)
+        else:
+            second_started.set()
+        return real_upload(*args, **kwargs)
+
+    monkeypatch.setattr(characters, "_persist_uploaded_character_voice", ordered_upload)
+    first = asyncio.create_task(
+        characters.upload_character_voice_sample(
+            project="demo",
+            name="秦",
+            slot="default",
+            file=UploadFile(file=io.BytesIO(b"first"), filename="voice.wav"),
+            user={"username": "admin"},
+        )
+    )
+    assert await asyncio.to_thread(first_started.wait, 1)
+    second = asyncio.create_task(
+        characters.upload_character_voice_sample(
+            project="demo",
+            name="秦",
+            slot="default",
+            file=UploadFile(file=io.BytesIO(b"second"), filename="voice.wav"),
+            user={"username": "admin"},
+        )
+    )
+    await asyncio.sleep(0)
+    assert not second_started.is_set()
+
+    release_first.set()
+    await asyncio.gather(first, second)
+
+    target = tmp_path / "assets/characters/秦/voices/voice_default.wav"
+    assert second_started.is_set()
+    assert target.read_bytes() == b"second"
+    assert character.reference_audio_sha256 == hashlib.sha256(b"second").hexdigest()
+
+
+@pytest.mark.asyncio
+async def test_upload_then_trim_same_voice_slot_uses_uploaded_file(
+    tmp_path, monkeypatch
+):
+    from novelvideo.api.routes import characters
+
+    rel_path = "assets/characters/秦/voices/voice_default.wav"
+    character = NovelCharacter(name="秦")
+    store = _CharacterStore([character])
+    _patch_project(monkeypatch, characters, tmp_path, store)
+    upload_started = threading.Event()
+    release_upload = threading.Event()
+    trim_started = threading.Event()
+    real_upload = characters._persist_uploaded_character_voice
+
+    def blocking_upload(*args, **kwargs):
+        upload_started.set()
+        assert release_upload.wait(timeout=3)
+        return real_upload(*args, **kwargs)
+
+    def trim_uploaded(**kwargs):
+        trim_started.set()
+        source = tmp_path / kwargs["source_path"]
+        assert source.read_bytes() == b"uploaded"
+        content = b"trimmed-uploaded"
+        source.write_bytes(content)
+        return (
+            rel_path,
+            hashlib.sha256(content).hexdigest(),
+            "2026-08-28T00:00:00+00:00",
+        )
+
+    monkeypatch.setattr(characters, "_persist_uploaded_character_voice", blocking_upload)
+    monkeypatch.setattr(characters, "trim_existing_character_voice_file", trim_uploaded)
+    upload = asyncio.create_task(
+        characters.upload_character_voice_sample(
+            project="demo",
+            name="秦",
+            slot="default",
+            file=UploadFile(file=io.BytesIO(b"uploaded"), filename="voice.wav"),
+            user={"username": "admin"},
+        )
+    )
+    assert await asyncio.to_thread(upload_started.wait, 1)
+    trim = asyncio.create_task(
+        characters.trim_character_voice_sample(
+            project="demo",
+            name="秦",
+            slot="default",
+            body=SimpleNamespace(
+                source_path=rel_path,
+                start_seconds=0.0,
+                duration_seconds=1.0,
+            ),
+            user={"username": "admin"},
+        )
+    )
+    await asyncio.sleep(0)
+    assert not trim_started.is_set()
+
+    release_upload.set()
+    await asyncio.gather(upload, trim)
+
+    assert trim_started.is_set()
+    assert (tmp_path / rel_path).read_bytes() == b"trimmed-uploaded"
+    assert character.reference_audio_sha256 == hashlib.sha256(
+        b"trimmed-uploaded"
+    ).hexdigest()

--- a/tests/test_api_compose_export_contract.py
+++ b/tests/test_api_compose_export_contract.py
@@ -1,4 +1,7 @@
 from io import BytesIO
+from pathlib import Path
+import tempfile
+import threading
 import zipfile
 
 import pytest
@@ -53,6 +56,27 @@ def _write_export_assets(project_dir, episode: int = 3) -> None:
     (project_dir / "videos" / "episodes" / f"{ep_tag}_final.mp4").write_bytes(b"final")
 
 
+def _download_scope() -> dict:
+    return {
+        "type": "http",
+        "asgi": {"version": "3.0"},
+        "http_version": "1.1",
+        "method": "GET",
+        "scheme": "http",
+        "path": "/export.zip",
+        "raw_path": b"/export.zip",
+        "query_string": b"",
+        "headers": [],
+        "client": None,
+        "server": None,
+        "extensions": {},
+    }
+
+
+async def _unused_receive() -> dict:
+    return {"type": "http.disconnect"}
+
+
 def test_export_video_returns_final_video_file(monkeypatch, tmp_path):
     _write_export_assets(tmp_path)
     response = _client(monkeypatch, tmp_path).get(
@@ -74,11 +98,356 @@ def test_export_zip_contains_beat_media_final_video_and_srt(monkeypatch, tmp_pat
     assert response.status_code == 200
     with zipfile.ZipFile(BytesIO(response.content)) as zf:
         names = set(zf.namelist())
+        compression = {item.filename: item.compress_type for item in zf.infolist()}
 
     assert "audio/beat_01.mp3" in names
     assert "video/beat_01.mp4" in names
     assert "ep003_final.mp4" in names
     assert "ep003.srt" in names
+    assert compression["audio/beat_01.mp3"] == zipfile.ZIP_STORED
+    assert compression["video/beat_01.mp4"] == zipfile.ZIP_STORED
+    assert compression["ep003_final.mp4"] == zipfile.ZIP_STORED
+    assert compression["ep003.srt"] == zipfile.ZIP_DEFLATED
+
+
+def test_export_zip_writes_off_loop_and_removes_temp_after_response(monkeypatch, tmp_path):
+    from novelvideo.export import episode_export
+
+    _write_export_assets(tmp_path)
+    endpoint_thread_ids: list[int] = []
+    writer_thread_ids: list[int] = []
+    temp_paths: list[Path] = []
+    real_zip_file = zipfile.ZipFile
+    real_named_temporary_file = tempfile.NamedTemporaryFile
+
+    async def fake_build_srt_content(*_args, **_kwargs):
+        endpoint_thread_ids.append(threading.get_ident())
+        return "1\n00:00:00,000 --> 00:00:01,000\nHello\n"
+
+    class TrackingZipFile(real_zip_file):
+        def write(self, *args, **kwargs):
+            writer_thread_ids.append(threading.get_ident())
+            return super().write(*args, **kwargs)
+
+    def tracking_named_temporary_file(*args, **kwargs):
+        tmp = real_named_temporary_file(*args, **kwargs)
+        temp_paths.append(Path(tmp.name))
+        return tmp
+
+    monkeypatch.setattr(episode_export, "build_srt_content", fake_build_srt_content)
+    monkeypatch.setattr(zipfile, "ZipFile", TrackingZipFile)
+    monkeypatch.setattr(tempfile, "NamedTemporaryFile", tracking_named_temporary_file)
+
+    response = _client(monkeypatch, tmp_path).post(
+        "/projects/demo/episodes/3/export/zip",
+    )
+
+    assert response.status_code == 200
+    assert writer_thread_ids
+    assert endpoint_thread_ids
+    assert set(writer_thread_ids).isdisjoint(endpoint_thread_ids)
+    assert temp_paths and all(not path.exists() for path in temp_paths)
+
+
+def test_export_zip_removes_temp_when_write_fails(monkeypatch, tmp_path):
+    _write_export_assets(tmp_path)
+    temp_paths: list[Path] = []
+    real_zip_file = zipfile.ZipFile
+    real_named_temporary_file = tempfile.NamedTemporaryFile
+
+    class FailingZipFile(real_zip_file):
+        def write(self, *_args, **_kwargs):
+            raise OSError("disk full")
+
+    def tracking_named_temporary_file(*args, **kwargs):
+        tmp = real_named_temporary_file(*args, **kwargs)
+        temp_paths.append(Path(tmp.name))
+        return tmp
+
+    monkeypatch.setattr(zipfile, "ZipFile", FailingZipFile)
+    monkeypatch.setattr(tempfile, "NamedTemporaryFile", tracking_named_temporary_file)
+
+    with pytest.raises(OSError, match="disk full"):
+        _client(monkeypatch, tmp_path).post(
+            "/projects/demo/episodes/3/export/zip",
+        )
+
+    assert temp_paths and all(not path.exists() for path in temp_paths)
+
+
+@pytest.mark.asyncio
+async def test_export_zip_cancellation_waits_for_writer_and_removes_temp(monkeypatch, tmp_path):
+    import asyncio
+    import anyio
+
+    from novelvideo.api.routes import generation
+
+    _write_export_assets(tmp_path)
+    _client(monkeypatch, tmp_path)
+    writer_started = threading.Event()
+    release_writer = threading.Event()
+    shield_calls = 0
+    temp_paths: list[Path] = []
+    real_zip_file = zipfile.ZipFile
+    real_named_temporary_file = tempfile.NamedTemporaryFile
+    real_shield = asyncio.shield
+
+    class BlockingZipFile(real_zip_file):
+        def write(self, *args, **kwargs):
+            writer_started.set()
+            release_writer.wait(timeout=5)
+            return super().write(*args, **kwargs)
+
+    def tracking_named_temporary_file(*args, **kwargs):
+        tmp = real_named_temporary_file(*args, **kwargs)
+        temp_paths.append(Path(tmp.name))
+        return tmp
+
+    def tracking_shield(awaitable):
+        nonlocal shield_calls
+        shield_calls += 1
+        return real_shield(awaitable)
+
+    monkeypatch.setattr(zipfile, "ZipFile", BlockingZipFile)
+    monkeypatch.setattr(tempfile, "NamedTemporaryFile", tracking_named_temporary_file)
+    monkeypatch.setattr(asyncio, "shield", tracking_shield)
+
+    scope_ready = asyncio.Event()
+    scope_holder = {}
+
+    async def cancel_and_release() -> None:
+        await scope_ready.wait()
+        assert await asyncio.to_thread(writer_started.wait, 1)
+        scope_holder["scope"].cancel()
+        await asyncio.sleep(0.05)
+        release_writer.set()
+
+    controller = asyncio.create_task(cancel_and_release())
+    try:
+        with anyio.CancelScope() as scope:
+            scope_holder["scope"] = scope
+            scope_ready.set()
+            await generation.export_zip("demo", 3, user={"username": "alice"})
+        assert scope.cancel_called
+    finally:
+        release_writer.set()
+        await controller
+    assert shield_calls == 2
+    assert temp_paths and all(not path.exists() for path in temp_paths)
+
+
+@pytest.mark.asyncio
+async def test_export_zip_repeated_direct_cancellation_waits_and_cleans_temp(
+    monkeypatch, tmp_path
+):
+    import asyncio
+
+    from novelvideo.api.routes import generation
+    from novelvideo.utils import async_ops
+
+    _write_export_assets(tmp_path)
+    _client(monkeypatch, tmp_path)
+    writer_started = threading.Event()
+    release_writer = threading.Event()
+    temp_paths: list[Path] = []
+    response_constructions: list[str] = []
+    build_tasks: list[asyncio.Task] = []
+    real_zip_file = zipfile.ZipFile
+    real_named_temporary_file = tempfile.NamedTemporaryFile
+
+    class BlockingZipFile(real_zip_file):
+        def write(self, *args, **kwargs):
+            writer_started.set()
+            assert release_writer.wait(timeout=5)
+            return super().write(*args, **kwargs)
+
+    def tracking_named_temporary_file(*args, **kwargs):
+        tmp = real_named_temporary_file(*args, **kwargs)
+        temp_paths.append(Path(tmp.name))
+        return tmp
+
+    class TrackingResponse(generation._TemporaryFileResponse):
+        def __init__(self, *args, **kwargs):
+            response_constructions.append(str(kwargs.get("path", args[0] if args else "")))
+            super().__init__(*args, **kwargs)
+
+    real_call_blocking = async_ops.call_blocking
+
+    async def tracking_call_blocking(*args, **kwargs):
+        task = asyncio.current_task()
+        assert task is not None
+        build_tasks.append(task)
+        return await real_call_blocking(*args, **kwargs)
+
+    monkeypatch.setattr(zipfile, "ZipFile", BlockingZipFile)
+    monkeypatch.setattr(tempfile, "NamedTemporaryFile", tracking_named_temporary_file)
+    monkeypatch.setattr(generation, "_TemporaryFileResponse", TrackingResponse)
+    monkeypatch.setattr(async_ops, "call_blocking", tracking_call_blocking)
+
+    route_task = asyncio.create_task(
+        generation.export_zip("demo", 3, user={"username": "alice"})
+    )
+    try:
+        assert await asyncio.to_thread(writer_started.wait, 1)
+        route_task.cancel("first-cancel")
+        await asyncio.sleep(0)
+        route_task.cancel("second-cancel")
+        await asyncio.sleep(0)
+        route_task.cancel("third-cancel")
+        await asyncio.sleep(0)
+        assert not route_task.done()
+        assert temp_paths and any(path.exists() for path in temp_paths)
+    finally:
+        release_writer.set()
+
+    with pytest.raises(asyncio.CancelledError) as raised:
+        await route_task
+
+    assert raised.value.args == ("first-cancel",)
+    assert all(not path.exists() for path in temp_paths)
+    assert response_constructions == []
+    assert build_tasks and all(task.done() for task in build_tasks)
+
+
+@pytest.mark.asyncio
+async def test_export_zip_worker_error_wins_after_repeated_cancellation(
+    monkeypatch, tmp_path
+):
+    import asyncio
+
+    from novelvideo.api.routes import generation
+
+    _write_export_assets(tmp_path)
+    _client(monkeypatch, tmp_path)
+    writer_started = threading.Event()
+    release_writer = threading.Event()
+    temp_paths: list[Path] = []
+    real_zip_file = zipfile.ZipFile
+    real_named_temporary_file = tempfile.NamedTemporaryFile
+
+    class FailingBlockingZipFile(real_zip_file):
+        def write(self, *_args, **_kwargs):
+            writer_started.set()
+            assert release_writer.wait(timeout=5)
+            raise OSError("zip worker failed")
+
+    def tracking_named_temporary_file(*args, **kwargs):
+        tmp = real_named_temporary_file(*args, **kwargs)
+        temp_paths.append(Path(tmp.name))
+        return tmp
+
+    monkeypatch.setattr(zipfile, "ZipFile", FailingBlockingZipFile)
+    monkeypatch.setattr(tempfile, "NamedTemporaryFile", tracking_named_temporary_file)
+
+    route_task = asyncio.create_task(
+        generation.export_zip("demo", 3, user={"username": "alice"})
+    )
+    try:
+        assert await asyncio.to_thread(writer_started.wait, 1)
+        route_task.cancel("first-cancel")
+        await asyncio.sleep(0)
+        route_task.cancel("second-cancel")
+        await asyncio.sleep(0)
+        assert not route_task.done()
+    finally:
+        release_writer.set()
+
+    with pytest.raises(OSError, match="zip worker failed"):
+        await route_task
+    assert temp_paths and all(not path.exists() for path in temp_paths)
+
+
+@pytest.mark.asyncio
+async def test_export_zip_response_removes_temp_after_successful_send(monkeypatch, tmp_path):
+    from novelvideo.api.routes import generation
+
+    _write_export_assets(tmp_path)
+    _client(monkeypatch, tmp_path)
+    response = await generation.export_zip("demo", 3, user={"username": "alice"})
+    archive_path = Path(response.path)
+    sent_messages: list[dict] = []
+
+    async def send(message: dict) -> None:
+        sent_messages.append(message)
+
+    assert archive_path.exists()
+    await response(_download_scope(), _unused_receive, send)
+
+    assert sent_messages[0]["type"] == "http.response.start"
+    response_headers = dict(sent_messages[0]["headers"])
+    assert response_headers[b"content-type"] == b"application/zip"
+    assert response_headers[b"accept-ranges"] == b"bytes"
+    assert b'demo_ep003.zip' in response_headers[b"content-disposition"]
+    assert any(message["type"] == "http.response.body" for message in sent_messages)
+    assert not archive_path.exists()
+
+
+@pytest.mark.asyncio
+async def test_export_zip_response_removes_temp_when_send_fails(monkeypatch, tmp_path):
+    from novelvideo.api.routes import generation
+
+    _write_export_assets(tmp_path)
+    _client(monkeypatch, tmp_path)
+    response = await generation.export_zip("demo", 3, user={"username": "alice"})
+    archive_path = Path(response.path)
+
+    async def send(message: dict) -> None:
+        if message["type"] == "http.response.body":
+            raise RuntimeError("client disconnected")
+
+    assert archive_path.exists()
+    with pytest.raises(RuntimeError, match="client disconnected"):
+        await response(_download_scope(), _unused_receive, send)
+    assert not archive_path.exists()
+
+
+@pytest.mark.asyncio
+async def test_export_zip_response_removes_temp_when_send_is_cancelled(monkeypatch, tmp_path):
+    import asyncio
+
+    from novelvideo.api.routes import generation
+
+    _write_export_assets(tmp_path)
+    _client(monkeypatch, tmp_path)
+    response = await generation.export_zip("demo", 3, user={"username": "alice"})
+    archive_path = Path(response.path)
+
+    async def send(message: dict) -> None:
+        if message["type"] == "http.response.body":
+            task = asyncio.current_task()
+            assert task is not None
+            task.cancel()
+            await asyncio.sleep(0)
+
+    assert archive_path.exists()
+    with pytest.raises(asyncio.CancelledError):
+        await response(_download_scope(), _unused_receive, send)
+    assert not archive_path.exists()
+
+
+@pytest.mark.asyncio
+async def test_export_zip_removes_temp_when_response_construction_fails(monkeypatch, tmp_path):
+    from novelvideo.api.routes import generation
+
+    _write_export_assets(tmp_path)
+    _client(monkeypatch, tmp_path)
+    temp_paths: list[Path] = []
+    real_named_temporary_file = tempfile.NamedTemporaryFile
+
+    def tracking_named_temporary_file(*args, **kwargs):
+        tmp = real_named_temporary_file(*args, **kwargs)
+        temp_paths.append(Path(tmp.name))
+        return tmp
+
+    def fail_response_construction(*_args, **_kwargs):
+        raise RuntimeError("response construction failed")
+
+    monkeypatch.setattr(tempfile, "NamedTemporaryFile", tracking_named_temporary_file)
+    monkeypatch.setattr(generation, "_TemporaryFileResponse", fail_response_construction)
+
+    with pytest.raises(RuntimeError, match="response construction failed"):
+        await generation.export_zip("demo", 3, user={"username": "alice"})
+    assert temp_paths and all(not path.exists() for path in temp_paths)
 
 
 def test_srt_export_falls_back_when_audio_duration_probe_fails(monkeypatch, tmp_path):

--- a/tests/test_api_compose_export_contract.py
+++ b/tests/test_api_compose_export_contract.py
@@ -186,11 +186,9 @@ async def test_export_zip_cancellation_waits_for_writer_and_removes_temp(monkeyp
     _client(monkeypatch, tmp_path)
     writer_started = threading.Event()
     release_writer = threading.Event()
-    shield_calls = 0
     temp_paths: list[Path] = []
     real_zip_file = zipfile.ZipFile
     real_named_temporary_file = tempfile.NamedTemporaryFile
-    real_shield = asyncio.shield
 
     class BlockingZipFile(real_zip_file):
         def write(self, *args, **kwargs):
@@ -203,14 +201,8 @@ async def test_export_zip_cancellation_waits_for_writer_and_removes_temp(monkeyp
         temp_paths.append(Path(tmp.name))
         return tmp
 
-    def tracking_shield(awaitable):
-        nonlocal shield_calls
-        shield_calls += 1
-        return real_shield(awaitable)
-
     monkeypatch.setattr(zipfile, "ZipFile", BlockingZipFile)
     monkeypatch.setattr(tempfile, "NamedTemporaryFile", tracking_named_temporary_file)
-    monkeypatch.setattr(asyncio, "shield", tracking_shield)
 
     scope_ready = asyncio.Event()
     scope_holder = {}
@@ -232,7 +224,6 @@ async def test_export_zip_cancellation_waits_for_writer_and_removes_temp(monkeyp
     finally:
         release_writer.set()
         await controller
-    assert shield_calls == 2
     assert temp_paths and all(not path.exists() for path in temp_paths)
 
 
@@ -310,7 +301,7 @@ async def test_export_zip_repeated_direct_cancellation_waits_and_cleans_temp(
 
 
 @pytest.mark.asyncio
-async def test_export_zip_worker_error_wins_after_repeated_cancellation(
+async def test_export_zip_cancellation_wins_over_late_worker_error(
     monkeypatch, tmp_path
 ):
     import asyncio
@@ -352,8 +343,9 @@ async def test_export_zip_worker_error_wins_after_repeated_cancellation(
     finally:
         release_writer.set()
 
-    with pytest.raises(OSError, match="zip worker failed"):
+    with pytest.raises(asyncio.CancelledError) as raised:
         await route_task
+    assert raised.value.args == ("first-cancel",)
     assert temp_paths and all(not path.exists() for path in temp_paths)
 
 
@@ -371,6 +363,7 @@ async def test_export_zip_response_removes_temp_after_successful_send(monkeypatc
         sent_messages.append(message)
 
     assert archive_path.exists()
+    assert response.background is None
     await response(_download_scope(), _unused_receive, send)
 
     assert sent_messages[0]["type"] == "http.response.start"

--- a/tests/test_api_ingest_chapter_preview.py
+++ b/tests/test_api_ingest_chapter_preview.py
@@ -1,11 +1,15 @@
 from __future__ import annotations
 
+import asyncio
 import io
 import os
 import stat
+import threading
 import zipfile
+from pathlib import Path
 from types import SimpleNamespace
 
+import anyio
 import pytest
 from fastapi import UploadFile
 
@@ -354,6 +358,183 @@ async def test_upload_novel_returns_nicegui_chapter_preview(tmp_path, monkeypatc
     uploads_dir = tmp_path / "uploads"
     assert (uploads_dir / "novel.txt").read_bytes() == raw
     assert list((uploads_dir / ".staging").glob("upload-*")) == []
+
+
+@pytest.mark.asyncio
+async def test_upload_novel_runs_staging_parse_and_preview_off_event_loop(
+    tmp_path, monkeypatch
+):
+    from novelvideo.api.routes import ingest
+
+    monkeypatch.setattr(
+        ingest,
+        "resolve_project_scope",
+        _project_scope_resolver(tmp_path),
+    )
+    event_loop_thread = threading.get_ident()
+    worker_threads: list[int] = []
+    real_stream = ingest.stream_to_file_with_limit
+    real_load = ingest.load_novel_text
+    real_preview = ingest.build_chapter_preview
+
+    def tracking_stream(*args, **kwargs):
+        worker_threads.append(threading.get_ident())
+        return real_stream(*args, **kwargs)
+
+    def tracking_load(*args, **kwargs):
+        worker_threads.append(threading.get_ident())
+        return real_load(*args, **kwargs)
+
+    def tracking_preview(*args, **kwargs):
+        worker_threads.append(threading.get_ident())
+        return real_preview(*args, **kwargs)
+
+    monkeypatch.setattr(ingest, "stream_to_file_with_limit", tracking_stream)
+    monkeypatch.setattr(ingest, "load_novel_text", tracking_load)
+    monkeypatch.setattr(ingest, "build_chapter_preview", tracking_preview)
+
+    response = await ingest.upload_novel(
+        project="demo",
+        file=UploadFile(
+            file=io.BytesIO(NOVEL_TEXT.encode("utf-8")),
+            filename="novel.txt",
+        ),
+        user={"username": "admin"},
+    )
+
+    assert response["ok"] is True
+    assert len(worker_threads) == 3
+    assert len(set(worker_threads)) == 1
+    assert worker_threads[0] != event_loop_thread
+
+
+@pytest.mark.asyncio
+async def test_cancelled_upload_keeps_capacity_and_cleans_staging_after_worker_finishes(
+    tmp_path, monkeypatch
+):
+    from novelvideo.api.routes import ingest
+
+    monkeypatch.setattr(
+        ingest,
+        "resolve_project_scope",
+        _project_scope_resolver(tmp_path),
+    )
+    limiter = anyio.CapacityLimiter(1)
+    limiter_var = ingest.RunVar("test_ingest_upload_limiter")
+    limiter_var.set(limiter)
+    monkeypatch.setattr(ingest, "_ingest_upload_limiter_var", limiter_var)
+
+    first_entered = threading.Event()
+    second_entered = threading.Event()
+    release_first = threading.Event()
+    real_load = ingest.load_novel_text
+
+    def blocking_load(path):
+        if Path(path).name.startswith("upload-") and not first_entered.is_set():
+            first_entered.set()
+            release_first.wait(timeout=5)
+        else:
+            second_entered.set()
+        return real_load(path)
+
+    monkeypatch.setattr(ingest, "load_novel_text", blocking_load)
+
+    first_task = asyncio.create_task(
+        ingest.upload_novel(
+            project="demo",
+            file=UploadFile(
+                file=io.BytesIO(NOVEL_TEXT.encode("utf-8")),
+                filename="first.txt",
+            ),
+            user={"username": "admin"},
+        )
+    )
+    assert await asyncio.to_thread(first_entered.wait, 1)
+    first_task.cancel()
+    await asyncio.sleep(0)
+
+    second_task = asyncio.create_task(
+        ingest.upload_novel(
+            project="demo",
+            file=UploadFile(
+                file=io.BytesIO(NOVEL_TEXT.encode("utf-8")),
+                filename="second.txt",
+            ),
+            user={"username": "admin"},
+        )
+    )
+
+    async def wait_until_second_is_queued() -> None:
+        while limiter.statistics().tasks_waiting != 1:
+            await asyncio.sleep(0)
+
+    await asyncio.wait_for(wait_until_second_is_queued(), timeout=1)
+    assert limiter.borrowed_tokens == 1
+    assert not first_task.done()
+    assert not second_entered.is_set()
+    assert list((tmp_path / "uploads" / ".staging").glob("upload-*"))
+
+    release_first.set()
+    with pytest.raises(asyncio.CancelledError):
+        await first_task
+    second_response = await second_task
+
+    assert second_response["ok"] is True
+    assert second_entered.is_set()
+    assert list((tmp_path / "uploads" / ".staging").glob("upload-*")) == []
+
+
+@pytest.mark.asyncio
+async def test_upload_novel_preserves_anyio_cancel_scope_marker_and_cleans_staging(
+    tmp_path, monkeypatch
+):
+    from novelvideo.api.routes import ingest
+
+    monkeypatch.setattr(
+        ingest,
+        "resolve_project_scope",
+        _project_scope_resolver(tmp_path),
+    )
+    worker_entered = threading.Event()
+    release_worker = threading.Event()
+    shield_calls = 0
+    real_shield = asyncio.shield
+    real_load = ingest.load_novel_text
+
+    def tracking_shield(awaitable):
+        nonlocal shield_calls
+        shield_calls += 1
+        return real_shield(awaitable)
+
+    def blocking_load(path):
+        worker_entered.set()
+        release_worker.wait(timeout=5)
+        return real_load(path)
+
+    async def cancel_and_release(scope: anyio.CancelScope) -> None:
+        assert await asyncio.to_thread(worker_entered.wait, 1)
+        scope.cancel()
+        await asyncio.sleep(0)
+        release_worker.set()
+
+    monkeypatch.setattr(ingest.asyncio, "shield", tracking_shield)
+    monkeypatch.setattr(ingest, "load_novel_text", blocking_load)
+
+    with anyio.CancelScope() as scope:
+        canceller = asyncio.create_task(cancel_and_release(scope))
+        await ingest.upload_novel(
+            project="demo",
+            file=UploadFile(
+                file=io.BytesIO(NOVEL_TEXT.encode("utf-8")),
+                filename="novel.txt",
+            ),
+            user={"username": "admin"},
+        )
+    await canceller
+
+    assert scope.cancel_called
+    assert shield_calls == 2
+    assert list((tmp_path / "uploads" / ".staging").glob("upload-*")) == []
 
 
 @pytest.mark.asyncio

--- a/tests/test_api_ingest_chapter_preview.py
+++ b/tests/test_api_ingest_chapter_preview.py
@@ -497,14 +497,7 @@ async def test_upload_novel_preserves_anyio_cancel_scope_marker_and_cleans_stagi
     )
     worker_entered = threading.Event()
     release_worker = threading.Event()
-    shield_calls = 0
-    real_shield = asyncio.shield
     real_load = ingest.load_novel_text
-
-    def tracking_shield(awaitable):
-        nonlocal shield_calls
-        shield_calls += 1
-        return real_shield(awaitable)
 
     def blocking_load(path):
         worker_entered.set()
@@ -517,7 +510,6 @@ async def test_upload_novel_preserves_anyio_cancel_scope_marker_and_cleans_stagi
         await asyncio.sleep(0)
         release_worker.set()
 
-    monkeypatch.setattr(ingest.asyncio, "shield", tracking_shield)
     monkeypatch.setattr(ingest, "load_novel_text", blocking_load)
 
     with anyio.CancelScope() as scope:
@@ -533,7 +525,6 @@ async def test_upload_novel_preserves_anyio_cancel_scope_marker_and_cleans_stagi
     await canceller
 
     assert scope.cancel_called
-    assert shield_calls == 2
     assert list((tmp_path / "uploads" / ".staging").glob("upload-*")) == []
 
 

--- a/tests/test_api_narrator_voice.py
+++ b/tests/test_api_narrator_voice.py
@@ -1,11 +1,17 @@
 from __future__ import annotations
 
 import base64
+import asyncio
+import hashlib
+import io
+import threading
 from dataclasses import dataclass
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
 from fastapi import FastAPI
+from fastapi import UploadFile
 from fastapi.testclient import TestClient
 
 pytestmark = pytest.mark.m04
@@ -88,6 +94,106 @@ def test_narrator_voice_upload_persists_project_reference(monkeypatch, tmp_path)
     assert (project_dir / "assets/narrator/voice.wav").read_bytes() == b"voice-bytes"
 
 
+def test_narrator_voice_upload_persist_and_config_run_off_event_loop(
+    monkeypatch, tmp_path
+):
+    from novelvideo.api.routes import projects
+
+    client, _project_config, project_dir, _state_dir = _client(monkeypatch, tmp_path)
+    loop_threads: list[int] = []
+    persist_threads: list[int] = []
+    config_threads: list[int] = []
+    real_persist = projects._persist_narrator_voice_content
+    real_set = projects.set_narrator_reference_audio_in_state_dir
+
+    async def tracking_store(_ctx):
+        loop_threads.append(threading.get_ident())
+        return DummyStore(str(project_dir))
+
+    def tracking_persist(**kwargs):
+        persist_threads.append(threading.get_ident())
+        return real_persist(**kwargs)
+
+    def tracking_set(*args, **kwargs):
+        config_threads.append(threading.get_ident())
+        return real_set(*args, **kwargs)
+
+    monkeypatch.setattr(projects, "make_sqlite_store_for_context", tracking_store)
+    monkeypatch.setattr(projects, "_persist_narrator_voice_content", tracking_persist)
+    monkeypatch.setattr(
+        projects, "set_narrator_reference_audio_in_state_dir", tracking_set
+    )
+    response = client.post(
+        "/projects/demo/narrator-voice/upload",
+        files={"file": ("voice.wav", b"voice", "audio/wav")},
+    )
+
+    assert response.status_code == 200
+    assert persist_threads == config_threads
+    assert set(persist_threads).isdisjoint(loop_threads)
+
+
+@pytest.mark.asyncio
+async def test_narrator_voice_upload_reads_in_memory_stream_in_voice_worker(
+    monkeypatch, tmp_path
+):
+    from novelvideo.api.routes import projects
+    from novelvideo.seedance2_i2v import character_voice_storage
+
+    project_dir = tmp_path / "output" / "admin" / "demo"
+    state_dir = tmp_path / "state" / "admin" / "demo"
+    ctx = SimpleNamespace(
+        project_id="demo",
+        project_name="demo",
+        owner_username="admin",
+        owner_project_label="admin/demo",
+        output_dir=project_dir,
+        state_dir=state_dir,
+        is_home_node=True,
+    )
+    store = DummyStore(str(project_dir))
+
+    async def resolve_context(**_kwargs):
+        return ctx
+
+    async def make_store(_ctx):
+        return store
+
+    monkeypatch.setattr(projects, "resolve_project_context", resolve_context)
+    monkeypatch.setattr(projects, "make_sqlite_store_for_context", make_store)
+    monkeypatch.setattr(
+        projects,
+        "make_static_url_for_context",
+        lambda _ctx, relative_path, local_path=None: f"/static/{relative_path}",
+    )
+    loop_thread = threading.get_ident()
+    read_threads: list[int] = []
+    borrowed_tokens: list[int] = []
+    voice_limiter = character_voice_storage._voice_media_limiter()
+
+    class RecordingBytesIO(io.BytesIO):
+        def read(self, *args, **kwargs):
+            read_threads.append(threading.get_ident())
+            borrowed_tokens.append(voice_limiter.borrowed_tokens)
+            return super().read(*args, **kwargs)
+
+    upload = UploadFile(
+        filename="voice.wav",
+        file=RecordingBytesIO(b"voice-from-memory"),
+    )
+
+    response = await projects.upload_narrator_voice(
+        project="demo",
+        file=upload,
+        user={"username": "admin"},
+    )
+
+    assert response["ok"] is True
+    assert read_threads and loop_thread not in read_threads
+    assert borrowed_tokens == [1]
+    assert (project_dir / "assets/narrator/voice.wav").read_bytes() == b"voice-from-memory"
+
+
 def test_narrator_voice_record_accepts_data_url(monkeypatch, tmp_path):
     client, project_config, project_dir, state_dir = _client(monkeypatch, tmp_path)
     encoded = base64.b64encode(b"recorded-voice").decode("ascii")
@@ -105,6 +211,63 @@ def test_narrator_voice_record_accepts_data_url(monkeypatch, tmp_path):
         "assets/narrator/voice.wav"
     )
     assert (project_dir / "assets/narrator/voice.wav").read_bytes() == b"recorded-voice"
+
+
+def test_narrator_voice_record_decodes_off_event_loop(monkeypatch, tmp_path):
+    from novelvideo.api.routes import projects
+
+    client, _project_config, _project_dir, _state_dir = _client(monkeypatch, tmp_path)
+    worker_thread_ids: list[int] = []
+    persist_thread_ids: list[int] = []
+    real_persist = projects._persist_narrator_voice_content
+
+    def fake_decode(_data_url):
+        worker_thread_ids.append(threading.get_ident())
+        return b"recorded-voice", ".wav"
+
+    def tracking_persist(**kwargs):
+        persist_thread_ids.append(threading.get_ident())
+        return real_persist(**kwargs)
+
+    monkeypatch.setattr(projects, "decode_recorded_audio_data_url", fake_decode)
+    monkeypatch.setattr(projects, "_persist_narrator_voice_content", tracking_persist)
+
+    response = client.post(
+        "/projects/demo/narrator-voice/record",
+        json={"data_url": "data:audio/webm;base64,eA=="},
+    )
+
+    assert response.status_code == 200
+    assert worker_thread_ids
+    assert persist_thread_ids == worker_thread_ids
+
+
+def test_narrator_voice_trim_runs_off_event_loop(monkeypatch, tmp_path):
+    from novelvideo.api.routes import projects
+
+    client, _project_config, _project_dir, _state_dir = _client(monkeypatch, tmp_path)
+    ensure_thread_ids: list[int] = []
+    worker_thread_ids: list[int] = []
+    real_ensure = projects._ensure_third_person_narrator
+
+    def tracking_ensure(ctx):
+        ensure_thread_ids.append(threading.get_ident())
+        return real_ensure(ctx)
+
+    def fake_trim(**_kwargs):
+        worker_thread_ids.append(threading.get_ident())
+
+    monkeypatch.setattr(projects, "_ensure_third_person_narrator", tracking_ensure)
+    monkeypatch.setattr(projects, "_trim_narrator_voice_content", fake_trim)
+
+    response = client.post(
+        "/projects/demo/narrator-voice/trim",
+        json={"start_seconds": 0, "duration_seconds": 4},
+    )
+
+    assert response.status_code == 200
+    assert worker_thread_ids
+    assert worker_thread_ids == ensure_thread_ids
 
 
 def test_narrator_voice_sources_and_copy(monkeypatch, tmp_path):
@@ -136,6 +299,62 @@ def test_narrator_voice_sources_and_copy(monkeypatch, tmp_path):
     assert (project_dir / "assets/narrator/voice.mp3").read_bytes() == b"source-voice"
 
 
+def test_narrator_voice_copy_stat_read_and_persist_run_off_event_loop(
+    monkeypatch, tmp_path
+):
+    from novelvideo.api.routes import projects
+
+    client, _project_config, project_dir, _state_dir = _client(monkeypatch, tmp_path)
+    source = project_dir / "audio/source.mp3"
+    source.parent.mkdir(parents=True)
+    source.write_bytes(b"source")
+    loop_threads: list[int] = []
+    stat_threads: list[int] = []
+    read_threads: list[int] = []
+    persist_threads: list[int] = []
+    real_exists = Path.exists
+    real_is_file = Path.is_file
+    real_read_bytes = Path.read_bytes
+    real_persist = projects._persist_narrator_voice_content
+
+    async def tracking_store(_ctx):
+        loop_threads.append(threading.get_ident())
+        return DummyStore(str(project_dir))
+
+    def tracking_read_bytes(path):
+        if path == source:
+            read_threads.append(threading.get_ident())
+        return real_read_bytes(path)
+
+    def tracking_exists(path):
+        if path == source:
+            stat_threads.append(threading.get_ident())
+        return real_exists(path)
+
+    def tracking_is_file(path):
+        if path == source:
+            stat_threads.append(threading.get_ident())
+        return real_is_file(path)
+
+    def tracking_persist(**kwargs):
+        persist_threads.append(threading.get_ident())
+        return real_persist(**kwargs)
+
+    monkeypatch.setattr(projects, "make_sqlite_store_for_context", tracking_store)
+    monkeypatch.setattr(Path, "exists", tracking_exists)
+    monkeypatch.setattr(Path, "is_file", tracking_is_file)
+    monkeypatch.setattr(Path, "read_bytes", tracking_read_bytes)
+    monkeypatch.setattr(projects, "_persist_narrator_voice_content", tracking_persist)
+    response = client.post(
+        "/projects/demo/narrator-voice/copy", json={"source_path": str(source)}
+    )
+
+    assert response.status_code == 200
+    assert stat_threads and set(stat_threads) == set(read_threads)
+    assert read_threads == persist_threads
+    assert set(read_threads).isdisjoint(loop_threads)
+
+
 def test_narrator_voice_delete_renames_file_and_clears_metadata(monkeypatch, tmp_path):
     client, project_config, project_dir, state_dir = _client(monkeypatch, tmp_path)
     target = project_dir / "assets/narrator/voice.wav"
@@ -154,3 +373,107 @@ def test_narrator_voice_delete_renames_file_and_clears_metadata(monkeypatch, tmp
     assert project_config.load_narrator_reference_audio_from_state_dir(state_dir)["path"] == ""
     assert not target.exists()
     assert list((project_dir / "assets/narrator").glob("voice_*.wav"))
+
+
+def test_narrator_voice_delete_config_and_archive_run_off_event_loop(
+    monkeypatch, tmp_path
+):
+    from novelvideo.api.routes import projects
+
+    client, project_config, project_dir, state_dir = _client(monkeypatch, tmp_path)
+    target = project_dir / "assets/narrator/voice.wav"
+    target.parent.mkdir(parents=True)
+    target.write_bytes(b"voice")
+    project_config.set_narrator_reference_audio_in_state_dir(
+        state_dir, relative_path="assets/narrator/voice.wav", sha256="sha"
+    )
+    loop_threads: list[int] = []
+    load_threads: list[int] = []
+    set_threads: list[int] = []
+    real_load = projects.load_narrator_reference_audio_from_state_dir
+    real_set = projects.set_narrator_reference_audio_in_state_dir
+
+    async def tracking_store(_ctx):
+        loop_threads.append(threading.get_ident())
+        return DummyStore(str(project_dir))
+
+    def tracking_load(*args, **kwargs):
+        load_threads.append(threading.get_ident())
+        return real_load(*args, **kwargs)
+
+    def tracking_set(*args, **kwargs):
+        set_threads.append(threading.get_ident())
+        return real_set(*args, **kwargs)
+
+    monkeypatch.setattr(projects, "make_sqlite_store_for_context", tracking_store)
+    monkeypatch.setattr(
+        projects, "load_narrator_reference_audio_from_state_dir", tracking_load
+    )
+    monkeypatch.setattr(
+        projects, "set_narrator_reference_audio_in_state_dir", tracking_set
+    )
+    response = client.post("/projects/demo/narrator-voice/delete")
+
+    assert response.status_code == 200
+    assert set_threads
+    assert load_threads[0] == set_threads[0]
+    assert set(set_threads).isdisjoint(loop_threads)
+
+
+@pytest.mark.asyncio
+async def test_narrator_voice_same_project_updates_are_serialized_and_consistent(
+    monkeypatch, tmp_path
+):
+    from novelvideo import project_config
+    from novelvideo.api.routes import projects
+
+    project_dir = tmp_path / "output/demo"
+    state_dir = tmp_path / "state/demo"
+    project_dir.mkdir(parents=True)
+    ctx = SimpleNamespace(output_dir=project_dir, state_dir=state_dir)
+    store = DummyStore(str(project_dir))
+    first_started = threading.Event()
+    first_payload_started = threading.Event()
+    release_first_payload = threading.Event()
+    second_started = threading.Event()
+    payload_calls = 0
+    real_upload = projects._upload_narrator_voice_content
+
+    def controlled_upload(*, ctx, filename, content):
+        if content == b"first":
+            first_started.set()
+        else:
+            second_started.set()
+        return real_upload(ctx=ctx, filename=filename, content=content)
+
+    def controlled_payload(_ctx, _store):
+        nonlocal payload_calls
+        payload_calls += 1
+        if payload_calls == 1:
+            first_payload_started.set()
+            release_first_payload.wait(timeout=3)
+        return {}
+
+    monkeypatch.setattr(projects, "_ensure_third_person_narrator", lambda _ctx: None)
+    monkeypatch.setattr(projects, "_narrator_voice_payload", controlled_payload)
+    first = asyncio.create_task(
+        projects._run_narrator_voice_update(
+            ctx, store, controlled_upload, ctx=ctx, filename="first.wav", content=b"first"
+        )
+    )
+    assert await asyncio.to_thread(first_started.wait, 1)
+    assert await asyncio.to_thread(first_payload_started.wait, 1)
+    second = asyncio.create_task(
+        projects._run_narrator_voice_update(
+            ctx, store, controlled_upload, ctx=ctx, filename="second.wav", content=b"second"
+        )
+    )
+    await asyncio.sleep(0)
+    assert not second_started.is_set()
+    release_first_payload.set()
+    await asyncio.gather(first, second)
+
+    target = project_dir / "assets/narrator/voice.wav"
+    stored = project_config.load_narrator_reference_audio_from_state_dir(state_dir)
+    assert target.read_bytes() == b"second"
+    assert stored["sha256"] == hashlib.sha256(target.read_bytes()).hexdigest()

--- a/tests/test_api_project_summary_paths.py
+++ b/tests/test_api_project_summary_paths.py
@@ -212,13 +212,6 @@ async def test_project_summary_preserves_anyio_cancel_scope_marker(
     record = _project_record(tmp_path)
     worker_entered = threading.Event()
     release_worker = threading.Event()
-    shield_calls = 0
-    original_shield = asyncio.shield
-
-    def tracking_shield(awaitable):
-        nonlocal shield_calls
-        shield_calls += 1
-        return original_shield(awaitable)
 
     def fake_load_config(_state_dir: str) -> dict:
         worker_entered.set()
@@ -233,7 +226,6 @@ async def test_project_summary_preserves_anyio_cancel_scope_marker(
         release_worker.set()
 
     monkeypatch.setattr(projects, "is_record_home_node", lambda _record: True)
-    monkeypatch.setattr(projects.asyncio, "shield", tracking_shield)
     monkeypatch.setattr(
         projects, "load_project_config_file_from_state_dir", fake_load_config
     )
@@ -244,7 +236,6 @@ async def test_project_summary_preserves_anyio_cancel_scope_marker(
     await canceller
 
     assert scope.cancel_called
-    assert shield_calls == 1
 
 
 @pytest.mark.asyncio

--- a/tests/test_api_project_summary_paths.py
+++ b/tests/test_api_project_summary_paths.py
@@ -1,9 +1,33 @@
+import asyncio
 import sqlite3
+import threading
 from pathlib import Path
 
+import anyio
 import pytest
 
 from novelvideo.ports.project import ProjectRecord
+
+
+def _project_record(tmp_path: Path, name: str = "demo") -> ProjectRecord:
+    state_dir = tmp_path / "state" / name
+    output_dir = tmp_path / "output" / name
+    runtime_dir = tmp_path / "runtime" / name
+    state_dir.mkdir(parents=True)
+    output_dir.mkdir(parents=True)
+    runtime_dir.mkdir(parents=True)
+    return ProjectRecord(
+        id=f"project-{name}",
+        owner_type="user",
+        owner_id="user-1",
+        owner_username="alice",
+        name=name,
+        home_node_id="local-dev",
+        output_dir=str(output_dir),
+        state_dir=str(state_dir),
+        runtime_dir=str(runtime_dir),
+        status="active",
+    )
 
 
 @pytest.mark.asyncio
@@ -49,3 +73,230 @@ async def test_project_summary_counts_from_registered_state_dir(
 
     assert summary.episode_count == 2
     assert summary.beat_count == 3
+
+
+@pytest.mark.asyncio
+async def test_project_summary_reads_files_off_the_event_loop(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from novelvideo.api.routes import projects
+
+    record = _project_record(tmp_path)
+    loop_thread_id = threading.get_ident()
+    reader_thread_ids: list[int] = []
+
+    def fake_load_config(_state_dir: str) -> dict:
+        reader_thread_ids.append(threading.get_ident())
+        return {}
+
+    monkeypatch.setattr(projects, "is_record_home_node", lambda _record: True)
+    monkeypatch.setattr(
+        projects, "load_project_config_file_from_state_dir", fake_load_config
+    )
+
+    await projects._summary_for_record(record)
+
+    assert reader_thread_ids
+    assert reader_thread_ids[0] != loop_thread_id
+
+
+@pytest.mark.asyncio
+async def test_project_summary_blocking_reads_use_a_small_shared_limiter(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from novelvideo.api.routes import projects
+
+    records = [_project_record(tmp_path, f"demo-{index}") for index in range(3)]
+    condition = threading.Condition()
+    active = 0
+    peak = 0
+
+    def fake_load_config(_state_dir: str) -> dict:
+        nonlocal active, peak
+        with condition:
+            active += 1
+            peak = max(peak, active)
+            condition.notify_all()
+            if active == 1:
+                condition.wait_for(lambda: peak >= 2, timeout=1)
+        try:
+            return {}
+        finally:
+            with condition:
+                active -= 1
+                condition.notify_all()
+
+    monkeypatch.setattr(projects, "is_record_home_node", lambda _record: True)
+    monkeypatch.setattr(
+        projects, "load_project_config_file_from_state_dir", fake_load_config
+    )
+
+    await asyncio.gather(*(projects._summary_for_record(record) for record in records))
+
+    assert peak == 2
+
+
+@pytest.mark.asyncio
+async def test_cancelled_project_summary_keeps_limiter_token_until_worker_finishes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from novelvideo.api.routes import projects
+
+    first_record = _project_record(tmp_path, "first")
+    second_record = _project_record(tmp_path, "second")
+    first_entered = threading.Event()
+    second_entered = threading.Event()
+    release_first = threading.Event()
+
+    def fake_load_config(state_dir: str) -> dict:
+        if Path(state_dir).name == "first":
+            first_entered.set()
+            release_first.wait(timeout=1)
+        else:
+            second_entered.set()
+        return {}
+
+    limiter = anyio.CapacityLimiter(1)
+    limiter_var = projects.RunVar("test_project_summary_limiter")
+    limiter_var.set(limiter)
+    monkeypatch.setattr(
+        projects,
+        "_project_summary_limiter_var",
+        limiter_var,
+    )
+    monkeypatch.setattr(projects, "is_record_home_node", lambda _record: True)
+    monkeypatch.setattr(
+        projects, "load_project_config_file_from_state_dir", fake_load_config
+    )
+
+    first_task = asyncio.create_task(projects._summary_for_record(first_record))
+    while not first_entered.is_set():
+        await asyncio.sleep(0)
+
+    second_task = asyncio.create_task(projects._summary_for_record(second_record))
+
+    async def wait_until_second_task_is_queued() -> None:
+        while limiter.statistics().tasks_waiting != 1:
+            await asyncio.sleep(0)
+
+    await asyncio.wait_for(wait_until_second_task_is_queued(), timeout=1)
+    assert limiter.statistics().borrowed_tokens == 1
+
+    first_task.cancel()
+    cancellation_delivered = asyncio.Event()
+    asyncio.get_running_loop().call_soon(cancellation_delivered.set)
+    await cancellation_delivered.wait()
+
+    assert not first_task.done()
+    assert limiter.statistics().borrowed_tokens == 1
+    assert limiter.statistics().tasks_waiting == 1
+    assert not second_entered.is_set()
+
+    release_first.set()
+    with pytest.raises(asyncio.CancelledError):
+        await first_task
+    await second_task
+    assert second_entered.is_set()
+
+
+@pytest.mark.asyncio
+async def test_project_summary_preserves_anyio_cancel_scope_marker(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from novelvideo.api.routes import projects
+
+    record = _project_record(tmp_path)
+    worker_entered = threading.Event()
+    release_worker = threading.Event()
+    shield_calls = 0
+    original_shield = asyncio.shield
+
+    def tracking_shield(awaitable):
+        nonlocal shield_calls
+        shield_calls += 1
+        return original_shield(awaitable)
+
+    def fake_load_config(_state_dir: str) -> dict:
+        worker_entered.set()
+        release_worker.wait(timeout=1)
+        return {}
+
+    async def cancel_and_release(scope: anyio.CancelScope) -> None:
+        while not worker_entered.is_set():
+            await asyncio.sleep(0)
+        scope.cancel()
+        await asyncio.sleep(0)
+        release_worker.set()
+
+    monkeypatch.setattr(projects, "is_record_home_node", lambda _record: True)
+    monkeypatch.setattr(projects.asyncio, "shield", tracking_shield)
+    monkeypatch.setattr(
+        projects, "load_project_config_file_from_state_dir", fake_load_config
+    )
+
+    with anyio.CancelScope() as scope:
+        canceller = asyncio.create_task(cancel_and_release(scope))
+        await projects._summary_for_record(record)
+    await canceller
+
+    assert scope.cancel_called
+    assert shield_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_list_project_summaries_runs_blocking_summaries_concurrently_in_record_order(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from novelvideo.api.routes import projects
+    from novelvideo.api.schemas import ProjectSummary
+
+    records = [_project_record(tmp_path, f"demo-{index}") for index in range(3)]
+    all_started = asyncio.Event()
+    started: list[str] = []
+
+    class FakeRegistry:
+        async def list_accessible_projects(self, _principals):
+            return records
+
+    class FakeAccess:
+        async def resolve_requester_principals(self, _user_id):
+            return []
+
+        async def effective_project_role(self, _record, _principals):
+            return "viewer"
+
+    async def fake_user_id(_user):
+        return "user-1"
+
+    async def fake_summary(record: ProjectRecord, *, effective_role: str = ""):
+        started.append(record.id)
+        if len(started) == len(records):
+            all_started.set()
+        await all_started.wait()
+        return ProjectSummary(
+            id=record.id,
+            name=record.name,
+            owner_type=record.owner_type,
+            owner_id=record.owner_id,
+            owner_username=record.owner_username,
+            effective_role=effective_role,
+            home_node_id=record.home_node_id,
+            status=record.status,
+        )
+
+    monkeypatch.setattr(projects, "user_id_from_api_user", fake_user_id)
+    monkeypatch.setattr(projects, "get_project_access", lambda: FakeAccess())
+    monkeypatch.setattr(projects, "get_project_registry", lambda: FakeRegistry())
+    monkeypatch.setattr(projects, "_summary_for_record", fake_summary)
+
+    response = await asyncio.wait_for(
+        projects.list_project_summaries(status="all", user={"username": "alice"}),
+        timeout=1,
+    )
+
+    assert [row["id"] for row in response["data"]] == [record.id for record in records]

--- a/tests/test_character_voice_storage.py
+++ b/tests/test_character_voice_storage.py
@@ -175,22 +175,53 @@ async def test_voice_media_capacity_is_held_until_cancelled_worker_finishes():
 
 
 @pytest.mark.asyncio
-async def test_voice_media_operation_preserves_anyio_cancel_scope_cancellation(monkeypatch):
+async def test_voice_media_operation_accepts_an_independent_worker_limiter():
+    import anyio
+
+    from novelvideo.seedance2_i2v import character_voice_storage
+
+    release_workers = threading.Event()
+    capacity_started = threading.Event()
+    started = 0
+    started_lock = threading.Lock()
+
+    def blocking_operation() -> None:
+        nonlocal started
+        with started_lock:
+            started += 1
+            if started == character_voice_storage._VOICE_MEDIA_CONCURRENCY:
+                capacity_started.set()
+        release_workers.wait(timeout=5)
+
+    blockers = [
+        asyncio.create_task(
+            character_voice_storage.run_voice_media_operation(blocking_operation)
+        )
+        for _ in range(character_voice_storage._VOICE_MEDIA_CONCURRENCY)
+    ]
+    try:
+        assert await asyncio.to_thread(capacity_started.wait, 1)
+        result = await asyncio.wait_for(
+            character_voice_storage.run_voice_media_operation(
+                lambda: "metadata",
+                worker_limiter=anyio.CapacityLimiter(1),
+            ),
+            timeout=1,
+        )
+        assert result == "metadata"
+    finally:
+        release_workers.set()
+        await asyncio.gather(*blockers, return_exceptions=True)
+
+
+@pytest.mark.asyncio
+async def test_voice_media_operation_preserves_anyio_cancel_scope_cancellation():
     import anyio
 
     from novelvideo.seedance2_i2v import character_voice_storage
 
     worker_started = threading.Event()
     release_worker = threading.Event()
-    shield_calls = 0
-    real_shield = asyncio.shield
-
-    def tracking_shield(awaitable):
-        nonlocal shield_calls
-        shield_calls += 1
-        return real_shield(awaitable)
-
-    monkeypatch.setattr(character_voice_storage.asyncio, "shield", tracking_shield)
 
     def blocking_operation() -> None:
         worker_started.set()
@@ -206,14 +237,13 @@ async def test_voice_media_operation_preserves_anyio_cancel_scope_cancellation(m
         with anyio.move_on_after(0.01) as scope:
             await character_voice_storage.run_voice_media_operation(blocking_operation)
         assert scope.cancel_called
-        assert shield_calls == 2
     finally:
         release_worker.set()
         await releaser
 
 
 @pytest.mark.asyncio
-async def test_cancelled_voice_worker_failure_is_not_hidden():
+async def test_cancelled_voice_worker_preserves_cancellation_precedence():
     from novelvideo.seedance2_i2v import character_voice_storage
 
     started = threading.Event()
@@ -231,12 +261,13 @@ async def test_cancelled_voice_worker_failure_is_not_hidden():
     task.cancel("cancel-worker")
     release.set()
 
-    with pytest.raises(RuntimeError, match="worker failed after cancellation"):
+    with pytest.raises(asyncio.CancelledError) as raised:
         await task
+    assert raised.value.args == ("cancel-worker",)
 
 
 @pytest.mark.asyncio
-async def test_cancelled_voice_finalizer_failure_is_not_hidden():
+async def test_cancelled_voice_finalizer_preserves_cancellation_precedence():
     from novelvideo.seedance2_i2v import character_voice_storage
 
     finalize_started = asyncio.Event()
@@ -257,8 +288,9 @@ async def test_cancelled_voice_finalizer_failure_is_not_hidden():
     task.cancel("cancel-finalize")
     release_finalize.set()
 
-    with pytest.raises(RuntimeError, match="finalize failed after cancellation"):
+    with pytest.raises(asyncio.CancelledError) as raised:
         await task
+    assert raised.value.args == ("cancel-finalize",)
 
 
 @pytest.mark.asyncio
@@ -553,3 +585,13 @@ def test_trim_existing_character_voice_file_rewrites_slot_with_short_clip(tmp_pa
         if path.name.startswith("voice_default_") and path.suffix == ".wav"
     ]
     assert archived
+
+
+@pytest.mark.parametrize("state_dir", ["", Path("")])
+def test_narrator_voice_resource_key_rejects_empty_state_dir(tmp_path, state_dir):
+    from novelvideo.seedance2_i2v.character_voice_storage import (
+        narrator_voice_resource_key,
+    )
+
+    with pytest.raises(ValueError, match="state_dir"):
+        narrator_voice_resource_key(project_dir=tmp_path, state_dir=state_dir)

--- a/tests/test_character_voice_storage.py
+++ b/tests/test_character_voice_storage.py
@@ -2,6 +2,10 @@
 
 from __future__ import annotations
 
+import asyncio
+import gc
+import threading
+import weakref
 from pathlib import Path
 
 import pytest
@@ -122,6 +126,255 @@ def test_age_group_slots_cover_known_values():
     assert set(AGE_GROUP_SLOTS) == {"child", "youth", "middle", "elder"}
 
 
+@pytest.mark.asyncio
+async def test_voice_media_capacity_is_held_until_cancelled_worker_finishes():
+    from novelvideo.seedance2_i2v import character_voice_storage
+
+    release_workers = threading.Event()
+    capacity_started = threading.Event()
+    lock = threading.Lock()
+    started_count = 0
+
+    def blocking_operation() -> None:
+        nonlocal started_count
+        with lock:
+            started_count += 1
+            if started_count == character_voice_storage._VOICE_MEDIA_CONCURRENCY:
+                capacity_started.set()
+        release_workers.wait(timeout=5)
+
+    tasks = [
+        asyncio.create_task(
+            character_voice_storage.run_voice_media_operation(blocking_operation)
+        )
+        for _ in range(character_voice_storage._VOICE_MEDIA_CONCURRENCY)
+    ]
+    third_task = None
+    try:
+        assert await asyncio.to_thread(capacity_started.wait, 1)
+        for task in tasks:
+            task.cancel()
+        await asyncio.sleep(0)
+        limiter = character_voice_storage._voice_media_limiter()
+        assert limiter.borrowed_tokens == character_voice_storage._VOICE_MEDIA_CONCURRENCY
+
+        third_task = asyncio.create_task(
+            character_voice_storage.run_voice_media_operation(blocking_operation)
+        )
+        for _ in range(20):
+            if limiter.statistics().tasks_waiting:
+                break
+            await asyncio.sleep(0)
+        assert limiter.statistics().tasks_waiting == 1
+        assert started_count == character_voice_storage._VOICE_MEDIA_CONCURRENCY
+    finally:
+        release_workers.set()
+        await asyncio.gather(*tasks, return_exceptions=True)
+        if third_task is not None:
+            await asyncio.gather(third_task, return_exceptions=True)
+
+
+@pytest.mark.asyncio
+async def test_voice_media_operation_preserves_anyio_cancel_scope_cancellation(monkeypatch):
+    import anyio
+
+    from novelvideo.seedance2_i2v import character_voice_storage
+
+    worker_started = threading.Event()
+    release_worker = threading.Event()
+    shield_calls = 0
+    real_shield = asyncio.shield
+
+    def tracking_shield(awaitable):
+        nonlocal shield_calls
+        shield_calls += 1
+        return real_shield(awaitable)
+
+    monkeypatch.setattr(character_voice_storage.asyncio, "shield", tracking_shield)
+
+    def blocking_operation() -> None:
+        worker_started.set()
+        release_worker.wait(timeout=5)
+
+    async def release_after_cancel() -> None:
+        assert await asyncio.to_thread(worker_started.wait, 1)
+        await asyncio.sleep(0.05)
+        release_worker.set()
+
+    releaser = asyncio.create_task(release_after_cancel())
+    try:
+        with anyio.move_on_after(0.01) as scope:
+            await character_voice_storage.run_voice_media_operation(blocking_operation)
+        assert scope.cancel_called
+        assert shield_calls == 2
+    finally:
+        release_worker.set()
+        await releaser
+
+
+@pytest.mark.asyncio
+async def test_cancelled_voice_worker_failure_is_not_hidden():
+    from novelvideo.seedance2_i2v import character_voice_storage
+
+    started = threading.Event()
+    release = threading.Event()
+
+    def failing_worker() -> None:
+        started.set()
+        release.wait(timeout=3)
+        raise RuntimeError("worker failed after cancellation")
+
+    task = asyncio.create_task(
+        character_voice_storage.run_voice_media_operation(failing_worker)
+    )
+    assert await asyncio.to_thread(started.wait, 1)
+    task.cancel("cancel-worker")
+    release.set()
+
+    with pytest.raises(RuntimeError, match="worker failed after cancellation"):
+        await task
+
+
+@pytest.mark.asyncio
+async def test_cancelled_voice_finalizer_failure_is_not_hidden():
+    from novelvideo.seedance2_i2v import character_voice_storage
+
+    finalize_started = asyncio.Event()
+    release_finalize = asyncio.Event()
+
+    async def failing_finalize(_result):
+        finalize_started.set()
+        await release_finalize.wait()
+        raise RuntimeError("finalize failed after cancellation")
+
+    task = asyncio.create_task(
+        character_voice_storage.run_voice_media_operation(
+            lambda: "published",
+            finalize=failing_finalize,
+        )
+    )
+    await asyncio.wait_for(finalize_started.wait(), 1)
+    task.cancel("cancel-finalize")
+    release_finalize.set()
+
+    with pytest.raises(RuntimeError, match="finalize failed after cancellation"):
+        await task
+
+
+@pytest.mark.asyncio
+async def test_voice_resource_lock_registry_releases_unused_locks():
+    from novelvideo.seedance2_i2v import character_voice_storage
+
+    key = ("gc-test", object())
+    lock = character_voice_storage.voice_resource_lock(key)
+    lock_ref = weakref.ref(lock)
+    registry = character_voice_storage._voice_resource_locks_var.get()
+    assert registry[key] is lock
+
+    del lock
+    gc.collect()
+
+    assert lock_ref() is None
+    assert key not in registry
+
+
+def test_voice_resource_lock_registry_is_isolated_between_async_runs():
+    from novelvideo.seedance2_i2v import character_voice_storage
+
+    async def registry_identity():
+        lock = character_voice_storage.voice_resource_lock(("loop", "isolated"))
+        assert lock is character_voice_storage.voice_resource_lock(("loop", "isolated"))
+        return character_voice_storage._voice_resource_locks_var.get()
+
+    first = asyncio.run(registry_identity())
+    second = asyncio.run(registry_identity())
+
+    assert first is not second
+
+
+@pytest.mark.asyncio
+async def test_cancelled_voice_resource_lock_waiter_never_starts_worker():
+    from novelvideo.seedance2_i2v import character_voice_storage
+
+    key = ("test-resource", "same")
+    worker_started = threading.Event()
+    lock = character_voice_storage.voice_resource_lock(key)
+
+    async def waiting_update() -> None:
+        async with character_voice_storage.voice_resource_lock(key):
+            await character_voice_storage.run_voice_media_operation(worker_started.set)
+
+    async with lock:
+        task = asyncio.create_task(waiting_update())
+        await asyncio.sleep(0)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+    assert not worker_started.is_set()
+
+
+@pytest.mark.asyncio
+async def test_distinct_character_voice_resources_can_run_in_parallel(tmp_path):
+    from novelvideo.seedance2_i2v import character_voice_storage
+
+    both_started = threading.Event()
+    release = threading.Event()
+    guard = threading.Lock()
+    started = 0
+
+    def blocking_worker() -> None:
+        nonlocal started
+        with guard:
+            started += 1
+            if started == 2:
+                both_started.set()
+        release.wait(timeout=3)
+
+    async def update(key: tuple[object, ...]) -> None:
+        async with character_voice_storage.voice_resource_lock(key):
+            await character_voice_storage.run_voice_media_operation(blocking_worker)
+
+    keys = [
+        character_voice_storage.character_voice_resource_key(
+            project_dir=tmp_path, character_name="秦", slot="default"
+        ),
+        character_voice_storage.character_voice_resource_key(
+            project_dir=tmp_path, character_name="楚", slot="youth"
+        ),
+    ]
+    tasks = [
+        asyncio.create_task(update(key))
+        for key in keys
+    ]
+    try:
+        assert await asyncio.to_thread(both_started.wait, 1)
+    finally:
+        release.set()
+        await asyncio.gather(*tasks)
+
+
+@pytest.mark.asyncio
+async def test_character_voice_resource_key_normalizes_path_name_and_slot(tmp_path):
+    from novelvideo.seedance2_i2v import character_voice_storage
+
+    first = character_voice_storage.character_voice_resource_key(
+        project_dir=tmp_path / ".",
+        character_name=" 王:小明 ",
+        slot=" YOUTH ",
+    )
+    second = character_voice_storage.character_voice_resource_key(
+        project_dir=tmp_path.resolve(),
+        character_name="王_小明",
+        slot="youth",
+    )
+
+    assert first == second
+    assert character_voice_storage.voice_resource_lock(
+        first
+    ) is character_voice_storage.voice_resource_lock(second)
+
+
 def test_probe_voice_sample_duration_times_out_as_value_error(monkeypatch, tmp_path):
     """ffprobe 卡住必须限时并转成 ValueError。
 
@@ -150,6 +403,53 @@ def test_probe_voice_sample_duration_times_out_as_value_error(monkeypatch, tmp_p
     with pytest.raises(ValueError, match="超时"):
         character_voice_storage.probe_voice_sample_duration_seconds(sample)
     assert seen["timeout"] == character_voice_storage.PROBE_DURATION_TIMEOUT_SECONDS
+
+
+def test_trim_voice_sample_content_times_out_as_value_error(monkeypatch):
+    import shutil
+    import subprocess
+
+    from novelvideo.seedance2_i2v import character_voice_storage
+
+    monkeypatch.setattr(shutil, "which", lambda _name: "/usr/bin/ffmpeg")
+    seen: dict[str, object] = {}
+
+    def fake_run(cmd, **kwargs):
+        seen.update(kwargs)
+        raise subprocess.TimeoutExpired(cmd, kwargs["timeout"])
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    with pytest.raises(ValueError, match="裁剪超时"):
+        character_voice_storage.trim_voice_sample_content(
+            b"audio",
+            filename="sample.wav",
+        )
+    assert seen["timeout"] == character_voice_storage.FFMPEG_TIMEOUT_SECONDS
+
+
+def test_recording_transcode_times_out_as_value_error(monkeypatch):
+    import base64
+    import shutil
+    import subprocess
+
+    from novelvideo.seedance2_i2v import character_voice_storage
+
+    monkeypatch.setattr(shutil, "which", lambda _name: "/usr/bin/ffmpeg")
+    seen: dict[str, object] = {}
+
+    def fake_run(cmd, **kwargs):
+        seen.update(kwargs)
+        raise subprocess.TimeoutExpired(cmd, kwargs["timeout"])
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    payload = base64.b64encode(b"webm-audio").decode("ascii")
+
+    with pytest.raises(ValueError, match="转码超时"):
+        character_voice_storage.decode_recorded_audio_data_url(
+            f"data:audio/webm;base64,{payload}"
+        )
+    assert seen["timeout"] == character_voice_storage.FFMPEG_TIMEOUT_SECONDS
 
 
 def test_trim_voice_sample_content_outputs_seedance2_ready_clip(tmp_path):

--- a/tests/test_org_scoped_narrator_voice.py
+++ b/tests/test_org_scoped_narrator_voice.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+import threading
 from types import SimpleNamespace
 
 import pytest
@@ -273,11 +274,14 @@ async def test_seedance2_narrator_trim_writes_only_store_state_dir(
     source = project_dir / "audio" / "source.wav"
     source.parent.mkdir(parents=True, exist_ok=True)
     source.write_bytes(b"source")
-    monkeypatch.setattr(
-        panel_service,
-        "trim_voice_sample_content",
-        lambda *_args, **_kwargs: (b"trimmed", "voice.mp3"),
-    )
+    event_loop_thread_id = threading.get_ident()
+    worker_thread_ids: list[int] = []
+
+    def fake_trim(*_args, **_kwargs):
+        worker_thread_ids.append(threading.get_ident())
+        return b"trimmed", "voice.mp3"
+
+    monkeypatch.setattr(panel_service, "trim_voice_sample_content", fake_trim)
     monkeypatch.setattr(project_config, "OUTPUT_DIR", state_root)
     store = SimpleNamespace(state_dir=str(state_dir))
 
@@ -291,6 +295,8 @@ async def test_seedance2_narrator_trim_writes_only_store_state_dir(
     )
 
     assert target is not None
+    assert worker_thread_ids
+    assert event_loop_thread_id not in worker_thread_ids
     assert project_config.load_narrator_reference_audio_from_state_dir(state_dir)["path"]
     assert not (state_root / "alice" / "demo" / "project_config.json").exists()
 

--- a/tests/test_seedance2_assets.py
+++ b/tests/test_seedance2_assets.py
@@ -765,10 +765,10 @@ async def test_crop_seedance2_asset_to_first_frame_writes_video_input_override(
     source = paths.frame(2)
     _write_png(source)
 
-    async def fake_crop_image_to_path(_source, *, output_path, **_kwargs):
+    def fake_crop_image_to_path(_source, *, output_path, **_kwargs):
         _write_png(Path(output_path), width=720, height=1280)
 
-    monkeypatch.setattr(panel_service, "crop_image_to_path", fake_crop_image_to_path)
+    monkeypatch.setattr(panel_service, "_crop_image_to_path_sync", fake_crop_image_to_path)
     monkeypatch.setattr(panel_service, "validate_seedance2_reference_image", lambda _path: "")
 
     class Store:

--- a/tests/test_seedance2_panel_voice_offload.py
+++ b/tests/test_seedance2_panel_voice_offload.py
@@ -1,0 +1,957 @@
+from __future__ import annotations
+
+import asyncio
+import io
+import json
+import threading
+from pathlib import Path
+
+import pytest
+from fastapi import UploadFile
+
+
+class RecordingStore:
+    def __init__(self) -> None:
+        self.calls: list[dict] = []
+        self.thread_ids: list[int] = []
+
+    async def update_beat_asset(self, **kwargs) -> None:
+        self.thread_ids.append(threading.get_ident())
+        self.calls.append(kwargs)
+
+
+@pytest.mark.asyncio
+async def test_seedance2_route_reads_in_memory_upload_in_voice_worker(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    from novelvideo.api.routes import generation
+    from novelvideo.seedance2_i2v import character_voice_storage
+
+    loop_thread = threading.get_ident()
+    read_threads: list[int] = []
+    borrowed_tokens: list[int] = []
+    voice_limiter = character_voice_storage._voice_media_limiter()
+
+    class RecordingBytesIO(io.BytesIO):
+        def read(self, *args, **kwargs):
+            read_threads.append(threading.get_ident())
+            borrowed_tokens.append(voice_limiter.borrowed_tokens)
+            return super().read(*args, **kwargs)
+
+    store = RecordingStore()
+    beat = {"beat_number": 2, "seedance2_config_json": "{}"}
+
+    async def panel_context(**_kwargs):
+        return {"store": store, "beat": beat, "output_dir": tmp_path}
+
+    monkeypatch.setattr(generation, "_seedance2_panel_context", panel_context)
+    monkeypatch.setattr(
+        generation,
+        "_seedance2_status_response",
+        lambda **_kwargs: {"ok": True},
+    )
+    upload = UploadFile(
+        filename="voice.wav",
+        file=RecordingBytesIO(b"seedance-voice"),
+        headers={"content-type": "audio/wav"},
+    )
+
+    response = await generation.upload_seedance2_asset(
+        project="demo",
+        episode_num=1,
+        beat_num=2,
+        file=upload,
+        user={"username": "admin"},
+    )
+
+    assert response == {"ok": True}
+    assert read_threads and loop_thread not in read_threads
+    assert borrowed_tokens == [1]
+    targets = list((tmp_path / "seedance2_uploads").rglob("voice.wav"))
+    assert len(targets) == 1 and targets[0].read_bytes() == b"seedance-voice"
+
+
+@pytest.mark.asyncio
+async def test_seedance2_upload_file_and_config_prepare_run_in_voice_worker(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    from novelvideo.seedance2_i2v import panel_service
+
+    loop_thread = threading.get_ident()
+    worker_threads: list[int] = []
+    helper_threads: list[int] = []
+    real_prepare = panel_service._prepare_seedance2_uploaded_asset
+    real_mkdir = Path.mkdir
+    real_write = Path.write_bytes
+    real_read = Path.read_bytes
+    real_parse = panel_service.parse_seedance2_config
+    real_dump = panel_service.dump_seedance2_config
+
+    def tracking_prepare(**kwargs):
+        worker_threads.append(threading.get_ident())
+        return real_prepare(**kwargs)
+
+    def tracking_mkdir(path, *args, **kwargs):
+        if str(path).startswith(str(tmp_path)):
+            helper_threads.append(threading.get_ident())
+        return real_mkdir(path, *args, **kwargs)
+
+    def tracking_write(path, content):
+        if str(path).startswith(str(tmp_path)):
+            helper_threads.append(threading.get_ident())
+        return real_write(path, content)
+
+    def tracking_parse(value):
+        helper_threads.append(threading.get_ident())
+        return real_parse(value)
+
+    def tracking_dump(value):
+        helper_threads.append(threading.get_ident())
+        return real_dump(value)
+
+    monkeypatch.setattr(
+        panel_service, "_prepare_seedance2_uploaded_asset", tracking_prepare
+    )
+    monkeypatch.setattr(Path, "mkdir", tracking_mkdir)
+    monkeypatch.setattr(Path, "write_bytes", tracking_write)
+    monkeypatch.setattr(panel_service, "parse_seedance2_config", tracking_parse)
+    monkeypatch.setattr(panel_service, "dump_seedance2_config", tracking_dump)
+    store = RecordingStore()
+    beat = {"beat_number": 2, "seedance2_config_json": "{}"}
+
+    target = await panel_service.save_seedance2_uploaded_asset(
+        store=store,
+        episode=1,
+        beat=beat,
+        project_dir=tmp_path,
+        filename="voice.wav",
+        content=b"voice",
+        content_type="audio/wav",
+    )
+
+    assert target is not None and real_read(target) == b"voice"
+    assert worker_threads and loop_thread not in worker_threads
+    assert helper_threads and set(helper_threads) == set(worker_threads)
+    assert store.thread_ids == [loop_thread]
+    assert store.calls[0]["seedance2_config_json"] == beat["seedance2_config_json"]
+
+
+@pytest.mark.asyncio
+async def test_seedance2_trim_read_publish_and_config_prepare_run_in_voice_worker(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    from novelvideo.seedance2_i2v import panel_service
+
+    source = tmp_path / "audio" / "source.wav"
+    source.parent.mkdir(parents=True)
+    source.write_bytes(b"source")
+    loop_thread = threading.get_ident()
+    worker_threads: list[int] = []
+    helper_threads: list[int] = []
+    real_prepare = panel_service._prepare_trimmed_seedance2_audio
+    real_exists = Path.exists
+    real_is_file = Path.is_file
+    real_read = Path.read_bytes
+    real_mkdir = Path.mkdir
+    real_write = Path.write_bytes
+    real_parse = panel_service.parse_seedance2_config
+    real_dump = panel_service.dump_seedance2_config
+
+    def tracking_prepare(**kwargs):
+        worker_threads.append(threading.get_ident())
+        return real_prepare(**kwargs)
+
+    def track_call(operation):
+        def tracking(path, *args, **kwargs):
+            if str(path).startswith(str(tmp_path)):
+                helper_threads.append(threading.get_ident())
+            return operation(path, *args, **kwargs)
+
+        return tracking
+
+    def tracking_parse(value):
+        helper_threads.append(threading.get_ident())
+        return real_parse(value)
+
+    def tracking_dump(value):
+        helper_threads.append(threading.get_ident())
+        return real_dump(value)
+
+    monkeypatch.setattr(
+        panel_service, "_prepare_trimmed_seedance2_audio", tracking_prepare
+    )
+    monkeypatch.setattr(Path, "exists", track_call(real_exists))
+    monkeypatch.setattr(Path, "is_file", track_call(real_is_file))
+    monkeypatch.setattr(Path, "read_bytes", track_call(real_read))
+    monkeypatch.setattr(Path, "mkdir", track_call(real_mkdir))
+    monkeypatch.setattr(Path, "write_bytes", track_call(real_write))
+    monkeypatch.setattr(panel_service, "parse_seedance2_config", tracking_parse)
+    monkeypatch.setattr(panel_service, "dump_seedance2_config", tracking_dump)
+    monkeypatch.setattr(
+        panel_service,
+        "trim_voice_sample_content",
+        lambda content, **_kwargs: (content + b"-trimmed", "voice.mp3"),
+    )
+    store = RecordingStore()
+    beat = {"beat_number": 3, "seedance2_config_json": "{}"}
+
+    target = await panel_service.trim_seedance2_audio_to_reference(
+        store=store,
+        episode=1,
+        beat=beat,
+        project_dir=tmp_path,
+        asset_key="reference:audio",
+        source_path=source,
+    )
+
+    assert target is not None and real_read(target) == b"source-trimmed"
+    assert worker_threads and loop_thread not in worker_threads
+    assert helper_threads and set(helper_threads) == set(worker_threads)
+    assert store.thread_ids == [loop_thread]
+    assert store.calls[0]["seedance2_config_json"] == beat["seedance2_config_json"]
+
+
+@pytest.mark.asyncio
+async def test_seedance2_upload_cancellation_finishes_file_and_metadata(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    from novelvideo.seedance2_i2v import panel_service
+
+    metadata_started = asyncio.Event()
+    release_metadata = asyncio.Event()
+
+    class BlockingStore(RecordingStore):
+        async def update_beat_asset(self, **kwargs) -> None:
+            metadata_started.set()
+            await release_metadata.wait()
+            await super().update_beat_asset(**kwargs)
+
+    store = BlockingStore()
+    beat = {"beat_number": 1, "seedance2_config_json": "{}"}
+    task = asyncio.create_task(
+        panel_service.save_seedance2_uploaded_asset(
+            store=store,
+            episode=1,
+            beat=beat,
+            project_dir=tmp_path,
+            filename="voice.wav",
+            content=b"voice",
+            content_type="audio/wav",
+        )
+    )
+    await asyncio.wait_for(metadata_started.wait(), 1)
+    task.cancel()
+    task.cancel()
+    release_metadata.set()
+
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    targets = list((tmp_path / "seedance2_uploads").rglob("voice.wav"))
+    assert len(targets) == 1 and targets[0].read_bytes() == b"voice"
+    assert store.calls
+    assert beat["seedance2_config_json"] == store.calls[0]["seedance2_config_json"]
+
+
+@pytest.mark.asyncio
+async def test_seedance2_upload_preserves_anyio_cancel_marker_through_finalize(
+    tmp_path: Path,
+) -> None:
+    import anyio
+
+    from novelvideo.seedance2_i2v import panel_service
+
+    metadata_started = asyncio.Event()
+    release_metadata = threading.Event()
+
+    class BlockingStore(RecordingStore):
+        async def update_beat_asset(self, **kwargs) -> None:
+            metadata_started.set()
+            await asyncio.to_thread(release_metadata.wait, 2)
+            await super().update_beat_asset(**kwargs)
+
+    store = BlockingStore()
+    beat = {"beat_number": 1, "seedance2_config_json": "{}"}
+
+    async def release_after_finalize_starts() -> None:
+        await metadata_started.wait()
+        await asyncio.sleep(0.03)
+        release_metadata.set()
+
+    releaser = asyncio.create_task(release_after_finalize_starts())
+    try:
+        with anyio.move_on_after(0.01) as scope:
+            await panel_service.save_seedance2_uploaded_asset(
+                store=store,
+                episode=1,
+                beat=beat,
+                project_dir=tmp_path,
+                filename="voice.wav",
+                content=b"voice",
+                content_type="audio/wav",
+            )
+        assert scope.cancel_called
+        assert store.calls
+        assert beat["seedance2_config_json"] == store.calls[0]["seedance2_config_json"]
+    finally:
+        release_metadata.set()
+        await releaser
+
+
+@pytest.mark.asyncio
+async def test_seedance2_same_name_uploads_are_serialized_without_lost_metadata(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    from novelvideo.seedance2_i2v import panel_service
+
+    first_write_started = threading.Event()
+    release_first_write = threading.Event()
+    selected_names: list[str] = []
+    real_next = panel_service._next_available_upload_path
+    real_write = Path.write_bytes
+
+    def tracking_next(upload_dir, filename):
+        target = real_next(upload_dir, filename)
+        selected_names.append(target.name)
+        return target
+
+    def controlled_write(path, content):
+        if path.name == "voice.wav" and not first_write_started.is_set():
+            first_write_started.set()
+            release_first_write.wait(timeout=3)
+        return real_write(path, content)
+
+    monkeypatch.setattr(panel_service, "_next_available_upload_path", tracking_next)
+    monkeypatch.setattr(Path, "write_bytes", controlled_write)
+    store = RecordingStore()
+    beat = {"beat_number": 1, "seedance2_config_json": "{}"}
+
+    first = asyncio.create_task(
+        panel_service.save_seedance2_uploaded_asset(
+            store=store,
+            episode=1,
+            beat=beat,
+            project_dir=tmp_path,
+            filename="voice.wav",
+            content=b"first",
+            content_type="audio/wav",
+        )
+    )
+    assert await asyncio.to_thread(first_write_started.wait, 1)
+    second = asyncio.create_task(
+        panel_service.save_seedance2_uploaded_asset(
+            store=store,
+            episode=1,
+            beat=beat,
+            project_dir=tmp_path,
+            filename="voice.wav",
+            content=b"second",
+            content_type="audio/wav",
+        )
+    )
+    await asyncio.sleep(0)
+    assert selected_names == ["voice.wav"]
+    release_first_write.set()
+    first_target, second_target = await asyncio.gather(first, second)
+
+    assert first_target is not None and first_target.read_bytes() == b"first"
+    assert second_target is not None and second_target.read_bytes() == b"second"
+    assert selected_names == ["voice.wav", "voice_1.wav"]
+    paths = json.loads(beat["seedance2_config_json"])["reference_audio_paths"]
+    assert paths == [str(first_target), str(second_target)]
+    assert len(store.calls) == 2
+    assert store.calls[-1]["seedance2_config_json"] == beat["seedance2_config_json"]
+
+
+@pytest.mark.asyncio
+async def test_seedance2_upload_then_delete_share_lock_without_resurrection(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    from novelvideo.seedance2_i2v import panel_service
+
+    write_started = threading.Event()
+    release_write = threading.Event()
+    real_write = Path.write_bytes
+
+    def blocking_write(path, content):
+        if path.name == "voice.wav":
+            write_started.set()
+            release_write.wait(timeout=3)
+        return real_write(path, content)
+
+    monkeypatch.setattr(Path, "write_bytes", blocking_write)
+    store = RecordingStore()
+    beat = {"beat_number": 1, "seedance2_config_json": "{}"}
+    target = tmp_path / "seedance2_uploads/ep001/beat_01/audios/voice.wav"
+    upload = asyncio.create_task(
+        panel_service.save_seedance2_uploaded_asset(
+            store=store,
+            episode=1,
+            beat=beat,
+            project_dir=tmp_path,
+            filename="voice.wav",
+            content=b"voice",
+            content_type="audio/wav",
+        )
+    )
+    assert await asyncio.to_thread(write_started.wait, 1)
+    delete = asyncio.create_task(
+        panel_service.remove_seedance2_uploaded_asset(
+            store=store,
+            episode=1,
+            beat=beat,
+            project_dir=tmp_path,
+            media_kind="audios",
+            path=str(target),
+        )
+    )
+    await asyncio.sleep(0)
+    assert not delete.done()
+    release_write.set()
+
+    _, removed = await asyncio.gather(upload, delete)
+    assert removed is True
+    assert not target.exists()
+    paths = json.loads(beat["seedance2_config_json"])["reference_audio_paths"]
+    assert str(target) not in paths
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("mutation", ["config", "template"])
+async def test_seedance2_panel_mutations_wait_for_media_and_preserve_both_changes(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, mutation: str
+) -> None:
+    from novelvideo.seedance2_i2v import panel_service
+
+    write_started = threading.Event()
+    release_write = threading.Event()
+    mutation_parse_started = threading.Event()
+    real_write = Path.write_bytes
+    real_parse = panel_service.parse_seedance2_config
+
+    def blocking_write(path, content):
+        if path.name == "reference.png":
+            write_started.set()
+            release_write.wait(timeout=3)
+        return real_write(path, content)
+
+    def tracking_parse(value):
+        if write_started.is_set() and not release_write.is_set():
+            mutation_parse_started.set()
+        return real_parse(value)
+
+    monkeypatch.setattr(Path, "write_bytes", blocking_write)
+    monkeypatch.setattr(panel_service, "parse_seedance2_config", tracking_parse)
+    store = RecordingStore()
+    beat = {"beat_number": 1, "seedance2_config_json": "{}"}
+    upload = asyncio.create_task(
+        panel_service.save_seedance2_uploaded_asset(
+            store=store,
+            episode=1,
+            beat=beat,
+            project_dir=tmp_path,
+            filename="reference.png",
+            content=b"image",
+            content_type="image/png",
+        )
+    )
+    assert await asyncio.to_thread(write_started.wait, 1)
+
+    if mutation == "config":
+        update = asyncio.create_task(
+            panel_service.save_seedance2_video_panel_config(
+                store=store,
+                state_dir=tmp_path / "state",
+                episode=1,
+                beat=beat,
+                project_dir=tmp_path,
+                duration=8,
+            )
+        )
+    else:
+        update = asyncio.create_task(
+            panel_service.append_seedance2_prompt_guidance_template(
+                store=store,
+                episode=1,
+                beat=beat,
+                project_dir=tmp_path,
+                label="无字幕",
+            )
+        )
+    await asyncio.sleep(0)
+    assert not mutation_parse_started.is_set()
+    assert not update.done()
+    release_write.set()
+    upload_target, _ = await asyncio.gather(upload, update)
+
+    assert upload_target is not None
+    config = json.loads(beat["seedance2_config_json"])
+    assert config["reference_image_paths"] == [str(upload_target)]
+    if mutation == "config":
+        assert config["duration"] == 8
+    else:
+        assert "无字幕：" in config["prompt_guidance"]
+    assert store.calls[-1]["seedance2_config_json"] == beat["seedance2_config_json"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("mutation", ["config", "template"])
+async def test_cancelled_seedance2_panel_mutation_waiter_does_not_write(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, mutation: str
+) -> None:
+    from novelvideo.seedance2_i2v import panel_service
+    from novelvideo.seedance2_i2v.character_voice_storage import (
+        seedance2_asset_resource_key,
+        voice_resource_lock,
+    )
+
+    parse_started = threading.Event()
+    real_parse = panel_service.parse_seedance2_config
+
+    def tracking_parse(value):
+        parse_started.set()
+        return real_parse(value)
+
+    monkeypatch.setattr(panel_service, "parse_seedance2_config", tracking_parse)
+    store = RecordingStore()
+    initial = json.dumps({"duration": 4})
+    beat = {"beat_number": 1, "seedance2_config_json": initial}
+    key = seedance2_asset_resource_key(
+        project_dir=tmp_path, episode=1, beat_number=1
+    )
+    async with voice_resource_lock(key):
+        if mutation == "config":
+            task = asyncio.create_task(
+                panel_service.save_seedance2_video_panel_config(
+                    store=store,
+                    state_dir=tmp_path / "state",
+                    episode=1,
+                    beat=beat,
+                    project_dir=tmp_path,
+                    duration=8,
+                )
+            )
+        else:
+            task = asyncio.create_task(
+                panel_service.append_seedance2_prompt_guidance_template(
+                    store=store,
+                    episode=1,
+                    beat=beat,
+                    project_dir=tmp_path,
+                    label="无字幕",
+                )
+            )
+        await asyncio.sleep(0)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+    assert not parse_started.is_set()
+    assert beat["seedance2_config_json"] == initial
+    assert store.calls == []
+
+
+@pytest.mark.asyncio
+async def test_seedance2_panel_config_different_beats_do_not_share_resource_lock(
+    tmp_path: Path,
+) -> None:
+    from novelvideo.seedance2_i2v import panel_service
+    from novelvideo.seedance2_i2v.character_voice_storage import (
+        seedance2_asset_resource_key,
+        voice_resource_lock,
+    )
+
+    store = RecordingStore()
+    beat = {"beat_number": 2, "seedance2_config_json": "{}"}
+    held_key = seedance2_asset_resource_key(
+        project_dir=tmp_path, episode=1, beat_number=1
+    )
+    async with voice_resource_lock(held_key):
+        await asyncio.wait_for(
+            panel_service.save_seedance2_video_panel_config(
+                store=store,
+                state_dir=tmp_path / "state",
+                episode=1,
+                beat=beat,
+                project_dir=tmp_path,
+                duration=8,
+            ),
+            timeout=1,
+        )
+
+    assert json.loads(beat["seedance2_config_json"])["duration"] == 8
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("mutation", ["config", "template"])
+async def test_seedance2_panel_mutation_parse_and_dump_run_in_voice_worker(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, mutation: str
+) -> None:
+    from novelvideo.seedance2_i2v import panel_service
+
+    loop_thread = threading.get_ident()
+    helper_threads: list[int] = []
+    real_parse = panel_service.parse_seedance2_config
+    real_dump = panel_service.dump_seedance2_config
+
+    def tracking_parse(value):
+        helper_threads.append(threading.get_ident())
+        return real_parse(value)
+
+    def tracking_dump(value):
+        helper_threads.append(threading.get_ident())
+        return real_dump(value)
+
+    monkeypatch.setattr(panel_service, "parse_seedance2_config", tracking_parse)
+    monkeypatch.setattr(panel_service, "dump_seedance2_config", tracking_dump)
+    store = RecordingStore()
+    beat = {"beat_number": 1, "seedance2_config_json": "{}"}
+
+    if mutation == "config":
+        await panel_service.save_seedance2_video_panel_config(
+            store=store,
+            state_dir=tmp_path / "state",
+            episode=1,
+            beat=beat,
+            project_dir=tmp_path,
+            duration=8,
+        )
+    else:
+        await panel_service.append_seedance2_prompt_guidance_template(
+            store=store,
+            episode=1,
+            beat=beat,
+            project_dir=tmp_path,
+            label="无字幕",
+        )
+
+    assert helper_threads
+    assert loop_thread not in helper_threads
+
+
+@pytest.mark.asyncio
+async def test_seedance2_trim_then_delete_share_lock_without_resurrection(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    from novelvideo.seedance2_i2v import panel_service
+
+    source = tmp_path / "audio/source.wav"
+    source.parent.mkdir(parents=True)
+    source.write_bytes(b"source")
+    trim_started = threading.Event()
+    release_trim = threading.Event()
+
+    def blocking_trim(content, **_kwargs):
+        trim_started.set()
+        release_trim.wait(timeout=3)
+        return content + b"-trimmed", "voice.mp3"
+
+    monkeypatch.setattr(panel_service, "trim_voice_sample_content", blocking_trim)
+    store = RecordingStore()
+    beat = {"beat_number": 1, "seedance2_config_json": "{}"}
+    target = tmp_path / "seedance2_crops/ep001/beat_01/reference_audio_trimmed.mp3"
+    trim = asyncio.create_task(
+        panel_service.trim_seedance2_audio_to_reference(
+            store=store,
+            episode=1,
+            beat=beat,
+            project_dir=tmp_path,
+            asset_key="reference:audio",
+            source_path=source,
+        )
+    )
+    assert await asyncio.to_thread(trim_started.wait, 1)
+    delete = asyncio.create_task(
+        panel_service.remove_seedance2_uploaded_asset(
+            store=store,
+            episode=1,
+            beat=beat,
+            project_dir=tmp_path,
+            media_kind="audios",
+            path=str(target),
+        )
+    )
+    await asyncio.sleep(0)
+    assert not delete.done()
+    release_trim.set()
+
+    _, removed = await asyncio.gather(trim, delete)
+    assert removed is True
+    assert not target.exists()
+    paths = json.loads(beat["seedance2_config_json"])["reference_audio_paths"]
+    assert str(target) not in paths
+
+
+@pytest.mark.asyncio
+async def test_seedance2_crop_then_upload_share_lock_without_lost_paths(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    from PIL import Image
+
+    from novelvideo.seedance2_i2v import panel_service
+
+    source = tmp_path / "source.png"
+    Image.new("RGB", (8, 8), "red").save(source)
+    crop_started = threading.Event()
+    release_crop = threading.Event()
+    upload_worker_started = threading.Event()
+    real_crop = panel_service._crop_image_to_path_sync
+    real_prepare_upload = panel_service._prepare_seedance2_uploaded_asset
+
+    def blocking_crop(*args, **kwargs):
+        crop_started.set()
+        release_crop.wait(timeout=3)
+        return real_crop(*args, **kwargs)
+
+    def tracking_upload(**kwargs):
+        upload_worker_started.set()
+        return real_prepare_upload(**kwargs)
+
+    monkeypatch.setattr(panel_service, "_crop_image_to_path_sync", blocking_crop)
+    monkeypatch.setattr(
+        panel_service, "validate_seedance2_reference_image", lambda _path: ""
+    )
+    monkeypatch.setattr(
+        panel_service, "_prepare_seedance2_uploaded_asset", tracking_upload
+    )
+    store = RecordingStore()
+    beat = {"beat_number": 1, "seedance2_config_json": "{}"}
+    crop = asyncio.create_task(
+        panel_service.crop_seedance2_asset_to_reference(
+            store=store,
+            episode=1,
+            beat=beat,
+            project_dir=tmp_path,
+            asset_key="manual:crop",
+            source_path=source,
+            crop_data={"x": 0, "y": 0, "width": 4, "height": 4},
+        )
+    )
+    assert await asyncio.to_thread(crop_started.wait, 1)
+    upload = asyncio.create_task(
+        panel_service.save_seedance2_uploaded_asset(
+            store=store,
+            episode=1,
+            beat=beat,
+            project_dir=tmp_path,
+            filename="upload.png",
+            content=source.read_bytes(),
+            content_type="image/png",
+        )
+    )
+    await asyncio.sleep(0)
+    assert not upload_worker_started.is_set()
+    release_crop.set()
+    crop_target, upload_target = await asyncio.gather(crop, upload)
+
+    assert crop_target is not None and upload_target is not None
+    paths = json.loads(beat["seedance2_config_json"])["reference_image_paths"]
+    assert paths == [str(crop_target), str(upload_target)]
+    assert len(store.calls) == 2
+
+
+@pytest.mark.asyncio
+async def test_seedance2_remove_double_cancel_finishes_file_and_metadata(
+    tmp_path: Path,
+) -> None:
+    from novelvideo.seedance2_i2v import panel_service
+
+    target = tmp_path / "seedance2_uploads/ep001/beat_01/audios/voice.wav"
+    target.parent.mkdir(parents=True)
+    target.write_bytes(b"voice")
+    initial = json.dumps({"reference_audio_paths": [str(target)]})
+    beat = {"beat_number": 1, "seedance2_config_json": initial}
+    metadata_started = asyncio.Event()
+    release_metadata = asyncio.Event()
+
+    class BlockingStore(RecordingStore):
+        async def update_beat_asset(self, **kwargs) -> None:
+            metadata_started.set()
+            await release_metadata.wait()
+            await super().update_beat_asset(**kwargs)
+
+    store = BlockingStore()
+    task = asyncio.create_task(
+        panel_service.remove_seedance2_uploaded_asset(
+            store=store,
+            episode=1,
+            beat=beat,
+            project_dir=tmp_path,
+            media_kind="audios",
+            path=str(target),
+        )
+    )
+    await asyncio.wait_for(metadata_started.wait(), 1)
+    task.cancel()
+    task.cancel()
+    release_metadata.set()
+
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    assert not target.exists()
+    assert str(target) not in json.loads(beat["seedance2_config_json"])[
+        "reference_audio_paths"
+    ]
+    assert store.calls[-1]["seedance2_config_json"] == beat["seedance2_config_json"]
+
+
+@pytest.mark.asyncio
+async def test_seedance2_crop_anyio_cancel_finishes_file_and_metadata(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    import anyio
+    from PIL import Image
+
+    from novelvideo.seedance2_i2v import panel_service
+
+    source = tmp_path / "source.png"
+    Image.new("RGB", (8, 8), "red").save(source)
+    monkeypatch.setattr(
+        panel_service, "validate_seedance2_reference_image", lambda _path: ""
+    )
+    metadata_started = asyncio.Event()
+    release_metadata = threading.Event()
+
+    class BlockingStore(RecordingStore):
+        async def update_beat_asset(self, **kwargs) -> None:
+            metadata_started.set()
+            await asyncio.to_thread(release_metadata.wait, 2)
+            await super().update_beat_asset(**kwargs)
+
+    store = BlockingStore()
+    beat = {"beat_number": 1, "seedance2_config_json": "{}"}
+
+    async def release_after_metadata() -> None:
+        await metadata_started.wait()
+        await asyncio.sleep(0.03)
+        release_metadata.set()
+
+    releaser = asyncio.create_task(release_after_metadata())
+    try:
+        with anyio.move_on_after(0.01) as scope:
+            await panel_service.crop_seedance2_asset_to_reference(
+                store=store,
+                episode=1,
+                beat=beat,
+                project_dir=tmp_path,
+                asset_key="manual:crop",
+                source_path=source,
+                crop_data={"x": 0, "y": 0, "width": 4, "height": 4},
+            )
+        assert scope.cancel_called
+        paths = json.loads(beat["seedance2_config_json"])["reference_image_paths"]
+        assert len(paths) == 1 and Path(paths[0]).exists()
+        assert store.calls[-1]["seedance2_config_json"] == beat["seedance2_config_json"]
+    finally:
+        release_metadata.set()
+        await releaser
+
+
+@pytest.mark.asyncio
+async def test_cancelled_crop_lock_waiter_does_not_touch_source(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    from novelvideo.seedance2_i2v import panel_service
+    from novelvideo.seedance2_i2v.character_voice_storage import (
+        seedance2_asset_resource_key,
+        voice_resource_lock,
+    )
+
+    prepare_started = threading.Event()
+    monkeypatch.setattr(
+        panel_service,
+        "_prepare_cropped_seedance2_asset",
+        lambda **_kwargs: prepare_started.set(),
+    )
+    beat = {"beat_number": 1, "seedance2_config_json": "{}"}
+    key = seedance2_asset_resource_key(
+        project_dir=tmp_path, episode=1, beat_number=1
+    )
+    async with voice_resource_lock(key):
+        task = asyncio.create_task(
+            panel_service.crop_seedance2_asset_to_reference(
+                store=RecordingStore(),
+                episode=1,
+                beat=beat,
+                project_dir=tmp_path,
+                asset_key="manual:crop",
+                source_path=tmp_path / "missing.png",
+                crop_data={"x": 0, "y": 0, "width": 4, "height": 4},
+            )
+        )
+        await asyncio.sleep(0)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+    assert not prepare_started.is_set()
+
+
+@pytest.mark.asyncio
+async def test_seedance2_crop_and_remove_blocking_helpers_run_in_voice_worker(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    from PIL import Image
+
+    from novelvideo.seedance2_i2v import panel_service
+
+    source = tmp_path / "source.png"
+    Image.new("RGB", (8, 8), "red").save(source)
+    loop_thread = threading.get_ident()
+    crop_helper_threads: list[int] = []
+    remove_helper_threads: list[int] = []
+    real_open = Image.open
+    real_parse = panel_service.parse_seedance2_config
+    real_dump = panel_service.dump_seedance2_config
+    real_unlink = panel_service._seedance2_unlink_user_reference_file
+
+    def tracking_open(*args, **kwargs):
+        crop_helper_threads.append(threading.get_ident())
+        return real_open(*args, **kwargs)
+
+    def tracking_parse(value):
+        target = crop_helper_threads if not crop_helper_threads else remove_helper_threads
+        target.append(threading.get_ident())
+        return real_parse(value)
+
+    def tracking_dump(value):
+        target = crop_helper_threads if not remove_helper_threads else remove_helper_threads
+        target.append(threading.get_ident())
+        return real_dump(value)
+
+    monkeypatch.setattr(Image, "open", tracking_open)
+    monkeypatch.setattr(panel_service, "parse_seedance2_config", tracking_parse)
+    monkeypatch.setattr(panel_service, "dump_seedance2_config", tracking_dump)
+    monkeypatch.setattr(
+        panel_service, "validate_seedance2_reference_image", lambda _path: ""
+    )
+    store = RecordingStore()
+    beat = {"beat_number": 1, "seedance2_config_json": "{}"}
+    crop_target = await panel_service.crop_seedance2_asset_to_reference(
+        store=store,
+        episode=1,
+        beat=beat,
+        project_dir=tmp_path,
+        asset_key="manual:crop",
+        source_path=source,
+        crop_data={"x": 0, "y": 0, "width": 4, "height": 4},
+    )
+    assert crop_target is not None
+
+    def tracking_unlink(path):
+        remove_helper_threads.append(threading.get_ident())
+        return real_unlink(path)
+
+    monkeypatch.setattr(
+        panel_service, "_seedance2_unlink_user_reference_file", tracking_unlink
+    )
+    removed = await panel_service.remove_seedance2_uploaded_asset(
+        store=store,
+        episode=1,
+        beat=beat,
+        project_dir=tmp_path,
+        media_kind="images",
+        path=str(crop_target),
+    )
+
+    assert removed
+    assert crop_helper_threads and loop_thread not in crop_helper_threads
+    assert remove_helper_threads and loop_thread not in remove_helper_threads

--- a/tests/test_seedance2_panel_voice_offload.py
+++ b/tests/test_seedance2_panel_voice_offload.py
@@ -21,21 +21,24 @@ class RecordingStore:
 
 
 @pytest.mark.asyncio
-async def test_seedance2_route_reads_in_memory_upload_in_voice_worker(
+async def test_seedance2_route_reads_in_memory_upload_in_asset_worker(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     from novelvideo.api.routes import generation
-    from novelvideo.seedance2_i2v import character_voice_storage
+    from novelvideo.seedance2_i2v import character_voice_storage, panel_service
 
     loop_thread = threading.get_ident()
     read_threads: list[int] = []
-    borrowed_tokens: list[int] = []
+    borrowed_tokens: list[tuple[int, int]] = []
     voice_limiter = character_voice_storage._voice_media_limiter()
+    asset_limiter = panel_service._seedance2_asset_limiter()
 
     class RecordingBytesIO(io.BytesIO):
         def read(self, *args, **kwargs):
             read_threads.append(threading.get_ident())
-            borrowed_tokens.append(voice_limiter.borrowed_tokens)
+            borrowed_tokens.append(
+                (voice_limiter.borrowed_tokens, asset_limiter.borrowed_tokens)
+            )
             return super().read(*args, **kwargs)
 
     store = RecordingStore()
@@ -66,7 +69,7 @@ async def test_seedance2_route_reads_in_memory_upload_in_voice_worker(
 
     assert response == {"ok": True}
     assert read_threads and loop_thread not in read_threads
-    assert borrowed_tokens == [1]
+    assert borrowed_tokens == [(0, 1)]
     targets = list((tmp_path / "seedance2_uploads").rglob("voice.wav"))
     assert len(targets) == 1 and targets[0].read_bytes() == b"seedance-voice"
 

--- a/tests/test_task_route_threading.py
+++ b/tests/test_task_route_threading.py
@@ -1,0 +1,157 @@
+import threading
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+
+class RecordingTaskManager:
+    def __init__(self, task=None, tasks=None):
+        self.task = task
+        self.tasks = tasks or []
+        self.call_thread_id = None
+
+    def get_task_for_project(self, *_args, **_kwargs):
+        self.call_thread_id = threading.get_ident()
+        return self.task
+
+    def list_tasks_for_project(self, *_args, **_kwargs):
+        self.call_thread_id = threading.get_ident()
+        return self.tasks
+
+
+def assert_called_off_event_loop(manager, event_loop_thread_id):
+    assert manager.call_thread_id is not None
+    assert manager.call_thread_id != event_loop_thread_id
+
+
+@pytest.mark.asyncio
+async def test_episode_scene_planner_reads_task_state_off_event_loop(monkeypatch):
+    from novelvideo.api.routes import episodes
+
+    ctx = SimpleNamespace(project_id="proj_123")
+    manager = RecordingTaskManager(task=SimpleNamespace(status="running"))
+
+    async def resolve_project_scope(*_args, **_kwargs):
+        return SimpleNamespace(ctx=ctx)
+
+    monkeypatch.setattr(episodes, "resolve_project_scope", resolve_project_scope)
+    monkeypatch.setattr(episodes, "get_task_manager", lambda: manager)
+
+    await episodes._enqueue_episode_asset_planner(
+        project="proj_123",
+        episode_num=1,
+        asset_kind="scene",
+        user={"username": "admin"},
+    )
+
+    assert_called_off_event_loop(manager, threading.get_ident())
+
+
+@pytest.mark.asyncio
+async def test_episode_identity_planner_reads_task_state_off_event_loop(monkeypatch):
+    from novelvideo.api.routes import episodes
+
+    ctx = SimpleNamespace(project_id="proj_123")
+    manager = RecordingTaskManager(task=SimpleNamespace(status="running"))
+
+    async def resolve_project_scope(*_args, **_kwargs):
+        return SimpleNamespace(ctx=ctx)
+
+    monkeypatch.setattr(episodes, "resolve_project_scope", resolve_project_scope)
+    monkeypatch.setattr(episodes, "get_task_manager", lambda: manager)
+
+    await episodes.plan_episode_identities(
+        project="proj_123",
+        episode_num=1,
+        user={"username": "admin"},
+    )
+
+    assert_called_off_event_loop(manager, threading.get_ident())
+
+
+@pytest.mark.asyncio
+async def test_scene_build_reads_task_list_off_event_loop(monkeypatch, tmp_path: Path):
+    from novelvideo.api.routes import scenes
+
+    ctx = SimpleNamespace(project_id="proj_123", state_dir=tmp_path / "state")
+    manager = RecordingTaskManager(
+        tasks=[SimpleNamespace(task_type="episode_scene_planner", status="running")]
+    )
+
+    async def resolve_scene_project(*_args, **_kwargs):
+        return ctx, "admin", "demo", tmp_path, tmp_path / "output", SimpleNamespace()
+
+    monkeypatch.setattr(scenes, "_resolve_scene_project", resolve_scene_project)
+    monkeypatch.setattr(scenes, "has_imported_novel", lambda _path: True)
+    monkeypatch.setattr(
+        scenes,
+        "load_project_config_file_from_state_dir",
+        lambda _path: {"spine_template": "drama"},
+    )
+    monkeypatch.setattr(scenes, "scene_build_applies", lambda *_args: True)
+    monkeypatch.setattr(scenes, "get_task_manager", lambda: manager)
+
+    await scenes.build_scenes(project="proj_123", user={"username": "admin"})
+
+    assert_called_off_event_loop(manager, threading.get_ident())
+
+
+@pytest.mark.asyncio
+async def test_freezone_job_result_reads_task_state_off_event_loop(
+    monkeypatch, tmp_path: Path
+):
+    from novelvideo.api.routes import freezone
+
+    ctx = SimpleNamespace(project_id="proj_123")
+    manager = RecordingTaskManager(
+        task=SimpleNamespace(status="failed", error="boom", logs=[], current_task=None)
+    )
+
+    async def resolve_freezone_project(*_args, **_kwargs):
+        return ctx, "admin", "demo", tmp_path, tmp_path / "output"
+
+    monkeypatch.setattr(freezone, "_resolve_freezone_project", resolve_freezone_project)
+    monkeypatch.setattr(freezone, "get_task_manager", lambda: manager)
+
+    await freezone.freezone_job_result(
+        project="proj_123",
+        task_type="freezone_edit",
+        job_id="job_1",
+        user={"username": "admin"},
+    )
+
+    assert_called_off_event_loop(manager, threading.get_ident())
+
+
+@pytest.mark.asyncio
+async def test_freezone_skill_result_reads_task_state_off_event_loop(
+    monkeypatch, tmp_path: Path
+):
+    from novelvideo.api.routes import freezone
+
+    ctx = SimpleNamespace(project_id="proj_123")
+    manager = RecordingTaskManager(task=SimpleNamespace(status="running"))
+
+    async def resolve_freezone_project(*_args, **_kwargs):
+        return ctx, "admin", "demo", tmp_path, tmp_path / "output"
+
+    monkeypatch.setattr(freezone, "_resolve_freezone_project", resolve_freezone_project)
+    monkeypatch.setattr(
+        freezone,
+        "_read_skill_run_metadata",
+        lambda *_args: {
+            "task_type": "freezone_edit",
+            "job_id": "job_1",
+            "task_key": "task-key",
+        },
+    )
+    monkeypatch.setattr(freezone, "get_task_manager", lambda: manager)
+
+    await freezone.freezone_skill_run_result(
+        project="proj_123",
+        run_id="freezone_edit:job_1",
+        user={"username": "admin"},
+    )
+
+    assert_called_off_event_loop(manager, threading.get_ident())

--- a/tests/test_task_route_threading.py
+++ b/tests/test_task_route_threading.py
@@ -19,6 +19,10 @@ class RecordingTaskManager:
         self.call_thread_id = threading.get_ident()
         return self.tasks
 
+    def get_task(self, *_args, **_kwargs):
+        self.call_thread_id = threading.get_ident()
+        return self.task
+
 
 def assert_called_off_event_loop(manager, event_loop_thread_id):
     assert manager.call_thread_id is not None
@@ -125,6 +129,32 @@ async def test_freezone_job_result_reads_task_state_off_event_loop(
 
 
 @pytest.mark.asyncio
+async def test_legacy_freezone_job_result_reads_task_state_off_event_loop(
+    monkeypatch, tmp_path: Path
+):
+    from novelvideo.api.routes import freezone
+
+    manager = RecordingTaskManager(
+        task=SimpleNamespace(status="failed", error="boom", logs=[], current_task=None)
+    )
+
+    async def resolve_freezone_project(*_args, **_kwargs):
+        return None, "admin", "demo", tmp_path, tmp_path / "output"
+
+    monkeypatch.setattr(freezone, "_resolve_freezone_project", resolve_freezone_project)
+    monkeypatch.setattr(freezone, "get_task_manager", lambda: manager)
+
+    await freezone.freezone_job_result(
+        project="demo",
+        task_type="freezone_edit",
+        job_id="job_1",
+        user={"username": "admin"},
+    )
+
+    assert_called_off_event_loop(manager, threading.get_ident())
+
+
+@pytest.mark.asyncio
 async def test_freezone_skill_result_reads_task_state_off_event_loop(
     monkeypatch, tmp_path: Path
 ):
@@ -150,6 +180,38 @@ async def test_freezone_skill_result_reads_task_state_off_event_loop(
 
     await freezone.freezone_skill_run_result(
         project="proj_123",
+        run_id="freezone_edit:job_1",
+        user={"username": "admin"},
+    )
+
+    assert_called_off_event_loop(manager, threading.get_ident())
+
+
+@pytest.mark.asyncio
+async def test_legacy_freezone_skill_result_reads_task_state_off_event_loop(
+    monkeypatch, tmp_path: Path
+):
+    from novelvideo.api.routes import freezone
+
+    manager = RecordingTaskManager(task=SimpleNamespace(status="running"))
+
+    async def resolve_freezone_project(*_args, **_kwargs):
+        return None, "admin", "demo", tmp_path, tmp_path / "output"
+
+    monkeypatch.setattr(freezone, "_resolve_freezone_project", resolve_freezone_project)
+    monkeypatch.setattr(
+        freezone,
+        "_read_skill_run_metadata",
+        lambda *_args: {
+            "task_type": "freezone_edit",
+            "job_id": "job_1",
+            "task_key": "task-key",
+        },
+    )
+    monkeypatch.setattr(freezone, "get_task_manager", lambda: manager)
+
+    await freezone.freezone_skill_run_result(
+        project="demo",
         run_id="freezone_edit:job_1",
         user={"username": "admin"},
     )


### PR DESCRIPTION
## Summary
- offload synchronous task, project-summary, media, upload, ffmpeg, and ZIP work from async routes
- add bounded concurrency, cancellation-safe cleanup, and resource-level serialization
- cover cancellation, cleanup, upload limits, and metadata consistency with focused regressions

## Test Plan
- uv run pytest -q focused async-route regression suite (312 passed)
- uv run ruff check changed files
- git diff --check