### PR TITLE
feat(compose): build the bundled gateway from a sibling dramaclaw-gateway checkout by default

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -38,8 +38,10 @@ ST_TASK_ENVELOPE_KEYRING_B64_JSON=
 # DRAMACLAW_GATEWAY_VERSION=v1.0.0-rc.24-dramaclaw.1
 # 网关后台端口默认只绑本机回环；要从别的机器访问网关后台时放开：
 # ST_NEWAPI_BIND=0.0.0.0
-# 源码构建（docker compose up -d --build）默认从 git main 拉网关代码；要改网关代码就指向旁路 checkout：
+# 源码构建（docker compose up -d --build）默认用与本仓并排的 ../dramaclaw-gateway checkout 构建网关（先 git clone 它）；
+# clone 放在别处、或不想 clone 而让 Docker 直接从 git 拉时改这里：
 # DRAMACLAW_GATEWAY_SRC=../dramaclaw-gateway
+# DRAMACLAW_GATEWAY_SRC=https://github.com/dramaclaw/dramaclaw-gateway.git#main
 
 # 官方渠道在网页「设置 → 模型配置 → 官方渠道」填写 DC key。
 # 本地渠道使用 CE 随附的 NewAPI，并由配置向导自动创建运行 token。

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,10 @@
-# DramaClaw CE — 源码构建（默认入口）：api、web 用本地 checkout 构建，网关直接从 dramaclaw-gateway 的 git main 构建，三件全部本地产出。
+# DramaClaw CE — 源码构建（默认入口）：api、web 用本地 checkout 构建，网关用旁边的 dramaclaw-gateway checkout 构建，三件全部本地产出。
+#   git clone https://github.com/dramaclaw/dramaclaw-gateway.git ../dramaclaw-gateway
 #   cp .env.example .env && docker compose up -d --build
 # 运行定义（env / 端口 / 卷 / 健康检查）全部 extends 自 docker-compose.release.yml，这里只加 build 与本地镜像名。
 # 只想拉已发布镜像：docker compose -f docker-compose.release.yml up -d
-# 想改网关代码：把 fork 克隆到旁边，.env 设 DRAMACLAW_GATEWAY_SRC=../dramaclaw-gateway。
+# 网关源码默认取 ../dramaclaw-gateway（与本仓并排的 clone，改代码直接改那里）；放在别处或想让 Docker 直接从 git 拉：
+#   .env 设 DRAMACLAW_GATEWAY_SRC=<路径> 或 DRAMACLAW_GATEWAY_SRC=https://github.com/dramaclaw/dramaclaw-gateway.git#main
 # 本地构建的镜像命名为 dramaclaw-local/*，不会覆盖本机缓存里的 claymorelab/* 发布镜像。
 services:
   api:
@@ -24,7 +26,7 @@ services:
       service: newapi
     image: dramaclaw-local/gateway
     build:
