### PR TITLE
docs(readme): add Vietnamese and Thai READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Why, and the FAQ: <a href="https://github.com/dramaclaw/dramaclaw/issues/475">#4
 [![Release](https://img.shields.io/github/v/release/dramaclaw/dramaclaw?include_prereleases&sort=semver)](https://github.com/dramaclaw/dramaclaw/releases)
 [![Docker](https://img.shields.io/badge/docker-ready-2496ED?logo=docker&logoColor=white)](#quick-start)
 
-**English** &nbsp;|&nbsp; [简体中文](./readme/README_zh.md) &nbsp;|&nbsp; [Website](https://dramaclaw.ai) &nbsp;|&nbsp; [Docs](./docs/en/README.md) &nbsp;|&nbsp; [Quick Start](./docs/en/getting-started/quickstart.md)
+**English** &nbsp;|&nbsp; [简体中文](./readme/README_zh.md) &nbsp;|&nbsp; [Tiếng Việt](./readme/README_vi.md) &nbsp;|&nbsp; [ไทย](./readme/README_th.md) &nbsp;|&nbsp; [Website](https://dramaclaw.ai) &nbsp;|&nbsp; [Docs](./docs/en/README.md) &nbsp;|&nbsp; [Quick Start](./docs/en/getting-started/quickstart.md)
 
 </div>
 

--- a/license-inventory.csv
+++ b/license-inventory.csv
@@ -1457,6 +1457,8 @@ frontend/vitest.config.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml agg
 license-inventory.csv,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 llms.txt,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 pyproject.toml,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
+readme/README_th.md,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
+readme/README_vi.md,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 readme/README_zh.md,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 sbom.spdx.json,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 scripts/acceptance/api_coverage_report.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation

--- a/readme/README_th.md
+++ b/readme/README_th.md
@@ -1,0 +1,464 @@
+<div align="center">
+
+<!-- TBD: replace with official logo assets/logo.svg -->
+<h1>DramaClaw</h1>
+
+## Make Your Own DC.
+
+<p align="left">
+
+เขาบอกว่าคุณล้าสมัยแล้ว<br/>
+บางทีสิ่งที่ล้าสมัยจริง ๆ อาจเป็นแนวคิด "ทำงานให้คนอื่น" ต่างหาก<br/>
+<br/>
+ในยุค AI คำถามที่แท้จริงไม่ใช่ว่าเครื่องจักรจะมาแทนคนหรือไม่<br/>
+คำถามที่แท้จริงคือ<br/>
+ใครเป็นเจ้าของเครื่องจักร<br/>
+ใครเป็นเจ้าของสายการผลิต<br/>
+ใครเป็นเจ้าของกำลังการผลิตแบบอุตสาหกรรม<br/>
+<br/>
+ถ้าคำตอบคือบริษัทเทคยักษ์ใหญ่เสมอ<br/>
+AI ก็ไม่ใช่การมอบอำนาจ<br/>
+มันเป็นแค่กำแพงใหม่<br/>
+<br/>
+ผมชื่อ Eric<br/>
+<br/>
+นี่ไม่ใช่เดโม<br/>
+ไม่ใช่ของเล่น<br/>
+ไม่ใช่เวอร์ชันตัดฟีเจอร์<br/>
+<br/>
+นี่คือสายการผลิตละครแบบอุตสาหกรรมที่ทีมของเราใช้งานจริงทุกวัน<br/>
+ตั้งแต่บทไปจนถึงสตอรีบอร์ด ตั้งแต่แอสเซ็ตไปจนถึงหนังที่ตัดเสร็จ — ครบทั้งสายการผลิต<br/>
+<br/>
+เพราะคนไม่ใช่สัตว์ใช้แรงงาน<br/>
+เพราะความคิดสร้างสรรค์คือแนวป้องกันสุดท้ายของมนุษยชาติ<br/>
+<br/>
+สิ่งที่ DramaClaw ตั้งใจทำนั้นเรียบง่าย<br/>
+<br/>
+<strong>ทลายกำแพง</strong><br/>
+<br/>
+นำพลังการผลิตละครแบบอุตสาหกรรมที่เคยมีแต่บริษัทเทคยักษ์ใหญ่เท่านั้น<br/>
+มาส่งถึงมือครีเอเตอร์ธรรมดา<br/>
+<br/>
+โค้ดอยู่ตรงนี้แล้ว<br/>
+ถ้าคุณรู้สึกเหมือนกัน ฝาก ⭐ ไว้สักดวง<br/>
+เราจะทลายกำแพงต่อไป
+
+</p>
+
+<p align="left">
+
+<strong>และใช่ คุณหาเงินจากมันได้</strong><br/>
+DramaClaw ใช้สัญญาอนุญาต <a href="../LICENSES/Elastic-2.0.txt">Elastic License 2.0</a> รันได้ แก้ได้ ขายสิ่งที่คุณสร้างจากมันได้ —<br/>
+เวอร์ชัน standalone ใช้เชิงพาณิชย์ได้ฟรี ไม่ต้องขออนุญาต<br/>
+เราขอแค่อย่างเดียว: ข้อความเล็ก ๆ "Powered by DramaClaw" ที่มุม UI ของคุณ<br/>
+ประตูบานเดียวที่ยังปิดอยู่คือการนำไปห่อเป็น SaaS แบบโฮสต์ให้คนอื่นใช้ สิทธิ์ส่วนนั้นยังไม่เปิด<br/>
+เหตุผลและคำถามที่พบบ่อย: <a href="https://github.com/dramaclaw/dramaclaw/issues/475">#475</a>
+
+</p>
+
+<br/>
+
+[![License](https://img.shields.io/badge/License-Elastic_2.0-blue.svg)](../LICENSES/Elastic-2.0.txt)
+[![GitHub stars](https://img.shields.io/github/stars/dramaclaw/dramaclaw?style=social)](https://github.com/dramaclaw/dramaclaw/stargazers)
+[![Release](https://img.shields.io/github/v/release/dramaclaw/dramaclaw?include_prereleases&sort=semver)](https://github.com/dramaclaw/dramaclaw/releases)
+[![Docker](https://img.shields.io/badge/docker-ready-2496ED?logo=docker&logoColor=white)](#quick-start)
+
+[English](../README.md) &nbsp;|&nbsp; [简体中文](./README_zh.md) &nbsp;|&nbsp; [Tiếng Việt](./README_vi.md) &nbsp;|&nbsp; **ไทย** &nbsp;|&nbsp; [เว็บไซต์](https://dramaclaw.ai) &nbsp;|&nbsp; [เอกสาร](../docs/en/README.md) &nbsp;|&nbsp; [เริ่มต้นอย่างรวดเร็ว](../docs/en/getting-started/quickstart.md)
+
+</div>
+
+<br/>
+
+<p align="center">
+  <img src="../assets/hero.png" alt="DramaClaw — นักเล่าเรื่อง กลับมาอยู่หน้ากล้องอีกครั้ง" width="820"/>
+</p>
+
+<!--
+  Demo video — after uploading, paste the user-attachments link on its own line below.
+  How to upload: open a new Issue on github.com (don't submit it), drag the demo
+  video into the body, wait for it to finish uploading and auto-generate a
+  https://github.com/user-attachments/assets/...mp4 link, copy it here, then
+  discard the Issue. GitHub renders a URL on its own line as an inline player.
+
+  https://github.com/user-attachments/assets/REPLACE-AFTER-UPLOAD
+-->
+
+<p align="center">
+  <sub>🎬 ตัวอย่างหนัง: <a href="https://www.bilibili.com/video/BV1iQV26cE4S">Bilibili</a> &nbsp;·&nbsp; <a href="https://www.youtube.com/watch?v=64apa3maxK0">YouTube</a></sub>
+</p>
+
+<br/>
+
+<div align="center">
+
+## 🎬 สร้างด้วย DramaClaw
+
+<sub>ละครสั้นของจริงที่ทีมเราผลิตบนสายการผลิตนี้ &mdash; คลิกลิงก์เพื่อเล่น</sub>
+
+<table>
+  <tr>
+    <td align="center" width="205" valign="top">
+      <img src="https://nfg-web-assets.cdnfg.com/dramaclaw/guilingsi/guilingsi-cover.png?v=2" width="185" alt="归灵司"/><br/>
+      <b>归灵司</b><br/>
+      <a href="https://nfg-web-assets.cdnfg.com/dramaclaw/guilingsi/guilingsi-ep01.mp4">▶ ตอนที่ 1</a>
+    </td>
+    <td align="center" width="205" valign="top">
+      <img src="https://nfg-web-assets.cdnfg.com/dramaclaw/luban/luban-cover.png?v=2" width="185" alt="鲁班"/><br/>
+      <b>鲁班</b><br/>
+      <a href="https://nfg-web-assets.cdnfg.com/dramaclaw/luban/luban-ep01.mp4">▶ ตอนที่ 1</a>
+    </td>
+    <td align="center" width="205" valign="top">
+      <img src="https://nfg-web-assets.cdnfg.com/dramaclaw/shixiong-butianle/shixiong-butianle-cover.png?v=2" width="185" alt="师兄你怎么不舔了"/><br/>
+      <b>师兄你怎么不舔了</b><br/>
+      <a href="https://nfg-web-assets.cdnfg.com/dramaclaw/shixiong-butianle/shixiong-butianle-ep01.mp4">▶ ตอนที่ 1</a>
+    </td>
+  </tr>
+  <tr>
+    <td align="center" width="205" valign="top">
+      <img src="https://nfg-web-assets.cdnfg.com/dramaclaw/tianmingbukeqi/tianmingbukeqi-cover.png?v=2" width="185" alt="天命不可欺"/><br/>
+      <b>天命不可欺</b><br/>
+      <a href="https://nfg-web-assets.cdnfg.com/dramaclaw/tianmingbukeqi/tianmingbukeqi-ep02.mp4">▶ ตอนที่ 02</a> &nbsp;·&nbsp; <a href="https://nfg-web-assets.cdnfg.com/dramaclaw/tianmingbukeqi/tianmingbukeqi-ep58.mp4">ตอนที่ 58</a>
+    </td>
+    <td align="center" width="205" valign="top">
+      <img src="https://nfg-web-assets.cdnfg.com/dramaclaw/wulongxiantu/wulongxiantu-cover.png?v=2" width="185" alt="乌龙仙途"/><br/>
+      <b>乌龙仙途</b><br/>
+      <a href="https://nfg-web-assets.cdnfg.com/dramaclaw/wulongxiantu/wulongxiantu-ep01.mp4">▶ ตอนที่ 1</a>
+    </td>
+    <td align="center" width="205" valign="top">
+      <img src="https://nfg-web-assets.cdnfg.com/dramaclaw/feiyi-zhouwu/feiyi-zhouwu-cover.png?v=2" width="185" alt="非遗㑇舞"/><br/>
+      <b>非遗㑇舞</b><br/>
+      <a href="https://nfg-web-assets.cdnfg.com/dramaclaw/feiyi-zhouwu/feiyi-zhouwu.mp4">▶ เล่น</a>
+    </td>
+  </tr>
+</table>
+
+<sub>คลิปเพิ่มเติม:
+<a href="https://nfg-web-assets.cdnfg.com/dramaclaw/3d-anime-montage-demo/3d-anime-montage-demo.mp4">3D 动漫混剪 demo</a> &nbsp;·&nbsp;
+<a href="https://nfg-web-assets.cdnfg.com/dramaclaw/dongtai-dadou/dongtai-dadou.mp4">动态打斗</a></sub>
+
+</div>
+
+<br/>
+
+## DramaClaw คืออะไร?
+
+DramaClaw คือ**สายการผลิตละคร AI แบบเปิดเผยซอร์สโค้ด (source available)** — และยิ่งนับวันก็ยิ่งครอบคลุมเรื่องราวภาพทุกแบบที่คุณอยากเล่าด้วย generative model มันมีสองด้านที่ใช้คลังแอสเซ็ตเดียวกันและ agent ตัวเดียวกัน:
+
+- **XiaHua — canvas ไร้ขอบเขต** เวิร์กเบนช์แบบ node ที่คุณสร้าง แก้ไข และเชื่อมต่อภาพ วิดีโอ เสียง ฉาก 3D และบทได้อย่างอิสระ แล้วส่งสิ่งที่ถูกใจกลับเข้าซีรีส์ นี่คือที่ที่งานสร้างสรรค์ส่วนใหญ่ของเราเกิดขึ้นในวันนี้ และเป็นทิศทางที่ DramaClaw กำลังมุ่งไป
+- **Series (XiaJi) — สายการผลิต** วางต้นฉบับหรือบทภาพยนตร์ลงไป แล้ว DramaClaw จะรับงานหนักทั้งหมด: จัดโครงสร้างเรื่อง วางแผนตอน เขียนบท วาดสตอรีบอร์ดและเฟรมแรก สังเคราะห์เสียงพากย์ และตัดต่อหนังให้เสร็จ
+
+**Xia Director** agent ในตัว ทำงานคร่อมทั้งสองด้าน: ตอบคำถามเกี่ยวกับโปรเจกต์ของคุณ ขับเคลื่อนงานในสายการผลิต และสร้างพร้อมรัน node graph บน canvas ให้คุณได้
+
+มันถูกสร้างมาเพื่อครีเอเตอร์ สตูดิโออิสระ และ creative engineer — รัน "โรงงานผลิตละคร" ทั้งโรงบนเครื่องของคุณเอง โดยไม่ต้องปะติดปะต่อเครื่องมือกระจัดกระจายเป็นสิบตัว หรือส่งวัตถุดิบของคุณให้บริการคลาวด์กล่องดำที่มองไม่เห็นข้างใน แม้จะสร้างขึ้นโดยมีละครเป็นแกนกลาง แต่ canvas และสายการผลิตชุดเดียวกันนี้ก็ใช้ทำโฆษณาสั้น วิดีโอสินค้าอีคอมเมิร์ซ และรูปแบบภาพอื่น ๆ ได้เช่นกัน
+
+<p align="center">
+  <img src="https://nfg-web-assets.cdnfg.com/dramaclaw/readme/dual-mode-workflow.jpg?v=2" width="600" alt="双模式工作流 · Dual-mode Workflow"/>
+</p>
+
+<br/>
+
+## ความสามารถหลัก
+
+<p align="center">
+  <img src="https://nfg-web-assets.cdnfg.com/dramaclaw/readme/oss-launch.jpg?v=2" width="760" alt="DramaClaw 源码发布 · source-available launch"/>
+</p>
+
+### XiaHua — canvas ไร้ขอบเขต
+
+<p align="center">
+  <img src="../assets/xiahua-canvas.jpg" width="900" alt="XiaHua canvas: เวิร์กโฟลว์หนังสั้น 17 node ที่ Xia Director จัดวางและรันจาก prompt เดียว"/>
+</p>
+<p align="center"><sub>prompt เดียวถึง Xia Director (ขวา) กลายเป็นเวิร์กโฟลว์ 17 node 32 เส้นเชื่อมบน canvas (ซ้าย): บรีฟ → ทิศทางเรื่อง → ภาพอ้างอิงตัวละครและฉาก → เฟรมแรกของ 5 ช็อต → วิดีโอ 5 ช็อต → เสียงพากย์และดนตรีประกอบ → ตัดต่อขั้นสุดท้าย</sub></p>
+
+- **node 18 ชนิดบน canvas เดียว** &mdash; อัปโหลด, สร้าง / แก้ไขภาพ, สร้างสตอรีบอร์ด, บท, บริบท beat, วิดีโอ, ประกอบวิดีโอ, video story, เสียง, สไตล์, skill, กลุ่ม, คำอธิบายข้อความ, ตัวดูภาพพาโนรามา 360°, โลก 3D, ส่งออก และอื่น ๆ เชื่อมต่อได้อย่างอิสระ ทุก node เก็บประวัติการสร้างของตัวเอง
+- **เครื่องมือภาพ** &mdash; สร้าง, แก้ไข, วาดใหม่, outpaint, จัดแสงใหม่, upscale, หลายมุมมอง, แก้ไขจากเทมเพลต, reverse-prompt, ตรวจจับ mark; **style wall 45 ลุคละครสั้น** สำหรับ image-to-image
+- **เครื่องมือวิดีโอ** &mdash; ข้อความ / ภาพ / keyframe เป็นวิดีโอ, การสร้างแบบ omni-reference ที่ใช้**ไฟล์ ลิงก์เว็บ และภาพอ้างอิงบน canvas** ได้, แก้ไขวิดีโอ, ลบออก, upscale, แยกเสียง, เทมเพลตมุมกล้อง, วิเคราะห์ช็อต; Seedance 2.5 อยู่ในแคตตาล็อกที่แนะนำ
+- **เสียง** &mdash; สังเคราะห์เสียงพูดพร้อมคลังเสียง, เสียงอ้างอิง, สร้างดนตรี
+- **Canvas skills** &mdash; skill แบบคลิกเดียว เช่น sketch-from-context, frame-from-context, set-background, scene-360, ตรวจทานเฟรม และวางแผน beat-graph
+- **สร้างมาเพื่อ canvas ขนาดใหญ่** &mdash; แท็บ canvas, โครงร่างองค์ประกอบ, minimap และบุ๊กมาร์ก viewport, snap-align, การ render แบบ level-of-detail, เลือกหลายรายการและ node แบบกลุ่ม, คีย์ลัด, ประวัติการแก้ไขพร้อมกู้คืน, ล็อกแยกราย canvas
+- **ส่งเข้าซีรีส์** &mdash; ดูตัวอย่างผลกระทบก่อน แล้วส่ง node เดียวหรือทั้งชุดเข้าคลังแอสเซ็ตหรือตอนใดตอนหนึ่ง; ฉายซีรีส์กลับลง canvas จาก preset ได้
+- **Director World — ฉากที่คงความสม่ำเสมอเชิงพื้นที่** &mdash; ภาพ → ฉาก 3D Gaussian Splat และพาโนรามา scene-360 ในรูป node บน canvas: ฉากเสมือนที่จัดเฟรมได้ ล็อกโครงสร้างพื้นที่ ตำแหน่งตัวละคร และการวางกล้อง เพื่อให้สถานที่เดียวกันคงเดิมข้ามช็อต; จัดเฟรมช็อตในตัวดู 3D จับภาพ แล้วใช้เป็นพื้นหลังสำหรับการสร้างครั้งถัดไป<br/>
+  <img src="https://nfg-web-assets.cdnfg.com/dramaclaw/readme/world-model.jpg?v=2" width="600" alt="世界模型 · World Model (3GS)"/>
+
+### Series (XiaJi) — สายการผลิต
+
+<p align="center">
+  <img src="../assets/pipeline.png" alt="สายการผลิต DramaClaw — Ingest, Plan, Produce, Deliver" width="760"/>
+</p>
+
+ทุกขั้นตอนมีอินเทอร์เฟซของตัวเอง — รันตามลำดับ ข้ามขั้นตอน กลับมาทำต่อจาก checkpoint ใดก็ได้ หรือแม้แต่เสียบ orchestrator ของคุณเองเข้ามา
+
+- **นำเข้าแบบมีโครงสร้าง** &mdash; โปรเจกต์ใหม่สร้างตอน ตัวละคร และฉากตรงจากต้นฉบับหรือบทภาพยนตร์ (รองรับ Fountain) ไม่ต้องใช้ knowledge graph หรือ embedding; เส้นทาง story-graph ของ Cognee ยังคงไว้สำหรับโปรเจกต์เก่า
+- **คลังแอสเซ็ตและความสม่ำเสมอของตัวตน** &mdash; ตัวละคร ฉาก พร็อพ และเสียง จัดระเบียบตามวัตถุประสงค์และโฟลเดอร์; ตัวตนคงที่ข้ามตอน ภาพพอร์ตเทรตตัวละคร และตัวแปรรายตอน
+- **วางแผนตอนและสร้างบท** &mdash; แบ่งบท วางแผน beat โครงเรื่องหลายตอน; โหมดบทแบบดัดแปลง / ตามตัวอักษร / แบ่งเป็นขั้น พร้อมวงจรตรวจทานและซ่อมแซม
+- **สตอรีบอร์ดและเฟรมแรก** &mdash; การสร้างแบบมีสไตล์ที่ขับเคลื่อนด้วย beat, แบ่งกริด, เลือกจาก image pool<br/>
+  <img src="https://nfg-web-assets.cdnfg.com/dramaclaw/readme/storyboard-sketch.jpg?v=2" width="600" alt="独家线稿草图系统 · Line-art Storyboard System"/>
+- **เสียงพากย์ ประกอบวิดีโอ และส่งออก** &mdash; เสียงพูดที่รับรู้อารมณ์, ประกอบตอน, ส่งออกวิดีโอ + ซับไตเติล และชุดแอสเซ็ตครบถ้วน
+- **Visual Style** &mdash; อัปโหลดภาพอ้างอิงเพื่อดึงพารามิเตอร์สไตล์แล้วนำไปใช้กับทั้งโปรเจกต์
+- **Task Center** &mdash; สถานะ ความคืบหน้า log ยกเลิก / ลองใหม่ ทำต่อจาก checkpoint สำหรับงานที่รันยาว; ตรวจสอบเงื่อนไขเบื้องต้นก่อนงานเข้าคิว
+
+### Xia Director — agent
+
+<p align="center">
+  <img src="https://nfg-web-assets.cdnfg.com/dramaclaw/readme/director-agent.jpg?v=2" width="600" alt="导演智能体 · Director Agent"/>
+</p>
+
+**วันนี้**
+
+- **รู้จักโปรเจกต์ของคุณ** &mdash; ตรวจความคืบหน้า เดินหน้างานบท / ช็อต ตรวจสอบความครบถ้วนของงานส่งมอบ และแนะนำขั้นตอนถัดไป
+- **เปิดให้ agent อื่น** &mdash; MCP server บนเครื่องเปิด DramaClaw ให้ Claude Code, Codex และ MCP client ใด ๆ ใช้ได้ (loopback เท่านั้น ต้องเปิด trust flag อย่างชัดเจน); ดู [MCP สำหรับ Claude Code](../docs/en/guides/mcp-claude-code.md)
+
+**ถัดไป**
+
+- **ทำงานบน canvas** &mdash; ภาพหน้าจอด้านบนคือทิศทางที่กำลังไป: บรรยายหนังที่ต้องการ แล้ว Xia Director จะสร้างและเชื่อม node จัดวาง รัน และตรวจทานผลลัพธ์ โดยทุกคำสั่ง canvas ต้องได้รับการอนุมัติในเบราว์เซอร์ของคุณก่อน canvas + agent คือแกนกลางของ DramaClaw นับจากนี้; ดู [กำลังพัฒนา](#in-development)
+
+<br/>
+
+## ทำไมต้อง DramaClaw?
+
+**canvas ที่เข้าใจละคร และ agent ที่ทำงานบนมัน** node canvas ทั่วไปเชื่อมอะไรก็ได้แต่ไม่รู้จักตอน ตัวละคร หรือช็อต; เครื่องมือซีรีส์รู้จักงานฝีมือแต่ขังคุณไว้ใน wizard XiaHua ให้ canvas อิสระพร้อม node และ skill ที่เข้าใจละคร และ Xia Director กำลังถูกสร้างเพื่อจัดวาง รัน และตรวจทาน graph เหล่านั้นให้คุณ การผสมผสานนี้คือที่ที่ DramaClaw กำลังมุ่งไป
+
+**สร้างมาเพื่อนิยายสู่ละครสั้น** เครื่องมือเวิร์กโฟลว์ทั่วไปเชื่อม node เข้าด้วยกันได้ แต่ไม่รู้ว่า "beat ของตอน" คืออะไร ไม่เข้าใจว่าทำไมความสม่ำเสมอของตัวตนตัวละครข้ามฉากถึงสำคัญ และจะไม่คอยรักษาโครงอารมณ์ของบทหนึ่ง ๆ ให้คงอยู่ตลอดทั้งภาพ + เสียง + การตัดต่อ DramaClaw ฝังวิจารณญาณทั้งหมดนั้นไว้ในเครื่องมือ
+
+**canvas และสายการผลิต ไม่ใช่ canvas หรือสายการผลิต** เครื่องมือส่วนใหญ่ให้คุณเลือกอย่างใดอย่างหนึ่งระหว่าง node canvas อิสระกับ wizard ที่ตายตัว DramaClaw รันทั้งสองเป็นรางคู่บนคลังแอสเซ็ตเดียว: สำรวจบน canvas ส่งสิ่งที่ใช้ได้เข้าซีรีส์ แล้วฉายซีรีส์กลับลง canvas agent ทำงานได้ทั้งสองฝั่ง
+
+**ทุกขั้นตอนแยกส่วนได้** แต่ละสเตจเป็นงาน async อิสระที่มีอินเทอร์เฟซของตัวเอง รันตามลำดับ ข้ามขั้นตอน กลับมาทำต่อกลางทาง — toolchain เองคือผลิตภัณฑ์ ไม่มีกล่องดำซ่อนอยู่
+
+**โฮสต์เองได้ เป็นกลางเรื่อง model** ต้นฉบับของคุณ ตัวละครของคุณ model ของคุณ เซิร์ฟเวอร์ของคุณ ใช้ frontier model แบบปิดเมื่อต้องการผลลัพธ์ที่ดีที่สุด; สลับไป open-weight model เมื่อต้องการควบคุมเต็มที่ DramaClaw จะไม่ผูกคุณไว้กับผู้ให้บริการรายใดรายหนึ่ง
+
+### DramaClaw เทียบกับคู่แข่ง
+
+จุดแข็งไม่ใช่ "สร้างได้มากกว่า" — แต่คือการจัดระเบียบวงจรการผลิตละครสั้นทั้งวงจร (บท → แอสเซ็ต → ช็อต → canvas → ตัดต่อขั้นสุดท้าย) ให้กลายเป็นสิ่งที่ใช้ซ้ำได้ ทำงานร่วมกันได้ และขยายขนาดได้
+
+<sub>สัญลักษณ์: ✅ ครบ · ◐ บางส่วน · ○ วางแผนไว้ · ❌ ไม่มี — ชื่อคู่แข่งถูกปิดบางส่วน; การเปรียบเทียบอิงจากเอกสารผลิตภัณฑ์และการวางตำแหน่งที่เปิดเผยต่อสาธารณะ</sub>
+
+| ความสามารถ | L\*TV | R\*Hub | T\*Now | S\*ko | U\*dream | O\*II | J\*/K\* | **DramaClaw** |
+|---|:--:|:--:|:--:|:--:|:--:|:--:|:--:|:--:|
+| ดูตัวอย่างสตอรีบอร์ด (บท→ช็อต, บอร์ด) | ◐ | ✅ | ◐ | ✅ | ◐ | ❌ | ❌ | ✅ |
+| ซีรีส์แบบอินเทอร์แอคทีฟ (หลายตอน, แตกแขนง, IP) | ◐ | ◐ | ◐ | ✅ | ◐ | ❌ | ❌ | ✅ |
+| คลังแอสเซ็ต (ตัวละคร/ฉาก/พร็อพ/เสียง) | ◐ | ❌ | ◐ | ✅ | ◐ | ○ | ❌ | ✅ |
+| ความสม่ำเสมอของฉาก (ตัวแปร, 360°, หลายสถานะ) | ✅ | ◐ | ❌ | ❌ | ○ | ❌ | ❌ | ✅ |
+| โลกของผู้กำกับ (ฉาก 360°/3D, กล้อง, การจัดเฟรม) | ✅ | ◐ | ❌ | ❌ | ◐ | ❌ | ❌ | ✅ |
+| ส่งมอบขั้นสุดท้าย (หลายช็อต, ซับไตเติล/SRT, ชุดแอสเซ็ต) | ✅ | ○ | ○ | ✅ | ✅ | ❌ | ❌ | ✅ |
+| ผลิตแบบทีม (แชร์, บทบาท, งาน, ต้นทุน) | ✅ | ✅ | ○ | ✅ | ○ | ○ | ○ | ✅ |
+| canvas ไร้ขอบเขต (แบบ node, สำรวจอิสระ) | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ | ✅ | ✅ |
+| รางคู่ (สายการผลิตหลัก + สำรวจบน canvas) | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ |
+| สไตล์กำหนดเอง (เทมเพลต, prompt, negative) | ✅ | ◐ | ○ | ✅ | ◐ | ○ | ◐ | ✅ |
+| agent ในตัว (ผู้ช่วย, skill, คำแนะนำ) | ✅ | ✅ | ✅ | ○ | ✅ | ○ | ✅ | ✅ |
+| เพื่อนคู่คิดสร้างสรรค์ (บุคลิก, การกระตุ้น, ฟีดแบ็ก) | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ |
+| เปิดเผยซอร์สโค้ด (โฮสต์เอง, fork, ปรับแต่ง) | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ |
+
+<br/>
+
+## ความต้องการของระบบ
+
+DramaClaw รัน inference ทั้งหมดผ่าน **gateway ที่เข้ากันได้กับ OpenAI** — ไม่ว่าจะเป็นบริการ RelayClaw อย่างเป็นทางการ หรือ [dramaclaw-gateway](https://github.com/dramaclaw/dramaclaw-gateway) ที่มาพร้อมกันซึ่งส่งต่อไปยังผู้ให้บริการที่คุณกำหนด ไม่มี model ใดรันบนเครื่องของคุณ ดังนั้นการใช้ทรัพยากรในเครื่องจึงเบา แล็ปท็อปธรรมดาหรือ VPS ขนาดเล็กก็เพียงพอ
+
+| รายการ | ความต้องการ |
+|---|---|
+| **CPU / RAM** | แนะนำ ≥ 2 vCPU / 4 GB (ไม่รวม inference ของ model ซึ่งรันบน gateway) |
+| **GPU** | ไม่จำเป็นสำหรับสายการผลิตมาตรฐาน มีเพียงส่วนเสริม `world` ที่เป็นตัวเลือก (voxel / พาโนรามาเป็น 3D) เท่านั้นที่ต้องใช้ GPU + CUDA image |
+| **ดิสก์** | ไม่กี่ GB สำหรับ image บวกกับสื่อ/สถานะที่สร้างขึ้นใน volume `ce-data` (ไม่มีขั้นต่ำตายตัว) |
+| **OS** | macOS (Apple Silicon / Intel), Windows (Docker Desktop + WSL2 backend), Linux (Docker Engine + compose plugin) |
+| **Docker** | Docker + `docker compose` |
+| **พอร์ต** | `8080` เว็บ UI · `8780` REST API · `3000` admin UI ของ gateway ที่มาพร้อมกัน (ค่าเริ่มต้นเปิดเฉพาะ host ขยายได้) |
+| **Datastore** | ไม่ต้องใช้เลย — ไม่มี Postgres, Redis, Celery หรือ Ray งานรันใน process; สถานะอยู่บนระบบไฟล์ในเครื่อง (SQLite + ไฟล์) |
+| **เครือข่าย** | ต้องออกอินเทอร์เน็ตไปยัง gateway อย่างเป็นทางการ `relayclaw.cdnfg.com` และ/หรือผู้ให้บริการ model ที่คุณกำหนดใน gateway ที่มาพร้อมกัน |
+
+> การพัฒนาในเครื่อง (ไม่ใช้ Docker) ต้องใช้ Python 3.11–3.12 + [`uv`](https://docs.astral.sh/uv/) + `ffmpeg` เพิ่มเติม ดูข้อกำหนดเบื้องต้นฉบับเต็มใน [คู่มือโฮสต์เอง](../docs/en/guides/self-hosting.md)
+
+<br/>
+
+## <a name="quick-start"></a>เริ่มต้นอย่างรวดเร็ว
+
+### Docker (แนะนำ)
+
+ทุก GitHub Release เผยแพร่ image แบบ multi-arch (amd64/arm64) ไปยัง Docker Hub
+
+**สร้างจากซอร์ส (ค่าเริ่มต้น)** — clone DramaClaw และ [dramaclaw-gateway](https://github.com/dramaclaw/dramaclaw-gateway) ที่มาพร้อมกันไว้ข้างกัน; `docker compose up -d --build` จะสร้างทั้งสามบริการจาก checkout สองชุดนั้น
+
+```bash
+git clone https://github.com/dramaclaw/dramaclaw.git
+git clone https://github.com/dramaclaw/dramaclaw-gateway.git   # bundled gateway, built from ../dramaclaw-gateway
+cd dramaclaw
+
+cp .env.example .env
+# Edit .env — set PROMPT_EXPORT_PASSWORD to a non-default value.
+
+docker compose up -d --build   # builds and starts three services: api / newapi (bundled gateway) / web
+```
+
+checkout ทั้งสองเป็น git repo ธรรมดา: แก้ไข, `git pull`, สร้างใหม่ แก้แค่โค้ด DramaClaw? `docker compose up -d --build api web` แก้แค่ gateway? `docker compose up -d --build newapi` clone gateway ไว้ที่อื่น หรืออยากให้ Docker ดึงจาก git เอง? ตั้ง `DRAMACLAW_GATEWAY_SRC` ใน `.env` เป็น path นั้น หรือเป็น `https://github.com/dramaclaw/dramaclaw-gateway.git#main`
+
+**ไม่ต้อง build** — ดึง image ที่เผยแพร่แล้วแทน (ไม่ต้อง clone gateway):
+
+```bash
+docker compose -f docker-compose.release.yml up -d
+```
+
+เปิดแอปที่ <http://localhost:8080>; REST API อยู่ที่ <http://localhost:8780> ใน **Settings → Model Config** เลือกหนึ่งอย่าง:
+
+- **Official** — วาง DC key ของคุณ (รับได้ที่ <https://relayclaw.cdnfg.com>); ไม่ต้อง map model gateway ที่มาพร้อมกันจะอยู่เฉย ๆ
+- **Custom** — คลิกเดียวเพื่อเริ่มต้น gateway `newapi` ที่มาพร้อมกัน; จากนั้นเพิ่ม upstream channel ของคุณเอง
+- **Local + Official Hybrid** — ใช้ official สำหรับสายการผลิตหลัก ใช้ gateway ที่มาพร้อมกันสำหรับ channel เพิ่มเติม
+
+ขั้นตอนฉบับเต็มอยู่ใน [เริ่มต้นอย่างรวดเร็ว](../docs/en/getting-started/quickstart.md)
+
+ปักหมุดเวอร์ชันหรือสลับ registry ได้ใน `.env` (`DRAMACLAW_VERSION`, `DRAMACLAW_GATEWAY_VERSION`, `DRAMACLAW_IMAGE_PREFIX`) — ค่าเหล่านี้มีผลเฉพาะโหมด image (`docker-compose.release.yml`) เท่านั้น จีนแผ่นดินใหญ่: ตั้ง `DRAMACLAW_IMAGE_PREFIX=claymore-registry.cn-chengdu.cr.aliyuncs.com/dramaclaw` และปักหมุดทั้งสองเวอร์ชัน (mirror ของ ACR มีเฉพาะ tag ที่ปักหมุดไว้)
+
+> ย้ายมาจาก checkout เวอร์ชันเก่า? สำหรับการสร้างจากซอร์ส ให้ `git clone https://github.com/dramaclaw/dramaclaw-gateway.git ../dramaclaw-gateway` ก่อน (ตอนนี้ gateway สร้างจาก checkout ข้างเคียงนั้น; ถ้าไม่มี การ build จะหยุดพร้อม `unable to prepare context`) `docker-compose.selfhosted.yml` / `docker-compose.selfhosted.release.yml` ถูกลบออกแล้ว — ใช้ `docker-compose.yml` (สร้างจากซอร์ส) / `docker-compose.release.yml` (image) แทน ชื่อบริการและ volume `ce-data` / `newapi-data` ไม่เปลี่ยน; ข้อมูลเดิมถูกนำมาใช้ต่อได้ทันที พอร์ตของ gateway ที่มาพร้อมกันตอนนี้ bind เฉพาะ `127.0.0.1` โดยค่าเริ่มต้น; ตั้ง `ST_NEWAPI_BIND=0.0.0.0` ใน `.env` ถ้าต้องการเข้าถึงจากระยะไกล
+
+### การพัฒนาในเครื่อง (uv + Python 3.11+)
+
+```bash
+git clone https://github.com/dramaclaw/dramaclaw.git
+cd dramaclaw
+
+uv sync
+cp .env.example .env && $EDITOR .env
+
+uv run novelvideo api --port 8780   # start the REST API (CE defaults to inline tasks, no Ray/Redis)
+```
+
+รัน frontend ในเทอร์มินัลที่สอง: `cd frontend && pnpm install && pnpm dev`
+
+**Gateway** ในโหมด **Official** คุณไม่ต้องทำอะไรเพิ่ม สำหรับ **Custom** หรือ **Local + Official Hybrid** API คาดหวัง gateway ที่ `127.0.0.1:3000` ซึ่งมีไฟล์ SQLite อยู่ที่ `./state/newapi/one-api.db` (นั่นคือสิ่งที่ปุ่ม "Initialize" ใน Settings เขียนลงไป; `NEWAPI_ADMIN_BASE_URL` ใน `.env` ชี้ไปที่นั่นอยู่แล้ว) จะรัน image ที่เผยแพร่แล้วโดย mount ไดเรกทอรีนั้น:
+
+```bash
+mkdir -p state/newapi
+docker run -d --name dramaclaw-gateway -p 127.0.0.1:3000:3000 \
+  -v "$PWD/state/newapi:/data" \
+  claymorelab/dramaclaw-gateway:v1.0.0-rc.24-dramaclaw.1
+```
+
+หรือรัน gateway จากซอร์สใน checkout ข้างเคียงก็ได้ (`make dev-api` / `make dev-web` ใน [dramaclaw-gateway](https://github.com/dramaclaw/dramaclaw-gateway#develop) หรือ `go build` แล้วสตาร์ท binary ด้วย `SQLITE_PATH=<path to>/dramaclaw/state/newapi/one-api.db`)
+
+<br/>
+
+## Model และผู้ให้บริการที่รองรับ
+
+DramaClaw เป็นกลางเรื่อง model — model ข้อความ / ภาพ / วิดีโอ / เสียงทั้งหมดเชื่อมต่อผ่าน **gateway ที่เข้ากันได้กับ OpenAI** เลือกโหมดใน **Settings → Model Config**:
+
+- **Official (แนะนำ)** — วาง DC key ของคุณ (รับได้ที่ <https://relayclaw.cdnfg.com>) บันทึก เสร็จ RelayClaw มี model mapping ทุกตัวที่ DramaClaw ต้องการอยู่แล้ว; ไม่ต้องตั้งค่าอะไรเลย
+- **Custom** — คลิกเดียวเพื่อเริ่มต้น `dramaclaw-gateway` ที่มาพร้อมกัน จากนั้นเพิ่ม channel ของผู้ให้บริการของคุณเอง (API key, model ID) ใน admin UI ของมัน ทุก model ที่ DramaClaw เรียกจะผ่าน channel ของคุณ
+- **Local + Official Hybrid** — ใช้ model official สำหรับสายการผลิตหลัก และเพิ่ม channel อื่น (เช่นเวิร์กโฟลว์วิดีโอ ComfyUI ในเครื่อง) ผ่าน gateway ที่มาพร้อมกัน
+
+คำแนะนำฉบับเต็มอยู่ใน [การตั้งค่า Model](../docs/en/getting-started/configuring-models.md)
+
+### gateway ที่มาพร้อมกัน: dramaclaw-gateway
+
+บริการ `newapi` ใน `docker-compose.yml` คือ [**dramaclaw-gateway**](https://github.com/dramaclaw/dramaclaw-gateway) fork ของ [New API](https://github.com/QuantumNous/new-api) ที่ DramaClaw ดูแลเอง มันพูดสัญญา **DC-Media** ที่ DramaClaw ใช้สำหรับภาพ / วิดีโอ / เสียง (media role, ภาพอ้างอิง, เฟรมแรก / เฟรมสุดท้าย) และแปลงแต่ละคำขอเป็น API ดั้งเดิมของผู้ให้บริการ image: [`claymorelab/dramaclaw-gateway`](https://hub.docker.com/r/claymorelab/dramaclaw-gateway) บน Docker Hub ปักหมุดด้วย `DRAMACLAW_GATEWAY_VERSION` ใน `.env` มันอยู่เฉย ๆ ในโหมด Official และจะถูกใช้ก็ต่อเมื่อคุณสลับไป **Custom** หรือ **Local + Official Hybrid**
+
+adapter ของผู้ให้บริการที่มากับ gateway ในวันนี้ (ดูสถานะการตรวจสอบใน [ตารางรองรับ channel](https://github.com/dramaclaw/dramaclaw-gateway/blob/main/docs/providers/en/README.md)): ComfyUI · MiniMax / Hailuo · VolcEngine Doubao / Seedance · fal.ai · Alibaba · Kling · Jimeng · Vertex AI · Gemini · OpenAI / Sora · Suno อยากได้ผู้ให้บริการอื่น? gateway มี [scaffold generator และคู่มือการมีส่วนร่วม](https://github.com/dramaclaw/dramaclaw-gateway/blob/main/CONTRIBUTING.md)
+
+| ขั้นตอน              | โหมด Official (RelayClaw)                          | โหมด Custom / Hybrid (gateway ที่มาพร้อมกัน)                    |
+|----------------------|----------------------------------------------------|-----------------------------------------------------------|
+| **ข้อความ / LLM**       | model `DC-*-LLM` ไม่ต้อง map               | chat channel ใดก็ได้ที่เข้ากันได้กับ OpenAI                        |
+| **ภาพ**            | gpt-image · nano-banana                            | image channel ใดก็ได้ที่ลงทะเบียนใน gateway              |
+| **วิดีโอ**            | Seedance 1.0 / 1.5 / 2.0 series · happyhorse       | DC-Media video adapter ใดก็ได้ (Seedance, Hailuo, Kling, ComfyUI, …) |
+| **เสียงพากย์**       | IndexTTS2                                          | audio channel ใดก็ได้ที่ลงทะเบียนใน gateway              |
+| **Story graph**      | Cognee (`DC-cognee-embedding`)                     | embedding channel ใดก็ได้                                     |
+| **Task runtime**     | inline ใน process (ไม่มี Ray / Redis / Celery)        | เหมือนกัน                                                      |
+| **Storage**          | ระบบไฟล์ในเครื่อง                                   | เหมือนกัน                                                      |
+
+<br/>
+
+## <a name="in-development"></a>กำลังพัฒนา
+
+สิ่งเหล่านี้กำลังถูกสร้างอย่างเปิดเผยและยังไม่อยู่ใน release ติดตาม branch หรือมาช่วยกันได้
+
+- **Xia Director บน canvas** &mdash; agent สร้างและเชื่อม node อัปเดตข้อมูล node จัดวางและจัดกลุ่ม node รัน action ของ node และสร้าง workflow graph ทั้งชุด โดยทุกคำสั่ง canvas ต้องได้รับการอนุมัติในเบราว์เซอร์ที่เปิดอยู่ก่อน
+- **แคตตาล็อกเวิร์กโฟลว์และ skill จากชุมชน** &mdash; แคตตาล็อก workflow skill 11 รายการและ recipe 60 รายการ (ละครสั้น, โฆษณาอีคอมเมิร์ซ, โฆษณาตัวละคร IP, แคมเปญโซเชียล, สไตล์อนิเมะ / Pixar / LEGO / กังฟู…) ที่จัดวาง generation graph ทั้งชุด; skill และ recipe เป็น bundle ที่ติดตั้ง ส่งออก และแชร์ได้
+- **agent-kit** &mdash; แพ็กเกจพกพาที่นำเวิร์กโฟลว์ DramaClaw ชุดเดียวกันไปยัง Hermes, OpenClaw, WorkBuddy, Claude Code และ Codex
+- **Previz stage** &mdash; เวที 3D blocking ในเบราว์เซอร์ในรูป node บน canvas: timeline หลายแทร็ก, rig และเส้นทางตัวละคร, กล้องจำลองเลนส์ / เซ็นเซอร์จริง, ติดตามภาพระยะใกล้ แล้วจับภาพช็อตที่จัดเฟรมแล้วส่งตรงเข้า node ถัดไป Branch: `feat/previz-canvas-node`
+- **เรื่องราวแบบอินเทอร์แอคทีฟ** &mdash; จุดเลือกแบบแตกแขนงบน canvas คอมไพล์เป็น ink story และส่งออกเป็น HTML player แบบ self-contained พร้อมสถิติ playtest และ path coverage Branch: `feat/canvas-fmv`
+- **โฆษณาแบบอินเทอร์แอคทีฟ** &mdash; ad skill และ recipe ด้านบน ผสมกับการเล่นแบบแตกแขนง สำหรับวิดีโอสินค้าที่ผู้ชมเลือกทางเองได้
+
+<br/>
+
+## <a name="documentation"></a>เอกสาร
+
+- [**คู่มือผู้ใช้ผลิตภัณฑ์**](https://neo-flying.feishu.cn/docx/JGNTdsjJuo748TxJkxecoYs2nth) — คู่มือ UI ฉบับเต็ม (Feishu)
+- [ภาพรวมฟีเจอร์](../docs/en/concepts/features.md)
+- [สถาปัตยกรรม](../docs/en/concepts/architecture.md)
+- [เริ่มต้นอย่างรวดเร็ว](../docs/en/getting-started/quickstart.md)
+- [คู่มือโฮสต์เอง](../docs/en/guides/self-hosting.md)
+- [การตั้งค่าผู้ให้บริการ model](../docs/en/getting-started/configuring-models.md)
+- [เอกสารเพิ่มเติม &rarr;](../docs/en/README.md)
+
+<br/>
+
+## เข้าร่วมชุมชน / มีส่วนร่วม
+
+- [รายงานบั๊ก](https://github.com/dramaclaw/dramaclaw/issues/new?template=bug_report.yml)
+- [ขอฟีเจอร์](https://github.com/dramaclaw/dramaclaw/issues/new?template=feature_request.yml)
+- [เข้าร่วมการสนทนา](https://github.com/dramaclaw/dramaclaw/discussions)
+- [คู่มือการมีส่วนร่วม](../CONTRIBUTING.md)
+- [นโยบายความปลอดภัย](../SECURITY.md)
+
+เราคัดสรรและติดป้าย [`good first issue`](https://github.com/dramaclaw/dramaclaw/labels/good%20first%20issue) อย่างต่อเนื่อง — จุดเริ่มต้นที่ดีเยี่ยม
+
+<br/>
+
+## ผู้มีส่วนร่วม
+
+ผู้คนที่สร้าง DramaClaw — ขอบคุณ 💜
+
+<table>
+  <tr>
+    <td align="center"><a href="https://github.com/bopy-zou"><img src="https://github.com/bopy-zou.png?size=100" width="72" alt="bopy-zou"/><br/><sub>bopy-zou</sub></a></td>
+    <td align="center"><a href="https://github.com/Handanhhhy"><img src="https://github.com/Handanhhhy.png?size=100" width="72" alt="Handanhhhy"/><br/><sub>Handanhhhy</sub></a></td>
+    <td align="center"><a href="https://github.com/Hanlin-Gabriel"><img src="https://github.com/Hanlin-Gabriel.png?size=100" width="72" alt="Hanlin-Gabriel"/><br/><sub>Hanlin-Gabriel</sub></a></td>
+    <td align="center"><a href="https://github.com/ryanhuang-duat"><img src="https://github.com/ryanhuang-duat.png?size=100" width="72" alt="ryanhuang-duat"/><br/><sub>ryanhuang-duat</sub></a></td>
+    <td align="center"><a href="https://github.com/lywaterman"><img src="https://github.com/lywaterman.png?size=100" width="72" alt="lywaterman"/><br/><sub>lywaterman</sub></a></td>
+    <td align="center"><a href="https://github.com/n7s4"><img src="https://github.com/n7s4.png?size=100" width="72" alt="n7s4"/><br/><sub>n7s4</sub></a></td>
+  </tr>
+  <tr>
+    <td align="center"><a href="https://github.com/NewYuee"><img src="https://github.com/NewYuee.png?size=100" width="72" alt="NewYuee"/><br/><sub>NewYuee</sub></a></td>
+    <td align="center"><a href="https://github.com/SimonRen"><img src="https://github.com/SimonRen.png?size=100" width="72" alt="SimonRen"/><br/><sub>SimonRen</sub></a></td>
+    <td align="center"><a href="https://github.com/vkiki"><img src="https://github.com/vkiki.png?size=100" width="72" alt="vkiki"/><br/><sub>vkiki</sub></a></td>
+    <td align="center"><a href="https://github.com/wangwenqq"><img src="https://github.com/wangwenqq.png?size=100" width="72" alt="wangwenqq"/><br/><sub>wangwenqq</sub></a></td>
+    <td align="center"><a href="https://github.com/zhen2025109"><img src="https://github.com/zhen2025109.png?size=100" width="72" alt="zhen2025109"/><br/><sub>zhen2025109</sub></a></td>
+  </tr>
+</table>
+
+<br/>
+
+## ผลิตโดย
+
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="../assets/partners/neoflying-lab-dark.png">
+    <img src="../assets/partners/neoflying-lab.png" alt="Neo Flying AI Laboratory" height="48">
+  </picture>
+</p>
+
+<p align="center"><sub>โลโก้เป็นเครื่องหมายการค้าของเจ้าของแต่ละราย แสดงโดยได้รับอนุญาต</sub></p>
+
+<br/>
+
+## สัญญาอนุญาต
+
+[Elastic License 2.0](../LICENSES/Elastic-2.0.txt) ใช้ แก้ไข แจกจ่ายต่อ และขายสิ่งที่คุณสร้างจากมันได้ฟรี; เก็บข้อความเล็ก ๆ "Powered by DramaClaw" ไว้ใน UI ของคุณ ข้อจำกัดเดียวคือคุณไม่สามารถนำเสนอซอฟต์แวร์นี้เองเป็นบริการแบบโฮสต์ให้ผู้อื่นได้ ดู [คำอธิบายสัญญาอนุญาต](../docs/en/license.md) และ [แถลงการณ์เรื่องสัญญาอนุญาต](https://github.com/dramaclaw/dramaclaw/issues/475)
+
+<br/>
+
+## ประวัติ Star
+
+<a href="https://www.star-history.com/?repos=dramaclaw%2Fdramaclaw&type=date&legend=top-left">
+ <picture>
+   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=dramaclaw/dramaclaw&type=date&theme=dark&legend=top-left&sealed_token=CWTXgm9EqgQmnSFWk0inuf_iZSml5r1nclyIsUyisWgYhUzFVJdI8G61vyFACIQe14weeMtjWSxpkzWdtFqyb93uV4uaRElaXWQv2kFxFFyL8KbUQBCOBUWXDtZc81J8YlaSiBVVXeOygLYZliOK4VQo4i1Ioqkxn5js-Bq0gbqVOH_wF3GCQ_EnMGLy" />
+   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=dramaclaw/dramaclaw&type=date&legend=top-left&sealed_token=CWTXgm9EqgQmnSFWk0inuf_iZSml5r1nclyIsUyisWgYhUzFVJdI8G61vyFACIQe14weeMtjWSxpkzWdtFqyb93uV4uaRElaXWQv2kFxFFyL8KbUQBCOBUWXDtZc81J8YlaSiBVVXeOygLYZliOK4VQo4i1Ioqkxn5js-Bq0gbqVOH_wF3GCQ_EnMGLy" />
+   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=dramaclaw/dramaclaw&type=date&legend=top-left&sealed_token=CWTXgm9EqgQmnSFWk0inuf_iZSml5r1nclyIsUyisWgYhUzFVJdI8G61vyFACIQe14weeMtjWSxpkzWdtFqyb93uV4uaRElaXWQv2kFxFFyL8KbUQBCOBUWXDtZc81J8YlaSiBVVXeOygLYZliOK4VQo4i1Ioqkxn5js-Bq0gbqVOH_wF3GCQ_EnMGLy" />
+ </picture>
+</a>
+
+<br/><br/>
+
+<div align="center">
+  <sub>สร้างเพื่อนักเล่าเรื่อง เปิดเผยซอร์สโค้ดให้ทุกคน</sub>
+</div>
+
+## Notices
+
+See `NOTICE` for required branding and third-party attribution notices.

--- a/readme/README_vi.md
+++ b/readme/README_vi.md
@@ -1,0 +1,464 @@
+<div align="center">
+
+<!-- TBD: thay bằng logo chính thức assets/logo.svg -->
+<h1>DramaClaw</h1>
+
+## Make Your Own DC.
+
+<p align="left">
+
+Họ nói bạn đã lỗi thời.<br/>
+Có lẽ chính cái ý tưởng "đi làm thuê cho người khác" mới là thứ lỗi thời.<br/>
+<br/>
+Trong thời đại AI, câu hỏi thật sự không phải là máy móc có thay thế con người hay không.<br/>
+Câu hỏi thật sự là:<br/>
+Ai sở hữu máy móc?<br/>
+Ai sở hữu quy trình?<br/>
+Ai sở hữu năng lực sản xuất công nghiệp hóa?<br/>
+<br/>
+Nếu câu trả lời luôn là các ông lớn công nghệ,<br/>
+thì AI không phải là trao quyền.<br/>
+Nó chỉ là một bức tường mới.<br/>
+<br/>
+Tôi là Eric.<br/>
+<br/>
+Đây không phải một bản demo.<br/>
+Không phải đồ chơi.<br/>
+Không phải bản cắt xén.<br/>
+<br/>
+Đây là dây chuyền sản xuất phim drama công nghiệp hóa mà chính đội ngũ chúng tôi chạy mỗi ngày.<br/>
+Từ kịch bản đến storyboard, từ tài sản đến phim hoàn chỉnh — trọn vẹn cả chuỗi.<br/>
+<br/>
+Vì con người không phải trâu ngựa.<br/>
+Vì sức sáng tạo là phòng tuyến cuối cùng của nhân loại.<br/>
+<br/>
+Điều DramaClaw muốn làm rất đơn giản:<br/>
+<br/>
+<strong>Phá bỏ bức tường.</strong><br/>
+<br/>
+Đưa năng lực sản xuất phim drama công nghiệp hóa mà trước đây chỉ các ông lớn mới có<br/>
+vào tay những người sáng tạo bình thường.<br/>
+<br/>
+Mã nguồn đã ở đây.<br/>
+Nếu bạn thấy đồng cảm, hãy để lại một ⭐.<br/>
+Chúng tôi sẽ tiếp tục phá tường.
+
+</p>
+
+<p align="left">
+
+<strong>Và đúng vậy, bạn có thể kiếm tiền với nó.</strong><br/>
+DramaClaw dùng giấy phép <a href="../LICENSES/Elastic-2.0.txt">Elastic License 2.0</a>. Chạy nó, sửa nó, bán những gì bạn xây bằng nó —<br/>
+phiên bản độc lập được dùng thương mại miễn phí, không cần xin phép.<br/>
+Chúng tôi chỉ xin một điều: một dòng nhỏ "Powered by DramaClaw" ở góc giao diện của bạn.<br/>
+Cánh cửa duy nhất còn đóng là đóng gói nó thành SaaS lưu trữ để bán cho người khác; giấy phép đó chưa mở.<br/>
+Lý do và các câu hỏi thường gặp: <a href="https://github.com/dramaclaw/dramaclaw/issues/475">#475</a>.
+
+</p>
+
+<br/>
+
+[![License](https://img.shields.io/badge/License-Elastic_2.0-blue.svg)](../LICENSES/Elastic-2.0.txt)
+[![GitHub stars](https://img.shields.io/github/stars/dramaclaw/dramaclaw?style=social)](https://github.com/dramaclaw/dramaclaw/stargazers)
+[![Release](https://img.shields.io/github/v/release/dramaclaw/dramaclaw?include_prereleases&sort=semver)](https://github.com/dramaclaw/dramaclaw/releases)
+[![Docker](https://img.shields.io/badge/docker-ready-2496ED?logo=docker&logoColor=white)](#quick-start)
+
+[English](../README.md) &nbsp;|&nbsp; [简体中文](./README_zh.md) &nbsp;|&nbsp; **Tiếng Việt** &nbsp;|&nbsp; [ไทย](./README_th.md) &nbsp;|&nbsp; [Website](https://dramaclaw.ai) &nbsp;|&nbsp; [Tài liệu](../docs/en/README.md) &nbsp;|&nbsp; [Bắt đầu nhanh](../docs/en/getting-started/quickstart.md)
+
+</div>
+
+<br/>
+
+<p align="center">
+  <img src="../assets/hero.png" alt="DramaClaw — người kể chuyện, trở lại trước ống kính" width="820"/>
+</p>
+
+<!--
+  Video demo — sau khi upload, dán link user-attachments vào một dòng riêng bên dưới.
+  Cách upload: mở một Issue mới trên github.com (đừng gửi), kéo video demo vào
+  phần nội dung, đợi upload xong và tự sinh link
+  https://github.com/user-attachments/assets/...mp4, copy vào đây, rồi
+  hủy Issue đó. GitHub sẽ render URL đứng riêng một dòng thành trình phát inline.
+
+  https://github.com/user-attachments/assets/REPLACE-AFTER-UPLOAD
+-->
+
+<p align="center">
+  <sub>🎬 Trailer: <a href="https://www.bilibili.com/video/BV1iQV26cE4S">Bilibili</a> &nbsp;·&nbsp; <a href="https://www.youtube.com/watch?v=64apa3maxK0">YouTube</a></sub>
+</p>
+
+<br/>
+
+<div align="center">
+
+## 🎬 Làm bằng DramaClaw
+
+<sub>Những bộ phim drama ngắn thật do đội ngũ chúng tôi sản xuất trên chính dây chuyền này &mdash; bấm vào link để xem.</sub>
+
+<table>
+  <tr>
+    <td align="center" width="205" valign="top">
+      <img src="https://nfg-web-assets.cdnfg.com/dramaclaw/guilingsi/guilingsi-cover.png?v=2" width="185" alt="归灵司"/><br/>
+      <b>归灵司</b><br/>
+      <a href="https://nfg-web-assets.cdnfg.com/dramaclaw/guilingsi/guilingsi-ep01.mp4">▶ Tập 1</a>
+    </td>
+    <td align="center" width="205" valign="top">
+      <img src="https://nfg-web-assets.cdnfg.com/dramaclaw/luban/luban-cover.png?v=2" width="185" alt="鲁班"/><br/>
+      <b>鲁班</b><br/>
+      <a href="https://nfg-web-assets.cdnfg.com/dramaclaw/luban/luban-ep01.mp4">▶ Tập 1</a>
+    </td>
+    <td align="center" width="205" valign="top">
+      <img src="https://nfg-web-assets.cdnfg.com/dramaclaw/shixiong-butianle/shixiong-butianle-cover.png?v=2" width="185" alt="师兄你怎么不舔了"/><br/>
+      <b>师兄你怎么不舔了</b><br/>
+      <a href="https://nfg-web-assets.cdnfg.com/dramaclaw/shixiong-butianle/shixiong-butianle-ep01.mp4">▶ Tập 1</a>
+    </td>
+  </tr>
+  <tr>
+    <td align="center" width="205" valign="top">
+      <img src="https://nfg-web-assets.cdnfg.com/dramaclaw/tianmingbukeqi/tianmingbukeqi-cover.png?v=2" width="185" alt="天命不可欺"/><br/>
+      <b>天命不可欺</b><br/>
+      <a href="https://nfg-web-assets.cdnfg.com/dramaclaw/tianmingbukeqi/tianmingbukeqi-ep02.mp4">▶ Tập 02</a> &nbsp;·&nbsp; <a href="https://nfg-web-assets.cdnfg.com/dramaclaw/tianmingbukeqi/tianmingbukeqi-ep58.mp4">Tập 58</a>
+    </td>
+    <td align="center" width="205" valign="top">
+      <img src="https://nfg-web-assets.cdnfg.com/dramaclaw/wulongxiantu/wulongxiantu-cover.png?v=2" width="185" alt="乌龙仙途"/><br/>
+      <b>乌龙仙途</b><br/>
+      <a href="https://nfg-web-assets.cdnfg.com/dramaclaw/wulongxiantu/wulongxiantu-ep01.mp4">▶ Tập 1</a>
+    </td>
+    <td align="center" width="205" valign="top">
+      <img src="https://nfg-web-assets.cdnfg.com/dramaclaw/feiyi-zhouwu/feiyi-zhouwu-cover.png?v=2" width="185" alt="非遗㑇舞"/><br/>
+      <b>非遗㑇舞</b><br/>
+      <a href="https://nfg-web-assets.cdnfg.com/dramaclaw/feiyi-zhouwu/feiyi-zhouwu.mp4">▶ Phát</a>
+    </td>
+  </tr>
+</table>
+
+<sub>Thêm clip:
+<a href="https://nfg-web-assets.cdnfg.com/dramaclaw/3d-anime-montage-demo/3d-anime-montage-demo.mp4">3D 动漫混剪 demo</a> &nbsp;·&nbsp;
+<a href="https://nfg-web-assets.cdnfg.com/dramaclaw/dongtai-dadou/dongtai-dadou.mp4">动态打斗</a></sub>
+
+</div>
+
+<br/>
+
+## DramaClaw là gì?
+
+DramaClaw là một **dây chuyền sản xuất phim drama AI với mã nguồn công khai (source available)** — và ngày càng mở rộng cho bất kỳ câu chuyện hình ảnh nào bạn muốn kể bằng các model sinh nội dung. Nó có hai gương mặt, dùng chung một thư viện tài sản và một agent:
+
+- **XiaHua — bảng vẽ vô hạn (infinite canvas).** Một bàn làm việc dạng node, nơi bạn tự do tạo, chỉnh sửa và kết nối hình ảnh, video, âm thanh, bối cảnh 3D và kịch bản, rồi đưa những gì ưng ý trở lại series. Đây là nơi phần lớn công việc sáng tạo của chính chúng tôi diễn ra hôm nay, và cũng là hướng DramaClaw đang tiến tới.
+- **Series (XiaJi) — pipeline.** Thả vào một bản thảo hoặc kịch bản, DramaClaw sẽ gánh phần việc nặng: cấu trúc hóa câu chuyện, lên kế hoạch từng tập, viết kịch bản, vẽ storyboard và khung hình đầu, tổng hợp lồng tiếng, và dựng thành phim hoàn chỉnh.
+
+**Xia Director**, agent tích hợp sẵn, đứng giữa cả hai: trả lời câu hỏi về dự án của bạn, điều khiển các tác vụ pipeline, và có thể dựng rồi chạy các đồ thị node trên canvas thay bạn.
+
+Nó được xây cho người sáng tạo, studio độc lập và kỹ sư sáng tạo — chạy trọn "nhà máy phim drama" trên chính máy của bạn, không cần chắp vá hàng chục công cụ rời rạc hay giao tài liệu của mình cho một dịch vụ đám mây hộp đen. Dù được xây quanh phim drama, cùng một canvas và pipeline này vẫn áp dụng cho quảng cáo ngắn, video sản phẩm thương mại điện tử và các định dạng hình ảnh khác.
+
+<p align="center">
+  <img src="https://nfg-web-assets.cdnfg.com/dramaclaw/readme/dual-mode-workflow.jpg?v=2" width="600" alt="双模式工作流 · Quy trình hai chế độ"/>
+</p>
+
+<br/>
+
+## Năng lực cốt lõi
+
+<p align="center">
+  <img src="https://nfg-web-assets.cdnfg.com/dramaclaw/readme/oss-launch.jpg?v=2" width="760" alt="DramaClaw 源码发布 · ra mắt mã nguồn công khai"/>
+</p>
+
+### XiaHua — bảng vẽ vô hạn
+
+<p align="center">
+  <img src="../assets/xiahua-canvas.jpg" width="900" alt="Canvas XiaHua: quy trình phim ngắn 17 node mà Xia Director đã bố trí và chạy chỉ từ một prompt"/>
+</p>
+<p align="center"><sub>Một prompt gửi cho Xia Director (bên phải) đã trở thành quy trình 17 node, 32 cạnh này trên canvas (bên trái): brief → định hướng câu chuyện → tham chiếu nhân vật và bối cảnh → khung hình đầu của năm cảnh quay → video năm cảnh quay → lồng tiếng và nhạc nền → bản dựng cuối.</sub></p>
+
+- **18 loại node trên một canvas** &mdash; upload, tạo / chỉnh sửa ảnh, tạo storyboard, kịch bản, ngữ cảnh beat, video, ghép video, video kể chuyện, âm thanh, phong cách, skill, nhóm, chú thích văn bản, trình xem toàn cảnh 360°, thế giới 3D, xuất và nhiều hơn nữa. Kết nối tự do; mỗi node giữ lịch sử sinh nội dung riêng.
+- **Công cụ ảnh** &mdash; tạo, chỉnh sửa, vẽ lại, mở rộng khung (outpaint), chiếu sáng lại, upscale, đa góc nhìn, chỉnh sửa theo mẫu, suy ngược prompt, phát hiện đánh dấu; một **bức tường phong cách với 45 look phim drama ngắn** cho image-to-image
+- **Công cụ video** &mdash; text / image / keyframe sang video, sinh nội dung tham chiếu toàn diện với **tham chiếu từ file, link web và ngay trên canvas**, chỉnh sửa video, xóa, upscale, tách âm thanh, mẫu chuyển động camera, phân tích cảnh quay; Seedance 2.5 có trong danh mục khuyến nghị
+- **Âm thanh** &mdash; tổng hợp giọng nói với thư viện giọng, giọng tham chiếu, tạo nhạc
+- **Skill trên canvas** &mdash; các skill một chạm như phác thảo từ ngữ cảnh, khung hình từ ngữ cảnh, đặt nền, cảnh 360, review khung hình và lập kế hoạch beat-graph
+- **Xây cho canvas lớn** &mdash; tab canvas, dàn ý phần tử, minimap và bookmark vùng nhìn, căn chỉnh bám lưới, render theo mức chi tiết (level-of-detail), chọn nhiều và nhóm node, phím tắt, lịch sử phiên bản có khôi phục, khóa theo từng canvas
+- **Commit vào series** &mdash; xem trước tác động, rồi đưa một node hoặc cả một lô vào thư viện tài sản hoặc một tập; chiếu series ngược lại lên canvas từ các preset
+- **Director World — bối cảnh nhất quán về không gian** &mdash; ảnh → bối cảnh 3D Gaussian Splat và toàn cảnh scene-360 dưới dạng node trên canvas: một phim trường ảo có thể lấy khung hình, khóa cấu trúc không gian, vị trí nhân vật và vị trí đặt camera, để cùng một địa điểm giữ nhất quán qua các cảnh quay; lấy khung trong trình xem 3D, chụp lại, rồi dùng làm nền cho lần sinh nội dung tiếp theo<br/>
+  <img src="https://nfg-web-assets.cdnfg.com/dramaclaw/readme/world-model.jpg?v=2" width="600" alt="世界模型 · World Model (3GS)"/>
+
+### Series (XiaJi) — pipeline
+
+<p align="center">
+  <img src="../assets/pipeline.png" alt="Pipeline DramaClaw — Nạp vào, Lên kế hoạch, Sản xuất, Bàn giao" width="760"/>
+</p>
+
+Mỗi bước có giao diện riêng — chạy theo thứ tự, bỏ qua bước, tiếp tục từ bất kỳ checkpoint nào, hoặc thậm chí cắm orchestrator của riêng bạn vào.
+
+- **Nạp vào có cấu trúc** &mdash; dự án mới dựng thẳng các tập, nhân vật và bối cảnh từ bản thảo hoặc kịch bản (hỗ trợ Fountain), không cần knowledge graph hay embedding; đường story-graph bằng Cognee vẫn giữ cho các dự án cũ
+- **Thư viện tài sản & nhất quán danh tính** &mdash; nhân vật, bối cảnh, đạo cụ và giọng nói được sắp xếp theo mục đích và thư mục; danh tính ổn định xuyên suốt các tập, chân dung nhân vật và biến thể theo từng tập
+- **Lên kế hoạch tập & sinh kịch bản** &mdash; phân đoạn chương, lập kế hoạch beat, cung truyện đa tập; các chế độ kịch bản chuyển thể / bám sát / dàn dựng với vòng lặp review-và-sửa
+- **Storyboard & khung hình đầu** &mdash; sinh nội dung cách điệu theo beat, chia lưới, chọn từ kho ảnh<br/>
+  <img src="https://nfg-web-assets.cdnfg.com/dramaclaw/readme/storyboard-sketch.jpg?v=2" width="600" alt="独家线稿草图系统 · Hệ thống storyboard nét vẽ"/>
+- **Lồng tiếng, ghép video & xuất** &mdash; giọng nói nhận biết cảm xúc, lắp ráp tập, xuất video + phụ đề và trọn bộ gói tài sản
+- **Phong cách hình ảnh** &mdash; upload một ảnh tham chiếu để trích xuất tham số phong cách và áp dụng cho toàn bộ dự án
+- **Trung tâm tác vụ** &mdash; trạng thái, tiến độ, log, hủy / thử lại, tiếp tục từ checkpoint cho các lần chạy dài; điều kiện tiên quyết được kiểm tra trước khi tác vụ vào hàng đợi
+
+### Xia Director — agent
+
+<p align="center">
+  <img src="https://nfg-web-assets.cdnfg.com/dramaclaw/readme/director-agent.jpg?v=2" width="600" alt="导演智能体 · Agent đạo diễn"/>
+</p>
+
+**Hiện tại**
+
+- **Hiểu dự án của bạn** &mdash; kiểm tra tiến độ, đẩy các tác vụ kịch bản / cảnh quay, rà soát mức độ hoàn chỉnh của sản phẩm bàn giao và gợi ý bước tiếp theo
+- **Mở cho các agent khác** &mdash; một MCP server cục bộ đưa DramaClaw đến Claude Code, Codex và bất kỳ MCP client nào (chỉ loopback, cần cờ tin cậy rõ ràng); xem [MCP cho Claude Code](../docs/en/guides/mcp-claude-code.md)
+
+**Tiếp theo**
+
+- **Làm việc trên canvas** &mdash; ảnh chụp màn hình phía trên là hướng đi: bạn mô tả bộ phim, Xia Director tạo và kết nối các node, bố trí chúng, chạy chúng và review kết quả, với mọi lệnh canvas đều được duyệt trong trình duyệt của bạn trước. Canvas + agent là cốt lõi của DramaClaw từ đây trở đi; xem [Đang phát triển](#in-development).
+
+<br/>
+
+## Tại sao chọn DramaClaw?
+
+**Một canvas hiểu phim drama, và một agent làm việc trên đó.** Các canvas node đa dụng nối được mọi thứ nhưng chẳng biết gì về tập, nhân vật hay cảnh quay; các công cụ series hiểu nghề nhưng nhốt bạn trong một wizard. XiaHua cho bạn canvas tự do với các node và skill hiểu phim drama, còn Xia Director đang được xây để bố trí, chạy và review những đồ thị đó thay bạn. Sự kết hợp ấy chính là nơi DramaClaw đang hướng tới.
+
+**Xây cho việc chuyển tiểu thuyết thành phim drama ngắn.** Các công cụ workflow chung có thể nối node với nhau, nhưng chúng không biết "beat của tập" là gì, không hiểu vì sao sự nhất quán danh tính nhân vật xuyên cảnh lại quan trọng, và sẽ không bảo vệ cung cảm xúc của một chương xuyên suốt ảnh + giọng nói + dựng phim. DramaClaw đưa toàn bộ những phán đoán đó vào công cụ.
+
+**Canvas và pipeline, không phải canvas hoặc pipeline.** Hầu hết công cụ cho bạn hoặc một canvas node tự do, hoặc một wizard cứng nhắc. DramaClaw chạy cả hai như hai đường ray song song trên cùng một thư viện tài sản: khám phá trên canvas, commit thứ hiệu quả vào series, chiếu series ngược lại lên canvas. Agent làm việc trên cả hai.
+
+**Mọi bước đều có thể tách rời.** Mỗi giai đoạn là một tác vụ bất đồng bộ độc lập với giao diện riêng. Chạy tuần tự, bỏ qua bước, tiếp tục giữa chừng — chính chuỗi công cụ là sản phẩm, không có hộp đen nào ẩn giấu.
+
+**Tự lưu trữ được, trung lập về model.** Bản thảo của bạn, nhân vật của bạn, model của bạn, máy chủ của bạn. Dùng các model tiên tiến đóng khi bạn muốn kết quả tốt nhất; chuyển sang các model open-weight khi bạn muốn toàn quyền kiểm soát. DramaClaw sẽ không trói bạn vào bất kỳ nhà cung cấp nào.
+
+### DramaClaw so với các sản phẩm khác
+
+Lợi thế không phải là "sinh nội dung nhiều hơn" — mà là tổ chức toàn bộ vòng sản xuất phim drama ngắn (kịch bản → tài sản → cảnh quay → canvas → bản dựng cuối) thành thứ có thể tái sử dụng, cộng tác và mở rộng quy mô.
+
+<sub>Chú giải: ✅ Đầy đủ · ◐ Một phần · ○ Dự kiến · ❌ Không có — tên đối thủ được che một phần; so sánh dựa trên tài liệu sản phẩm và định vị công khai.</sub>
+
+| Năng lực | L\*TV | R\*Hub | T\*Now | S\*ko | U\*dream | O\*II | J\*/K\* | **DramaClaw** |
+|---|:--:|:--:|:--:|:--:|:--:|:--:|:--:|:--:|
+| Xem trước storyboard (kịch bản→cảnh quay, bảng phân cảnh) | ◐ | ✅ | ◐ | ✅ | ◐ | ❌ | ❌ | ✅ |
+| Series tương tác (đa tập, phân nhánh, IP) | ◐ | ◐ | ◐ | ✅ | ◐ | ❌ | ❌ | ✅ |
+| Thư viện tài sản (nhân vật/bối cảnh/đạo cụ/giọng nói) | ◐ | ❌ | ◐ | ✅ | ◐ | ○ | ❌ | ✅ |
+| Nhất quán bối cảnh (biến thể, 360°, đa trạng thái) | ✅ | ◐ | ❌ | ❌ | ○ | ❌ | ❌ | ✅ |
+| Thế giới đạo diễn (bối cảnh 360°/3D, camera, khung hình) | ✅ | ◐ | ❌ | ❌ | ◐ | ❌ | ❌ | ✅ |
+| Bàn giao cuối (đa cảnh quay, phụ đề/SRT, gói tài sản) | ✅ | ○ | ○ | ✅ | ✅ | ❌ | ❌ | ✅ |
+| Sản xuất theo nhóm (chia sẻ, vai trò, tác vụ, chi phí) | ✅ | ✅ | ○ | ✅ | ○ | ○ | ○ | ✅ |
+| Bảng vẽ vô hạn (dạng node, khám phá tự do) | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ | ✅ | ✅ |
+| Hai đường ray (pipeline chính + khám phá trên canvas) | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ |
+| Phong cách tùy chỉnh (mẫu, prompt, negative prompt) | ✅ | ◐ | ○ | ✅ | ◐ | ○ | ◐ | ✅ |
+| Agent tích hợp (trợ lý, skill, gợi ý) | ✅ | ✅ | ✅ | ○ | ✅ | ○ | ✅ | ✅ |
+| Bạn đồng hành sáng tạo (nhân cách, nhắc nhở, phản hồi) | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ |
+| Mã nguồn công khai (tự lưu trữ, fork, tùy biến) | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ |
+
+<br/>
+
+## Yêu cầu hệ thống
+
+DramaClaw chạy toàn bộ suy luận qua một **gateway tương thích OpenAI** — hoặc dịch vụ RelayClaw chính thức, hoặc [dramaclaw-gateway](https://github.com/dramaclaw/dramaclaw-gateway) đi kèm để định tuyến tới các nhà cung cấp bạn cấu hình. Không có model nào chạy trên máy của bạn, nên tài nguyên cục bộ cần rất ít. Một chiếc laptop bình thường hoặc một VPS nhỏ là đủ.
+
+| Hạng mục | Yêu cầu |
+|---|---|
+| **CPU / RAM** | Khuyến nghị ≥ 2 vCPU / 4 GB (không tính suy luận model — phần đó chạy trên gateway) |
+| **GPU** | Không bắt buộc với pipeline tiêu chuẩn. Chỉ phần mở rộng tùy chọn `world` (voxel / toàn cảnh sang 3D) mới cần GPU + image CUDA |
+| **Ổ đĩa** | Vài GB cho image cộng với media/trạng thái sinh ra trong volume `ce-data` (không có mức tối thiểu cứng) |
+| **Hệ điều hành** | macOS (Apple Silicon / Intel), Windows (Docker Desktop + backend WSL2), Linux (Docker Engine + plugin compose) |
+| **Docker** | Docker + `docker compose` |
+| **Cổng** | `8080` giao diện web · `8780` REST API · `3000` giao diện quản trị gateway đi kèm (mặc định chỉ host, có thể mở rộng) |
+| **Kho dữ liệu** | Không cần gì — không Postgres, Redis, Celery hay Ray. Tác vụ chạy trong tiến trình; trạng thái nằm trên hệ thống file cục bộ (SQLite + file) |
+| **Mạng** | Truy cập ra ngoài tới gateway chính thức `relayclaw.cdnfg.com`, và/hoặc tới các nhà cung cấp model bạn cấu hình trong gateway đi kèm |
+
+> Phát triển cục bộ (không Docker) cần thêm Python 3.11–3.12 + [`uv`](https://docs.astral.sh/uv/) + `ffmpeg`. Điều kiện tiên quyết đầy đủ trong [Hướng dẫn tự lưu trữ](../docs/en/guides/self-hosting.md).
+
+<br/>
+
+## <a name="quick-start"></a>Bắt đầu nhanh
+
+### Docker (khuyến nghị)
+
+Mỗi GitHub Release đều phát hành image đa kiến trúc (amd64/arm64) lên Docker Hub.
+
+**Build từ mã nguồn (mặc định)** — clone DramaClaw và [dramaclaw-gateway](https://github.com/dramaclaw/dramaclaw-gateway) đi kèm cạnh nhau; `docker compose up -d --build` sẽ build cả ba dịch vụ từ hai checkout đó.
+
+```bash
+git clone https://github.com/dramaclaw/dramaclaw.git
+git clone https://github.com/dramaclaw/dramaclaw-gateway.git   # gateway đi kèm, build từ ../dramaclaw-gateway
+cd dramaclaw
+
+cp .env.example .env
+# Sửa .env — đặt PROMPT_EXPORT_PASSWORD thành giá trị khác mặc định.
+
+docker compose up -d --build   # build và khởi động ba dịch vụ: api / newapi (gateway đi kèm) / web
+```
+
+Cả hai checkout đều là repo git bình thường: sửa, `git pull`, build lại. Chỉ mã DramaClaw thay đổi? `docker compose up -d --build api web`. Chỉ gateway? `docker compose up -d --build newapi`. Clone gateway ở nơi khác, hoặc muốn Docker tự lấy từ git? Đặt `DRAMACLAW_GATEWAY_SRC` trong `.env` thành đường dẫn đó hoặc `https://github.com/dramaclaw/dramaclaw-gateway.git#main`.
+
+**Không build** — kéo image đã phát hành thay thế (không cần clone gateway):
+
+```bash
+docker compose -f docker-compose.release.yml up -d
+```
+
+Mở ứng dụng tại <http://localhost:8080>; REST API ở <http://localhost:8780>. Trong **Settings → Model Config** chọn một trong:
+
+- **Official** — dán DC key của bạn (lấy tại <https://relayclaw.cdnfg.com>); không cần ánh xạ model. Gateway đi kèm ở trạng thái chờ.
+- **Custom** — một cú bấm khởi tạo gateway `newapi` đi kèm; sau đó thêm các kênh upstream của riêng bạn.
+- **Local + Official Hybrid** — official cho pipeline chính, gateway đi kèm cho các kênh bổ sung.
+
+Các bước đầy đủ trong [Bắt đầu nhanh](../docs/en/getting-started/quickstart.md).
+
+Ghim phiên bản hoặc đổi registry trong `.env` (`DRAMACLAW_VERSION`, `DRAMACLAW_GATEWAY_VERSION`, `DRAMACLAW_IMAGE_PREFIX`) — các giá trị này chỉ áp dụng cho chế độ image (`docker-compose.release.yml`). Trung Quốc đại lục: đặt `DRAMACLAW_IMAGE_PREFIX=claymore-registry.cn-chengdu.cr.aliyuncs.com/dramaclaw` và ghim cả hai phiên bản (mirror ACR chỉ có các tag đã ghim).
+
+> Di chuyển từ một checkout cũ? Với build từ mã nguồn, trước tiên `git clone https://github.com/dramaclaw/dramaclaw-gateway.git ../dramaclaw-gateway` (gateway giờ được build từ checkout kế bên đó; thiếu nó, build sẽ dừng với `unable to prepare context`). `docker-compose.selfhosted.yml` / `docker-compose.selfhosted.release.yml` đã bị gỡ — dùng `docker-compose.yml` (build từ mã nguồn) / `docker-compose.release.yml` (image). Tên dịch vụ và các volume `ce-data` / `newapi-data` không đổi; dữ liệu hiện có được dùng lại nguyên trạng. Cổng của gateway đi kèm giờ mặc định chỉ bind vào `127.0.0.1`; đặt `ST_NEWAPI_BIND=0.0.0.0` trong `.env` nếu bạn cần truy cập từ xa.
+
+### Phát triển cục bộ (uv + Python 3.11+)
+
+```bash
+git clone https://github.com/dramaclaw/dramaclaw.git
+cd dramaclaw
+
+uv sync
+cp .env.example .env && $EDITOR .env
+
+uv run novelvideo api --port 8780   # khởi động REST API (CE mặc định chạy tác vụ inline, không Ray/Redis)
+```
+
+Frontend ở một terminal thứ hai: `cd frontend && pnpm install && pnpm dev`.
+
+**Gateway.** Ở chế độ **Official** bạn không cần gì thêm. Với **Custom** hoặc **Local + Official Hybrid**, API cần một gateway ở `127.0.0.1:3000` với file SQLite là `./state/newapi/one-api.db` (đó là nơi nút "Initialize" trong Settings ghi vào; `NEWAPI_ADMIN_BASE_URL` trong `.env` đã trỏ sẵn tới đó). Hoặc chạy image đã phát hành với thư mục đó được mount:
+
+```bash
+mkdir -p state/newapi
+docker run -d --name dramaclaw-gateway -p 127.0.0.1:3000:3000 \
+  -v "$PWD/state/newapi:/data" \
+  claymorelab/dramaclaw-gateway:v1.0.0-rc.24-dramaclaw.1
+```
+
+hoặc chạy gateway từ mã nguồn trong checkout kế bên (`make dev-api` / `make dev-web` trong [dramaclaw-gateway](https://github.com/dramaclaw/dramaclaw-gateway#develop), hoặc `go build` rồi khởi động binary với `SQLITE_PATH=<đường dẫn tới>/dramaclaw/state/newapi/one-api.db`).
+
+<br/>
+
+## Model & nhà cung cấp được hỗ trợ
+
+DramaClaw giữ trung lập về model — mọi model text / ảnh / video / âm thanh đều kết nối qua một **gateway tương thích OpenAI**. Chọn chế độ trong **Settings → Model Config**:
+
+- **Official (khuyến nghị)** — dán DC key của bạn (lấy tại <https://relayclaw.cdnfg.com>), lưu, xong. RelayClaw đã có sẵn mọi ánh xạ model mà DramaClaw cần; không phải cấu hình gì.
+- **Custom** — một cú bấm khởi tạo `dramaclaw-gateway` đi kèm, rồi thêm các kênh nhà cung cấp của riêng bạn (API key, model ID) trong giao diện quản trị của nó. Mọi model DramaClaw gọi đều đi qua kênh của bạn.
+- **Local + Official Hybrid** — giữ các model official cho pipeline chính và thêm các kênh bổ sung (ví dụ một workflow video ComfyUI cục bộ) qua gateway đi kèm.
+
+Hướng dẫn đầy đủ trong [Cấu hình model](../docs/en/getting-started/configuring-models.md).
+
+### Gateway đi kèm: dramaclaw-gateway
+
+Dịch vụ `newapi` trong `docker-compose.yml` là [**dramaclaw-gateway**](https://github.com/dramaclaw/dramaclaw-gateway), fork riêng của DramaClaw từ [New API](https://github.com/QuantumNous/new-api). Nó hiểu giao thức **DC-Media** mà DramaClaw dùng cho ảnh / video / âm thanh (vai trò media, tham chiếu, khung hình đầu / cuối) và chuyển đổi mỗi yêu cầu sang API gốc của nhà cung cấp. Image: [`claymorelab/dramaclaw-gateway`](https://hub.docker.com/r/claymorelab/dramaclaw-gateway) trên Docker Hub, ghim bởi `DRAMACLAW_GATEWAY_VERSION` trong `.env`. Nó ở trạng thái chờ trong chế độ Official và chỉ được dùng khi bạn chuyển sang **Custom** hoặc **Local + Official Hybrid**.
+
+Các adapter nhà cung cấp có sẵn trong gateway hiện nay (xem [ma trận hỗ trợ kênh](https://github.com/dramaclaw/dramaclaw-gateway/blob/main/docs/providers/en/README.md) để biết trạng thái xác minh): ComfyUI · MiniMax / Hailuo · VolcEngine Doubao / Seedance · fal.ai · Alibaba · Kling · Jimeng · Vertex AI · Gemini · OpenAI / Sora · Suno. Muốn thêm nhà cung cấp khác? Gateway có [trình tạo scaffold và hướng dẫn đóng góp](https://github.com/dramaclaw/dramaclaw-gateway/blob/main/CONTRIBUTING.md).
+
+| Giai đoạn            | Chế độ Official (RelayClaw)                        | Chế độ Custom / Hybrid (gateway đi kèm)                   |
+|----------------------|----------------------------------------------------|-----------------------------------------------------------|
+| **Text / LLM**       | các model `DC-*-LLM`, không cần ánh xạ             | bất kỳ kênh chat tương thích OpenAI nào                   |
+| **Ảnh**              | gpt-image · nano-banana                            | bất kỳ kênh ảnh nào đăng ký trong gateway                 |
+| **Video**            | dòng Seedance 1.0 / 1.5 / 2.0 · happyhorse         | bất kỳ adapter video DC-Media nào (Seedance, Hailuo, Kling, ComfyUI, …) |
+| **Lồng tiếng**       | IndexTTS2                                          | bất kỳ kênh âm thanh nào đăng ký trong gateway            |
+| **Story graph**      | Cognee (`DC-cognee-embedding`)                     | bất kỳ kênh embedding nào                                 |
+| **Runtime tác vụ**   | inline trong tiến trình (không Ray / Redis / Celery) | như trên                                                |
+| **Lưu trữ**          | hệ thống file cục bộ                               | như trên                                                  |
+
+<br/>
+
+## <a name="in-development"></a>Đang phát triển
+
+Những tính năng này đang được xây dựng công khai và chưa có trong bản phát hành nào. Hãy theo dõi các nhánh, hoặc đến góp sức.
+
+- **Xia Director trên canvas** &mdash; agent tạo và kết nối node, cập nhật dữ liệu node, bố trí và nhóm node, chạy các hành động node và dựng cả đồ thị workflow, với mọi lệnh canvas đều được duyệt trong trình duyệt đang mở trước.
+- **Danh mục workflow và skill cộng đồng** &mdash; một danh mục gồm 11 workflow skill và 60 recipe (phim drama ngắn, quảng cáo thương mại điện tử, quảng cáo nhân vật IP, chiến dịch mạng xã hội, phong cách anime / Pixar / LEGO / kung-fu…) tự bố trí trọn đồ thị sinh nội dung; skill và recipe dưới dạng bundle cài đặt, xuất và chia sẻ được
+- **agent-kit** &mdash; một gói di động mang cùng các workflow DramaClaw tới Hermes, OpenClaw, WorkBuddy, Claude Code và Codex
+- **Sân khấu previz** &mdash; một sân khấu dàn cảnh 3D ngay trong trình duyệt dưới dạng node canvas: timeline đa track, rig và đường di chuyển nhân vật, mô hình camera với ống kính / cảm biến thật, theo dõi cận cảnh, rồi chụp cảnh quay đã lấy khung thẳng vào node tiếp theo. Nhánh: `feat/previz-canvas-node`
+- **Truyện tương tác** &mdash; các điểm lựa chọn phân nhánh trên canvas, biên dịch thành truyện ink và xuất ra trình phát HTML độc lập, kèm thống kê playtest và độ phủ đường đi. Nhánh: `feat/canvas-fmv`
+- **Quảng cáo tương tác** &mdash; các skill và recipe quảng cáo ở trên, kết hợp với phát lại phân nhánh, cho những video sản phẩm mà người xem có thể tự điều hướng
+
+<br/>
+
+## <a name="documentation"></a>Tài liệu
+
+- [**Sổ tay người dùng sản phẩm**](https://neo-flying.feishu.cn/docx/JGNTdsjJuo748TxJkxecoYs2nth) — hướng dẫn đầy đủ giao diện (Feishu)
+- [Tổng quan tính năng](../docs/en/concepts/features.md)
+- [Kiến trúc](../docs/en/concepts/architecture.md)
+- [Bắt đầu nhanh](../docs/en/getting-started/quickstart.md)
+- [Hướng dẫn tự lưu trữ](../docs/en/guides/self-hosting.md)
+- [Cấu hình nhà cung cấp model](../docs/en/getting-started/configuring-models.md)
+- [Thêm tài liệu &rarr;](../docs/en/README.md)
+
+<br/>
+
+## Tham gia cộng đồng / Đóng góp
+
+- [Báo lỗi](https://github.com/dramaclaw/dramaclaw/issues/new?template=bug_report.yml)
+- [Đề xuất tính năng](https://github.com/dramaclaw/dramaclaw/issues/new?template=feature_request.yml)
+- [Tham gia thảo luận](https://github.com/dramaclaw/dramaclaw/discussions)
+- [Hướng dẫn đóng góp](../CONTRIBUTING.md)
+- [Chính sách bảo mật](../SECURITY.md)
+
+Chúng tôi liên tục chọn lọc và gắn nhãn [`good first issue`](https://github.com/dramaclaw/dramaclaw/labels/good%20first%20issue) — một nơi tuyệt vời để bắt đầu.
+
+<br/>
+
+## Người đóng góp
+
+Những người đang xây dựng DramaClaw — cảm ơn các bạn. 💜
+
+<table>
+  <tr>
+    <td align="center"><a href="https://github.com/bopy-zou"><img src="https://github.com/bopy-zou.png?size=100" width="72" alt="bopy-zou"/><br/><sub>bopy-zou</sub></a></td>
+    <td align="center"><a href="https://github.com/Handanhhhy"><img src="https://github.com/Handanhhhy.png?size=100" width="72" alt="Handanhhhy"/><br/><sub>Handanhhhy</sub></a></td>
+    <td align="center"><a href="https://github.com/Hanlin-Gabriel"><img src="https://github.com/Hanlin-Gabriel.png?size=100" width="72" alt="Hanlin-Gabriel"/><br/><sub>Hanlin-Gabriel</sub></a></td>
+    <td align="center"><a href="https://github.com/ryanhuang-duat"><img src="https://github.com/ryanhuang-duat.png?size=100" width="72" alt="ryanhuang-duat"/><br/><sub>ryanhuang-duat</sub></a></td>
+    <td align="center"><a href="https://github.com/lywaterman"><img src="https://github.com/lywaterman.png?size=100" width="72" alt="lywaterman"/><br/><sub>lywaterman</sub></a></td>
+    <td align="center"><a href="https://github.com/n7s4"><img src="https://github.com/n7s4.png?size=100" width="72" alt="n7s4"/><br/><sub>n7s4</sub></a></td>
+  </tr>
+  <tr>
+    <td align="center"><a href="https://github.com/NewYuee"><img src="https://github.com/NewYuee.png?size=100" width="72" alt="NewYuee"/><br/><sub>NewYuee</sub></a></td>
+    <td align="center"><a href="https://github.com/SimonRen"><img src="https://github.com/SimonRen.png?size=100" width="72" alt="SimonRen"/><br/><sub>SimonRen</sub></a></td>
+    <td align="center"><a href="https://github.com/vkiki"><img src="https://github.com/vkiki.png?size=100" width="72" alt="vkiki"/><br/><sub>vkiki</sub></a></td>
+    <td align="center"><a href="https://github.com/wangwenqq"><img src="https://github.com/wangwenqq.png?size=100" width="72" alt="wangwenqq"/><br/><sub>wangwenqq</sub></a></td>
+    <td align="center"><a href="https://github.com/zhen2025109"><img src="https://github.com/zhen2025109.png?size=100" width="72" alt="zhen2025109"/><br/><sub>zhen2025109</sub></a></td>
+  </tr>
+</table>
+
+<br/>
+
+## Sản xuất bởi
+
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="../assets/partners/neoflying-lab-dark.png">
+    <img src="../assets/partners/neoflying-lab.png" alt="Neo Flying AI Laboratory" height="48">
+  </picture>
+</p>
+
+<p align="center"><sub>Logo là thương hiệu của chủ sở hữu tương ứng, được hiển thị với sự cho phép.</sub></p>
+
+<br/>
+
+## Giấy phép
+
+[Elastic License 2.0](../LICENSES/Elastic-2.0.txt). Tự do sử dụng, sửa đổi, phân phối lại và bán những gì bạn xây bằng nó; giữ một dòng nhỏ "Powered by DramaClaw" trong giao diện của bạn. Hạn chế duy nhất là bạn không được cung cấp chính phần mềm này như một dịch vụ lưu trữ cho người khác. Xem [giải thích giấy phép](../docs/en/license.md) và [tuyên bố cấp phép](https://github.com/dramaclaw/dramaclaw/issues/475).
+
+<br/>
+
+## Lịch sử Star
+
+<a href="https://www.star-history.com/?repos=dramaclaw%2Fdramaclaw&type=date&legend=top-left">
+ <picture>
+   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=dramaclaw/dramaclaw&type=date&theme=dark&legend=top-left&sealed_token=CWTXgm9EqgQmnSFWk0inuf_iZSml5r1nclyIsUyisWgYhUzFVJdI8G61vyFACIQe14weeMtjWSxpkzWdtFqyb93uV4uaRElaXWQv2kFxFFyL8KbUQBCOBUWXDtZc81J8YlaSiBVVXeOygLYZliOK4VQo4i1Ioqkxn5js-Bq0gbqVOH_wF3GCQ_EnMGLy" />
+   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=dramaclaw/dramaclaw&type=date&legend=top-left&sealed_token=CWTXgm9EqgQmnSFWk0inuf_iZSml5r1nclyIsUyisWgYhUzFVJdI8G61vyFACIQe14weeMtjWSxpkzWdtFqyb93uV4uaRElaXWQv2kFxFFyL8KbUQBCOBUWXDtZc81J8YlaSiBVVXeOygLYZliOK4VQo4i1Ioqkxn5js-Bq0gbqVOH_wF3GCQ_EnMGLy" />
+   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=dramaclaw/dramaclaw&type=date&legend=top-left&sealed_token=CWTXgm9EqgQmnSFWk0inuf_iZSml5r1nclyIsUyisWgYhUzFVJdI8G61vyFACIQe14weeMtjWSxpkzWdtFqyb93uV4uaRElaXWQv2kFxFFyL8KbUQBCOBUWXDtZc81J8YlaSiBVVXeOygLYZliOK4VQo4i1Ioqkxn5js-Bq0gbqVOH_wF3GCQ_EnMGLy" />
+ </picture>
+</a>
+
+<br/><br/>
+
+<div align="center">
+  <sub>Xây dựng cho người kể chuyện. Mã nguồn công khai cho tất cả.</sub>
+</div>
+
+## Notices
+
+See `NOTICE` for required branding and third-party attribution notices.

--- a/readme/README_zh.md
+++ b/readme/README_zh.md
@@ -63,7 +63,7 @@ DramaClaw 采用 <a href="../LICENSE">Elastic License 2.0</a>。自己跑、自�
 [![Release](https://img.shields.io/github/v/release/dramaclaw/dramaclaw?include_prereleases&sort=semver)](https://github.com/dramaclaw/dramaclaw/releases)
 [![Docker](https://img.shields.io/badge/docker-ready-2496ED?logo=docker&logoColor=white)](#quick-start)
 
-[English](../README.md) &nbsp;|&nbsp; **简体中文** &nbsp;|&nbsp; [官网](https://dramaclaw.ai) &nbsp;|&nbsp; [文档](../docs/zh/README.md) &nbsp;|&nbsp; [快速开始](../docs/zh/getting-started/quickstart.md)
+[English](../README.md) &nbsp;|&nbsp; **简体中文** &nbsp;|&nbsp; [Tiếng Việt](./README_vi.md) &nbsp;|&nbsp; [ไทย](./README_th.md) &nbsp;|&nbsp; [官网](https://dramaclaw.ai) &nbsp;|&nbsp; [文档](../docs/zh/README.md) &nbsp;|&nbsp; [快速开始](../docs/zh/getting-started/quickstart.md)
 
 </div>
 


### PR DESCRIPTION
## What

- `readme/README_vi.md` (Tiếng Việt) and `readme/README_th.md` (ไทย), translated from `README.md` with identical structure: 23 headings, 27 images, 34 table rows, 8 code fences, 81 `<br/>` in each, same line count as the English source.
- Language switcher in all four READMEs links every language. The Vietnamese and Thai switchers keep the English docs / quick-start targets because there are no `vi` / `th` docs yet.
- Not translated: product names (DramaClaw, XiaHua, XiaJi, Xia Director, Director World, RelayClaw, dramaclaw-gateway), commands, env vars, `DC-*-LLM` aliases, model / vendor names, screenplay-format keywords, the Chinese drama titles in the showcase, and common AI/video terms creators use in English.
- "Source available" is rendered as "mã nguồn công khai" / "เปิดเผยซอร์สโค้ด"; the banned-word linter passes.
- `license-inventory.csv` rows for both files; the compliance generator test passes.

## Verification

- Every `../` link and image path in both files resolves against the repo tree.
- `scripts/lint_banned_words.py` clean; `tests/test_p0b_compliance_generator.py` passes.

Native-speaker review welcome; related: #489 (Vietnamese UI locale contribution).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NQrE65FQLj4endsbo3Wdsw