### PR TITLE
docs: local development section explains when and how to run the gateway

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,7 +309,18 @@ cp .env.example .env && $EDITOR .env
 uv run novelvideo api --port 8780   # start the REST API (CE defaults to inline tasks, no Ray/Redis)
 ```
 
-Frontend: `cd frontend && pnpm install && pnpm dev`. The gateway has its own dev loop (`make dev-api` / `make dev-web`) in the [dramaclaw-gateway](https://github.com/dramaclaw/dramaclaw-gateway#develop) repo.
+Frontend in a second terminal: `cd frontend && pnpm install && pnpm dev`.
+
+**Gateway.** In **Official** mode you need nothing else. For **Custom** or **Local + Official Hybrid** the API expects a gateway on `127.0.0.1:3000` whose SQLite file is `./state/newapi/one-api.db` (that is what "Initialize" in Settings writes to; `NEWAPI_ADMIN_BASE_URL` in `.env` already points there). Either run the published image with that directory mounted:
+
+```bash
+mkdir -p state/newapi
+docker run -d --name dramaclaw-gateway -p 127.0.0.1:3000:3000 \
+  -v "$PWD/state/newapi:/data" \
+  claymorelab/dramaclaw-gateway:v1.0.0-rc.24-dramaclaw.1
+```
+
+or run the gateway from source in the sibling checkout (`make dev-api` / `make dev-web` in [dramaclaw-gateway](https://github.com/dramaclaw/dramaclaw-gateway#develop), or `go build` and start the binary with `SQLITE_PATH=<path to>/dramaclaw/state/newapi/one-api.db`).
 
 <br/>
 

--- a/docs/en/getting-started/installation.md
+++ b/docs/en/getting-started/installation.md
@@ -77,6 +77,19 @@ CE defaults to `ST_EDITION=ce`, no-login single local user, and in-process inlin
 curl http://localhost:8780/api/v1/config   # a 200 response means it's working
 ```
 
+### 4. Gateway (only for Custom / Local + Official Hybrid mode)
+
+Official mode needs nothing else. For the other two modes the API expects a gateway on `127.0.0.1:3000` (the `NEWAPI_ADMIN_BASE_URL` default in `.env`) whose SQLite file is `./state/newapi/one-api.db`, which is what **Initialize** in Settings writes to. Run the published image with that directory mounted:
+
+```bash
+mkdir -p state/newapi
+docker run -d --name dramaclaw-gateway -p 127.0.0.1:3000:3000 \
+  -v "$PWD/state/newapi:/data" \
+  claymorelab/dramaclaw-gateway:v1.0.0-rc.24-dramaclaw.1
+```
+
+or build and run the gateway from the sibling `dramaclaw-gateway` checkout with `SQLITE_PATH` pointing at that file. See [Configuring Models](configuring-models.md) for the mode setup.
+
 ---
 
 ## Optional: world features (3DGS / SHARP depth)

--- a/docs/zh/getting-started/installation.md
+++ b/docs/zh/getting-started/installation.md
@@ -77,6 +77,19 @@ CE 默认 `ST_EDITION=ce`、免登录单本地用户、任务进程内 inline �
 curl http://localhost:8780/api/v1/config   # 返回 200 即正常
 ```
 
+### 4. 网关（仅自定义 / 本地 + 官方混合模式需要）
+
+官方模式什么都不用再跑。另外两种模式下，API 需要一个跑在 `127.0.0.1:3000` 的网关（`.env` 里 `NEWAPI_ADMIN_BASE_URL` 的默认值），且它的 SQLite 文件在 `./state/newapi/one-api.db`，设置页的「初始化」写的就是这个文件。用发布镜像并把这个目录挂进去：
+
+```bash
+mkdir -p state/newapi
+docker run -d --name dramaclaw-gateway -p 127.0.0.1:3000:3000 \
+  -v "$PWD/state/newapi:/data" \
+  claymorelab/dramaclaw-gateway:v1.0.0-rc.24-dramaclaw.1
+```
+
+或者在旁边的 `dramaclaw-gateway` checkout 里构建并用 `SQLITE_PATH` 指向该文件来启动。模式配置见[配置模型供应商](configuring-models.md)。
+
 ---
 
 ## 可选:world 特性(3DGS / SHARP 深度)

--- a/readme/README_zh.md
+++ b/readme/README_zh.md
@@ -308,7 +308,18 @@ cp .env.example .env && $EDITOR .env
 uv run novelvideo api --port 8780   # 启动 REST API（CE 默认 inline 任务，无需 Ray/Redis）
 ```
 
-前端：`cd frontend && pnpm install && pnpm dev`。网关有自己的开发流程（`make dev-api` / `make dev-web`），见 [dramaclaw-gateway](https://github.com/dramaclaw/dramaclaw-gateway/blob/main/README.zh_CN.md#开发) 仓库。
+另开一个终端起前端：`cd frontend && pnpm install && pnpm dev`。
+
+**网关。** **官方**模式什么都不用再跑。**自定义**或**本地 + 官方混合**模式下，API 需要一个跑在 `127.0.0.1:3000` 的网关，且它的 SQLite 文件在 `./state/newapi/one-api.db`（设置页的「初始化」写的就是这个文件；`.env` 里的 `NEWAPI_ADMIN_BASE_URL` 默认已指向这个地址）。要么用发布镜像并把这个目录挂进去：
+
+```bash
+mkdir -p state/newapi
+docker run -d --name dramaclaw-gateway -p 127.0.0.1:3000:3000 \
+  -v "$PWD/state/newapi:/data" \
+  claymorelab/dramaclaw-gateway:v1.0.0-rc.24-dramaclaw.1
+```
+
+要么在旁边的 checkout 里从源码跑网关（[dramaclaw-gateway](https://github.com/dramaclaw/dramaclaw-gateway/blob/main/README.zh_CN.md#开发) 的 `make dev-api` / `make dev-web`，或者 `go build` 后用 `SQLITE_PATH=<路径>/dramaclaw/state/newapi/one-api.db` 启动二进制）。
 
 <br/>
 


### PR DESCRIPTION
## Why

The "Local development (uv + Python 3.11+)" section in the README and step B of the installation guide start the API on the host but never say whether a gateway is needed or where it comes from.

## What

`README.md`, `readme/README_zh.md`, `docs/en|zh/getting-started/installation.md`:

- **Official** mode: nothing else to run.
- **Custom / Local + Official Hybrid**: the API expects a gateway on `127.0.0.1:3000` (the `NEWAPI_ADMIN_BASE_URL` default in `.env`) whose SQLite file is `./state/newapi/one-api.db`, which is what **Initialize** in Settings writes to (`newapi_provisioner._ce_sqlite_path()` = `STATE_DIR/newapi/one-api.db`, `STATE_DIR` defaults to `./state`).
- Recipe A: `docker run` the published gateway image with `./state/newapi` bind-mounted on `/data`, bound to `127.0.0.1`.
- Recipe B: run the gateway from source in the sibling `dramaclaw-gateway` checkout with `SQLITE_PATH` pointing at that file.
- Frontend dev command moved to its own line.

## Verification

- Recipe A smoke-tested locally: container starts, `/api/status` returns 200, `one-api.db` appears in the host directory.
- `scripts/lint_banned_words.py` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NQrE65FQLj4endsbo3Wdsw