### PR TITLE
fix: enforce node-specific video generation modes

### DIFF
--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -6002,6 +6002,8 @@
     },
     "videoModel": {
       "reason": {
+        "imageUnsupported": "This model does not support image inputs. Remove the images or choose a model that supports them.",
+        "modeUnsupported": "This model does not support the selected generation mode. Choose a supported mode for this node.",
         "videoUnsupported": "This model doesn’t accept video assets",
         "audioUnsupported": "This model doesn’t accept audio assets",
         "singleImageOnly": "This model accepts only 1 image per run",

--- a/frontend/public/locales/zh/translation.json
+++ b/frontend/public/locales/zh/translation.json
@@ -6002,6 +6002,8 @@
     },
     "videoModel": {
       "reason": {
+        "imageUnsupported": "当前模型不支持图片输入，请移除图片或选择支持图片的模型。",
+        "modeUnsupported": "当前模型不支持此生成模式，请选择该节点支持的模式。",
         "videoUnsupported": "该模型不支持视频素材",
         "audioUnsupported": "该模型不支持音频素材",
         "singleImageOnly": "该模型单次仅支持 1 张图片",

--- a/frontend/src/__tests__/features/canvas/video-model-capabilities.test.ts
+++ b/frontend/src/__tests__/features/canvas/video-model-capabilities.test.ts
@@ -307,10 +307,10 @@ describe("videoSubmitMediaRejectionReason — 提交前素材守卫 (P1/P2)", ()
 
   it("Seedance 1.x：单图 / 纯文本 → 放行", () => {
     expect(
-      videoSubmitMediaRejectionReason("imageToVideo", SEEDANCE10_PRO_FAST, { ...none, images: 1 }),
+      videoSubmitMediaRejectionReason("firstFrame", SEEDANCE10_PRO_FAST, { ...none, images: 1 }),
     ).toBeNull();
     expect(
-      videoSubmitMediaRejectionReason("imageReference", SEEDANCE10_PRO_FAST, { ...none, images: 1 }),
+      videoSubmitMediaRejectionReason("firstFrame", SEEDANCE10_PRO_FAST, { ...none, images: 1 }),
     ).toBeNull();
     expect(videoSubmitMediaRejectionReason("textToVideo", SEEDANCE10_PRO_FAST, none)).toBeNull();
   });
@@ -529,7 +529,7 @@ describe("videoModelReferenceDisabledReason — 模型选择器置灰守卫", ()
       const counts = { ...none, images };
       const pickerBlocked = videoModelReferenceDisabledReason(SEEDANCE15_PRO, counts) != null;
       const submitBlocked =
-        videoSubmitMediaRejectionReason("imageToVideo", SEEDANCE15_PRO, counts) != null;
+        videoSubmitMediaRejectionReason("firstFrame", SEEDANCE15_PRO, counts) != null;
       expect(pickerBlocked).toBe(submitBlocked);
     }
   });
@@ -1284,5 +1284,21 @@ describe("VideoNode 接线：素材撤空 → 文生视频", () => {
     expect(source).not.toContain(
       "videoModeRequiresPrompt(genMode)\n        ? !hasPromptText\n        : !hasRequiredMediaForMode",
     );
+  });
+});
+
+
+describe("node-specific video modes", () => {
+  const textOnly = { id: "text-only", supportedModes: ["text_to_video"] };
+  it("rejects unsupported modes even when a single image is present", () => {
+    expect(videoSubmitMediaRejectionReason("imageToVideo", textOnly,
+      { images: 1, videos: 0, audios: 0 })).toBe("node.videoModel.reason.modeUnsupported");
+  });
+  it("does not infer or silently discard image input for a text-only model", () => {
+    expect(videoUpstreamImageDefaultMode(textOnly)).toBeNull();
+    expect(videoSubmitMediaRejectionReason("textToVideo", textOnly,
+      { images: 1, videos: 0, audios: 0 })).toBe("node.videoModel.reason.imageUnsupported");
+    expect(videoSubmitMediaRejectionReason("textToVideo", textOnly,
+      { images: 0, videos: 0, audios: 0 })).toBeNull();
   });
 });

