### PR TITLE
fix(i18n): 进度文案的 i18n code 要能活过一次落库

### DIFF
--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -2785,7 +2785,9 @@
       },
       "props": {
         "perEpisode": "Props are generated per episode"
-      }
+      },
+      "started": "Task started",
+      "cancelled": "Task cancelled"
     },
     "log": {
       "ingest": {

--- a/frontend/public/locales/zh/translation.json
+++ b/frontend/public/locales/zh/translation.json
@@ -2785,7 +2785,9 @@
       },
       "props": {
         "perEpisode": "道具按分集生成"
-      }
+      },
+      "started": "任务已开始",
+      "cancelled": "任务已取消"
     },
     "log": {
       "ingest": {

--- a/src/novelvideo/task_state.py
+++ b/src/novelvideo/task_state.py
@@ -779,7 +779,12 @@ class TaskStateManager:
                 return False
             state.status = "running"
             state.progress = max(float(state.progress or 0.0), 0.01)
-            state.current_task = "任务已开始"
+            # 走 helper 而不是直接赋值：直接赋值只换掉中文兜底，上一条
+            # tasks.progress.queued 的 code 会留在 metadata 里，英文界面就把一个
+            # running 的任务显示成 "Task queued"。
+            self._apply_progress_message(
+                state, lmsg("tasks.progress.started", "任务已开始"), None
+            )
             if metadata is not None:
                 state.metadata = self._merge_task_metadata(state.metadata, metadata)
                 state.result = self._merge_metadata_into_result(state.result, state.metadata)
@@ -819,7 +824,9 @@ class TaskStateManager:
             if state.status not in {"submitting", "queued"}:
                 return False, state
             state.status = "cancelled"
-            state.current_task = "任务已取消"
+            self._apply_progress_message(
+                state, lmsg("tasks.progress.cancelled", "任务已取消"), None
+            )
             state.completed_at = state.completed_at or utc_now_iso()
             state.updated_at = utc_now_iso()
             state.metadata = self._merge_task_metadata(
@@ -1657,6 +1664,13 @@ class TaskStateManager:
 
     @staticmethod
     def _save_on_connection(conn, task_key: str, state: TaskState, expires_at: str | None) -> None:
+        # metadata 没有自己的列，靠 result_json.task_metadata 落库（见 _row_to_state）。
+        # 合并必须发生在写库边界，不能指望每个调用点自己同步：_apply_progress_message
+        # 改的是 state.metadata，而各调用点的手工合并大多挂在 `if metadata is not None`
+        # 下面，调用方没顺手传 metadata 时，进度文案的 i18n code 就在这一跳丢了——
+        # reserve 写的 tasks.progress.submitting、update_progress 传进来的
+        # LocalizableMessage 都是这么没的，英文界面因此还是渲染中文兜底。
+        result = TaskStateManager._merge_metadata_into_result(state.result, state.metadata)
         conn.execute(
             """
             INSERT INTO task_states (
@@ -1704,11 +1718,7 @@ class TaskStateManager:
                 state.status,
                 state.progress,
                 state.current_task,
-                (
-                    json.dumps(state.result, ensure_ascii=False)
-                    if state.result is not None
-                    else None
-                ),
+                (json.dumps(result, ensure_ascii=False) if result is not None else None),
                 state.error,
                 json.dumps(state.logs, ensure_ascii=False),
                 state.created_at,

--- a/tests/test_task_progress_i18n.py
+++ b/tests/test_task_progress_i18n.py
@@ -18,6 +18,7 @@ from novelvideo.i18n_message import (
     message_payload,
     message_text,
 )
+from novelvideo.project_context import ProjectContext
 from novelvideo.task_state import TaskState, TaskStateManager
 
 
@@ -169,3 +170,123 @@ def test_serialized_task_omits_the_i18n_field_when_nothing_is_localizable():
 
     assert payload["logs"] == ["任务已开始"]
     assert "logs_i18n" not in payload
+
+
+# ---------------------------------------------------------------------------
+# 落库往返
+#
+# review #462：`TaskState.metadata` 没有自己的列，靠 `result_json.task_metadata`
+# 落库。`_apply_progress_message()` 改的是 `state.metadata`，而各调用点的手工合并
+# 大多挂在 `if metadata is not None:` 下面——调用方没顺手传 metadata 时，code 就在
+# 写库这一跳丢了，前端永远拿不到 `current_task_code`，整套本地化等于没生效。
+# 合并因此挪到了写库边界，这几条钉住的就是「经过一次真实往返之后 code 还在」。
+# ---------------------------------------------------------------------------
+
+
+def _project_ctx(tmp_path) -> ProjectContext:
+    return ProjectContext(
+        project_id="proj_i18n",
+        project_name="demo",
+        owner_type="user",
+        owner_id="owner",
+        owner_username="alice",
+        requester_user_id="editor",
+        requester_username="bob",
+        requester_principals=(("user", "editor"),),
+        effective_role="editor",
+        home_node_id="node_a",
+        output_dir=tmp_path / "output",
+        state_dir=tmp_path / "state",
+        runtime_dir=tmp_path / "runtime",
+        is_home_node=True,
+    )
+
+
+def _reread_message(manager: TaskStateManager, ctx) -> dict | None:
+    """重新从库里读出来的 `current_task_message`。"""
+    state = manager.get_task_for_project(ctx, "single_video", 1)
+    assert state is not None
+    return (state.metadata or {}).get("current_task_message")
+
+
+def test_reserved_task_keeps_its_submitting_code_across_a_db_round_trip(tmp_path):
+    manager = TaskStateManager()
+    ctx = _project_ctx(tmp_path)
+
+    manager.reserve_task_for_project(ctx, "single_video", 1)
+
+    assert _reread_message(manager, ctx) == {"code": "tasks.progress.submitting"}
+
+
+def test_queued_code_survives_without_the_caller_passing_metadata(tmp_path):
+    """调用方不传 metadata 是常态，不能靠它捎带把 code 写进去。"""
+    manager = TaskStateManager()
+    ctx = _project_ctx(tmp_path)
+    state, _ = manager.reserve_task_for_project(ctx, "single_video", 1)
+
+    assert manager.mark_task_enqueued_for_project(
+        ctx, "single_video", 1, expected_task_id=state.task_id
+    )
+
+    assert _reread_message(manager, ctx) == {"code": "tasks.progress.queued"}
+
+
+def test_progress_update_keeps_both_code_and_params_across_a_db_round_trip(tmp_path):
+    manager = TaskStateManager()
+    ctx = _project_ctx(tmp_path)
+    manager.reserve_task_for_project(ctx, "single_video", 1)
+
+    manager.update_progress_for_project(
+        ctx,
+        "single_video",
+        1,
+        progress=0.5,
+        current_task=lmsg("tasks.log.ingest.readingFile", "读取文件: /a.docx", path="/a.docx"),
+    )
+
+    assert _reread_message(manager, ctx) == {
+        "code": "tasks.log.ingest.readingFile",
+        "params": {"path": "/a.docx"},
+    }
+
+
+def test_started_task_no_longer_carries_the_queued_code(tmp_path):
+    """begin 直接赋值 current_task 时，英文界面会把 running 显示成 "Task queued"。"""
+    manager = TaskStateManager()
+    ctx = _project_ctx(tmp_path)
+    state, _ = manager.reserve_task_for_project(ctx, "single_video", 1)
+    manager.mark_task_enqueued_for_project(
+        ctx, "single_video", 1, expected_task_id=state.task_id
+    )
+
+    assert manager.begin_task_execution_for_project(
+        ctx, "single_video", 1, expected_task_id=state.task_id
+    )
+
+    reread = manager.get_task_for_project(ctx, "single_video", 1)
+    assert reread.current_task == "任务已开始"
+    assert (reread.metadata or {}).get("current_task_message") == {
+        "code": "tasks.progress.started"
+    }
+
+
+def test_cancelled_task_no_longer_carries_the_queued_code(tmp_path):
+    manager = TaskStateManager()
+    ctx = _project_ctx(tmp_path)
+    state, _ = manager.reserve_task_for_project(ctx, "single_video", 1)
+    manager.mark_task_enqueued_for_project(
+        ctx, "single_video", 1, expected_task_id=state.task_id
+    )
+
+    cancelled, _ = manager.cancel_queued_task_for_project(
+        ctx, "single_video", 1, expected_task_id=state.task_id
+    )
+    assert cancelled
+
+    reread = manager.get_task_for_project(ctx, "single_video", 1)
+    assert reread.current_task == "任务已取消"
+    assert (reread.metadata or {}).get("current_task_message") == {
+        "code": "tasks.progress.cancelled"
+    }
+    # 退款判定挂在同一个 metadata 上，边界合并不能把它挤掉。
+    assert reread.metadata["refund_eligible"] is True


### PR DESCRIPTION
承接 #462 的 review（claymorelab/SuperTale#171，reviewer @lywaterman）。两条都在本地复现了，#462 的进度本地化在 CE 自己身上就基本没生效。

## P1 —— 进度文案的 i18n code 落库就丢

`TaskState.metadata` 没有自己的列，靠 `result_json.task_metadata` 持久化（见 `_row_to_state`），但写库只序列化 `state.result`。`_apply_progress_message()` 改的是 `state.metadata`，而各调用点的手工合并大多挂在 `if metadata is not None:` 下面 —— 调用方没顺手传 metadata 时，code 就在这一跳没了。

`reserve_task_for_project` 更是必丢：第 728 行先算好 `result=_merge_metadata_into_result(None, metadata)`，第 735 行才 `_apply_progress_message(submitting)`。

修复前（真实 SQLite 往返）：

```
reserve  in-memory : 任务正在投递  {'code': 'tasks.progress.submitting'}
reserve  reread    : 任务正在投递  None          ← code 没了
update   reread    : 正在提取场景  None          ← code 没了
enqueue  reread    : 任务已进入队列 {'code': 'tasks.progress.queued'}
```

`enqueue` 那行之所以侥幸保住，只是因为调用方顺手传了 `metadata={"backend": "celery"}`。

**改法**：合并挪到 `_save_on_connection()` 这个写库边界统一做一次，不再依赖每个调用点。现有那十几处调用点的手工合并保持不动 —— 幂等，而且有调用方（比如 `cancel_queued_task_for_project`）会直接把返回的 `state.result` 交给上层。

## P2 —— begin / cancel 遗留上一条 queued code

`task_state.py:782` 和 `:822` 直接 `state.current_task = "任务已开始" / "任务已取消"`，绕过 helper，只换掉中文兜底，metadata 里的 `tasks.progress.queued` 原样留着。前端优先按 code 翻译，于是：

```
begin    reread    : 任务已开始  {'code': 'tasks.progress.queued'}   ← 英文界面显示 "Task queued"
cancel   reread    : 任务已取消  {'code': 'tasks.progress.queued'}   ← 同上
```

**改法**：改走 `_apply_progress_message()`，新增 `tasks.progress.started` / `tasks.progress.cancelled` 两个 code 并补齐中英文词条。

## 修复后

```
reserve  reread    : 任务正在投递  {'code': 'tasks.progress.submitting'}
update   reread    : 正在提取场景  {'code': 'tasks.progress.scenes.extracting'}
enqueue  reread    : 任务已进入队列 {'code': 'tasks.progress.queued'}
begin    reread    : 任务已开始    {'code': 'tasks.progress.started'}
cancel   reread    : 任务已取消    {'code': 'tasks.progress.cancelled'}
```

## 测试

`tests/test_task_progress_i18n.py` 新增 5 条真实 SQLite 往返用例，覆盖 reviewer 点名的全部场景：

- reserve → reread，`tasks.progress.submitting` 仍在
- **不带 metadata** 的 enqueue → reread，`tasks.progress.queued` 仍在
- 带 `params` 的 `LocalizableMessage` 更新 → reread，code 和 params 都在
- queued → started，不再携带 queued code
- queued → cancelled，不再携带 queued code，且 `refund_eligible` 没被边界合并挤掉

`git stash` 掉 `task_state.py` 的修复后这 5 条全挂，不是空断言。

## 验证

- `pytest tests/test_task_progress_i18n.py` → 14 passed
- 任务状态相关 9 个套件 → 94 passed
- `pytest -k task`（不含 integration）→ 621 passed；6 个失败里 5 个在 main 上同样失败（`ports/test_tasks.py`、`test_task_envelope_local_signing_key.py`、`test_video_prompt_language.py`），剩下 1 个 `test_concurrent_first_boot_converges_on_one_key` 单跑三次两次通过，是并发用例的抖动
- `ruff check` / `scripts/check_backend_i18n.py`（475 处 / 29 文件，未增加）/ `scripts/check_frontend_i18n.py`（0 处）
- `tsc -b`、`pnpm build`、`vitest run src/__tests__/task-center src/__tests__/hooks` → 199 passed
- 无新增被跟踪文件，`license-inventory.csv` 无需变动

## 后续

EE 侧 `claymorelab/SuperTale#171` 的 `_pg_state_params()` 和 3 处直接赋值（`task_state_store.py:892`、`:926`、`:1359` 含 async 路径）是同一个问题，等这个合了之后连同 CE pin 一起在那边处理。部署时 API 与 Celery worker 都要重启。
