### PR TITLE
feat: add self-service password dialog

### DIFF
--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -432,9 +432,26 @@
     "account": {
       "open": "Open account menu",
       "changeAvatar": "Change avatar",
+      "changePassword": "Change password",
       "selectLanguage": "Select language",
       "languageChinese": "中文",
       "languageEnglish": "English",
+      "passwordDialog": {
+        "title": "Change password",
+        "description": "Changing your password signs you out on every device. Sign in again with the new password.",
+        "current": "Current password",
+        "new": "New password",
+        "confirm": "Confirm new password",
+        "requirement": "Use at least 8 characters and choose a password different from the current one.",
+        "mismatch": "The new passwords do not match.",
+        "unchanged": "The new password must differ from the current password.",
+        "currentIncorrect": "The current password is incorrect.",
+        "submit": "Change password",
+        "saving": "Changing…",
+        "success": "Password changed. Sign in again with your new password.",
+        "partialSuccess": "Password changed. Sign in again; some sessions are still being signed out.",
+        "error": "Could not change the password. Try again."
+      },
       "avatarDialog": {
         "title": "Change avatar",
         "description": "Choose an image for your avatar. A clear square image works best.",

--- a/frontend/public/locales/zh/translation.json
+++ b/frontend/public/locales/zh/translation.json
@@ -432,9 +432,26 @@
     "account": {
       "open": "打开个人信息",
       "changeAvatar": "更换头像",
+      "changePassword": "修改密码",
       "selectLanguage": "选择语言",
       "languageChinese": "中文",
       "languageEnglish": "English",
+      "passwordDialog": {
+        "title": "修改密码",
+        "description": "修改成功后会退出所有设备，需要使用新密码重新登录。",
+        "current": "当前密码",
+        "new": "新密码",
+        "confirm": "确认新密码",
+        "requirement": "新密码至少 8 位，且不能与当前密码相同。",
+        "mismatch": "两次输入的新密码不一致。",
+        "unchanged": "新密码不能与当前密码相同。",
+        "currentIncorrect": "当前密码不正确。",
+        "submit": "修改密码",
+        "saving": "修改中…",
+        "success": "密码已修改，请使用新密码重新登录。",
+        "partialSuccess": "密码已修改，请重新登录；部分会话正在同步退出。",
+        "error": "密码修改失败，请重试。"
+      },
       "avatarDialog": {
         "title": "更换头像",
         "description": "选择一张图片作为你的头像，建议使用清晰的正方形图片。",

--- a/frontend/src/__tests__/components/account/password-change-dialog.test.tsx
+++ b/frontend/src/__tests__/components/account/password-change-dialog.test.tsx
@@ -1,0 +1,144 @@
+// SPDX-License-Identifier: Elastic-2.0
+// Copyright (c) 2026 ClaymoreLab
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { PasswordChangeDialog } from "@/components/account/password-change-dialog";
+
+const toast = vi.hoisted(() => ({ success: vi.fn(), warning: vi.fn() }));
+
+vi.mock("sonner", () => ({ toast }));
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+describe("PasswordChangeDialog", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    toast.success.mockReset();
+    toast.warning.mockReset();
+  });
+
+  function fillValidForm() {
+    fireEvent.change(screen.getByLabelText("header.account.passwordDialog.current"), {
+      target: { value: "current-password" },
+    });
+    fireEvent.change(screen.getByLabelText("header.account.passwordDialog.new"), {
+      target: { value: "brand-new-password" },
+    });
+    fireEvent.change(screen.getByLabelText("header.account.passwordDialog.confirm"), {
+      target: { value: "brand-new-password" },
+    });
+  }
+
+  it("submits the current and new password, then signs the local session out", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          ok: true,
+          data: { sessions_revoked: 2, agent_sessions_revoked: 1 },
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+    const onPasswordChanged = vi.fn();
+    const onOpenChange = vi.fn();
+    render(
+      <PasswordChangeDialog
+        open
+        onOpenChange={onOpenChange}
+        onPasswordChanged={onPasswordChanged}
+      />,
+    );
+
+    fillValidForm();
+    fireEvent.click(screen.getByRole("button", { name: "header.account.passwordDialog.submit" }));
+
+    await waitFor(() => expect(onPasswordChanged).toHaveBeenCalledOnce());
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/v1/account/password",
+      expect.objectContaining({
+        method: "POST",
+        credentials: "include",
+        body: JSON.stringify({
+          current_password: "current-password",
+          new_password: "brand-new-password",
+        }),
+      }),
+    );
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    expect(toast.success).toHaveBeenCalledWith("header.account.passwordDialog.success");
+  });
+
+  it("keeps the dialog open when the current password is incorrect", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ detail: "current password incorrect" }), {
+        status: 401,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    const onPasswordChanged = vi.fn();
+    const onOpenChange = vi.fn();
+    render(
+      <PasswordChangeDialog
+        open
+        onOpenChange={onOpenChange}
+        onPasswordChanged={onPasswordChanged}
+      />,
+    );
+
+    fillValidForm();
+    fireEvent.click(screen.getByRole("button", { name: "header.account.passwordDialog.submit" }));
+
+    expect(
+      await screen.findByText("header.account.passwordDialog.currentIncorrect"),
+    ).toBeInTheDocument();
+    expect(onPasswordChanged).not.toHaveBeenCalled();
+    expect(onOpenChange).not.toHaveBeenCalledWith(false);
+  });
+
+  it("blocks mismatched confirmation before making a request", () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch");
+    render(
+      <PasswordChangeDialog open onOpenChange={vi.fn()} onPasswordChanged={vi.fn()} />,
+    );
+
+    fireEvent.change(screen.getByLabelText("header.account.passwordDialog.current"), {
+      target: { value: "current-password" },
+    });
+    fireEvent.change(screen.getByLabelText("header.account.passwordDialog.new"), {
+      target: { value: "brand-new-password" },
+    });
+    fireEvent.change(screen.getByLabelText("header.account.passwordDialog.confirm"), {
+      target: { value: "different-password" },
+    });
+
+    expect(screen.getByText("header.account.passwordDialog.mismatch")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "header.account.passwordDialog.submit" }),
+    ).toBeDisabled();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("signs out after a committed password change with partial cache invalidation", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({ detail: { code: "PASSWORD_CHANGED_CACHE_PARTIAL" } }),
+        { status: 503, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+    const onPasswordChanged = vi.fn();
+    render(
+      <PasswordChangeDialog open onOpenChange={vi.fn()} onPasswordChanged={onPasswordChanged} />,
+    );
+
+    fillValidForm();
+    fireEvent.click(screen.getByRole("button", { name: "header.account.passwordDialog.submit" }));
+
+    await waitFor(() => expect(onPasswordChanged).toHaveBeenCalledOnce());
+    expect(toast.warning).toHaveBeenCalledWith(
+      "header.account.passwordDialog.partialSuccess",
+    );
+  });
+});