--- a/frontend/src/__tests__/features/canvas/video-node-generation-matrix.test.tsx
+++ b/frontend/src/__tests__/features/canvas/video-node-generation-matrix.test.tsx
@@ -79,6 +79,10 @@ vi.mock("@/api/ops", async (importOriginal) => {
     ...(await importOriginal<typeof import("@/api/ops")>()),
     fetchFreezoneVideoModels: vi.fn(async () => [
       {
+        id: "text-only", providerId: "newapi", label: "Text only",
+        apiModel: "text-only", supportedModes: ["text_to_video"],
+      },
+      {
         id: "huimeng/seedance-1.5-pro",
         providerId: "huimeng",
         apiModel: "seedance-1.5-pro",
@@ -388,13 +392,14 @@ describe("视频节点：genMode → 提交端点的分派", () => {
         [edge("e1", "img-1")],
       );
 
-    await submitAndSettle();
+    const { result } = renderHook(() => useVideoGenerationForm("vid-1"));
+    await waitFor(() => expect(result.current.submitDisabled).toBe(true));
+    await result.current.submit();
 
     for (const endpoint of ALL_ENDPOINTS) {
       expect(vi.mocked(endpoint)).not.toHaveBeenCalled();
     }
-    expect(showErrorDialog).toHaveBeenCalled();
-    expect(String(vi.mocked(showErrorDialog).mock.calls[0][0])).toContain("Seedance 2.0");
+    expect(showErrorDialog).not.toHaveBeenCalled();
   });
 });
 
@@ -478,4 +483,18 @@ describe("视频节点：恢复与历史", () => {
       expect(onGenerationSettled).toHaveBeenCalled();
     });
   });
+});
+
+
+it("rejects AI-persisted imageToVideo on a text-only model before submitting", async () => {
+  useCanvasStore.getState().setCanvasData(
+    [videoNode({ model: "text-only", genMode: "imageToVideo" }),
+      uploadImageNode("img-1", "/static/a.png")],
+    [edge("e1", "img-1")],
+  );
+  const { result } = renderHook(() => useVideoGenerationForm("vid-1"));
+  await waitFor(() => expect(result.current.selectedVideoModelId).toBe("text-only"));
+  expect(result.current.submitDisabled).toBe(true);
+  await result.current.submit();
+  for (const endpoint of ALL_ENDPOINTS) expect(endpoint).not.toHaveBeenCalled();
 });

--- a/frontend/src/__tests__/features/freezone/canvas-command-validator.test.ts
+++ b/frontend/src/__tests__/features/freezone/canvas-command-validator.test.ts
@@ -1,4 +1,6 @@
-import { describe, expect, it } from "vitest";
+import * as videoModels from "@/features/canvas/hooks/useFreezoneVideoModels";
+import { buildCanvasNodeActionCatalog } from "@/features/freezone/canvasNodeActionCatalog";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { CANVAS_NODE_TYPES, type CanvasNode } from "@/features/canvas/domain/canvasNodes";
 import { validateCanvasChatCommandEnvelopes } from "@/features/freezone/context/canvasCommandValidator";
