### PR TITLE
feat: add Seedance 2.5 to CE media catalog

### DIFF
--- a/src/novelvideo/official_media_models.json
+++ b/src/novelvideo/official_media_models.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "catalogVersion": "2026.08.27.1",
+  "catalogVersion": "2026.09.02.1",
   "name": "DramaClaw CE official media models",
   "mediaModels": {
     "LingShan-G2": {
@@ -166,6 +166,40 @@
         "referenceLinkMax": 1,
         "referenceFileTypes": ["docx", "doc", "xlsx", "xls", "pptx", "ppt", "pdf", "txt", "key", "pages", "numbers", "md"],
         "supportsGenerateAudio": true
+      }
+    },
+    "seedance-2.5": {
+      "provider": "newapi",
+      "upstreamModel": "seedance-2.5",
+      "mediaType": "video",
+      "label": "Seedance 2.5",
+      "enabled": true,
+      "sortOrder": 100,
+      "aliases": ["newapi_seedance-2.5"],
+      "config": {
+        "request": {
+          "endpoint": "video/generations",
+          "parameters": [
+            {"key": "output_format", "label": "输出格式", "control": "select", "options": ["mp4", "mov"], "requestPath": "metadata.output_format"}
+          ]
+        },
+        "humanReview": true,
+        "minDuration": 4,
+        "maxDuration": 30,
+        "ratioOptions": ["1:1", "16:9", "9:16", "4:3", "3:4", "21:9", "auto"],
+        "supportedModes": ["text_to_video", "image_reference", "all_reference", "video_edit", "first_last_frame"],
+        "referenceAudioMax": 10,
+        "referenceAudioMinSeconds": 2,
+        "referenceAudioMaxSeconds": 30,
+        "referenceAudioTotalMinSeconds": 2,
+        "referenceAudioTotalMaxSeconds": 30,
+        "referenceImageMax": 30,
+        "referenceVideoMax": 10,
+        "referenceVideoMinSeconds": 2,
+        "referenceVideoMaxSeconds": 30,
+        "referenceVideoTotalMinSeconds": 2,
+        "referenceVideoTotalMaxSeconds": 30,
+        "resolutionOptions": ["480p", "720p", "1080p"]
       }
     },
     "seedance-2.0-fast": {

--- a/tests/test_model_gateway_settings.py
+++ b/tests/test_model_gateway_settings.py
@@ -77,6 +77,31 @@ def _newer_bundled_catalog_version(offset: int = 1) -> str:
     return ".".join(parts)
 
 
+def test_bundled_catalog_includes_seedance_25_capabilities():
+    bundled = json.loads(
+        Path(model_gateway_settings.__file__)
+        .with_name("official_media_models.json")
+        .read_text(encoding="utf-8")
+    )
+
+    model = bundled["mediaModels"]["seedance-2.5"]
+    assert model["upstreamModel"] == "seedance-2.5"
+    assert model["mediaType"] == "video"
+    assert model["config"]["supportedModes"] == [
+        "text_to_video",
+        "image_reference",
+        "all_reference",
+        "video_edit",
+        "first_last_frame",
+    ]
+    assert model["config"]["referenceImageMax"] == 30
+    assert model["config"]["referenceVideoMax"] == 10
+    assert model["config"]["referenceAudioMax"] == 10
+    assert model["config"]["maxDuration"] == 30
+    assert model["config"]["referenceVideoTotalMaxSeconds"] == 30
+    assert model["config"]["referenceAudioTotalMaxSeconds"] == 30
+
+
 def test_generic_comfyui_i2v_defaults_to_widescreen():
     config = model_gateway._default_comfyui_media_model_config("wan-i2v")
 
@@ -3324,7 +3349,7 @@ def test_official_media_model_catalog_uses_ce_export_shape():
     videos = get_official_media_model_catalog("video")
 
     assert len(images) == 6
-    assert len(videos) == 10
+    assert len(videos) == 11
     assert [entry["id"] for entry in videos[:2]] == [
         "wan3.0-video-prime",
         "wan3.0-video",
@@ -3333,6 +3358,10 @@ def test_official_media_model_catalog_uses_ce_export_shape():
     assert wan["referenceFileMax"] == 1
     assert wan["referenceLinkMax"] == 1
     assert "pdf" in wan["referenceFileTypes"]
+    seedance_25 = next(entry for entry in videos if entry["id"] == "seedance-2.5")
+    assert seedance_25["apiModel"] == "newapi_seedance-2.5"
+    assert seedance_25["resolutionOptions"] == ["480p", "720p", "1080p"]
+    assert seedance_25["ratioOptions"][-1] == "auto"
     seedream = next(entry for entry in images if entry["id"] == "seedream-5.0-pro")
     assert seedream["gatewayModel"] == "seedream-5.0-pro"
     assert seedream["resolutionOptions"] == ["1k", "2k"]


### PR DESCRIPTION
## PR 类型 / Type of PR
- [ ] 🐞 Bug 修复 / Bug fix
- [x] ✨ 新功能 / Feature
- [ ] 📝 文档 / Documentation
- [ ] 🧹 重构 / 清理 / Refactor or cleanup
- [ ] ⚙️ 构建 / CI / Build or CI
- [ ] ⚠️ 破坏性变更 / Breaking change

## 改动说明 / What this PR does and why
在 DramaClaw CE 官方媒体模型目录中新增 Seedance 2.5，使 CE 媒体目录可直接选择并配置该视频模型。

目录能力与提供的模型配置保持一致，包括：
- 4-30 秒视频时长与 480p/720p/1080p 分辨率
- 固定比例及 auto 比例
- 文生视频、图片参考、全能参考、视频编辑和首尾帧模式
- 最多 30 张图片、10 段视频和 10 段音频参考
- 参考音视频单项及总时长 2-30 秒
- mp4/mov 输出格式和真人审核

同时将官方目录版本更新为 2026.09.02.1，并补充目录加载与 CE 导出形状测试。

## 关联 issue / Linked issues
Closes #461

## 给 reviewer 的说明 / Notes for the reviewer
重点确认 Seedance 2.5 的能力边界是否与网关实际支持一致。目录字段经过现有媒体模型 schema 校验；本 PR 不修改视频请求组装逻辑。

本地验证：
`UV_CACHE_DIR=/Users/newyue/claymorelab/.uv-cache uv run pytest tests/test_model_gateway_settings.py tests/test_publish_official_media_catalog.py`

结果：107 passed。

## 面向用户的变更 / User-facing change
```release-note
DramaClaw CE 官方媒体模型目录新增 Seedance 2.5 视频模型。
```

## 自检 / Checklist
- [x] 已自测，相关 pytest 测试通过 / Self-tested, relevant pytest tests pass
- [x] 必要的文档已更新或无需更新 / Docs updated where needed or not required
- [x] 提交信息清晰（建议 Conventional Commits）/ Clear commits (Conventional Commits suggested)
- [x] 每个 commit 都已 `git commit -s` 附 DCO 签署 / Every commit signed off with `git commit -s` (DCO)
- [x] 我已阅读并同意[贡献者协议](../CONTRIBUTING.md#贡献者协议) / I've read and agree to the [contributor terms](../CONTRIBUTING.md#贡献者协议)