--- a/frontend/src/__tests__/components/layout/header.test.tsx
+++ b/frontend/src/__tests__/components/layout/header.test.tsx
@@ -62,6 +62,7 @@ vi.mock("react-i18next", () => ({
         "header.account.open": "Open account",
         "header.notifications": "Announcement Center",
         "header.account.changeAvatar": "Change avatar",
+        "header.account.changePassword": "Change password",
         "header.account.selectLanguage": "Select language",
         "header.account.languageChinese": "Chinese",
         "header.account.languageEnglish": "English",
@@ -176,6 +177,7 @@ describe("Header runtime gating", () => {
     fireEvent.mouseEnter(screen.getByLabelText("Open account").parentElement!);
 
     expect(await screen.findByText("Log out")).toBeInTheDocument();
+    expect(screen.getByText("Change password")).toBeInTheDocument();
   });
 
   it("moves the announcement entry from the header actions into the account panel", async () => {
@@ -281,6 +283,7 @@ describe("Header runtime gating", () => {
       expect(screen.getByText("local")).toBeInTheDocument();
     });
     expect(screen.queryByText("Log out")).not.toBeInTheDocument();
+    expect(screen.queryByText("Change password")).not.toBeInTheDocument();
   });
 
   it("purges user-scoped caches after logout so the next account can't see stale data", async () => {

--- a/frontend/src/components/account/password-change-dialog.tsx
+++ b/frontend/src/components/account/password-change-dialog.tsx
@@ -1,0 +1,212 @@
+// SPDX-License-Identifier: Elastic-2.0
+// Copyright (c) 2026 ClaymoreLab
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { Loader2 } from "lucide-react";
+import { toast } from "sonner";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+
+const MIN_PASSWORD_LENGTH = 8;
+
+type PasswordErrorBody = {
+  detail?: string | { code?: string; message?: string };
+};
+
+export function PasswordChangeDialog({
+  open,
+  onOpenChange,
+  onPasswordChanged,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onPasswordChanged: () => void;
+}) {
+  const { t } = useTranslation();
+  const [currentPassword, setCurrentPassword] = useState("");
+  const [newPassword, setNewPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const mismatch = confirmPassword.length > 0 && newPassword !== confirmPassword;
+  const unchanged = newPassword.length > 0 && newPassword === currentPassword;
+  const submitDisabled =
+    saving ||
+    currentPassword.length === 0 ||
+    newPassword.length < MIN_PASSWORD_LENGTH ||
+    confirmPassword.length === 0 ||
+    mismatch ||
+    unchanged;
+
+  const resetSecrets = () => {
+    setCurrentPassword("");
+    setNewPassword("");
+    setConfirmPassword("");
+    setSaving(false);
+    setError(null);
+  };
+
+  const handleOpenChange = (nextOpen: boolean) => {
+    if (saving) return;
+    onOpenChange(nextOpen);
+    if (!nextOpen) resetSecrets();
+  };
+
+  const finishPasswordChange = (partial: boolean) => {
+    onOpenChange(false);
+    resetSecrets();
+    if (partial) {
+      toast.warning(t("header.account.passwordDialog.partialSuccess"));
+    } else {
+      toast.success(t("header.account.passwordDialog.success"));
+    }
+    onPasswordChanged();
+  };
+
+  const handleSubmit = async (event: React.FormEvent) => {
+    event.preventDefault();
+    if (submitDisabled) return;
+    setSaving(true);
+    setError(null);
+    try {
+      const response = await fetch("/api/v1/account/password", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        credentials: "include",
+        body: JSON.stringify({
+          current_password: currentPassword,
+          new_password: newPassword,
+        }),
+      });
+      const body = (await response.json().catch(() => ({}))) as PasswordErrorBody;
+      const detail = body.detail;
+      const code = typeof detail === "object" ? detail.code : undefined;
+      if (response.status === 503 && code === "PASSWORD_CHANGED_CACHE_PARTIAL") {
+        finishPasswordChange(true);
+        return;
+      }
+      if (!response.ok) {
+        setError(
+          response.status === 401
+            ? t("header.account.passwordDialog.currentIncorrect")
+            : t("header.account.passwordDialog.error"),
+        );
+        setSaving(false);
+        return;
+      }
+      finishPasswordChange(false);
+    } catch {
+      setError(t("header.account.passwordDialog.error"));
+      setSaving(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent
+        className="w-[380px] gap-0 rounded-xl border border-border bg-popover p-0 text-popover-foreground shadow-lg"
+        overlayClassName="bg-black/55"
+      >
+        <DialogHeader className="px-5 pb-3 pt-5">
+          <DialogTitle>{t("header.account.passwordDialog.title")}</DialogTitle>
+          <DialogDescription className="text-xs leading-5">
+            {t("header.account.passwordDialog.description")}
+          </DialogDescription>
+        </DialogHeader>
+
+        <form onSubmit={handleSubmit}>
+          <div className="space-y-3 px-5 pb-5">
+            <PasswordField
+              autoComplete="current-password"
+              label={t("header.account.passwordDialog.current")}
+              value={currentPassword}
+              onChange={setCurrentPassword}
+            />
+            <PasswordField
+              autoComplete="new-password"
+              label={t("header.account.passwordDialog.new")}
+              value={newPassword}
+              onChange={setNewPassword}
+            />
+            <PasswordField
+              autoComplete="new-password"
+              label={t("header.account.passwordDialog.confirm")}
+              value={confirmPassword}
+              onChange={setConfirmPassword}
+            />
+
+            {mismatch ? (
+              <p className="text-xs text-destructive" role="alert">
+                {t("header.account.passwordDialog.mismatch")}
+              </p>
+            ) : unchanged ? (
+              <p className="text-xs text-destructive" role="alert">
+                {t("header.account.passwordDialog.unchanged")}
+              </p>
+            ) : error ? (
+              <p className="text-xs text-destructive" role="alert">
+                {error}
+              </p>
+            ) : (
+              <p className="text-xs text-muted-foreground">
+                {t("header.account.passwordDialog.requirement")}
+              </p>
+            )}
+          </div>
+
+          <DialogFooter className="p-4 pt-0">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => handleOpenChange(false)}
+              disabled={saving}
+            >
+              {t("common.cancel")}
+            </Button>
+            <Button type="submit" disabled={submitDisabled}>
+              {saving ? <Loader2 className="size-4 animate-spin" /> : null}
+              {saving
+                ? t("header.account.passwordDialog.saving")
+                : t("header.account.passwordDialog.submit")}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function PasswordField({
+  autoComplete,
+  label,
+  onChange,
+  value,
+}: {
+  autoComplete: "current-password" | "new-password";
+  label: string;
+  onChange: (value: string) => void;
+  value: string;
+}) {
+  return (
+    <label className="block space-y-1.5 text-sm">
+      <span>{label}</span>
+      <Input
+        type="password"
+        autoComplete={autoComplete}
+        aria-label={label}
+        value={value}
+        onChange={(event) => onChange(event.currentTarget.value)}
+      />
+    </label>
+  );
+}

--- a/frontend/src/components/layout/header.tsx
+++ b/frontend/src/components/layout/header.tsx
@@ -3,7 +3,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { ReactNode, RefObject } from "react";
 import { createPortal } from "react-dom";
-import { Link, useParams } from "@tanstack/react-router";
+import { Link, useNavigate, useParams } from "@tanstack/react-router";
 import { useTranslation } from "react-i18next";
 import {
   AlertTriangle,
@@ -14,10 +14,12 @@ import {
   ChevronRight,
   Languages,
   LogOut,
+  KeyRound,
   X,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { AvatarUploadDialog } from "@/components/account/avatar-upload-dialog";
+import { PasswordChangeDialog } from "@/components/account/password-change-dialog";
 import {
   Tooltip,
   TooltipContent,
@@ -57,12 +59,14 @@ const ACCOUNT_PANEL_TRANSITION_MS = 350;
 
 export function Header({ ambientBackground = false }: { ambientBackground?: boolean }) {
   const { t, i18n } = useTranslation();
+  const navigate = useNavigate();
   const params = useParams({ strict: false }) as { project?: string };
   const [companionOpen, setCompanionOpen] = useState(false);
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [notificationOpen, setNotificationOpen] = useState(false);
   const [releaseNotificationStateVersion, setReleaseNotificationStateVersion] = useState(0);
   const [avatarDialogOpen, setAvatarDialogOpen] = useState(false);
+  const [passwordDialogOpen, setPasswordDialogOpen] = useState(false);
   const [accountPanelOpen, setAccountPanelOpen] = useState(false);
   const [accountPanelVisible, setAccountPanelVisible] = useState(false);
   const [settingsWarningBubbleDismissed, setSettingsWarningBubbleDismissed] = useState(false);
@@ -297,6 +301,16 @@ export function Header({ ambientBackground = false }: { ambientBackground?: bool
     setAvatarDialogOpen(true);
   };
 
+  const openPasswordDialog = () => {
+    closeAccountPanelNow();
+    setPasswordDialogOpen(true);
+  };
+
+  const handlePasswordChanged = () => {
+    resetUserSessionState({ queryClient });
+    void navigate({ to: "/login", replace: true });
+  };
+
   return (
     <div
       className={`relative z-20 shrink-0 text-sidebar-foreground ${
@@ -429,6 +443,7 @@ export function Header({ ambientBackground = false }: { ambientBackground?: bool
               displayName={displayName}
               hasUnreadNotification={hasUnreadNotification}
               onChangeAvatar={openAvatarDialog}
+              onChangePassword={showLogout ? openPasswordDialog : undefined}
               onLanguageChange={switchLanguage}
               onNotifications={openNotifications}
               onClose={scheduleCloseAccountPanel}
@@ -461,6 +476,11 @@ export function Header({ ambientBackground = false }: { ambientBackground?: bool
         displayName={displayName}
         open={avatarDialogOpen}
         onOpenChange={setAvatarDialogOpen}
+      />
+      <PasswordChangeDialog
+        open={passwordDialogOpen}
+        onOpenChange={setPasswordDialogOpen}
+        onPasswordChanged={handlePasswordChanged}
       />
       {ceRuntime ? <SettingsDialog open={settingsOpen} onOpenChange={setSettingsOpen} /> : null}
       {settingsWarningBubble
@@ -545,6 +565,7 @@ function AccountPanel({
   displayName,
   hasUnreadNotification,
   onChangeAvatar,
+  onChangePassword,
   onLanguageChange,
   onNotifications,
   onClose,
@@ -561,6 +582,7 @@ function AccountPanel({
   displayName: string;
   hasUnreadNotification: boolean;
   onChangeAvatar: () => void;
+  onChangePassword?: () => void;
   onLanguageChange: (lang: "zh" | "en") => void;
   onNotifications: () => void;
   onClose: () => void;
@@ -613,6 +635,13 @@ function AccountPanel({
             label={t("header.account.changeAvatar")}
             onClick={onChangeAvatar}
           />
+          {onChangePassword ? (
+            <AccountMenuRow
+              icon={<KeyRound className="size-3.5" />}
+              label={t("header.account.changePassword")}
+              onClick={onChangePassword}
+            />
+          ) : null}
           <AccountMenuRow
             active={languageOpen}
             icon={<Languages className="size-3.5" />}

--- a/license-inventory.csv
+++ b/license-inventory.csv
@@ -287,6 +287,7 @@ frontend/src/__tests__/api/freezone-video-edit.test.ts,Elastic-2.0,2026 SuperTal
 frontend/src/__tests__/api/style-templates-shape.test.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/__tests__/api/task-poll-timeout.test.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/__tests__/components/account/avatar-upload-dialog.test.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
+frontend/src/__tests__/components/account/password-change-dialog.test.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/__tests__/components/assets/asset-panels-rename.test.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/__tests__/components/assets/asset-tabs-beats-contract.test.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/__tests__/components/assets/character-image-source-select.test.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
@@ -698,6 +699,7 @@ frontend/src/assets/icons/two-finger-pan.gif,Elastic-2.0,2026 SuperTale contribu
 frontend/src/commands/image.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/components/GlobalErrorDialog.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/components/account/avatar-upload-dialog.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
+frontend/src/components/account/password-change-dialog.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/components/app-update-available.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/components/app-update-required.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/components/assets/asset-beat-references.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation


### PR DESCRIPTION
## PR 类型 / Type of PR

- [x] ✨ 新功能 / Feature

## 改动说明 / What this PR does and why

为 EE 登录用户在右上角头像账号菜单增加自助修改密码入口和弹窗：

- 输入当前密码、新密码及确认密码
- 前端校验长度、一致性及新旧密码不同
- 调用 EE 的 POST /api/v1/account/password
- 修改成功后清理用户级缓存并返回登录页
- 通过 auth_required 运行时配置隐藏 CE 入口

## 关联 PR / Linked PR

- 配套 EE 后端：https://github.com/claymorelab/SuperTale/pull/162

## 给 reviewer 的说明 / Notes for the reviewer

CE 没有平台账号体系，因此不会显示修改密码入口；本功能只在 EE auth_required=true 时出现。

## 面向用户的变更 / User-facing change

```release-note
EE 用户现在可以从头像账号菜单自助修改密码，修改后所有旧会话会失效并需要重新登录。
```

## 验证 / Validation

- 前端完整测试：406 files / 2899 tests passed
- TypeScript：tsc --noEmit 通过
- 生产构建通过
- Design lint：0 errors，15 条既有 warnings
- 已在隔离 EE 环境完成真实改密和重新登录验证

## 自检 / Checklist

- [x] 已自测
- [x] 必要的文档已更新或不适用
- [x] 提交信息清晰
- [x] 每个 commit 都已附 DCO Signed-off-by
- [x] 已阅读并同意贡献者协议