### PR TITLE
fix(video): restore safe provider errors for organization users

### DIFF
--- a/src/novelvideo/generators/video_generator.py
+++ b/src/novelvideo/generators/video_generator.py
@@ -24,6 +24,8 @@ from typing import Any, Callable, Optional
 from novelvideo.shared.provider_errors import (
     classify_provider_video_task_error,
     provider_video_error_code_from_text,
+    provider_video_error_message_from_text,
+    provider_video_task_error_message,
 )
 
 import aiohttp
@@ -3647,6 +3649,7 @@ class NewApiVideoGenerator(VideoGeneratorBase):
                     safe_task_error = (
                         (
                             classify_provider_video_task_error(task)
+                            or provider_video_task_error_message(task)
                             or "EGRESS_OPERATION_UNKNOWN"
                         )
                         if organization_request
@@ -3741,7 +3744,11 @@ class NewApiVideoGenerator(VideoGeneratorBase):
                 error_message=type(exc).__name__,
             )
             safe_exception_error = (
-                _safe_video_error_code(exc, "EGRESS_OPERATION_UNKNOWN")
+                (
+                    _safe_video_error_code(exc, "")
+                    or provider_video_error_message_from_text(str(exc))
+                    or "EGRESS_OPERATION_UNKNOWN"
+                )
                 if organization_request
                 else str(exc)
             )

--- a/src/novelvideo/shared/provider_errors.py
+++ b/src/novelvideo/shared/provider_errors.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
+import json
 import re
 from collections.abc import Mapping
 from typing import Any
+
+from novelvideo.utils.error_redaction import redact_secrets
 
 CONTENT_MODERATION_FAILED_CODE = "CONTENT_MODERATION_FAILED"
 CONTENT_MODERATION_FAILED_MESSAGE = "图片生成结果未通过内容审核，请调整提示词后重试"
@@ -37,6 +40,12 @@ _PROVIDER_VIDEO_ERROR_CODE_RE = re.compile(r"VIDEO_[A-Z0-9]+(?:_[A-Z0-9]+)*")
 _PROVIDER_VIDEO_ERROR_BODY_CODE_RE = re.compile(
     r"[\"']code[\"']\s*:\s*[\"'](VIDEO_[A-Z0-9_]+)[\"']"
 )
