### PR TITLE
fix(settings): let Custom mode map DC-character-builder-LLM

### DIFF
--- a/docs/en/getting-started/configuring-models.md
+++ b/docs/en/getting-started/configuring-models.md
@@ -160,7 +160,7 @@ After a profile is saved, a channel key should show “Saved” and a masked pre
 
 #### Feature models
 
-DramaClaw uses stable logical names such as `DC-scene-builder-LLM` and `DC-freezone-vision-LLM`. In Custom mode, keep those internal names and map them to real upstream models in NewAPI.
+DramaClaw uses stable logical names such as `DC-character-builder-LLM`, `DC-scene-builder-LLM` and `DC-freezone-vision-LLM`. In Custom mode, keep those internal names and map them to real upstream models in NewAPI.
 
 - Text features can use text-only models.
 - Vision features send images or video and require a suitable multimodal model.

--- a/docs/en/getting-started/configuring-models.md
+++ b/docs/en/getting-started/configuring-models.md
@@ -166,6 +166,7 @@ DramaClaw uses stable logical names such as `DC-character-builder-LLM`, `DC-scen
 - Vision features send images or video and require a suitable multimodal model.
 - Bulk fill changes drafts only; click Save Mapping afterward.
 - Hermes may use a separate model. Other `DC-*-LLM` mappings can share one upstream model or be overridden individually.
+- After an upgrade that adds a feature row (for example `DC-character-builder-LLM` in v2.0.3), the new row starts empty and is not written to NewAPI until you pick a model and click Save Mapping, or re-apply a quick profile. Until then that feature fails with `No available channel for model DC-...`.
 
 #### Embedding
 

--- a/docs/zh/getting-started/configuring-models.md
+++ b/docs/zh/getting-started/configuring-models.md
@@ -166,6 +166,7 @@ DramaClaw 使用稳定的内部逻辑模型名，例如 `DC-character-builder-LL
 - 视觉理解功能会发送图片或视频，必须选择支持相应输入的多模态模型。
 - 批量填充只修改页面草稿，仍需点击保存映射。
 - Hermes 可以使用独立模型；其他 `DC-*-LLM` 可以按需要统一映射或单独覆盖。
+- 升级后如果新增了功能行（例如 v2.0.3 新增的 `DC-character-builder-LLM`），新行默认为空，不会写入 NewAPI；需要选好模型后点「保存映射」，或重新应用一次快捷配置。在此之前该功能会报 `No available channel for model DC-...`。
 
 #### Embedding
 

--- a/docs/zh/getting-started/configuring-models.md
+++ b/docs/zh/getting-started/configuring-models.md
@@ -160,7 +160,7 @@ DramaClaw 不保存管理员密码。初始化完成后请自行保管该密码�
 
 #### 业务模型
 
-DramaClaw 使用稳定的内部逻辑模型名，例如 `DC-scene-builder-LLM` 和 `DC-freezone-vision-LLM`。自定义模式下，应保留这些内部名称，在 NewAPI 渠道中把它们映射到真实上游模型。
+DramaClaw 使用稳定的内部逻辑模型名，例如 `DC-character-builder-LLM`、`DC-scene-builder-LLM` 和 `DC-freezone-vision-LLM`。自定义模式下，应保留这些内部名称，在 NewAPI 渠道中把它们映射到真实上游模型。
 
 - 文本理解与生成可以选择普通文本模型。
 - 视觉理解功能会发送图片或视频，必须选择支持相应输入的多模态模型。

--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -6872,6 +6872,7 @@
           "LITERAL_BEAT_META": "Split and annotate shots line by line",
           "EPISODE_SCENE_PLANNER": "Plan episode scenes",
           "EPISODE_PROP_PLANNER": "Plan episode props",
+          "CHARACTER_BUILD": "Extract and adjudicate characters from the source text",
           "SCENE_BUILD": "Analyze and enrich scene descriptions",
           "FREEZONE_TRANSLATION": "Prompt zh/en translation",
           "FREEZONE_TEXT_WRITER": "AI text generation",

