### PR TITLE
feat(freezone): slim vision analysis images

### DIFF
--- a/src/novelvideo/freezone/jobs.py
+++ b/src/novelvideo/freezone/jobs.py
@@ -1600,8 +1600,7 @@ async def run_freezone_analyze_shots(
     from novelvideo.freezone import vision_gateway
     from novelvideo.freezone.vision_gateway import (
         FREEZONE_VIDEO_ANALYSIS_TIMEOUT_SECONDS,
-        VisionInput,
-        image_media_type,
+        load_compact_vision_inputs,
         resolve_freezone_vision_model,
     )
 
@@ -1633,25 +1632,22 @@ async def run_freezone_analyze_shots(
     )
 
     del api_key
-    frame_bytes = [
-        (Path(path).read_bytes(), image_media_type(path))
-        for path in frame_paths
-        if Path(path).exists()
-    ]
+    frame_inputs = await load_compact_vision_inputs(
+        [path for path in frame_paths if Path(path).exists()]
+    )
+    if not frame_inputs:
+        raise ValueError("no readable frames to analyze")
     vision_egress = await prepare_freezone_vision_egress(
         egress_context=egress_context,
         model_name=resolve_freezone_vision_model(model),
         prompt=prompt,
-        images=[data for data, _ in frame_bytes],
+        images=[image.data for image in frame_inputs],
         timeout_seconds=FREEZONE_VIDEO_ANALYSIS_TIMEOUT_SECONDS,
     )
     try:
         vision_model, text = await vision_gateway.call_freezone_vision_model(
             prompt=prompt,
-            images=[
-                VisionInput(data=data, media_type=media_type)
-                for data, media_type in frame_bytes
-            ],
+            images=frame_inputs,
             model_override=model,
             timeout_seconds=FREEZONE_VIDEO_ANALYSIS_TIMEOUT_SECONDS,
             transport_context=(

--- a/src/novelvideo/freezone/text_node.py
+++ b/src/novelvideo/freezone/text_node.py
@@ -640,7 +640,7 @@ async def generate_freezone_story_script_with_vision(
     """
     from pydantic_ai import BinaryContent
 
-    from novelvideo.freezone.vision_gateway import image_media_type
+    from novelvideo.freezone.vision_gateway import load_compact_vision_inputs
 
     frames = [Path(path) for path in (frame_paths or []) if Path(path).exists()]
     character_images = [
@@ -668,9 +668,10 @@ async def generate_freezone_story_script_with_vision(
             character_refs=character_refs,
         )
 
+    vision_inputs = await load_compact_vision_inputs((*frames, *character_images))
     attachments: list[Any] = [
-        BinaryContent(data=path.read_bytes(), media_type=image_media_type(str(path)))
-        for path in (*frames, *character_images)
+        BinaryContent(data=image.data, media_type=image.media_type)
+        for image in vision_inputs
     ]
     from novelvideo.model_gateway_runtime import model_gateway_request_scope
 

--- a/src/novelvideo/freezone/vision_gateway.py
+++ b/src/novelvideo/freezone/vision_gateway.py
@@ -20,6 +20,8 @@ FREEZONE_MARK_TIMEOUT_SECONDS = 90.0
 FREEZONE_VISION_IMAGE_MAX_EDGE = 1280
 FREEZONE_VISION_IMAGE_JPEG_QUALITY = 92
 FREEZONE_VISION_IMAGE_COMPACT_CONCURRENCY = 1
+FREEZONE_VISION_IMAGE_MAX_SOURCE_BYTES = 64 * 1024 * 1024
+FREEZONE_VISION_IMAGE_MAX_SOURCE_PIXELS = 40_000_000
 
 logger = logging.getLogger(__name__)
 _VISION_IMAGE_COMPACTION_SLOTS = threading.BoundedSemaphore(
@@ -55,9 +57,30 @@ def _compact_vision_images(
 
     for raw_path in paths:
         path = Path(raw_path)
-        original_bytes += path.stat().st_size
+        source_bytes = path.stat().st_size
+        if source_bytes > FREEZONE_VISION_IMAGE_MAX_SOURCE_BYTES:
+            raise ValueError(
+                f"vision image exceeds source byte limit: {source_bytes} > "
+                f"{FREEZONE_VISION_IMAGE_MAX_SOURCE_BYTES}"
+            )
+        original_bytes += source_bytes
         with ExitStack() as stack:
             source = stack.enter_context(Image.open(path))
+
+            # Image.open only reads the header. Validate the dimensions before
+            # exif_transpose, convert, resize, or any other operation that can
+            # allocate the full decoded bitmap. Highly compressible PNGs can be
+            # tiny on disk while expanding to hundreds of MiB in memory.
+            source_width, source_height = source.size
+            if source_width <= 0 or source_height <= 0:
+                raise ValueError("vision image dimensions must be positive")
+            source_pixels = source_width * source_height
+            if source_pixels > FREEZONE_VISION_IMAGE_MAX_SOURCE_PIXELS:
+                raise ValueError(
+                    f"vision image exceeds pixel limit: {source_pixels} > "
+                    f"{FREEZONE_VISION_IMAGE_MAX_SOURCE_PIXELS}"
+                )
+
             image = ImageOps.exif_transpose(source)
             if image is not source:
                 stack.callback(image.close)

--- a/src/novelvideo/freezone/vision_gateway.py
+++ b/src/novelvideo/freezone/vision_gateway.py
@@ -2,20 +2,150 @@
 
 from __future__ import annotations
 
+import asyncio
+import io
+import logging
+import threading
+import time
+from contextlib import ExitStack
 from dataclasses import dataclass, field
-from typing import Any
+from pathlib import Path
+from typing import Any, Sequence
 
 from novelvideo.official_defaults import DEFAULT_FREEZONE_VISION_MODEL
 
 FREEZONE_VIDEO_ANALYSIS_TIMEOUT_SECONDS = 300.0
 FREEZONE_IMAGE_REVERSE_PROMPT_TIMEOUT_SECONDS = 180.0
 FREEZONE_MARK_TIMEOUT_SECONDS = 90.0
+FREEZONE_VISION_IMAGE_MAX_EDGE = 1280
+FREEZONE_VISION_IMAGE_JPEG_QUALITY = 92
+FREEZONE_VISION_IMAGE_COMPACT_CONCURRENCY = 1
+
+logger = logging.getLogger(__name__)
+_VISION_IMAGE_COMPACTION_SLOTS = threading.BoundedSemaphore(
+    FREEZONE_VISION_IMAGE_COMPACT_CONCURRENCY
+)
 
 
 @dataclass(frozen=True)
 class VisionInput:
     data: bytes
     media_type: str = "image/png"
+
+
+def _compact_vision_images(
+    paths: Sequence[str | Path],
+    *,
+    max_edge: int,
+    jpeg_quality: int,
+) -> list[VisionInput]:
+    """Load image paths sequentially and return compact JPEG model inputs."""
+    from PIL import Image, ImageOps
+
+    if max_edge <= 0:
+        raise ValueError("max_edge must be positive")
+    if not 1 <= jpeg_quality <= 95:
+        raise ValueError("jpeg_quality must be between 1 and 95")
+
+    started_at = time.perf_counter()
+    inputs: list[VisionInput] = []
+    original_bytes = 0
+    compact_bytes = 0
+    resized_count = 0
+
+    for raw_path in paths:
+        path = Path(raw_path)
+        original_bytes += path.stat().st_size
+        with ExitStack() as stack:
+            source = stack.enter_context(Image.open(path))
+            image = ImageOps.exif_transpose(source)
+            if image is not source:
+                stack.callback(image.close)
+
+            if image.mode in {"RGBA", "LA"} or (
+                image.mode == "P" and "transparency" in image.info
+            ):
+                rgba = image.convert("RGBA")
+                stack.callback(rgba.close)
+                rgb = Image.new("RGB", rgba.size, (255, 255, 255))
+                stack.callback(rgb.close)
+                alpha = rgba.getchannel("A")
+                stack.callback(alpha.close)
+                rgb.paste(rgba, mask=alpha)
+                image = rgb
+            elif image.mode != "RGB":
+                rgb = image.convert("RGB")
+                stack.callback(rgb.close)
+                image = rgb
+
+            width, height = image.size
+            longest = max(width, height)
+            if longest > max_edge:
+                scale = max_edge / longest
+                resized = image.resize(
+                    (
+                        max(1, int(round(width * scale))),
+                        max(1, int(round(height * scale))),
+                    ),
+                    Image.Resampling.LANCZOS,
+                )
+                stack.callback(resized.close)
+                image = resized
+                resized_count += 1
+
+            with io.BytesIO() as buffer:
+                image.save(
+                    buffer,
+                    format="JPEG",
+                    quality=jpeg_quality,
+                    optimize=True,
+                )
+                data = buffer.getvalue()
+            compact_bytes += len(data)
+            inputs.append(VisionInput(data=data, media_type="image/jpeg"))
+
+    logger.info(
+        "Freezone vision images compacted: count=%d resized=%d "
+        "original_bytes=%d compact_bytes=%d elapsed_ms=%.1f max_edge=%d quality=%d",
+        len(inputs),
+        resized_count,
+        original_bytes,
+        compact_bytes,
+        (time.perf_counter() - started_at) * 1000,
+        max_edge,
+        jpeg_quality,
+    )
+    return inputs
+
+
+def _compact_vision_images_with_slot(
+    paths: Sequence[str | Path],
+    *,
+    max_edge: int,
+    jpeg_quality: int,
+) -> list[VisionInput]:
+    """Bound per-process image decoding so concurrent tasks cannot multiply RSS."""
+    with _VISION_IMAGE_COMPACTION_SLOTS:
+        return _compact_vision_images(
+            paths,
+            max_edge=max_edge,
+            jpeg_quality=jpeg_quality,
+        )
+
+
+async def load_compact_vision_inputs(
+    paths: Sequence[str | Path],
+    *,
+    max_edge: int = FREEZONE_VISION_IMAGE_MAX_EDGE,
+    jpeg_quality: int = FREEZONE_VISION_IMAGE_JPEG_QUALITY,
+) -> list[VisionInput]:
+    """Compact model-bound images without blocking the async task loop."""
+    return await asyncio.to_thread(
+        _compact_vision_images_with_slot,
+        paths,
+        max_edge=max_edge,
+        jpeg_quality=jpeg_quality,
+    )
 
 
 @dataclass(frozen=True, slots=True)

--- a/tests/test_freezone_text_backend.py
+++ b/tests/test_freezone_text_backend.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
-from pathlib import Path
+import io
 import json
+from pathlib import Path
 
 import pytest
+from PIL import Image
 
 from novelvideo.api.routes import freezone as freezone_routes
 from novelvideo.api.schemas import FreezoneStoryScriptGenerateData, FreezoneStoryScriptRow
@@ -505,7 +507,7 @@ async def test_generate_story_script_with_vision_attaches_frames(
     frames = []
     for index in range(3):
         frame = tmp_path / f"frame_{index}.png"
-        frame.write_bytes(b"png-bytes")
+        Image.new("RGB", (1600, 900), (index * 40, 48, 96)).save(frame)
         frames.append(frame)
     captured: dict[str, object] = {}
 
@@ -533,7 +535,12 @@ async def test_generate_story_script_with_vision_attaches_frames(
     assert isinstance(messages[0], str)
     # 三张关键帧必须真的作为附件送进模型，而不是只在提示词里被提一句。
     assert len(messages) == 1 + len(frames)
-    assert all(getattr(item, "data", None) == b"png-bytes" for item in messages[1:])
+    assert all(
+        getattr(item, "media_type", None) == "image/jpeg" for item in messages[1:]
+    )
+    for item in messages[1:]:
+        with Image.open(io.BytesIO(item.data)) as compacted:
+            assert compacted.size == (1280, 720)
 
 
 def test_build_freezone_character_story_script_task_uses_prompt_as_story() -> None:
@@ -560,7 +567,7 @@ async def test_generate_story_script_with_vision_accepts_character_images_only(
     # 前端一旦挂了素材就只发提示词、把 source_text 留空；
     # 「仅角色图」这一路以前会在这里抛 ValueError，任务必挂。
     portrait = tmp_path / "ningyao.png"
-    portrait.write_bytes(b"png-bytes")
+    Image.new("RGB", (640, 960), (24, 48, 96)).save(portrait)
     captured: dict[str, object] = {}
 
     class FakeAgent:
@@ -590,7 +597,9 @@ async def test_generate_story_script_with_vision_accepts_character_images_only(
     assert "角色参考图" in task
     assert "以这个角色生成一段雪山对决" in task
     assert len(messages) == 2
-    assert getattr(messages[1], "data", None) == b"png-bytes"
+    assert getattr(messages[1], "media_type", None) == "image/jpeg"
+    with Image.open(io.BytesIO(messages[1].data)) as compacted:
+        assert compacted.size == (640, 960)
 
 
 def test_bind_story_script_assets_fills_frames_and_character_images() -> None:

--- a/tests/test_freezone_video_story_backend.py
+++ b/tests/test_freezone_video_story_backend.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+import io
 from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
+from PIL import Image
 
 from novelvideo.api.routes import freezone as freezone_routes
 from novelvideo.freezone import vision_gateway
@@ -136,7 +138,7 @@ async def test_video_story_analysis_uses_shared_freezone_vision_model(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     frame = tmp_path / "frame.png"
-    frame.write_bytes(b"png")
+    Image.new("RGB", (1920, 1080), (24, 48, 96)).save(frame)
     captured: dict[str, object] = {}
 
     async def fake_call_freezone_vision_model(**kwargs):
@@ -160,6 +162,10 @@ async def test_video_story_analysis_uses_shared_freezone_vision_model(
     assert result["model"] == "DC-freezone-vision-LLM"
     assert result["video_story"] == {"shots": []}
     assert len(captured["images"]) == 1
+    image = captured["images"][0]
+    assert image.media_type == "image/jpeg"
+    with Image.open(io.BytesIO(image.data)) as compacted:
+        assert compacted.size == (1280, 720)
     assert captured["timeout_seconds"] == FREEZONE_VIDEO_ANALYSIS_TIMEOUT_SECONDS
 
 

--- a/tests/test_freezone_vision_gateway.py
+++ b/tests/test_freezone_vision_gateway.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
+import io
 import os
+from pathlib import Path
 
 import pytest
+from PIL import Image
 from pydantic_ai.models.test import TestModel
 
 from novelvideo import config
@@ -12,6 +15,7 @@ from novelvideo.freezone.vision_gateway import (
     VisionTransportContext,
     call_freezone_vision_model,
     image_media_type,
+    load_compact_vision_inputs,
 )
 
 
@@ -111,3 +115,57 @@ async def test_vision_gateway_uses_pydantic_agent_and_logical_model(
 )
 def test_image_media_type(path: str, expected: str) -> None:
     assert image_media_type(path) == expected
+
+
+@pytest.mark.asyncio
+async def test_compact_vision_inputs_resize_to_1280_jpeg_without_touching_source(
+    tmp_path: Path,
+) -> None:
+    source_path = tmp_path / "frame.png"
+    Image.new("RGB", (3840, 2160), (32, 64, 96)).save(source_path)
+    source_bytes = source_path.read_bytes()
+
+    inputs = await load_compact_vision_inputs([source_path])
+
+    assert len(inputs) == 1
+    assert inputs[0].media_type == "image/jpeg"
+    assert inputs[0].data.startswith(b"\xff\xd8")
+    with Image.open(io.BytesIO(inputs[0].data)) as compacted:
+        assert compacted.mode == "RGB"
+        assert compacted.size == (1280, 720)
+    assert source_path.read_bytes() == source_bytes
+
+
+@pytest.mark.asyncio
+async def test_compact_vision_inputs_do_not_upscale_and_flatten_alpha(
+    tmp_path: Path,
+) -> None:
+    source_path = tmp_path / "transparent.png"
+    source = Image.new("RGBA", (640, 360), (0, 0, 0, 0))
+    source.putpixel((320, 180), (255, 0, 0, 255))
+    source.save(source_path)
+
+    inputs = await load_compact_vision_inputs([source_path])
+
+    with Image.open(io.BytesIO(inputs[0].data)) as compacted:
+        assert compacted.size == (640, 360)
+        assert compacted.mode == "RGB"
+        background = compacted.getpixel((0, 0))
+        assert all(channel >= 245 for channel in background)
+
+
+@pytest.mark.asyncio
+async def test_compact_vision_inputs_keep_batch_order(tmp_path: Path) -> None:
+    paths: list[Path] = []
+    for index, color in enumerate(((240, 20, 20), (20, 20, 240))):
+        path = tmp_path / f"frame_{index}.png"
+        Image.new("RGB", (320, 180), color).save(path)
+        paths.append(path)
+
+    inputs = await load_compact_vision_inputs(paths)
+
+    assert len(inputs) == 2
+    with Image.open(io.BytesIO(inputs[0].data)) as first:
+        assert first.getpixel((160, 90))[0] > first.getpixel((160, 90))[2]
+    with Image.open(io.BytesIO(inputs[1].data)) as second:
+        assert second.getpixel((160, 90))[2] > second.getpixel((160, 90))[0]

--- a/tests/test_freezone_vision_gateway.py
+++ b/tests/test_freezone_vision_gateway.py
@@ -11,6 +11,8 @@ from pydantic_ai.models.test import TestModel
 from novelvideo import config
 from novelvideo.freezone.vision_gateway import (
     FREEZONE_VIDEO_ANALYSIS_TIMEOUT_SECONDS,
+    FREEZONE_VISION_IMAGE_MAX_SOURCE_BYTES,
+    FREEZONE_VISION_IMAGE_MAX_SOURCE_PIXELS,
     VisionInput,
     VisionTransportContext,
     call_freezone_vision_model,
@@ -169,3 +171,48 @@ async def test_compact_vision_inputs_keep_batch_order(tmp_path: Path) -> None:
         assert first.getpixel((160, 90))[0] > first.getpixel((160, 90))[2]
     with Image.open(io.BytesIO(inputs[1].data)) as second:
         assert second.getpixel((160, 90))[2] > second.getpixel((160, 90))[0]
+
+
+@pytest.mark.asyncio
+async def test_compact_vision_inputs_reject_compressed_large_image_before_decode(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from PIL import ImageOps
+
+    source_path = tmp_path / "compressed-large.png"
+    Image.new("RGB", (8000, 8000), (7, 7, 7)).save(source_path)
+    assert source_path.stat().st_size < FREEZONE_VISION_IMAGE_MAX_SOURCE_BYTES
+    assert 8000 * 8000 > FREEZONE_VISION_IMAGE_MAX_SOURCE_PIXELS
+
+    monkeypatch.setattr(
+        ImageOps,
+        "exif_transpose",
+        lambda *_args, **_kwargs: pytest.fail(
+            "oversized source reached full-decode path"
+        ),
+    )
+
+    with pytest.raises(ValueError, match="exceeds pixel limit"):
+        await load_compact_vision_inputs([source_path])
+
+
+@pytest.mark.asyncio
+async def test_compact_vision_inputs_reject_large_file_before_open(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source_path = tmp_path / "oversized.bin"
+    with source_path.open("wb") as source_file:
+        source_file.truncate(FREEZONE_VISION_IMAGE_MAX_SOURCE_BYTES + 1)
+
+    monkeypatch.setattr(
+        Image,
+        "open",
+        lambda *_args, **_kwargs: pytest.fail(
+            "oversized source reached image header parsing"
+        ),
+    )
+
+    with pytest.raises(ValueError, match="exceeds source byte limit"):
+        await load_compact_vision_inputs([source_path])

--- a/tests/test_p0g4b_image_egress.py
+++ b/tests/test_p0g4b_image_egress.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import base64
 
 import pytest
+from PIL import Image
 
 from novelvideo.egress_context import TrustedEgressContext
 from novelvideo.ports.authz import BillingPrincipal
@@ -707,7 +708,7 @@ async def test_eg18b_freezone_analyze_shots_builds_explicit_transport_from_org_c
     built = _org_vision_ports(monkeypatch, context, operation_port)
 
     frame = tmp_path / "frame_001.png"
-    frame.write_bytes(b"frame")
+    Image.new("RGB", (1920, 1080), (24, 48, 96)).save(frame)
 
     payload = await jobs.run_freezone_analyze_shots(
         project_dir=tmp_path,
@@ -753,7 +754,7 @@ async def test_eg18b_freezone_analyze_shots_failure_leaves_no_dispatching_claim(
         exploding_call,
     )
     frame = tmp_path / "frame_001.png"
-    frame.write_bytes(b"frame")
+    Image.new("RGB", (1920, 1080), (24, 48, 96)).save(frame)
 
     with pytest.raises(RuntimeError, match="gateway exploded"):
         await jobs.run_freezone_analyze_shots(


### PR DESCRIPTION
## 目标

缩小 Freezone 视频解析与视觉故事脚本发送给模型的图片附件，避免最多 20 张原尺寸 PNG 放大请求体和任务内存。

## 改动

- 模型请求前逐张处理图片：EXIF 纠正、长边限制 1280、不放大小图、透明背景铺白、JPEG 质量 92
- 在线程中顺序压缩，避免阻塞异步任务循环
- 每进程最多同时压缩一批，给多用户并发提供内存背压
- 视频分析的组织出网摘要和实际发送内容统一使用压缩后字节
- 覆盖解析视频/分析镜头/视频故事分析及视觉故事脚本/角色参考图
- 保留原始抽帧，不上传 OSS，不改变 BinaryContent/base64 协议，不修改计费与业务结果

## 压测

20 张 4K 高噪点 PNG，单批原始约 258.3 MB：

- 单任务：压缩后约 5.21 MB，约 2.45 秒，进程峰值约 115.5 MB
- 4 任务同时到达：总输出约 20.85 MB，约 9.43 秒，进程峰值约 125.9 MB

## 验证

- uv run pytest -q：3965 passed, 16 skipped, 2 deselected
- Freezone 与出网相关回归：574 passed
- ruff、black（新增模块/测试）、禁用词及 git diff 检查通过

## 影响

无数据库迁移、无配置迁移、无前端改动、无计费逻辑改动。