-      context: ${DRAMACLAW_GATEWAY_SRC:-https://github.com/dramaclaw/dramaclaw-gateway.git#main}
+      context: ${DRAMACLAW_GATEWAY_SRC:-../dramaclaw-gateway}
       dockerfile: Dockerfile
   web:
     extends:

--- a/docs/en/getting-started/installation.md
+++ b/docs/en/getting-started/installation.md
@@ -32,10 +32,11 @@ Once installed:
 
 ```bash
 git clone https://github.com/dramaclaw/dramaclaw.git
+git clone https://github.com/dramaclaw/dramaclaw-gateway.git   # bundled gateway, built from ../dramaclaw-gateway
 cd dramaclaw
 cp .env.example .env        # at minimum, change PROMPT_EXPORT_PASSWORD to a non-default value
-docker compose up -d --build    # builds api, web and the bundled gateway from source
-# no build? docker compose -f docker-compose.release.yml up -d   # pulls published images
+docker compose up -d --build    # builds api, web and the gateway from the two checkouts
+# no build? docker compose -f docker-compose.release.yml up -d   # pulls published images, no gateway clone needed
 ```
 
 After it's up, open **`http://localhost:8080`** in your browser (the app UI); the REST API is at `http://localhost:8780`. Go to Settings → Model Configuration → Official Channel, paste your DC key, save, and you're ready. For the full walkthrough see [Quickstart](quickstart.md); for start/stop/backup see the [Self-Hosting Handbook](../guides/self-hosting.md).

--- a/docs/en/getting-started/quickstart.md
+++ b/docs/en/getting-started/quickstart.md
@@ -15,8 +15,9 @@ DramaClaw is the Community Edition (CE): it runs on a single machine with no Pos
 ## Steps
 
 ```bash
-# 1. Get the code
+# 1. Get the code — DramaClaw and the bundled gateway, side by side
 git clone https://github.com/dramaclaw/dramaclaw.git
+git clone https://github.com/dramaclaw/dramaclaw-gateway.git
 cd dramaclaw
 
 # 2. Prepare configuration
@@ -25,8 +26,8 @@ cp .env.example .env
 #    Configure the model channel and key in the web UI, not in .env.
 
 # 3. Start — brings up api / newapi / web
-docker compose up -d --build   # builds api, web and the bundled gateway from source
-# no build? docker compose -f docker-compose.release.yml up -d   # pulls published images
+docker compose up -d --build   # builds api, web (this checkout) and the gateway (../dramaclaw-gateway) from source
+# no build? docker compose -f docker-compose.release.yml up -d   # pulls published images, no gateway clone needed
 
 # 4. Confirm it's up
 docker compose ps   # api, newapi, and web should all be running

--- a/docs/en/guides/self-hosting.md
+++ b/docs/en/guides/self-hosting.md
@@ -106,11 +106,11 @@ docker run --rm -v dramaclaw-ce_newapi-data:/data -v "$PWD":/backup alpine \
 
 ## 6. Upgrades
 
-Source build:
+Source build (both checkouts):
 
 ```bash
+git -C ../dramaclaw-gateway pull   # first time after upgrading from an older checkout: git clone https://github.com/dramaclaw/dramaclaw-gateway.git ../dramaclaw-gateway
 git pull
-# edit .env: DRAMACLAW_VERSION=2.1.0 (and DRAMACLAW_GATEWAY_VERSION if the release notes say so)
 docker compose up -d --build
 ```
 
@@ -152,9 +152,9 @@ The script copies only missing files, never overwrites or deletes the source, an
 
 | Before | Now |
 |---|---|
-| `docker compose up -d --build` (official gateway, source build) | Same command; now also builds the bundled gateway (defaults to host-only, idle until used) |
+| `docker compose up -d --build` (official gateway, source build) | Same command, **after** `git clone https://github.com/dramaclaw/dramaclaw-gateway.git ../dramaclaw-gateway` (or `DRAMACLAW_GATEWAY_SRC=https://github.com/dramaclaw/dramaclaw-gateway.git#main` in `.env` to skip the clone); it now also builds the bundled gateway (host-only by default, idle until used). Without the clone the build stops with `unable to prepare context: path ".../dramaclaw-gateway" not found` |
 | `docker compose -f docker-compose.release.yml up -d` | Same command; the gateway image is now `claymorelab/dramaclaw-gateway` |
-| `docker compose -f docker-compose.selfhosted.yml up -d --build` | Use `docker compose up -d --build` instead; the `newapi-data` volume is reused — back it up first (rc.21 → rc.24 only adds tables) |
+| `docker compose -f docker-compose.selfhosted.yml up -d --build` | Clone the gateway as above, then `docker compose up -d --build`; the `newapi-data` volume is reused — back it up first (rc.21 → rc.24 only adds tables) |
 | `docker compose -f docker-compose.selfhosted.release.yml up -d` | Use `docker compose -f docker-compose.release.yml up -d` instead; same as above |
 | `.env`'s `NEWAPI_BASE_URL` / `NEWAPI_API_KEY` / `ST_*_PORT` / `INSTALL_WORLD` / `NEWAPI_PROVISIONER_ENABLED` | Unchanged, still effective |
 

--- a/docs/en/guides/self-hosting.md
+++ b/docs/en/guides/self-hosting.md
@@ -20,6 +20,7 @@ Two compose files ship in the repo: `docker-compose.yml` builds all three servic
 
 ```bash
 git clone https://github.com/dramaclaw/dramaclaw.git
+git clone https://github.com/dramaclaw/dramaclaw-gateway.git   # only for the source build; image mode does not need it
 cd dramaclaw
 cp .env.example .env
 ```
@@ -28,7 +29,7 @@ Two files, already set for you, no changes needed:
 
 | File | Mode | Command |
 |---|---|---|
-| `docker-compose.yml` | Source build (default) — builds `api`, `web`, and the bundled gateway from the checkout / git `main` | `docker compose up -d --build` |
+| `docker-compose.yml` | Source build (default) — builds `api` and `web` from this checkout and the bundled gateway from `../dramaclaw-gateway` (override with `DRAMACLAW_GATEWAY_SRC`, a path or a git URL) | `docker compose up -d --build` |
 | `docker-compose.release.yml` | Image only — pulls published images, never builds | `docker compose -f docker-compose.release.yml up -d` |
 
 Key points shared by both (defined once in `docker-compose.release.yml`, reused by `docker-compose.yml` via `extends`):
@@ -113,7 +114,7 @@ git pull
 docker compose up -d --build
 ```
 
-`docker compose up -d --build` also re-fetches and rebuilds the bundled gateway from `dramaclaw-gateway` git (Go + bun, several minutes). When only DramaClaw code changed, rebuild just the two local services: `docker compose up -d --build api web`.
+`docker compose up -d --build` also rebuilds the bundled gateway from `../dramaclaw-gateway` (Go + bun, several minutes); `git pull` there too when you want a newer gateway. When only DramaClaw code changed, rebuild just the two local services: `docker compose up -d --build api web`; when only the gateway changed, `docker compose up -d --build newapi`.
 
 Image mode:
 

--- a/docs/en/guides/troubleshooting.md
+++ b/docs/en/guides/troubleshooting.md
@@ -36,7 +36,8 @@
 | Symptom | Diagnosis |
 |---|---|
 | **Data gone after a rebuild** | Data lives in the named volume `ce-data` (`/data` inside the container). `docker compose down` keeps the volume—**do not add `-v`** (it deletes the volume). For backups see the [self-hosting handbook](self-hosting.md#5-where-the-data-lives--backups). |
-| **Config error after an upgrade** | Source build (`docker-compose.yml`): `git pull && docker compose up -d --build`. Prebuilt images (`docker-compose.release.yml`): `docker compose -f docker-compose.release.yml pull && docker compose -f docker-compose.release.yml up -d` (bump `DRAMACLAW_VERSION` / `DRAMACLAW_GATEWAY_VERSION` in `.env` if you pin them). See the self-hosting guide §6. |
+| **`unable to prepare context: path ".../dramaclaw-gateway" not found`** | The source build expects the gateway checkout next to this repo. `git clone https://github.com/dramaclaw/dramaclaw-gateway.git ../dramaclaw-gateway`, or set `DRAMACLAW_GATEWAY_SRC` in `.env` to your clone's path or to `https://github.com/dramaclaw/dramaclaw-gateway.git#main`. |
+| **Config error after an upgrade** | Source build (`docker-compose.yml`): `git -C ../dramaclaw-gateway pull && git pull && docker compose up -d --build`. Prebuilt images (`docker-compose.release.yml`): `docker compose -f docker-compose.release.yml pull && docker compose -f docker-compose.release.yml up -d` (bump `DRAMACLAW_VERSION` / `DRAMACLAW_GATEWAY_VERSION` in `.env` if you pin them). See the self-hosting guide §6. |
 
 ## world features (3DGS/SHARP)
 

--- a/docs/zh/getting-started/installation.md
+++ b/docs/zh/getting-started/installation.md
@@ -32,10 +32,11 @@ DramaClaw CE 是单机服务,**无需 PostgreSQL / Redis**。Docker 起 `api` + 
 
 ```bash
 git clone https://github.com/dramaclaw/dramaclaw.git
+git clone https://github.com/dramaclaw/dramaclaw-gateway.git   # 内置网关，从 ../dramaclaw-gateway 构建
 cd dramaclaw
 cp .env.example .env        # 至少把 PROMPT_EXPORT_PASSWORD 改成非默认值
-docker compose up -d --build    # 从源码构建 api、web 与内置网关
-# 免构建：docker compose -f docker-compose.release.yml up -d   # 拉已发布镜像
+docker compose up -d --build    # 用两个 checkout 从源码构建 api、web 与网关
+# 免构建：docker compose -f docker-compose.release.yml up -d   # 拉已发布镜像，不需要 clone 网关
 ```
 
 起好后浏览器打开 **`http://localhost:8080`**(应用界面);REST API 在 `http://localhost:8780`。进入设置 → 模型配置 → 官方渠道,粘贴 DC key 保存即用。完整步骤见 [快速开始](quickstart.md),起停/备份见 [自托管手册](../guides/self-hosting.md)。

--- a/docs/zh/getting-started/quickstart.md
+++ b/docs/zh/getting-started/quickstart.md
@@ -15,8 +15,9 @@ DramaClaw 是社区版(CE),单机运行、无需 PostgreSQL / Redis。默认 `do
 ## 步骤
 
 ```bash
-# 1. 取得代码
+# 1. 取得代码 —— DramaClaw 和内置网关并排放
 git clone https://github.com/dramaclaw/dramaclaw.git
+git clone https://github.com/dramaclaw/dramaclaw-gateway.git
 cd dramaclaw
 
 # 2. 准备配置
@@ -25,8 +26,8 @@ cp .env.example .env
 #    模型渠道和 key 在下一步通过网页配置，不写入 .env。
 
 # 3. 启动 —— 起 api / newapi / web 三个服务
-docker compose up -d --build   # 从源码构建 api、web 与内置网关
-# 免构建：docker compose -f docker-compose.release.yml up -d   # 拉已发布镜像
+docker compose up -d --build   # 从源码构建 api、web（本仓）与网关（../dramaclaw-gateway）
+# 免构建：docker compose -f docker-compose.release.yml up -d   # 拉已发布镜像，不需要 clone 网关
 
 # 4. 确认已起
 docker compose ps   # api、newapi、web 均应 running

--- a/docs/zh/guides/self-hosting.md
+++ b/docs/zh/guides/self-hosting.md
@@ -20,6 +20,7 @@ CE 三个容器：`api` + `newapi`（内置 DramaClaw 网关，切到自定义/�
 
 ```bash
 git clone https://github.com/dramaclaw/dramaclaw.git
+git clone https://github.com/dramaclaw/dramaclaw-gateway.git   # 只有源码构建需要；镜像模式不用
 cd dramaclaw
 cp .env.example .env
 ```
@@ -28,7 +29,7 @@ cp .env.example .env
 
 | 文件 | 模式 | 命令 |
 |---|---|---|
-| `docker-compose.yml` | 源码构建（默认）—— 从本地 checkout / git `main` 构建 `api`、`web` 与内置网关 | `docker compose up -d --build` |
+| `docker-compose.yml` | 源码构建（默认）—— `api`、`web` 用本仓 checkout，内置网关用 `../dramaclaw-gateway`（`DRAMACLAW_GATEWAY_SRC` 可改成别的路径或 git 地址） | `docker compose up -d --build` |
 | `docker-compose.release.yml` | 只拉镜像，不构建 | `docker compose -f docker-compose.release.yml up -d` |
 
 两者共享的关键点（定义在 `docker-compose.release.yml` 里，`docker-compose.yml` 通过 `extends` 复用）：
@@ -113,7 +114,7 @@ git pull
 docker compose up -d --build
 ```
 
-`docker compose up -d --build` 会连内置网关一起从 `dramaclaw-gateway` 的 git 重新拉取并构建（Go + bun，要几分钟）。只改了 DramaClaw 代码时，只重建两个本地服务即可：`docker compose up -d --build api web`。
+`docker compose up -d --build` 会连内置网关一起从 `../dramaclaw-gateway` 重新构建（Go + bun，要几分钟）；想要更新的网关就到那个目录 `git pull`。只改了 DramaClaw 代码时，只重建两个本地服务：`docker compose up -d --build api web`；只改了网关时：`docker compose up -d --build newapi`。
 
 镜像模式：
 

--- a/docs/zh/guides/self-hosting.md
+++ b/docs/zh/guides/self-hosting.md
@@ -106,11 +106,11 @@ docker run --rm -v dramaclaw-ce_newapi-data:/data -v "$PWD":/backup alpine \
 
 ## 6. 升级
 
-源码构建：
+源码构建（两个 checkout 都拉）：
 
 ```bash
+git -C ../dramaclaw-gateway pull   # 从旧 checkout 升级后的第一次：git clone https://github.com/dramaclaw/dramaclaw-gateway.git ../dramaclaw-gateway
 git pull
-# 编辑 .env：DRAMACLAW_VERSION=2.1.0（发布说明要求时同时改 DRAMACLAW_GATEWAY_VERSION）
 docker compose up -d --build
 ```
 
@@ -152,9 +152,9 @@ docker compose up -d
 
 | 以前 | 现在 |
 |---|---|
-| `docker compose up -d --build`（官方网关，源码） | 同一命令；多了内置网关（默认只绑本机、闲置待命） |
+| `docker compose up -d --build`（官方网关，源码） | 同一命令，但要**先** `git clone https://github.com/dramaclaw/dramaclaw-gateway.git ../dramaclaw-gateway`（不想 clone 就在 `.env` 设 `DRAMACLAW_GATEWAY_SRC=https://github.com/dramaclaw/dramaclaw-gateway.git#main`）；现在会连内置网关一起构建（默认只绑本机、闲置待命）。没 clone 会报 `unable to prepare context: path ".../dramaclaw-gateway" not found` |
 | `docker compose -f docker-compose.release.yml up -d` | 同一命令；网关镜像为 `claymorelab/dramaclaw-gateway` |
-| `docker compose -f docker-compose.selfhosted.yml up -d --build` | 改用 `docker compose up -d --build`；`newapi-data` 卷复用，先备份（rc.21 → rc.24 只加表） |
+| `docker compose -f docker-compose.selfhosted.yml up -d --build` | 按上一行先 clone 网关，再 `docker compose up -d --build`；`newapi-data` 卷复用，先备份（rc.21 → rc.24 只加表） |
 | `docker compose -f docker-compose.selfhosted.release.yml up -d` | 改用 `docker compose -f docker-compose.release.yml up -d`；同上 |
 | `.env` 里的 `NEWAPI_BASE_URL` / `NEWAPI_API_KEY` / `ST_*_PORT` / `INSTALL_WORLD` / `NEWAPI_PROVISIONER_ENABLED` | 含义不变，继续生效 |
 

--- a/docs/zh/guides/troubleshooting.md
+++ b/docs/zh/guides/troubleshooting.md
@@ -36,7 +36,8 @@
 | 现象 | 排查 |
 |---|---|
 | **重建后数据没了** | 数据在命名卷 `ce-data`(容器内 `/data`)。`docker compose down` 保留卷,**别加 `-v`**(会删卷)。备份见 [自托管手册](self-hosting.md#5-数据在哪--备份)。 |
-| **升级后报配置错误** | 源码构建（`docker-compose.yml`）：`git pull && docker compose up -d --build`。镜像模式（`docker-compose.release.yml`）：`docker compose -f docker-compose.release.yml pull && docker compose -f docker-compose.release.yml up -d`（如果在 `.env` 里钉了 `DRAMACLAW_VERSION` / `DRAMACLAW_GATEWAY_VERSION`，先改版本号）。详见自托管手册 §6。 |
+| **`unable to prepare context: path ".../dramaclaw-gateway" not found`** | 源码构建要求网关 checkout 放在本仓旁边。`git clone https://github.com/dramaclaw/dramaclaw-gateway.git ../dramaclaw-gateway`，或在 `.env` 里把 `DRAMACLAW_GATEWAY_SRC` 设成你的 clone 路径或 `https://github.com/dramaclaw/dramaclaw-gateway.git#main`。 |
+| **升级后报配置错误** | 源码构建（`docker-compose.yml`）：`git -C ../dramaclaw-gateway pull && git pull && docker compose up -d --build`。镜像模式（`docker-compose.release.yml`）：`docker compose -f docker-compose.release.yml pull && docker compose -f docker-compose.release.yml up -d`（如果在 `.env` 里钉了 `DRAMACLAW_VERSION` / `DRAMACLAW_GATEWAY_VERSION`，先改版本号）。详见自托管手册 §6。 |
 
 ## world 特性(3DGS/SHARP)类
 

--- a/tests/test_docker_persistence_config.py
+++ b/tests/test_docker_persistence_config.py
@@ -119,7 +119,7 @@ def test_source_file_extends_release_and_builds_all_three() -> None:
         "args": {"INSTALL_WORLD": "${INSTALL_WORLD:-0}"},
     }
     assert services["newapi"]["build"] == {
-        "context": "${DRAMACLAW_GATEWAY_SRC:-https://github.com/dramaclaw/dramaclaw-gateway.git#main}",
+        "context": "${DRAMACLAW_GATEWAY_SRC:-../dramaclaw-gateway}",
         "dockerfile": "Dockerfile",
     }
     assert services["web"]["build"] == {"context": "./frontend", "dockerfile": "Dockerfile"}


### PR DESCRIPTION
## Why

`docker-compose.yml` is the source-build entry point, and source builds are for people who change code, including gateway code. With the gateway fetched from a git URL at build time, its source lives only in Docker's build cache: you cannot see which commit you are running, and editing it requires knowing about `DRAMACLAW_GATEWAY_SRC`. Eric's call: the default should be a local clone next to DramaClaw.

## What

- `docker-compose.yml`: `newapi` build context defaults to `../dramaclaw-gateway`. `DRAMACLAW_GATEWAY_SRC` still overrides it with another path or the git URL (`https://github.com/dramaclaw/dramaclaw-gateway.git#main`) for anyone who does not want a second clone.
- `.env.example`: comment updated with both forms.
- `tests/test_docker_persistence_config.py`: expected context updated.
- Docs (`quickstart`, `installation`, `self-hosting`, en + zh): step 1 clones both repos side by side; notes that image mode needs no gateway clone; upgrade section says to `git pull` in `../dramaclaw-gateway` and adds `--build newapi` for gateway-only changes.

`docker-compose.release.yml` is untouched.

## Verification

- `docker compose config` with a sibling `../dramaclaw-gateway` resolves the build context to that directory; without it, `config` still succeeds and `docker compose build newapi` fails with a clear "path not found" for the missing checkout.
- `tests/test_docker_persistence_config.py` and `tests/test_bump_compose_default.py` pass; `scripts/lint_banned_words.py` clean.

README quick start is updated in #481 to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NQrE65FQLj4endsbo3Wdsw