--- a/frontend/public/locales/zh/translation.json
+++ b/frontend/public/locales/zh/translation.json
@@ -6872,6 +6872,7 @@
           "LITERAL_BEAT_META": "逐行拆分镜头与标注",
           "EPISODE_SCENE_PLANNER": "规划本集场景",
           "EPISODE_PROP_PLANNER": "规划本集道具",
+          "CHARACTER_BUILD": "从原文抽取并裁定角色",
           "SCENE_BUILD": "解析并完善场景描述",
           "FREEZONE_TRANSLATION": "文本提示词中英互译",
           "FREEZONE_TEXT_WRITER": "AI 文本生成",

--- a/frontend/src/__tests__/stores/settings-store-feature-model-config.test.ts
+++ b/frontend/src/__tests__/stores/settings-store-feature-model-config.test.ts
@@ -7,6 +7,7 @@ import {
   syncQuickProfileFromAdvancedSettings,
 } from "@/components/settings/settings-dialog";
 import type { NewApiChannelType } from "@/lib/queries/model-gateway";
+import { FEATURE_MODEL_GROUPS, FEATURE_MODEL_PRODUCT_GROUPS } from "@/lib/feature-models";
 import {
   DEFAULT_FEATURE_MODEL_SETTINGS,
   normalizeMediaModelEntries,
@@ -14,6 +15,28 @@ import {
 } from "@/stores/settingsStore";
 
 type QuickProfile = Parameters<typeof syncQuickProfileFromAdvancedSettings>[0];
+
+describe("Custom settings feature model visibility", () => {
+  it("includes character extraction among the displayed text model rows", () => {
+    const textFeatures = FEATURE_MODEL_PRODUCT_GROUPS.flatMap((group) =>
+      group.features.filter((feature) => !feature.requiresVision && feature.id !== "COGNEE"),
+    );
+    expect(textFeatures).toContainEqual({
+      id: "CHARACTER_BUILD",
+      defaultModel: "DC-character-builder-LLM",
+    });
+  });
+
+  it("exposes every registered feature except the separately configured Cognee model", () => {
+    const displayedIds = FEATURE_MODEL_PRODUCT_GROUPS.flatMap((group) =>
+      group.features.map((feature) => feature.id),
+    );
+    const configurableIds = FEATURE_MODEL_GROUPS.flatMap((group) =>
+      group.features.filter((feature) => feature.id !== "COGNEE").map((feature) => feature.id),
+    );
+    expect([...displayedIds].sort()).toEqual([...configurableIds].sort());
+  });
+});
 
 function quickProfileFixture(): QuickProfile {
   return {

--- a/frontend/src/lib/feature-models.ts
+++ b/frontend/src/lib/feature-models.ts
@@ -58,7 +58,10 @@ export const FEATURE_MODEL_GROUPS: readonly FeatureModelGroup[] = [
   },
   {
     key: "sceneLibrary",
-    features: [{ id: "SCENE_BUILD", defaultModel: "DC-scene-builder-LLM" }],
+    features: [
+      { id: "CHARACTER_BUILD", defaultModel: "DC-character-builder-LLM" },
+      { id: "SCENE_BUILD", defaultModel: "DC-scene-builder-LLM" },
+    ],
   },
   {
     key: "freezone",

--- a/frontend/src/lib/feature-models.ts
+++ b/frontend/src/lib/feature-models.ts
@@ -140,7 +140,10 @@ export const FEATURE_MODEL_PRODUCT_GROUPS: readonly FeatureModelGroup[] = [
     key: "xialiao",
     features: [productFeature("CONTENT_REWRITER"), productFeature("SCREENPLAY_NORMALIZER")],
   },
-  { key: "xiatan", features: [productFeature("SCENE_BUILD")] },
+  {
+    key: "xiatan",
+    features: [productFeature("CHARACTER_BUILD"), productFeature("SCENE_BUILD")],
+  },
   {
     key: "xiajing",
     features: [

--- a/license-inventory.csv
+++ b/license-inventory.csv
@@ -2020,6 +2020,7 @@ tests/test_episode_menu_normalization_parity.py,Elastic-2.0,2026 SuperTale contr
 tests/test_episode_optimizer_colors.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_episode_patch_concurrency.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_fanout_partial_dispatch.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
+tests/test_feature_models_cover_official_defaults.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_feature_settlement_safe_logging.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_fish_speech_prompt_removed.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_format_check.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation

--- a/tests/test_feature_models_cover_official_defaults.py
+++ b/tests/test_feature_models_cover_official_defaults.py
@@ -1,0 +1,41 @@
+"""Every DC-*-LLM alias the backend calls must be mappable in Custom mode.
+
+Custom mode writes NewAPI channel model mappings only for the rows listed in
+``frontend/src/lib/feature-models.ts``. An alias the backend uses but the
+frontend never lists can never be mapped, so NewAPI answers
+``No available channel for model DC-...`` (issue #490, DC-character-builder-LLM).
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from novelvideo import official_defaults
+
+REPOSITORY_ROOT = Path(__file__).parents[1]
+FEATURE_MODELS_TS = REPOSITORY_ROOT / "frontend" / "src" / "lib" / "feature-models.ts"
+
+
+def _frontend_default_models() -> set[str]:
+    text = FEATURE_MODELS_TS.read_text(encoding="utf-8")
+    return set(re.findall(r'defaultModel:\s*"([^"]+)"', text))
+
+
+def _backend_llm_aliases() -> set[str]:
+    aliases: set[str] = set()
+    for name in dir(official_defaults):
+        value = getattr(official_defaults, name)
+        if isinstance(value, dict):
+            for key, model in value.items():
+                if str(key).endswith("_MODEL") and str(model).startswith("DC-") and str(model).endswith("-LLM"):
+                    aliases.add(str(model))
+    return aliases
+
+
+def test_every_backend_llm_alias_has_a_custom_mode_feature_row() -> None:
+    missing = sorted(_backend_llm_aliases() - _frontend_default_models())
+    assert not missing, (
+        "backend calls these DC aliases but Custom mode cannot map them "
+        f"(add rows to frontend/src/lib/feature-models.ts): {missing}"
+    )

--- a/tests/test_feature_models_cover_official_defaults.py
+++ b/tests/test_feature_models_cover_official_defaults.py
@@ -28,7 +28,11 @@ def _backend_llm_aliases() -> set[str]:
         value = getattr(official_defaults, name)
         if isinstance(value, dict):
             for key, model in value.items():
-                if str(key).endswith("_MODEL") and str(model).startswith("DC-") and str(model).endswith("-LLM"):
+                if (
+                    str(key).endswith("_MODEL")
+                    and str(model).startswith("DC-")
+                    and str(model).endswith("-LLM")
+                ):
                     aliases.add(str(model))
     return aliases
 


### PR DESCRIPTION
## Why

Custom mode writes NewAPI channel `models` / `modelMapping` only for the rows listed in `frontend/src/lib/feature-models.ts`. Structured character extraction (v2.0.0) added `CHARACTER_BUILD_MODEL = DC-character-builder-LLM` on the backend but never added a frontend row, so the alias can never be mapped in Custom mode and NewAPI answers `No available channel for model DC-character-builder-LLM`. That is the first error in #490; the reporter worked around it by pointing `CHARACTER_BUILD_MODEL` at the scene-builder alias in `.env`. Official mode is unaffected (RelayClaw ships the alias).

## What

- `feature-models.ts`: `CHARACTER_BUILD` → `DC-character-builder-LLM` next to `SCENE_BUILD` in the asset-library group.
- zh / en labels for the new row.
- `configuring-models` docs (en + zh) list the alias among the logical model names.
- New test `tests/test_feature_models_cover_official_defaults.py`: every `DC-*-LLM` alias in `official_defaults` must have a frontend feature row. It fails on `main` without this change (reports `DC-character-builder-LLM`) and passes with it.

Note for the next `main → staging` sync: the same test will flag `DC-freezone-recipe-compiler-LLM`, which exists only on `staging` and also has no frontend row. Add that row on `staging` when syncing.

## Verification

- `vitest run src/__tests__/i18n/locales-json.test.ts`: 10 passed; `tsc --noEmit` clean.
- New pytest passes against this branch's `src`; `scripts/lint_banned_words.py` clean.

Addresses the mapping part of #490. The `Exceeded maximum output retries` part is separate and still under investigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NQrE65FQLj4endsbo3Wdsw