### PR TITLE
docs(readme): licensing in one breath, right under the manifesto

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,17 @@ We'll keep tearing down walls.
 
 </p>
 
+<p align="left">
+
+<strong>And yes, you can make money with it.</strong><br/>
+DramaClaw is <a href="./LICENSES/Elastic-2.0.txt">Elastic License 2.0</a>. Run it, modify it, sell what you build with it —<br/>
+the standalone version is free for commercial use, no permission needed.<br/>
+We ask for one thing: a small "Powered by DramaClaw" in the corner of your UI.<br/>
+The only door still closed is wrapping it up as a hosted SaaS for other people; that license isn't open yet.<br/>
+Why, and the FAQ: <a href="https://github.com/dramaclaw/dramaclaw/issues/475">#475</a>.
+
+</p>
+
 <br/>
 
 [![License](https://img.shields.io/badge/License-Elastic_2.0-blue.svg)](./LICENSES/Elastic-2.0.txt)
@@ -428,7 +439,7 @@ The people building DramaClaw — thank you. 💜
 
 ## License
 
-[Elastic License 2.0](./LICENSES/Elastic-2.0.txt). Free to use, modify, and redistribute — the only restriction is that you may not resell the software as a hosted service. See the [license explainer](./docs/en/license.md).
+[Elastic License 2.0](./LICENSES/Elastic-2.0.txt). Free to use, modify, redistribute and sell what you build with it; keep a small "Powered by DramaClaw" in your UI. The only restriction is that you may not offer the software itself as a hosted service to others. See the [license explainer](./docs/en/license.md) and the [licensing statement](https://github.com/dramaclaw/dramaclaw/issues/475).
 
 <br/>
 

--- a/readme/README_zh.md
+++ b/readme/README_zh.md
@@ -45,6 +45,17 @@ DramaClaw 要做的事很简单：<br/>
 
 </p>
 
+<p align="left">
+
+<strong>对，你可以拿它赚钱。</strong><br/>
+DramaClaw 采用 <a href="../LICENSE">Elastic License 2.0</a>。自己跑、自己改、自己卖，随便 ——<br/>
+单机版本可以自由商用，不用申请，不用付费。<br/>
+我们只有一个请求：在界面角落留一行小字「基于 DramaClaw」。<br/>
+唯一还没开的门，是把它包成 SaaS 卖给别人；这条授权暂不开放。<br/>
+原因和常见问题：<a href="https://github.com/dramaclaw/dramaclaw/issues/475">#475</a>。
+
+</p>
+
 <br/>
 
 [![License](https://img.shields.io/badge/License-Elastic_2.0-blue.svg)](../LICENSE)
@@ -427,7 +438,7 @@ DramaClaw 对模型侧保持中立 —— 所有文本 / 图片 / 视频 / 音�
 
 ## 许可证
 
-[Elastic License 2.0](../LICENSE)。源码可得（source available），允许自用、修改、再分发；唯一限制是不得将本软件作为托管服务转售。详见 [许可证说明](../docs/zh/license.md)。
+[Elastic License 2.0](../LICENSE)。源码可得（source available），允许自用、修改、再分发、拿它做的东西拿去卖；请在界面里保留一行小字「基于 DramaClaw」。唯一限制是不得把本软件本身作为托管服务提供给他人。详见 [许可证说明](../docs/zh/license.md) 和 [授权说明](https://github.com/dramaclaw/dramaclaw/issues/475)。
 
 <br/>
 


### PR DESCRIPTION
## Why

Licensing is the question we get most (pinned issue #475). The README only answered it at the very bottom.

## What

`README.md` / `readme/README_zh.md`:

- A short block right after the manifesto, in the same voice: ELv2; run it, modify it, sell what you build with it; standalone is free for commercial use; keep a small "Powered by DramaClaw"; hosted-SaaS licensing is the one door not open yet; link to #475 for the reasoning and FAQ.
- The License section at the bottom now says the same thing and links the statement.

No other changes. `scripts/lint_banned_words.py` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NQrE65FQLj4endsbo3Wdsw