### PR TITLE
fix: 补齐画布主线任务的模型计费参数

### DIFF
--- a/src/novelvideo/api/routes/freezone.py
+++ b/src/novelvideo/api/routes/freezone.py
@@ -1175,6 +1175,101 @@ def _skill_background_reference_mode(parameters: dict[str, object]) -> str:
     return "material_only"
 
 
+def _mainline_image_task_billing(config: dict, *, is_sketch: bool) -> dict:
+    """Price the same selection, mode and quality that the task runner consumes."""
+    from novelvideo.config import (
+        DEFAULT_RENDER_IMAGE_SELECTION,
+        DEFAULT_SKETCH_IMAGE_SELECTION,
+        get_render_generation_config,
+        get_sketch_generation_config,
+        normalize_image_generation_selection,
+    )
+
+    selection = normalize_image_generation_selection(
+        config.get("image_generation_selection"),
+        fallback=(
+            DEFAULT_SKETCH_IMAGE_SELECTION
+            if is_sketch
+            else DEFAULT_RENDER_IMAGE_SELECTION
+        ),
+    )
+    generation_config = (
+        get_sketch_generation_config(selection_override=selection)
+        if is_sketch
+        else get_render_generation_config(selection_override=selection)
+    )
+    image_quality = str(config.get("image_quality") or "").strip().lower()
+    if image_quality in {"low", "medium", "high"}:
+        generation_config["openai_image_quality"] = image_quality
+        generation_config["huimeng_image_quality"] = image_quality
+    return _mainline_generator_billing(
+        "mainline.sketch_regen" if is_sketch else "mainline.render_regen",
+        generation_config,
+        config["mode_key"],
+        is_sketch=is_sketch,
+    )
+
+
+def _mainline_generator_billing(
+    feature_key: str, generation_config: dict, mode_key: str, *, is_sketch: bool
+) -> dict:
+    from novelvideo.api.routes.model_credits import _image_billing_params
+    from novelvideo.generators.nanobanana_grid import (
+        REGEN_MODE_CONFIGS,
+        normalize_image_size,
+    )
+
+    provider = generation_config["provider"]
+    # generate_grid takes size from mode_key, even for director conversion.
+    size = normalize_image_size(REGEN_MODE_CONFIGS[mode_key]["image_size"], provider)
+    quality_key = (
+        "huimeng_image_quality"
+        if provider == "huimeng"
+        else "openai_sketch_image_quality" if is_sketch else "openai_image_quality"
+    )
+    return {
+        "feature_key": feature_key,
+        "pricing_kind": "image",
+        "pricing_model": generation_config["model"],
+        "pricing_params": _image_billing_params(
+            model=generation_config["model"],
+            image_size=size,
+            quality=generation_config.get(
+                quality_key, "low" if is_sketch else "medium"
+            ),
+        ),
+    }
+
+
+def _director_sketch_task_billing(
+    *,
+    username: str,
+    project_name: str,
+    mode_key: str,
+    projection_payload: dict | None = None,
+) -> dict:
+    from novelvideo.director_world.control_frame_to_sketch import (
+        get_director_sketch_generation_config,
+    )
+    from novelvideo.project_config import load_project_config_file
+    from novelvideo.task_backend.projection import read_projection
+
+    projection = read_projection(projection_payload or {})
+    selection = (
+        projection.require("sketch_image_selection")
+        if projection is not None
+        else load_project_config_file(username, project_name).get(
+            "sketch_image_selection"
+        )
+    )
+    return _mainline_generator_billing(
+        "mainline.director_control_to_sketch",
+        get_director_sketch_generation_config(selection),
+        mode_key,
+        is_sketch=True,
+    )
+
+
 async def _mainline_single_beat_config(
     *,
     ctx: ProjectContext,
@@ -1437,7 +1532,7 @@ async def _start_or_enqueue_mainline_sketch_from_context_job(
                 "config": config,
                 "canvas_id": canvas_id or "",
                 "node_id": node_id or "",
-                "billing": {"feature_key": "mainline.sketch_regen"},
+                "billing": _mainline_image_task_billing(config, is_sketch=True),
                 **display_payload,
                 **projection_payload,
             },
@@ -1633,7 +1728,7 @@ async def _start_or_enqueue_mainline_frame_from_context_job(
                 "config": config,
                 "canvas_id": canvas_id or "",
                 "node_id": node_id or "",
-                "billing": {"feature_key": "mainline.render_regen"},
+                "billing": _mainline_image_task_billing(config, is_sketch=False),
                 **display_payload,
                 **projection_payload,
             },
@@ -1876,6 +1971,7 @@ async def _start_or_enqueue_standalone_frame_from_context_job(
                 "output_dir": str(project_dir),
                 "mode_key": mode_key,
                 "config": config,
+                "billing": _mainline_image_task_billing(config, is_sketch=False),
                 "canvas_id": canvas_id or "",
                 "node_id": node_id or "",
                 **display_payload,
@@ -1996,7 +2092,11 @@ async def _start_or_enqueue_mainline_director_control_sketch_job(
             "aspect_ratio": _normalize_mainline_skill_aspect_ratio(aspect_ratio),
             "canvas_id": canvas_id or "",
             "node_id": node_id or "",
-            "billing": {"feature_key": "mainline.director_control_to_sketch"},
+            "billing": _director_sketch_task_billing(
+                username=ctx.owner_username, project_name=ctx.project_name,
+                mode_key=_mainline_mode_key_for_aspect(aspect_ratio, is_sketch=True),
+                projection_payload=projection_payload,
+            ),
             "task_family": "mainline_skill",
             "task_label": "导演合成图转草图",
             "display_name": f"导演合成图转草图 · EP{episode} / Beat {beat}",
@@ -2057,7 +2157,7 @@ async def _start_or_enqueue_mainline_beat_sketch_task(
             "config": config,
             "canvas_id": canvas_id or "",
             "node_id": node_id or "",
-            "billing": {"feature_key": "mainline.sketch_regen"},
+            "billing": _mainline_image_task_billing(config, is_sketch=True),
             "task_family": "mainline_skill",
             "task_label": "生成草图",
             "display_name": f"生成草图 · EP{episode} / Beat {beat}",

--- a/src/novelvideo/director_world/control_frame_to_sketch.py
+++ b/src/novelvideo/director_world/control_frame_to_sketch.py
@@ -26,6 +26,26 @@ from novelvideo.sqlite_store import SQLiteStore
 from novelvideo.utils.path_resolver import PathResolver, compute_scoped_grid_filename
 
 
+def get_director_sketch_generation_config(image_selection: str | None) -> dict:
+    """Resolve the existing director overrides for both execution and pricing."""
+    selection = (
+        os.environ.get("DIRECTOR_CONTROL_SKETCH_IMAGE_SELECTION") or image_selection
+    )
+    config = get_sketch_generation_config(selection_override=selection)
+    config["image_size"] = os.environ.get(
+        "DIRECTOR_CONTROL_SKETCH_IMAGE_SIZE", config.get("image_size") or "1K"
+    )
+    quality = os.environ.get("DIRECTOR_CONTROL_SKETCH_IMAGE_QUALITY", "low")
+    for key in (
+        "openai_image_quality",
+        "openai_sketch_image_quality",
+        "huimeng_image_quality",
+        "quality",
+    ):
+        config[key] = quality
+    return config
+
+
 def _json_default(value: Any) -> Any:
     if isinstance(value, Path):
         return str(value)
@@ -544,21 +564,7 @@ async def convert_control_frame_to_sketch(
         scene_menu = list(script.get("scene_menu") or [])
         prop_menu = list(script.get("prop_menu") or [])
 
-        director_selection = (
-            os.environ.get("DIRECTOR_CONTROL_SKETCH_IMAGE_SELECTION") or projected_image_selection
-        )
-        generator_config = get_sketch_generation_config(
-            selection_override=director_selection,
-        )
-        generator_config["image_size"] = os.environ.get(
-            "DIRECTOR_CONTROL_SKETCH_IMAGE_SIZE",
-            generator_config.get("image_size") or "1K",
-        )
-        sketch_quality = os.environ.get("DIRECTOR_CONTROL_SKETCH_IMAGE_QUALITY", "low")
-        generator_config["openai_image_quality"] = sketch_quality
-        generator_config["openai_sketch_image_quality"] = sketch_quality
-        generator_config["huimeng_image_quality"] = sketch_quality
-        generator_config["quality"] = sketch_quality
+        generator_config = get_director_sketch_generation_config(projected_image_selection)
         generator = NanoBananaGridGenerator(config=generator_config)
         if generator.provider not in {"openai", "huimeng", "openrouter", "google", "newapi"}:
             raise RuntimeError(

--- a/tests/test_control_frame_to_sketch_projection.py
+++ b/tests/test_control_frame_to_sketch_projection.py
@@ -211,7 +211,13 @@ async def test_enqueue_attaches_the_projection_for_the_control_sketch(monkeypatc
             return {
                 "task_type": task_type,
                 "projection_version": 1,
-                "fields": {"beats": [], "visual_style": "ink_wash"},
+                "fields": {
+                    "beats": [],
+                    "visual_style": "ink_wash",
+                    "characters": [],
+                    "sketch_colors": {},
+                    "sketch_image_selection": "newapi_gpt_image2",
+                },
             }
 
     async def fake_store(ctx):

--- a/tests/test_freezone_image_backend.py
+++ b/tests/test_freezone_image_backend.py
@@ -51,6 +51,201 @@ from novelvideo.task_backend.limits import ProjectUserTaskLimitExceeded
 from novelvideo.task_state import get_task_manager
 
 
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "entry", ["frame", "standalone_frame", "sketch", "beat_sketch", "director"]
+)
+@pytest.mark.parametrize(
+    "selection,model",
+    [
+        ("newapi_gpt_image2", "LingShan-G2"),
+        ("newapi_nanobanana2", "LingShan-NB-2"),
+    ],
+)
+@pytest.mark.parametrize("quality", ["low", "medium", "high"])
+@pytest.mark.parametrize("aspect", ["2:3", "16:9"])
+async def test_mainline_canvas_enqueue_carries_effective_feature_price(
+    tmp_path,
+    monkeypatch,
+    entry,
+    selection,
+    model,
+    quality,
+    aspect,
+):
+    from novelvideo import config as image_config, project_config
+    from novelvideo.ports.local.projection import NoOpTaskProjection
+    from novelvideo.ports.registry import register_port
+
+    register_port("task_projection", NoOpTaskProjection())
+    monkeypatch.setattr(
+        project_config,
+        "load_project_config",
+        lambda *_: {
+            "render_image_selection": selection,
+            "sketch_image_selection": selection,
+        },
+    )
+    monkeypatch.setattr(
+        project_config,
+        "load_project_config_file",
+        lambda *_: {
+            "sketch_image_selection": selection,
+        },
+    )
+    monkeypatch.setattr(image_config, "OPENAI_SKETCH_IMAGE_QUALITY", quality)
+    monkeypatch.setenv("DIRECTOR_CONTROL_SKETCH_IMAGE_QUALITY", quality)
+    monkeypatch.delenv("DIRECTOR_CONTROL_SKETCH_IMAGE_SELECTION", raising=False)
+    # This legacy setting is not a generate_grid override: mode_key wins.
+    monkeypatch.setenv("DIRECTOR_CONTROL_SKETCH_IMAGE_SIZE", "4K")
+    for key, name in [
+        ("newapi_gpt_image2", "LingShan-G2"),
+        ("newapi_nanobanana2", "LingShan-NB-2"),
+    ]:
+        monkeypatch.setitem(
+            image_config.IMAGE_GENERATION_SELECTIONS,
+            key,
+            {
+                "provider": "newapi",
+                "model": name,
+                "label": name,
+            },
+        )
+    ctx = _project_ctx(tmp_path)
+    source = ctx.output_dir / "freezone" / "source.png"
+    _write_image(source, size=(160, 90) if aspect == "16:9" else (80, 120))
+    url = "/api/v1/projects/proj_freezone/media/freezone/source.png"
+    captured = {}
+
+    async def store(_ctx):
+        return _FakeContextBeatStore()
+
+    async def enqueue(_ctx, **kwargs):
+        captured.update(kwargs)
+        return SimpleNamespace(
+            task_state=SimpleNamespace(task_id="billing-test"),
+            backend="celery",
+            queue="test",
+        )
+
+    monkeypatch.setattr(freezone_routes, "make_sqlite_store_for_context", store)
+    monkeypatch.setattr(
+        freezone_routes,
+        "get_task_backend",
+        lambda: SimpleNamespace(enqueue_project_task=enqueue),
+    )
+    common = dict(
+        ctx=ctx, username="admin", project_name="demo", project_dir=ctx.output_dir
+    )
+    if entry == "frame":
+        await freezone_routes._start_or_enqueue_mainline_frame_from_context_job(
+            **common,
+            episode=1,
+            beat=8,
+            beat_payload=None,
+            sketch_url=url,
+            reference_urls=[],
+            quality=quality,
+        )
+    elif entry == "standalone_frame":
+        await freezone_routes._start_or_enqueue_standalone_frame_from_context_job(
+            **common,
+            beat_input=freezone_routes.ResolvedSkillInput(
+                **_standalone_skill_beat_input()
+            ),
+            sketch_url=url,
+            reference_urls=[],
+            quality=quality,
+        )
+    elif entry == "sketch":
+        await freezone_routes._start_or_enqueue_mainline_sketch_from_context_job(
+            **common,
+            episode=1,
+            beat=8,
+            beat_payload=None,
+            background_url=url,
+            aspect_ratio=aspect,
+        )
+    elif entry == "beat_sketch":
+        await freezone_routes._start_or_enqueue_mainline_beat_sketch_task(
+            **common,
+            episode=1,
+            beat=8,
+            canvas_id=None,
+            node_id=None,
+        )
+    else:
+        await freezone_routes._start_or_enqueue_mainline_director_control_sketch_job(
+            ctx=ctx,
+            project_dir=ctx.output_dir,
+            episode=1,
+            beat=8,
+            director_combined_url=url,
+            aspect_ratio=aspect,
+            canvas_id=None,
+            node_id=None,
+        )
+    feature = (
+        "render_regen"
+        if "frame" in entry
+        else "director_control_to_sketch" if entry == "director" else "sketch_regen"
+    )
+    params = {"size": "1K"}
+    if selection == "newapi_gpt_image2":
+        params["quality"] = quality
+    assert captured["payload"]["billing"] == {
+        "feature_key": f"mainline.{feature}",
+        "pricing_kind": "image",
+        "pricing_model": model,
+        "pricing_params": params,
+    }
+    if entry != "director":
+        assert captured["payload"]["config"]["image_generation_selection"] == selection
+
+
+def test_director_canvas_billing_uses_projection_and_director_override(monkeypatch):
+    from novelvideo import project_config
+
+    def no_local_read(*_):
+        raise AssertionError("projected director task must use its projected model")
+
+    monkeypatch.setattr(project_config, "load_project_config_file", no_local_read)
+    monkeypatch.delenv("DIRECTOR_CONTROL_SKETCH_IMAGE_SELECTION", raising=False)
+    projection = {
+        "projection": {
+            "projection_version": 1,
+            "task_type": "mainline_director_control_sketch",
+            "fields": {
+                "sketch_image_selection": "newapi_nanobanana2",
+                "beats": [],
+                "characters": [],
+                "sketch_colors": {},
+                "visual_style": "",
+            },
+        }
+    }
+    args = dict(
+        username="admin",
+        project_name="demo",
+        mode_key="1x1_16-9_sketch",
+        projection_payload=projection,
+    )
+    billing = freezone_routes._director_sketch_task_billing(**args)
+    assert (
+        billing["pricing_model"]
+        == freezone_routes.IMAGE_GENERATION_SELECTIONS["newapi_nanobanana2"]["model"]
+    )
+    assert billing["pricing_params"] == {"size": "1K"}
+    monkeypatch.setenv("DIRECTOR_CONTROL_SKETCH_IMAGE_SELECTION", "newapi_gpt_image2")
+    monkeypatch.setenv("DIRECTOR_CONTROL_SKETCH_IMAGE_QUALITY", "high")
+    billing = freezone_routes._director_sketch_task_billing(**args)
+    assert (
+        billing["pricing_model"]
+        == freezone_routes.IMAGE_GENERATION_SELECTIONS["newapi_gpt_image2"]["model"]
+    )
+    assert billing["pricing_params"] == {"size": "1K", "quality": "high"}
+
+
 def _project_ctx(tmp_path: Path) -> ProjectContext:
     return ProjectContext(
         project_id="proj_freezone",
@@ -5379,7 +5574,10 @@ async def test_skill_run_frame_accepts_plain_canvas_image_as_sketch_input(
     assert captured["task_type"] == "mainline_frame_from_context"
     assert captured["product_surface"] == "freezone"
     assert captured["payload"]["billing"] == {
-        "feature_key": "mainline.render_regen"
+        "feature_key": "mainline.render_regen",
+        "pricing_kind": "image",
+        "pricing_model": freezone_routes.IMAGE_GENERATION_SELECTIONS["newapi_gpt_image2"]["model"],
+        "pricing_params": {"size": "1K", "quality": "medium"},
     }
     assert captured["payload"]["config"]["canvas_sketch_paths"]["8"].endswith(
         "/freezone/plain_sketch.png"
@@ -5525,7 +5723,10 @@ async def test_skill_run_normalizes_project_media_url_before_dispatch(
     assert captured["task_type"] == "mainline_sketch_from_context"
     assert captured["product_surface"] == "freezone"
     assert captured["payload"]["billing"] == {
-        "feature_key": "mainline.sketch_regen"
+        "feature_key": "mainline.sketch_regen",
+        "pricing_kind": "image",
+        "pricing_model": freezone_routes.IMAGE_GENERATION_SELECTIONS["newapi_gpt_image2"]["model"],
+        "pricing_params": {"size": "1K", "quality": "low"},
     }
     assert captured["episode"] == 1
     assert captured["beat_num"] == 8
@@ -6771,7 +6972,10 @@ async def test_skill_run_sketch_accepts_director_combined_background(
     assert response.run_id == "mainline_director_control_sketch:job_director"
     assert captured["task_type"] == "mainline_director_control_sketch"
     assert captured["payload"]["billing"] == {
-        "feature_key": "mainline.director_control_to_sketch"
+        "feature_key": "mainline.director_control_to_sketch",
+        "pricing_kind": "image",
+        "pricing_model": freezone_routes.IMAGE_GENERATION_SELECTIONS["newapi_gpt_image2"]["model"],
+        "pricing_params": {"size": "1K", "quality": "low"},
     }
     assert captured["episode"] == 1
     assert captured["beat_num"] == 8
@@ -6858,7 +7062,10 @@ async def test_skill_run_sketch_prefers_director_combined_over_background(
 
     assert captured["task_type"] == "mainline_director_control_sketch"
     assert captured["payload"]["billing"] == {
-        "feature_key": "mainline.director_control_to_sketch"
+        "feature_key": "mainline.director_control_to_sketch",
+        "pricing_kind": "image",
+        "pricing_model": freezone_routes.IMAGE_GENERATION_SELECTIONS["newapi_gpt_image2"]["model"],
+        "pricing_params": {"size": "1K", "quality": "low"},
     }
     assert captured["episode"] == 1
     assert captured["beat_num"] == 8

--- a/tests/test_freezone_mainline_enqueue_projection.py
+++ b/tests/test_freezone_mainline_enqueue_projection.py
@@ -51,7 +51,12 @@ def enqueue_harness(monkeypatch: pytest.MonkeyPatch, tmp_path):
         )
 
     async def fake_single_beat_config(**kwargs):
-        return {"beats": [{"beat_number": 1}], "style": "chinese_period_drama"}
+        return {
+            "beats": [{"beat_number": 1}],
+            "style": "chinese_period_drama",
+            "mode_key": kwargs["mode_key"],
+            "image_generation_selection": "newapi_gpt_image2",
+        }
 
     async def fake_store_for_context(ctx):
         return _FakeStore()


### PR DESCRIPTION
## PR 类型 / Type of PR

- [x] 🐞 Bug 修复 / Bug fix

## 改动说明 / What this PR does and why

画布映射的五条主线图片任务入口未完整传递模型报价参数，导致已有功能价格配置仍报计费规则未配置。

- 为主线上下文渲染、独立上下文渲染、背景转草图、单 beat 草图、导演合成图转草图补齐 pricing_kind、pricing_model 和 pricing_params。
- 从原有任务配置解析模型、模式分辨率及质量，不写死模型、不新增设置、不修改已有功能 key 或价格规则。
- 导演转草图共用原有生成配置解析，保留模型覆盖及任务投射逻辑；分辨率跟随实际生成 mode_key。

## 关联 issue / Linked issues

N/A。仅需本仓库一个 PR，无配套跨仓库代码变更。

## 给 reviewer 的说明 / Notes for the reviewer

保留功能计费，不恢复全局模型调用计费，也不改为固定次数收费。主线原有渲染入口及扣费实现未修改。

本地验证：

- 画布、导演转换及渲染执行器：284 passed。
- 原有主线渲染接口、设置与计费错误处理：38 passed。
- 新增参数化用例覆盖五条入口、两个模型、三档质量、横竖比例，以及导演投射和覆盖配置。

未执行真实账户生成及实际扣费的线上端到端测试。

## 面向用户的变更 / User-facing change

```release-note
修复画布调用主线渲染、草图功能时遗漏模型计费参数，导致已有定价仍报计费规则未配置的问题。
```

## 自检 / Checklist

- [x] 已运行上述定向回归测试；全量测试由 CI 执行
- [x] 无新增配置，无需更新使用文档
- [x] 提交信息清晰
- [x] 每个 commit 均附 DCO Signed-off-by
