### PR TITLE
feat(Freezone): 支持 Bundle 法律元数据

### DIFF
--- a/src/novelvideo/freezone/agent_bundle_schema.py
+++ b/src/novelvideo/freezone/agent_bundle_schema.py
@@ -24,6 +24,33 @@ class _BundleBaseModel(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
 
+class AgentBundleLicense(_BundleBaseModel):
+    id: str
+    text: str
+
+    @field_validator("id", "text")
+    @classmethod
+    def validate_required_strings(cls, value: str) -> str:
+        stripped = value.strip()
+        if not stripped:
+            raise ValueError("legal license fields must be non-empty")
+        return stripped
+
+
+class AgentBundleLegal(_BundleBaseModel):
+    copyright: str
+    license: AgentBundleLicense
+    notice: str
+
+    @field_validator("copyright", "notice")
+    @classmethod
+    def validate_required_strings(cls, value: str) -> str:
+        stripped = value.strip()
+        if not stripped:
+            raise ValueError("legal fields must be non-empty")
+        return stripped
+
+
 class AgentSkillBundle(_BundleBaseModel):
     schema_version: str
     id: str
@@ -34,6 +61,7 @@ class AgentSkillBundle(_BundleBaseModel):
     license: str = ""
     min_dramaclaw_version: str
     tags: list[str] = Field(default_factory=list)
+    legal: AgentBundleLegal | None = None
     skill: dict[str, Any]
     recipes: list[dict[str, Any]] = Field(default_factory=list)
 

--- a/src/novelvideo/freezone/agent_bundle_schema.py
+++ b/src/novelvideo/freezone/agent_bundle_schema.py
@@ -106,6 +106,8 @@ class AgentSkillBundle(_BundleBaseModel):
         skill_id = str(self.skill.get("id") or "").strip()
         if skill_id and skill_id != self.id:
             raise ValueError("Bundle skill.id must match bundle id")
+        if self.legal is not None and self.license != self.legal.license.id:
+            raise ValueError("Bundle license must match legal.license.id")
         return self
 
 
@@ -114,7 +116,7 @@ def normalize_agent_bundle(payload: dict[str, Any]) -> dict[str, Any]:
 
     scan_agent_catalog_payload_for_unsafe_content(payload, label="Bundle")
     try:
-        bundle = AgentSkillBundle.model_validate(payload).model_dump(mode="json")
+        bundle = AgentSkillBundle.model_validate(payload).model_dump(mode="json", exclude_none=True)
     except ValidationError as exc:
         raise ValueError(f"invalid agent Bundle: {exc}") from exc
 

--- a/src/novelvideo/freezone/agent_bundle_store.py
+++ b/src/novelvideo/freezone/agent_bundle_store.py
@@ -92,6 +92,9 @@ def export_agent_bundle(
         "skill": _strip_catalog_metadata(skill),
         "recipes": [_strip_catalog_metadata(recipe) for recipe in recipes],
     }
+    legal = _bundle_meta_legal(skill, bundle_meta)
+    if legal is not None:
+        bundle["legal"] = legal
     return validate_agent_bundle(bundle, username=username)["bundle"]
 
 
@@ -216,6 +219,9 @@ def _bundle_metadata_for_storage(bundle: dict[str, Any]) -> dict[str, Any]:
         clean_tags = [item.strip() for item in tags if isinstance(item, str) and item.strip()]
         if clean_tags:
             metadata["_catalog_bundle_tags"] = clean_tags
+    legal = bundle.get("legal")
+    if isinstance(legal, dict):
+        metadata["_catalog_bundle_legal"] = deepcopy(legal)
     return metadata
 
 
@@ -239,6 +245,16 @@ def _bundle_meta_tags(skill: dict[str, Any], bundle_meta: dict[str, Any]) -> lis
     if isinstance(incoming_tags, list):
         return [item.strip() for item in incoming_tags if isinstance(item, str) and item.strip()]
     return []
+
+
+def _bundle_meta_legal(skill: dict[str, Any], bundle_meta: dict[str, Any]) -> dict[str, Any] | None:
+    stored = skill.get("_catalog_bundle_legal")
+    if isinstance(stored, dict):
+        return deepcopy(stored)
+    incoming = bundle_meta.get("legal")
+    if isinstance(incoming, dict):
+        return deepcopy(incoming)
+    return None
 
 
 def _default_bundle_author(skill: dict[str, Any], *, username: str) -> str:

--- a/tests/test_api_freezone_agent_bundles.py
+++ b/tests/test_api_freezone_agent_bundles.py
@@ -159,7 +159,13 @@ def test_bundle_api_round_trips_structured_legal_metadata(bundle_client: TestCli
     }
     install = bundle_client.post(
         "/api/v1/freezone/agent-config/bundles:install",
-        json={"bundle": {**_bundle_payload(), "legal": legal}},
+        json={
+            "bundle": {
+                **_bundle_payload(),
+                "license": legal["license"]["id"],
+                "legal": legal,
+            }
+        },
     )
     assert install.status_code == 200, install.text
 

--- a/tests/test_api_freezone_agent_bundles.py
+++ b/tests/test_api_freezone_agent_bundles.py
@@ -148,6 +148,30 @@ def test_export_bundle_api_returns_skill_with_recipes(bundle_client: TestClient)
     assert [recipe["id"] for recipe in bundle["recipes"]] == ["community-brief"]
 
 
+def test_bundle_api_round_trips_structured_legal_metadata(bundle_client: TestClient) -> None:
+    legal = {
+        "copyright": "2026 SuperTale contributors",
+        "license": {
+            "id": "Elastic-2.0",
+            "text": "Elastic License 2.0 terms.",
+        },
+        "notice": "DramaClaw trademark rights are reserved.",
+    }
+    install = bundle_client.post(
+        "/api/v1/freezone/agent-config/bundles:install",
+        json={"bundle": {**_bundle_payload(), "legal": legal}},
+    )
+    assert install.status_code == 200, install.text
+
+    response = bundle_client.post(
+        "/api/v1/freezone/agent-config/bundles:export",
+        json={"skill_id": "community-video", "bundle": {}},
+    )
+
+    assert response.status_code == 200, response.text
+    assert response.json()["data"]["legal"] == legal
+
+
 def test_community_catalog_endpoints_are_not_exposed(bundle_client: TestClient) -> None:
     catalog = bundle_client.get("/api/v1/freezone/agent-config/community/catalog")
     install = bundle_client.post(

--- a/tests/test_freezone_agent_bundle.py
+++ b/tests/test_freezone_agent_bundle.py
@@ -79,6 +79,17 @@ def _bundle_payload(**overrides) -> dict:
     return payload
 
 
+def _legal_payload() -> dict:
+    return {
+        "copyright": "2026 SuperTale contributors",
+        "license": {
+            "id": "Elastic-2.0",
+            "text": "Elastic License 2.0 terms.",
+        },
+        "notice": "DramaClaw trademark rights are reserved.",
+    }
+
+
 @pytest.fixture
 def isolated_catalog(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     monkeypatch.setattr(agent_config_store, "OUTPUT_DIR", str(tmp_path))
@@ -94,6 +105,14 @@ def test_validate_agent_bundle_accepts_skill_and_recipes(isolated_catalog: Path)
     assert result["skill_count"] == 1
     assert result["recipe_count"] == 1
     assert result["warnings"] == []
+
+
+def test_validate_agent_bundle_preserves_structured_legal_metadata(isolated_catalog: Path) -> None:
+    legal = _legal_payload()
+
+    result = agent_bundle_store.validate_agent_bundle(_bundle_payload(legal=legal))
+
+    assert result["bundle"]["legal"] == legal
 
 
 def test_validate_agent_bundle_rejects_missing_recipe_reference(isolated_catalog: Path) -> None:
@@ -160,6 +179,33 @@ def test_install_agent_bundle_saves_user_skill_and_recipes(isolated_catalog: Pat
     )
     assert json.loads(skill_path.read_text(encoding="utf-8"))["id"] == "community-video"
     assert json.loads(recipe_path.read_text(encoding="utf-8"))["id"] == "community-brief"
+
+
+def test_install_and_export_preserve_structured_legal_metadata(isolated_catalog: Path) -> None:
+    legal = _legal_payload()
+    agent_bundle_store.install_agent_bundle(
+        username="alice",
+        payload=_bundle_payload(legal=legal),
+    )
+
+    stored_skill_path = (
+        isolated_catalog
+        / "alice"
+        / "_account"
+        / "freezone"
+        / "agent_config"
+        / "skills"
+        / "community-video.json"
+    )
+    stored_skill = json.loads(stored_skill_path.read_text(encoding="utf-8"))
+    assert stored_skill["_catalog_bundle_legal"] == legal
+
+    exported = agent_bundle_store.export_agent_bundle(
+        username="alice",
+        skill_id="community-video",
+        bundle_meta={},
+    )
+    assert exported["legal"] == legal
 
 
 def test_export_agent_bundle_preserves_imported_bundle_metadata(isolated_catalog: Path) -> None:

--- a/tests/test_freezone_agent_bundle.py
+++ b/tests/test_freezone_agent_bundle.py
@@ -110,9 +110,20 @@ def test_validate_agent_bundle_accepts_skill_and_recipes(isolated_catalog: Path)
 def test_validate_agent_bundle_preserves_structured_legal_metadata(isolated_catalog: Path) -> None:
     legal = _legal_payload()
 
-    result = agent_bundle_store.validate_agent_bundle(_bundle_payload(legal=legal))
+    result = agent_bundle_store.validate_agent_bundle(
+        _bundle_payload(license=legal["license"]["id"], legal=legal)
+    )
 
     assert result["bundle"]["legal"] == legal
+
+
+def test_validate_agent_bundle_rejects_mismatched_legal_license_id(
+    isolated_catalog: Path,
+) -> None:
+    with pytest.raises(ValueError, match="license must match legal.license.id"):
+        agent_bundle_store.validate_agent_bundle(
+            _bundle_payload(license="MIT", legal=_legal_payload())
+        )
 
 
 def test_validate_agent_bundle_rejects_missing_recipe_reference(isolated_catalog: Path) -> None:
@@ -185,7 +196,7 @@ def test_install_and_export_preserve_structured_legal_metadata(isolated_catalog:
     legal = _legal_payload()
     agent_bundle_store.install_agent_bundle(
         username="alice",
-        payload=_bundle_payload(legal=legal),
+        payload=_bundle_payload(license=legal["license"]["id"], legal=legal),
     )
 
     stored_skill_path = (
@@ -206,6 +217,18 @@ def test_install_and_export_preserve_structured_legal_metadata(isolated_catalog:
         bundle_meta={},
     )
     assert exported["legal"] == legal
+
+
+def test_install_and_export_legacy_bundle_omits_legal_field(isolated_catalog: Path) -> None:
+    agent_bundle_store.install_agent_bundle(username="alice", payload=_bundle_payload())
+
+    exported = agent_bundle_store.export_agent_bundle(
+        username="alice",
+        skill_id="community-video",
+        bundle_meta={},
+    )
+
+    assert "legal" not in exported
 
 
 def test_export_agent_bundle_preserves_imported_bundle_metadata(isolated_catalog: Path) -> None:


### PR DESCRIPTION
## 变更内容

- 为 Skill Bundle 增加可选且严格校验的 `legal` 结构，包含版权、许可证标识与正文、NOTICE。
- 安装 Bundle 时将 `legal` 元数据持久化到 Skill 的 Bundle 元数据。
- 导出 Bundle 时恢复已保存的 `legal` 元数据。
- 新增 schema、存储导出与 API 安装→导出回归测试。

## 关联变更与合并顺序

本 PR 是 [dramaclaw-skills#1](https://github.com/dramaclaw/dramaclaw-skills/pull/1)（五个官方 Freezone 视频 Skill Bundle）的前置协议变更。该 PR 中的 Bundle 使用顶层 `legal` 字段交付 Elastic-2.0 正文、版权及 NOTICE。

请先合并并部署本 PR，再合并 skills PR #1；旧客户端的严格 schema 不认识 `legal`，会在安装校验阶段拒绝这些 Bundle。

## 兼容性

不含 `legal` 的现有 Bundle 继续正常校验、安装与导出。

## 验证

- `uv run pytest tests/test_freezone_agent_bundle.py tests/test_api_freezone_agent_bundles.py -q`
- `uv run ruff check src/novelvideo/freezone/agent_bundle_schema.py src/novelvideo/freezone/agent_bundle_store.py tests/test_freezone_agent_bundle.py tests/test_api_freezone_agent_bundles.py`
- 使用 dramaclaw-skills PR #1 的五个 Bundle 逐一通过真实 Bundle schema 校验。