@@ -756,5 +758,66 @@ describe("canvas command validator", () => {
     expect(validResult.issues).toEqual([]);
     expect(invalidResult.ok).toBe(false);
     expect(invalidResult.issues[0]?.message).toBe("unsupported audio download format: flac");
+  });
+});
+
+
+describe("node-specific mode command validation", () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  function catalog() {
+    vi.spyOn(videoModels, "getFreezoneVideoModelsSnapshot").mockReturnValue({
+      models: [
+        { id: "text-only", apiModel: "text-only", label: "Text only", providerId: "newapi", supportedModes: ["text_to_video"] },
+        { id: "first-only", apiModel: "first-only", label: "First frame", providerId: "newapi", supportedModes: ["text_to_video", "first_frame"] },
+      ],
+      isLoading: false, isFallback: false, error: null,
+    });
+  }
+
+  it("only advertises modes supported by the selected node model", () => {
+    catalog();
+    const target = node({ id: "v", type: CANVAS_NODE_TYPES.video, data: { model: "first-only" } });
+    expect(buildCanvasNodeActionCatalog(target).editable_schema.genMode.options)
+      .toEqual(["textToVideo", "firstFrame"]);
+  });
+
+  it("rejects an AI-created imageToVideo mode for a text-only model", () => {
+    catalog();
+    const result = validateCanvasChatCommandEnvelopes([{
+      schema_version: CANVAS_CHAT_COMMANDS_SCHEMA_VERSION,
+      commands: [{ type: "create_node", node_type: CANVAS_NODE_TYPES.video,
+        client_id: "v", data: { model: "text-only", genMode: "imageToVideo" } }],
+    }], [], []);
+    expect(result.ok).toBe(false);
+    expect(result.issues[0].message).toContain("field genMode");
+    expect(result.issues[0].message).toContain('Allowed values: "textToVideo"');
+  });
+
+  it("validates a simultaneous model and mode update against the new model", () => {
+    catalog();
+    const target = node({ id: "v", type: CANVAS_NODE_TYPES.video,
+      data: { model: "text-only", genMode: "textToVideo" } });
+    const result = validateCanvasChatCommandEnvelopes([{
+      schema_version: CANVAS_CHAT_COMMANDS_SCHEMA_VERSION,
+      commands: [{ type: "update_node_data", node_id: "v",
+        data: { model: "first-only", genMode: "firstFrame" } }],
+    }], [target], []);
+    expect(result.issues).toEqual([]);
+  });
+
+  it("validates later updates against the model selected earlier in the same batch", () => {
+    catalog();
+    const target = node({ id: "v", type: CANVAS_NODE_TYPES.video,
+      data: { model: "first-only", genMode: "textToVideo" } });
+    const result = validateCanvasChatCommandEnvelopes([{
+      schema_version: CANVAS_CHAT_COMMANDS_SCHEMA_VERSION,
+      commands: [
+        { type: "update_node_data", node_id: "v", data: { model: "text-only" } },
+        { type: "update_node_data", node_id: "v", data: { genMode: "firstFrame" } },
+      ],
+    }], [target], []);
+    expect(result.ok).toBe(false);
+    expect(result.issues[0].path).toContain("commands[1]");
   });
 });

--- a/frontend/src/features/canvas/nodes/VideoNode.tsx
+++ b/frontend/src/features/canvas/nodes/VideoNode.tsx
@@ -1538,7 +1538,7 @@ export const VideoNode = memo(
       } else {
         target = "textToVideo";
       }
-      if (genMode !== target) {
+      if (genMode !== target && isVideoModeSupportedByModel(target, selectedVideoModel)) {
         updateNodeData(id, { genMode: target });
       }
     }, [

--- a/frontend/src/features/canvas/nodes/shared/useVideoGenerationForm.ts
+++ b/frontend/src/features/canvas/nodes/shared/useVideoGenerationForm.ts
@@ -995,15 +995,15 @@ export function useVideoGenerationForm(
     if (isHappyHorseModel) return;
     if (data.genMode != null) return;
     if (referenceImages.length === 0) return;
-    updateNodeData(id, {
-      genMode: videoUpstreamImageDefaultMode(selectedVideoModelId),
-    });
+    const defaultMode = videoUpstreamImageDefaultMode(selectedVideoModel);
+    if (defaultMode) updateNodeData(id, { genMode: defaultMode });
   }, [
     data.genMode,
     id,
     isHappyHorseModel,
     referenceImages.length,
     selectedVideoModelId,
+    selectedVideoModel,
     updateNodeData,
   ]);
 
