### PR TITLE
chore: release v2.0.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "supertale-ce"
-version = "2.0.2"
+version = "2.0.3"
 description = "SuperTale Community Edition API and video pipeline"
 readme = "README.md"
 requires-python = ">=3.11,<3.13"

--- a/src/novelvideo/release-notes.md
+++ b/src/novelvideo/release-notes.md
@@ -1,35 +1,33 @@
 ---
-version: 2.0.2
+version: 2.0.3
 attention: medium
 ---
-# v2.0.2
+# v2.0.3
 
 ## User-facing Highlights (zh)
 
-- **视频参考能力进一步扩展**: 视频节点新增文件和网页链接参考，并支持从画布选择图片或视频作为参考素材、在提示词中替换引用素材；CE 推荐模型列表新增 Seedance 2.5。
-- **英文创作流程更加完整**: 完善前后端英文文案、英文剧本场景识别和 Fountain 格式指引，并确保英文剧本生成的资产继续使用原始语言。
-- **虾画创作效率提升**: 优化画布切换、节点对齐、历史资产、资产库管理和虾导消息体验，减少切换画布时的整页加载和重复操作。
-- **视频任务更稳定透明**: 在排队前检查缺失的提示词和参考素材，保留安全的上游错误原因，并确保已提交任务在组织 Key 轮换后仍能完成。
-- **账号与项目管理更方便**: 新增用户自助修改密码入口，并将项目名称长度上限统一为 64 个字符。
+- **自部署组合更加完整**: Docker 源码版会同时构建 DramaClaw、虾画前端和同级目录中的 dramaclaw-gateway；镜像版继续提供直接拉取已发布镜像的独立入口，社区用户可以更清楚地选择开发或稳定部署方式。
+- **自定义模型配置补齐角色构建**: 自定义模式现在可以正确映射 DC-character-builder-LLM，使用自定义模型网关时角色提取不再因缺少模型映射而失败。
+- **跨项目复制素材更可靠**: 在虾画中跨项目粘贴节点时，图片和视频素材由后端完成复制，并在迁移结束前暂停自动保存，减少引用丢失或保存到旧地址的问题。
+- **失败原因更容易定位**: 项目分享会明确提示用户不存在、已加入或邀请冲突等原因；角色提取重试耗尽时，日志会保留真正的失败原因，方便排查模型输出问题。
+- **社区文档覆盖更多语言**: README 新增越南语和泰语版本，并重新梳理源码开发、镜像部署、模型网关和许可证说明。
 
 ## User-facing Highlights (en)
 
-- **More flexible video references**: Video nodes now accept file and public web-link references, support picking image or video references directly from the canvas, and can replace referenced materials in prompts. Seedance 2.5 is included in the CE recommended model catalog.
-- **A more complete English workflow**: Frontend and backend English coverage, English screenplay scene parsing, and Fountain-format guidance have been improved, while generated assets preserve the screenplay's source language.
-- **Faster Canvas workflows**: Canvas switching, node alignment, generation history, asset management, and Xia Director messages have been refined to reduce full-page loading and repeated actions.
-- **More reliable and transparent video tasks**: Missing prompts and references are checked before queueing, safe upstream rejection details are retained, and accepted jobs can finish after an organization key rotation.
-- **Easier account and project management**: Users can now change their own password, and project names consistently support up to 64 characters.
+- **A more complete self-hosted stack**: The source Docker entry point now builds DramaClaw, the XiaHua frontend, and a sibling dramaclaw-gateway checkout together, while the release entry point remains dedicated to published images. Community users can choose development or stable deployment more clearly.
+- **Character building works in Custom mode**: Custom model configurations can now map DC-character-builder-LLM, preventing character extraction failures caused by a missing model mapping when using a custom gateway.
+- **More reliable cross-project asset copying**: When nodes are pasted across XiaHua projects, image and video assets are copied by the backend and autosave pauses until migration finishes, reducing broken or stale references.
+- **Clearer failure details**: Project sharing now distinguishes missing users, existing members, and invitation conflicts. Character extraction logs also preserve the actual cause after output retries are exhausted.
+- **More accessible community documentation**: Vietnamese and Thai READMEs are now available, with clearer guidance for source development, image-based deployment, model gateways, and licensing.
 
 ## Fixes
 