+_PROVIDER_URL_RE = re.compile(r"https?://[^\s<>{}\[\]\"']+", re.IGNORECASE)
+_PROVIDER_SENSITIVE_FRAGMENT_RE = re.compile(
+    r"(?i)\b(?:ossaccesskeyid|x-amz-(?:credential|signature)|api[_-]?key|"
+    r"access[_-]?key|token|secret)(?:\s*[:=]\s*|[-_/])[^\s,;]+"
+)
+_PROVIDER_ERROR_MESSAGE_MAX_LENGTH = 1000
 # 网关只给自由文本（`error_message`）时，按厂商原话里的关键字归类。
 _PROVIDER_VIDEO_ERROR_TEXT_MARKERS: tuple[tuple[str, str], ...] = (
     ("heighttoosmall", VIDEO_MEDIA_DIMENSIONS_INVALID_CODE),
@@ -128,6 +137,86 @@ def provider_video_error_code_from_text(text: str) -> str:
     return ""
 
 
+def _provider_video_message_from_value(value: object) -> str:
+    if isinstance(value, str):
+        text = value.strip()
+        if not text:
+            return ""
+        if text[:1] in {"{", "["}:
+            try:
+                parsed = json.loads(text)
+            except json.JSONDecodeError:
+                pass
+            else:
+                nested = _provider_video_message_from_value(parsed)
+                if nested:
+                    return nested
+        return text
+    if isinstance(value, Mapping):
+        for key in (
+            "content",
+            "error",
+            "message",
+            "error_message",
+            "fail_reason",
+            "detail",
+        ):
+            nested = _provider_video_message_from_value(value.get(key))
+            if nested:
+                return nested
+        return ""
+    if isinstance(value, (list, tuple)):
+        for item in value:
+            nested = _provider_video_message_from_value(item)
+            if nested:
+                return nested
+    return ""
+
+
+def _sanitize_provider_video_error_message(value: object) -> str:
+    message = _provider_video_message_from_value(value)
+    if not message:
+        return ""
+    message = _PROVIDER_URL_RE.sub("[redacted-url]", message)
+    message = redact_secrets(message)
+    message = _PROVIDER_SENSITIVE_FRAGMENT_RE.sub("[redacted]", message)
+    message = re.sub(r"\s+", " ", message).strip()
+    visible = message.replace("[redacted-url]", "").replace("[redacted]", "")
+    if not visible.strip(" -:：,，.;；"):
+        return ""
+    return message[:_PROVIDER_ERROR_MESSAGE_MAX_LENGTH]
+
+
+def provider_video_task_error_message(task: Mapping[str, Any]) -> str:
+    """Return a redacted provider message from a definitive failed-task response."""
+    for value in (
+        task.get("content"),
+        task.get("error"),
+        task.get("fail_reason"),
+        task.get("error_message"),
+    ):
+        message = _sanitize_provider_video_error_message(value)
+        if message:
+            return message
+    return ""
+
+
+def provider_video_error_message_from_text(text: str) -> str:
+    """Extract a redacted message from an embedded JSON provider error body."""
+    decoder = json.JSONDecoder()
+    for index, char in enumerate(text):
+        if char not in "{[":
+            continue
+        try:
+            payload, _end = decoder.raw_decode(text[index:])
+        except json.JSONDecodeError:
+            continue
+        message = _sanitize_provider_video_error_message(payload)
+        if message:
+            return message
+    return ""
+
+
 def classify_provider_video_task_error(task: Mapping[str, Any]) -> str:
     """把网关「任务失败」报文归成安全的 VIDEO_* 码，认不出返回空串。
 
@@ -179,6 +268,8 @@ __all__ = [
     "content_moderation_payload",
     "is_content_moderation_error",
     "provider_video_error_code_from_text",
+    "provider_video_error_message_from_text",
     "provider_video_error_payload",
+    "provider_video_task_error_message",
     "safe_provider_video_error_code",
 ]

--- a/tests/test_p0g4c_video_egress.py
+++ b/tests/test_p0g4c_video_egress.py
@@ -1738,21 +1738,41 @@ async def test_freezone_platform_context_preserves_legacy_leaf(
                 "status": "failed",
                 "error": {"code": "weird secret-canary", "message": "x"},
             },
-            "EGRESS_OPERATION_UNKNOWN",
+            "x",
+        ),
+        (
+            {
+                "status": "failed",
+                "error": "video generation failed",
+                "content": "提示词长度超过模型限制，请缩短后重试",
+            },
+            "提示词长度超过模型限制，请缩短后重试",
+        ),
+        (
+            {
+                "status": "failed",
+                "content": {
+                    "message": (
+                        "参考素材读取失败：https://relay.example/a.jpg?"
+                        "OSSAccessKeyId=secret-canary 请更换素材后重试"
+                    )
+                },
+            },
+            "参考素材读取失败：[redacted-url] 请更换素材后重试",
         ),
     ],
 )
-async def test_newapi_organization_failures_keep_safe_provider_error_codes(
+async def test_newapi_organization_failures_keep_safe_provider_error_details(
     monkeypatch,
     tmp_path: Path,
     poll_response: dict,
     expected_error: str,
 ) -> None:
-    """厂商明确打回（尺寸/审核）时，组织账号要拿到可读的错误码而不是一律 UNKNOWN。
+    """厂商明确打回时，组织账号拿到安全错误码或脱敏后的具体消息。
 
     2026-08-26 3060 上 creator02-zhu 的参考图 338x191 被火山 HeightTooSmall 拒了 8 次，
-    用户只看到 `EGRESS_OPERATION_UNKNOWN`。放行的只能是 `VIDEO_*` 这种枚举码，
-    厂商原文（含带签名的 relay URL）依旧不能进 result。
+    用户只看到 `EGRESS_OPERATION_UNKNOWN`。已知 `VIDEO_*` 枚举码继续优先放行；其他明确
+    失败恢复安全消息，但带签名的 relay URL 依旧不能进 result。
     """
     from novelvideo.generators.video_generator import (
         NewApiVideoGenerator,
@@ -1810,10 +1830,28 @@ async def test_newapi_organization_failures_keep_safe_provider_error_codes(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("response_body", "expected_error"),
+    [
+        (
+            '{"error": {"code": "VIDEO_MEDIA_DIMENSIONS_INVALID", '
+            '"message": "secret-canary"}}',
+            "VIDEO_MEDIA_DIMENSIONS_INVALID",
+        ),
+        (
+            '{"error": {"content": "请求参数不受当前模型支持：'
+            'https://relay.example/a.png?token=secret-canary 请调整后重试"}}',
+            "请求参数不受当前模型支持：[redacted-url] 请调整后重试",
+        ),
+    ],
+)
 async def test_newapi_organization_submit_rejection_keeps_safe_provider_error_code(
-    monkeypatch, tmp_path: Path
+    monkeypatch,
+    tmp_path: Path,
+    response_body: str,
+    expected_error: str,
 ) -> None:
-    """网关在提交阶段就用 `VIDEO_*` 码打回时，组织账号同样拿到该码，不泄漏响应原文。"""
+    """提交阶段明确拒绝时恢复安全详情，同时不泄漏响应中的签名 URL。"""
     from novelvideo.generators.video_generator import (
         NewApiVideoError,
         NewApiVideoGenerator,
@@ -1828,8 +1866,7 @@ async def test_newapi_organization_submit_rejection_keeps_safe_provider_error_co
 
     async def rejected(*_args, **_kwargs):
         raise NewApiVideoError(
-            'DramaClawAPI submit failed: HTTP 400 - {"error": {"code": '
-            '"VIDEO_MEDIA_DIMENSIONS_INVALID", "message": "secret-canary"}}',
+            f"DramaClawAPI submit failed: HTTP 400 - {response_body}",
             request_id="req-1",
             status_code=400,
         )
@@ -1850,6 +1887,6 @@ async def test_newapi_organization_submit_rejection_keeps_safe_provider_error_co
     )
 
     assert result.status is VideoGenStatus.FAILED
-    assert result.error == "VIDEO_MEDIA_DIMENSIONS_INVALID"
+    assert result.error == expected_error
     assert "secret-canary" not in repr(result)
     assert [name for name, _ in operation_port.events] == ["claim", "unknown"]


### PR DESCRIPTION
## Summary

- restore concrete failure details from `content`, `error`, `error_message`, and `fail_reason` for definitive organization video failures
- redact provider URLs and credential fragments before returning messages to users
- keep `EGRESS_OPERATION_UNKNOWN` for ambiguous submit, timeout, and missing-result states
- preserve the existing `VIDEO_*` safe-code mapping

## Verification

- `uv run pytest -q tests/test_p0g4c_video_egress.py tests/test_task_credit_errors.py` (65 passed)
- `pnpm test -- src/__tests__/lib/gateway-error-classify.test.ts` (406 files / 2899 tests passed)
- `uv run ruff check src/novelvideo/shared/provider_errors.py src/novelvideo/generators/video_generator.py tests/test_p0g4c_video_egress.py`
- `uv tool run pre-commit run --files src/novelvideo/generators/video_generator.py src/novelvideo/shared/provider_errors.py tests/test_p0g4c_video_egress.py`

No database migration, frontend code change, or EE change is required.