@@ -1025,11 +1025,14 @@ export function useVideoGenerationForm(
     } else if (images > 1) {
       target = "imageReference";
     } else if (images === 1) {
-      target = genMode === "imageReference" ? "imageReference" : "imageToVideo";
+      target = ["firstFrame", "imageToVideo", "imageReference"].includes(genMode)
+        && isVideoModeSupportedByModel(genMode, selectedVideoModel)
+        ? genMode
+        : (videoUpstreamImageDefaultMode(selectedVideoModel) ?? "textToVideo");
     } else {
       target = "textToVideo";
     }
-    if (genMode !== target) {
+    if (genMode !== target && isVideoModeSupportedByModel(target, selectedVideoModel)) {
       updateNodeData(id, { genMode: target });
     }
   }, [
@@ -1038,6 +1041,7 @@ export function useVideoGenerationForm(
     isHappyHorseModel,
     upstreamTypeCounts.images,
     upstreamTypeCounts.videos,
+    selectedVideoModel,
     updateNodeData,
   ]);
 
@@ -1131,9 +1135,8 @@ export function useVideoGenerationForm(
     if (genMode !== "textToVideo") return;
     if (upstreamCounts.images === 0 && upstreamCounts.audios === 0) return;
     if (upstreamCounts.images > 0) {
-      updateNodeData(id, {
-        genMode: videoUpstreamImageDefaultMode(selectedVideoModelId),
-      });
+      const defaultMode = videoUpstreamImageDefaultMode(selectedVideoModel);
+      if (defaultMode) updateNodeData(id, { genMode: defaultMode });
     } else if (isSeedance20Model) {
       updateNodeData(id, { genMode: "allReference" });
     }
@@ -1142,6 +1145,7 @@ export function useVideoGenerationForm(
     isHappyHorseModel,
     isSeedance20Model,
     selectedVideoModelId,
+    selectedVideoModel,
     upstreamCounts.images,
     upstreamCounts.audios,
     id,
@@ -1164,11 +1168,12 @@ export function useVideoGenerationForm(
     genMode === "videoEdit"
       ? upstreamCounts.videos > 0
       : upstreamCounts.images > 0;
-  const mediaRejectionReason = videoSubmitMediaRejectionReason(
+  const mediaRejectionReasonKey = videoSubmitMediaRejectionReason(
     genMode,
-    selectedVideoModelId,
+    selectedVideoModel,
     upstreamCounts,
   );
+  const mediaRejectionReason = mediaRejectionReasonKey ? t(mediaRejectionReasonKey) : null;
   // 媒体目录声明的逐模式素材上限：超了就别让用户点下去白等一次后端 400。
   const selectedModelReferenceError = selectedVideoModelReferenceDisabledReason(
     selectedVideoModel,

--- a/frontend/src/features/canvas/nodes/shared/videoModelCapabilities.ts
+++ b/frontend/src/features/canvas/nodes/shared/videoModelCapabilities.ts
@@ -627,6 +627,12 @@ export function videoSubmitMediaRejectionReason(
   model: VideoModelRef,
   counts: { images: number; videos: number; audios: number },
 ): string | null {
+  if (!isVideoModeSupportedByModel(mode, model)) {
+    return "node.videoModel.reason.modeUnsupported";
+  }
+  if (counts.images > 0 && videoEmptyStateCtaModes(model).length === 0) {
+    return "node.videoModel.reason.imageUnsupported";
+  }
   if (counts.videos > 0 && mode !== "allReference" && mode !== "videoEdit") {
     return "node.videoModel.reason.videoUnsupported";
   }
@@ -674,6 +680,9 @@ export function videoModelReferenceDisabledReason(
   counts: { images: number; videos: number; audios: number },
 ): string | null {
   if (typeof model === "object" && model !== null && (model.supportedModes?.length ?? 0) > 0) {
+    if (counts.images > 0 && videoEmptyStateCtaModes(model).length === 0) {
+      return "node.videoModel.reason.imageUnsupported";
+    }
     const supportsAllReference = isVideoModeSupportedByModel("allReference", model);
     const supportsVideoEdit = isVideoModeSupportedByModel("videoEdit", model);
     if (counts.videos > 0 && !supportsAllReference && !supportsVideoEdit) {

--- a/frontend/src/features/freezone/canvasNodeActionCatalog.ts
+++ b/frontend/src/features/freezone/canvasNodeActionCatalog.ts
@@ -13,6 +13,7 @@ import {
 } from "@/features/canvas/domain/mainlineNodeFlags";
 import { getFreezoneImageModelsSnapshot } from "@/features/canvas/hooks/useFreezoneImageModels";
 import { getFreezoneVideoModelsSnapshot } from "@/features/canvas/hooks/useFreezoneVideoModels";
+import { isVideoModeSupportedByModel } from "@/features/canvas/nodes/shared/videoModelCapabilities";
 import type { ModelOption } from "@/features/canvas/ui/ProviderModelPicker";
 import {
   VIDEO_UPSCALE_DENOISE_OPTIONS,
@@ -516,6 +517,8 @@ const VIDEO_GEN_MODE_OPTIONS = [
   "textToVideo",
   "allReference",
   "imageToVideo",
+  "firstFrame",
+  "videoEdit",
   "firstLastFrame",
   "imageReference",
 ] as const;
@@ -523,6 +526,8 @@ const VIDEO_GEN_MODE_OPTION_LABELS: Record<(typeof VIDEO_GEN_MODE_OPTIONS)[numbe
   textToVideo: "文生视频",
   allReference: "全能参考",
   imageToVideo: "图生视频",
+  firstFrame: "首帧视频",
+  videoEdit: "视频编辑",
   firstLastFrame: "首尾帧视频",
   imageReference: "图片参考视频",
 };
@@ -618,14 +623,23 @@ function videoDurationSchema(node: CanvasNode): CanvasEditableFieldSchema {
 }
 
 function videoGenModeSchema(node: CanvasNode): CanvasEditableFieldSchema {
+  const snapshot = getFreezoneVideoModelsSnapshot();
+  const modelId = (node.data as { model?: unknown }).model;
+  const model = typeof modelId === "string" && modelId
+    ? snapshot.models.find((item) => item.id === modelId)
+    : snapshot.models[0];
+  const options = model
+    ? VIDEO_GEN_MODE_OPTIONS.filter((mode) => isVideoModeSupportedByModel(mode, model))
+    : [];
   return {
     type: "enum",
     label: "视频生成模式",
-    options: [...VIDEO_GEN_MODE_OPTIONS],
-    option_labels: VIDEO_GEN_MODE_OPTION_LABELS,
+    options,
+    option_labels: Object.fromEntries(options.map((mode) => [mode, VIDEO_GEN_MODE_OPTION_LABELS[mode]])),
+    loading: snapshot.isLoading,
     current_value: (node.data as { genMode?: unknown }).genMode ?? "textToVideo",
     description:
-      "决定视频节点如何消费上游输入。textToVideo=只用当前提示词；imageToVideo=以图片作为主要输入；firstLastFrame=需要首帧和尾帧；allReference=可同时参考图片/视频/音频；imageReference=以图片作为参考约束。改视频模式时更新 genMode，不要把“模式”误改成 model。",
+      "仅可使用当前节点所选模型的 options；切换模型后必须重新查询模式选项，不得套用其他节点的模式。决定视频节点如何消费上游输入。textToVideo=只用当前提示词；imageToVideo=以图片作为主要输入；firstLastFrame=需要首帧和尾帧；allReference=可同时参考图片/视频/音频；imageReference=以图片作为参考约束。改视频模式时更新 genMode，不要把“模式”误改成 model。",
   };
 }
 

--- a/frontend/src/features/freezone/context/canvasCommandValidator.ts
+++ b/frontend/src/features/freezone/context/canvasCommandValidator.ts
@@ -1,4 +1,4 @@
-import type { CanvasEdge, CanvasNode } from "@/features/canvas/domain/canvasNodes";
+import type { CanvasEdge, CanvasNode, VideoGenMode } from "@/features/canvas/domain/canvasNodes";
 import { CANVAS_NODE_TYPES, type CanvasNodeData } from "@/features/canvas/domain/canvasNodes";
 import {
   isPresetManagedNode,
@@ -82,20 +82,24 @@ function makeVirtualNode(command: {
   } as CanvasNode;
 }
 
-function validateModelEnumField(
+function validateModelAndModeFields(
   issues: CanvasCommandValidationIssue[],
   path: string,
   node: CanvasNode,
   data: Partial<CanvasNodeData>,
 ): void {
   const schema = buildCanvasNodeActionCatalog(node).editable_schema;
-  for (const [field, value] of Object.entries(data)) {
-    if (field !== "model") continue;
+  const values = { ...data } as Record<string, unknown>;
+  if (node.type === CANVAS_NODE_TYPES.video && ("model" in data || "genMode" in data)) {
+    values.genMode = (node.data as { genMode?: unknown }).genMode ?? "textToVideo";
+  }
+  for (const [field, value] of Object.entries(values)) {
+    if (field !== "model" && field !== "genMode") continue;
     if (value === undefined || value === null || value === "") continue;
     const fieldSchema = schema[field];
     if (fieldSchema?.type !== "enum") continue;
     const options = fieldSchema.options ?? [];
-    if (options.length === 0) continue;
+    if (options.length === 0 && field === "model") continue;
     if (options.some((option) => Object.is(option, value))) continue;
     addIssue(
       issues,
@@ -211,7 +215,7 @@ export function validateCanvasChatCommandEnvelopes(
           if (reserved.length > 0) {
             addIssue(issues, path, `reserved data fields are not allowed: ${reserved.join(", ")}`);
           }
-          validateModelEnumField(
+          validateModelAndModeFields(
             issues,
             path,
             virtualNode ?? ({
@@ -263,7 +267,7 @@ export function validateCanvasChatCommandEnvelopes(
             addIssue(issues, path, `reserved data fields are not allowed: ${reserved.join(", ")}`);
           }
           if (nodeType) {
-            validateModelEnumField(
+            validateModelAndModeFields(
               issues,
               path,
               {
@@ -311,12 +315,13 @@ export function validateCanvasChatCommandEnvelopes(
             if (invalid.length > 0) {
               addIssue(issues, path, `fields are not editable on this node: ${invalid.join(", ")}`);
             }
-            validateModelEnumField(
+            validateModelAndModeFields(
               issues,
               path,
               { ...target, data: { ...target.data, ...data } as CanvasNodeData },
               data,
             );
+            nodeById.set(target.id, { ...target, data: { ...target.data, ...data } as CanvasNodeData });
           }
           break;
         }
@@ -431,6 +436,11 @@ export function validateCanvasChatCommandEnvelopes(
           if (!target) {
             addIssue(issues, path, `node not found: ${command.node_id}`);
             break;
+          }
+          if (target.type === CANVAS_NODE_TYPES.video && command.action === "generate_video") {
+            validateModelAndModeFields(issues, path, target, {
+              genMode: (target.data as { genMode?: VideoGenMode }).genMode ?? "textToVideo",
+            });
           }
           const action = buildCanvasNodeActionCatalog(target, { nodes, edges }).actions.find(
             (item) => item.action === command.action,


### PR DESCRIPTION
AI 创建视频节点时，通用模式列表允许写入所选模型不支持的模式，例如仅支持文生视频的模型被设置为 imageToVideo，直到提交后才收到后端 400。现在以当前节点所选模型的能力生成模式选项，并在命令校验和生成提交前拒绝不兼容组合。

- 节点编辑 schema 只返回当前模型支持的模式，包含独立的首帧和视频编辑模式。
- 创建、修改及生成命令校验模式；批量命令按前序修改后的节点状态继续校验。
- 共享视频表单使用完整模型能力推断图片模式；不支持图片输入时提前提示，不静默丢弃图片。
- 保留后端能力校验，并补充中英文提示及 AI 命令、节点表单回归测试。

验证（基于最新 staging）：
- 7 个相关测试文件：199 passed。
- TypeScript：`tsc -b` 通过。
- `git diff --check` 通过。

未进行真实模型调用或浏览器端到端验收。