-- 修复视频任务缺少必要提示词或素材时仍进入队列的问题，并完善上游明确拒绝的错误分类 (#413, #454, #464).
-- 修复组织 Gateway Key 轮换后，已被上游接受的视频任务无法继续查询的问题 (#422).
-- 修复英文剧本场景标记识别、生成资产语言继承和任务进度翻译问题 (#441, #462, #463, #469).
-- 修复部分同步工作阻塞 API 事件循环，以及上传取消和并发锁处理问题 (#444).
+- 修复自定义模式无法映射角色构建模型的问题 (#491).
+- 修复角色提取重试耗尽后只记录通用错误、无法定位真实原因的问题 (#492).
+- 修复项目分享失败时提示不明确的问题 (#479).
 
 ## Improvements
 
-- 增加视频文件/链接参考、画布素材选择和提示词素材替换能力 (#419, #424).
-- 优化画布切换、节点对齐、历史资产、资产库和虾导交互体验 (#409, #412, #417, #435).
-- 完善英文界面覆盖、Fountain 剧本格式说明，并增加中英文硬编码检查 (#447, #448).
-- 新增 Seedance 2.5 推荐配置、自助修改密码和项目名称长度统一限制 (#450, #453, #458).
+- 跨项目粘贴改由后端复制素材，并在迁移期间暂停自动保存 (#493).
+- 将源码开发和镜像部署拆分为清晰的 Docker Compose 入口，并默认集成同级 dramaclaw-gateway (#476, #482).
+- 重构 README 的产品、部署、网关和许可证说明，新增越南语与泰语文档 (#481, #483, #484, #486, #495).

--- a/tests/test_release_feed.py
+++ b/tests/test_release_feed.py
@@ -114,7 +114,7 @@ def test_built_wheel_contains_parseable_release_notes_artifact(tmp_path: Path) -
 def test_project_version_is_single_source_of_truth() -> None:
     pyproject = tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))
 
-    assert pyproject["project"]["version"] == "2.0.2"
+    assert pyproject["project"]["version"] == "2.0.3"
     assert importlib.metadata.version("supertale-ce") == pyproject["project"]["version"]
     assert "__version__" not in Path("src/novelvideo/__init__.py").read_text(encoding="utf-8")
 

--- a/uv.lock
+++ b/uv.lock
@@ -3428,7 +3428,7 @@ wheels = [
 
 [[package]]
 name = "supertale-ce"
-version = "2.0.2"
+version = "2.0.3"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## PR 类型 / Type of PR
- [ ] 🐞 Bug 修复 / Bug fix
- [ ] ✨ 新功能 / Feature
- [x] 📝 文档 / Documentation
- [ ] 🧹 重构 / 清理 / Refactor or cleanup
- [x] ⚙️ 构建 / CI / Build or CI
- [ ] ⚠️ 破坏性变更 / Breaking change

## 改动说明 / What this PR does and why

准备 DramaClaw v2.0.3 发布：

- 将项目版本和锁文件从 `2.0.2` 更新到 `2.0.3`
- 更新 Release Feed 版本真源测试
- 重写包内中英文发布说明，覆盖 v2.0.2 后合入的 11 个 PR
- 使用 `attention: medium` 提醒用户关注自部署组合、自定义角色模型映射和跨项目素材复制更新

## 关联 issue / Linked issues

N/A

## 给 reviewer 的说明 / Notes for the reviewer

本 PR 仅修改版本元数据、锁文件、版本测试字面量和包内 release notes。审核合入后再创建 `v2.0.3` 标签和 GitHub Release；当前没有提前打标签。

验证结果：

- `UV_CACHE_DIR=/Users/newyue/claymorelab/.uv-cache uv lock --check`
- `UV_CACHE_DIR=/Users/newyue/claymorelab/.uv-cache /Users/newyue/claymorelab/dramaclaw/.venv/bin/python -m pytest tests/test_release_feed.py -q` (`12 passed`)
- `UV_CACHE_DIR=/Users/newyue/claymorelab/.uv-cache /Users/newyue/claymorelab/dramaclaw/.venv/bin/python scripts/check_ce_port_closure.py`
- `python3 scripts/lint_ce_imports.py`
- `python3 scripts/ce_allowlist.py`
- `python3 scripts/lint_ee_terms.py`
- `python3 scripts/lint_banned_words.py`
- `python3 scripts/check_dco.py origin/main..HEAD`
- `git diff --check origin/main..HEAD`

## 面向用户的变更 / User-facing change

```release-note
v2.0.3 完善 DramaClaw 与 dramaclaw-gateway 的自部署组合，补齐自定义角色构建模型映射，并提升跨项目素材复制和失败提示的可靠性。
```

## 自检 / Checklist
- [x] 已自测，Release Feed 专项测试通过 / Self-tested with the release feed suite
- [x] 必要的文档已更新 / Docs updated where needed
- [x] 提交信息清晰（建议 Conventional Commits）/ Clear commits (Conventional Commits suggested)
- [x] 每个 commit 都已 `git commit -s` 附 DCO 签署 / Every commit signed off with `git commit -s` (DCO)
- [x] 我已阅读并同意[贡献者协议](../CONTRIBUTING.md#贡献者协议) / I have read and agree to the contributor terms