### PR TITLE
feat(i18n): add Vietnamese (vi) locale

### DIFF
--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -721,7 +721,7 @@
       "title": "Script Format Check",
       "close": "Close",
       "viewDetails": "View details",
-      "recommended": "Standard script example:\nEpisode 1\n1-1 City Cafe DAY INT\nCharacters: Lin Xia, Chen Mo\n△ Afternoon light crosses the window as Lin Xia places a letter on the table.\nLin Xia: The answer you wanted is right here.",
+      "recommended": "Standard script example:\nEPISODE 1\nINT. City Cafe - DAY\nCharacters: Lin Xia, Chen Mo\n△ Afternoon light crosses the window as Lin Xia places a letter on the table.\nLin Xia: The answer you wanted is right here.",
       "lineLabel": "Line {{line}}",
       "noIssues": "No specific issues found"
     },
@@ -2544,7 +2544,7 @@
         },
         "missingSceneHeaders": {
           "message": "No scene headings were recognized, so the system cannot tell where each scene begins.",
-          "fix": "Follow the standard format: start every episode with “Episode N”, give each scene its own “scene number, location, time, INT/EXT” heading, then list characters, action, and dialogue. For example: Episode 1 / 1-1 City Cafe DAY INT."
+          "fix": "Follow the standard format: start every episode with “EPISODE N”, give each scene its own “INT./EXT. location - TIME” heading, then list characters, action, and dialogue. For example: EPISODE 1 / INT. City Cafe - DAY."
         },
         "nonstandardSceneHeaders": {
           "message": "Scene boundaries were recognized, but some scene metadata is incomplete.",
@@ -2552,7 +2552,7 @@
         },
         "sceneHeadersMissingTime": {
           "message": "Some scene headings have no explicit time anchor, so time_of_day and scene variant inheritance may be unstable.",
-          "fix": "Add an explicit time to the scene heading, such as DAY, NIGHT, or LATE NIGHT. Scene boundaries are kept either way and normalized later."
+          "fix": "Add an explicit time to the scene heading. Only DAY, NIGHT, MORNING, AFTERNOON, EVENING, DAWN and DUSK are recognized. Scene boundaries are kept either way and normalized later."
         },
         "missingInteriorExterior": {
           "message": "The scene heading has no INT/EXT marker.",

--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -436,6 +436,7 @@
       "selectLanguage": "Select language",
       "languageChinese": "中文",
       "languageEnglish": "English",
+      "languageVietnamese": "Tiếng Việt",
       "passwordDialog": {
         "title": "Change password",
         "description": "Changing your password signs you out on every device. Sign in again with the new password.",

--- a/frontend/public/locales/vi/translation.json
+++ b/frontend/public/locales/vi/translation.json
@@ -1,0 +1,7414 @@
+{
+  "app": {
+    "title": "SuperTale",
+    "subtitle": "Bàn làm việc tạo và commit asset của SuperTale",
+    "updateRequired": {
+      "title": "App đã được cập nhật",
+      "description": "Trang này đang dùng file app đã hết hạn. Tải lại để dùng bản mới nhất.",
+      "refresh": "Tải lại trang"
+    },
+    "updateAvailable": {
+      "title": "Đã có phiên bản mới",
+      "description": "Tải lại trang để nhận các tính năng và bản sửa lỗi mới nhất.",
+      "refresh": "Tải lại ngay",
+      "dismiss": "Bỏ qua"
+    },
+    "routeError": {
+      "title": "Không tải được trang",
+      "description": "Hãy tải lại trang và thử lại."
+    },
+    "versionUpdate": {
+      "title": "Tính năng mới đã có mặt",
+      "confirm": "Đã hiểu",
+      "empty": "Phiên bản này không có ghi chú phát hành"
+    },
+    "logoHomeTooltip": "Bấm để quay về trung tâm quản lý dự án"
+  },
+  "loginCinematic": {
+    "moreInfo": "Xem thêm thông tin",
+    "moreInfoShort": "Thêm",
+    "announcement": {
+      "open": "Xem thông báo",
+      "label": "Thông báo",
+      "title": "Thông báo",
+      "close": "Đóng thông báo",
+      "confirm": "Xác nhận",
+      "markAllRead": "Đánh dấu đã đọc tất cả",
+      "unread": "{{n}} chưa đọc",
+      "pinned": "Đã ghim"
+    },
+    "testimonials": {
+      "heading": "Không còn trang giấy trắng",
+      "subheading": "Phim ngắn concept, thử nhân vật và đoạn phim liền mạch — đi từ một câu tiền đề thẳng vào dây chuyền.",
+      "quotes": {
+        "shortFilmDirector": {
+          "name": "Đạo diễn phim ngắn",
+          "tag": "Previz concept",
+          "text": "Không còn phải bắt đầu từ một timeline trắng. Thấy xung đột và cú máy trước, rồi mới quyết nhánh nào đáng làm."
+        },
+        "aiCreator": {
+          "name": "Người làm video AI",
+          "tag": "Đoạn phim liền mạch",
+          "text": "Cái đáng giá không phải tạo ra một tấm ảnh — mà là đẩy được một đoạn phim đi tiếp."
+        },
+        "screenwriter": {
+          "name": "Biên kịch",
+          "tag": "Thử nhân vật",
+          "text": "Khi nhân vật, xung đột và bối cảnh đã tách ra, tôi nhận ra nhanh hơn hẳn một câu chuyện có đáng viết hay không."
+        },
+        "animationTeam": {
+          "name": "Nhóm hoạt hình",
+          "tag": "Kiểm tra nhịp",
+          "text": "Bọn tôi dựng previz concept trước — soát nhịp và cú máy — rồi mới quyết có đưa vào sản xuất không."
+        },
+        "indieProducer": {
+          "name": "Nhà sản xuất độc lập",
+          "tag": "Dựng trailer",
+          "text": "Nó nén một ý tưởng thành thứ xem được, nên cuộc bàn bạc không còn dừng ở mấy dòng ghi chú."
+        },
+        "visualDirector": {
+          "name": "Giám đốc hình ảnh",
+          "tag": "Mở rộng thế giới",
+          "text": "Một thế giới cứ mọc thêm nhánh mới. Vẫn hoang dại, nhưng hướng đi thì vẫn lái được."
+        },
+        "storyPlanner": {
+          "name": "Người lên nội dung",
+          "tag": "Chọn nhánh",
+          "text": "Tôi dùng nó để loại nhanh những nhánh cụt và dồn thời gian cho nhánh thật sự có sức căng."
+        },
+        "creativeStudio": {
+          "name": "Studio sáng tạo",
+          "tag": "Bản mẫu chào hàng",
+          "text": "Từ một câu tiền đề tới một đoạn phim xem được — đủ để dẫn dắt một cuộc bàn sáng tạo cụ thể hơn nhiều."
+        },
+        "directorAssistant": {
+          "name": "Trợ lý đạo diễn",
+          "tag": "Gom cú máy",
+          "text": "Cú máy thôi tản mát. Mỗi lượt tạo đều rơi về một đường ray đẩy tiếp được."
+        }
+      }
+    },
+    "faq": {
+      "heading": "Hỏi gì đáp nấy, không vòng vo",
+      "subheading": "Về khâu tạo nội dung, khả năng kiểm soát, làm việc nhóm và hợp tác kinh doanh — chỉ những câu thật sự làm bạn đổi quyết định.",
+      "contactPrompt": "Có câu hỏi hợp tác cụ thể?",
+      "contactOpen": "Mở liên hệ kinh doanh",
+      "contactCta": "Liên hệ kinh doanh",
+      "contactLabel": "Liên hệ kinh doanh",
+      "qrAlt": "Mã QR WeChat doanh nghiệp",
+      "items": {
+        "difference": {
+          "question": "DramaClaw khác gì một công cụ tạo video AI thông thường?",
+          "answer": "Công cụ thông thường xoay quanh một prompt, một đoạn clip hay một tấm ảnh. DramaClaw dựng quanh cả một dự án hoàn chỉnh: nhập chữ, gây dựng asset, lên kế hoạch tập, sản xuất cú máy và dựng bản cuối — một vòng sản xuất truy vết được, làm nhóm được, dùng lại được."
+        },
+        "gettingStarted": {
+          "question": "Lần đầu dùng thì nên bắt đầu từ đâu?",
+          "answer": "Cứ đi theo luồng chính: nhập văn bản ở Shrimp Feed, xác nhận nhân vật / bối cảnh / đạo cụ / giọng ở Shrimp Pond, lên kế hoạch tập rồi tạo kịch bản và cú máy ở Shrimp Lens, cuối cùng xuất file dựng ở trang dựng phim. Mục tiêu đầu tiên không phải là hoàn hảo — mà là đưa trọn một tập đi hết dây chuyền."
+        },
+        "mirrorVsCanvas": {
+          "question": "Shrimp Lens và Shrimp Canvas mỗi cái mạnh ở đâu?",
+          "answer": "Shrimp Lens là dây chuyền sản xuất chính: làm hàng loạt, ổn định, tiến từng tập một. Shrimp Canvas là bàn làm việc của đạo diễn: chau chuốt những cú máy then chốt, thử nhiều phiên bản, chốt asset và xử lý phần video nặng. Trong một dự án thật, những cú máy thông thường chạy qua Shrimp Lens còn cú máy khó thì đưa sang Shrimp Canvas."
+        },
+        "canvasOverwrite": {
+          "question": "Kết quả trong Shrimp Canvas có tự ghi đè asset luồng chính của tôi không?",
+          "answer": "Không. Mọi thứ tạo ra hay tải lên trong Shrimp Canvas mặc định chỉ là bản ứng viên. Nó chỉ vào luồng chính của dự án khi bạn chủ động commit và chọn slot đích — nhân vật, bối cảnh, đạo cụ, phác thảo beat, khung đầu hay video."
+        },
+        "whyAssetsFirst": {
+          "question": "Vì sao phải sắp xếp nhân vật, bối cảnh, đạo cụ và giọng trước?",
+          "answer": "Nguyên nhân thường gặp khiến phải làm đi làm lại trong video AI không nằm ở khâu tạo cuối cùng — mà ở phía trên: nhân vật không ổn định, bối cảnh mơ hồ, đạo cụ không có ảnh mẫu, giọng không nhất quán. Biến những thứ đó thành asset ở Shrimp Pond sẽ gỡ được rất nhiều rối rắm ở khâu cú máy."
+        },
+        "contentTypes": {
+          "question": "DramaClaw hợp với những loại nội dung nào?",
+          "answer": "Phim ngắn AI, phim truyện tranh, trailer tiểu thuyết, video bình phim, quảng cáo và video đào tạo — cùng với những dự án nhóm cần duy trì nhân vật IP và nội dung ra theo tập trong thời gian dài. Người làm một mình chạy được cả dây chuyền; nhóm thì sản xuất cùng nhau được."
+        },
+        "teamRoles": {
+          "question": "Một nhóm nên chia việc thế nào?",
+          "answer": "Chia theo công đoạn: chủ dự án lo quản lý dự án, chi phí và kiểm định; người viết lo văn bản và kịch bản; chỉ đạo mỹ thuật giữ nhân vật, bối cảnh và đạo cụ; người làm storyboard/đạo diễn lo diễn xuất trong từng cú máy; người dựng video lo khung đầu, video và ghép phim. Quyền hạn tương ứng: người xem, người sửa, quản trị và chủ sở hữu."
+        },
+        "unstableResults": {
+          "question": "Khi kết quả lúc được lúc không thì nên kiểm tra gì trước?",
+          "answer": "Tìm đúng khâu đang hỏng: văn bản đã rõ chưa, tạo hình nhân vật đã đúng chưa, bối cảnh và đạo cụ đã có ảnh mẫu chưa, phác thảo đã mô tả được cú máy chưa, khung đầu đã ổn định chưa, âm thanh có khớp không? Đừng bắt đầu bằng cách tạo lại video hết lần này tới lần khác — sửa asset ở phía trên và phần mô tả cú máy trước đã."
+        },
+        "dcUniverse": {
+          "question": "“Make Your DC Universe.” nghĩa là gì?",
+          "answer": "DC không chỉ là viết tắt của DramaClaw — nó còn là vũ trụ nội dung của chính mỗi người sáng tạo. DramaClaw sinh ra để giúp bạn bắt đầu từ một câu chuyện rồi dựng dần lên nhân vật, thế giới, asset bối cảnh và khả năng sản xuất cả một bộ phim dài kỳ."
+        },
+        "afterLogin": {
+          "question": "Đăng nhập xong thì tôi vào đâu?",
+          "answer": "Vào trang tổng hợp dự án. Bạn mở một dự án có sẵn, hoặc tạo dự án mới để bắt đầu một bộ phim mới. Mỗi dự án là một không gian riêng, chứa văn bản, asset, tập, cú máy, video, tác vụ và bản dựng."
+        }
+      }
+    },
+    "fourth": {
+      "sets": {
+        "s1": {
+          "titleTop": "Câu chuyện của bạn",
+          "titleBottom": "vào dây chuyền",
+          "lead": "Bắt đầu từ một dòng. Nhân vật, xung đột, bối cảnh và cú máy được bóc thành những asset sáng tạo mà bạn đẩy tiếp được."
+        },
+        "s2": {
+          "titleTop": "Một thế giới,",
+          "titleBottom": "một thứ ánh sáng lạnh",
+          "lead": "Nhân vật giữ được nét, cú máy không chệch hướng. Mỗi lượt tạo đều quay về đúng một hướng kể."
+        },
+        "s3": {
+          "titleTop": "Ý tưởng được đẩy",
+          "titleBottom": "thành hình ảnh",
+          "lead": "Không phải một tấm ảnh rồi thôi — nó lớn dần thành storyboard, đoạn phim, trailer và tác phẩm đăng được."
+        }
+      },
+      "cards": {
+        "breakdown": {
+          "title": "Bóc tách câu chuyện",
+          "body": "Cắt một ý tưởng thành nhân vật, xung đột, bối cảnh và cú máy để câu chuyện không dừng lại ở một câu."
+        },
+        "lock": {
+          "title": "Khoá hình ảnh",
+          "body": "Giữ nhân vật, bối cảnh và cú máy trong cùng một tông, để mỗi lượt tạo bớt hẳn cảm giác mất kiểm soát."
+        },
+        "advance": {
+          "title": "Đẩy hình ảnh đi xa",
+          "body": "Đẩy một ý tưởng đơn lẻ thành đoạn phim, trailer và tác phẩm hoàn chỉnh hơn."
+        }
+      }
+    },
+    "fifth": {
+      "heading": "Biến nghìn ý tưởng thành asset",
+      "lead1": "DramaClaw sắp chúng vào thư viện asset của dự án,",
+      "lead2": "để những lần tạo cú máy sau tham chiếu được, quản lý một chỗ, và lùi về phiên bản cũ khi cần."
+    },
+    "seventh": {
+      "heading": "Từ quay số hên xui thành một dây chuyền thật",
+      "lead": "DramaClaw chia nhỏ cái bấp bênh của video AI ra thành văn bản, asset, cú máy và luồng tác vụ",
+      "steps": {
+        "01": {
+          "title": "Đưa tiền đề vào",
+          "body": "Một câu mở đầu trở thành nhân vật, bối cảnh và những ràng buộc kể chuyện."
+        },
+        "02": {
+          "title": "Bóc tách nhân vật",
+          "body": "Tạo hình, động cơ và quan hệ được chốt trước, để những lượt tạo sau khỏi trôi dạt."
+        },
+        "03": {
+          "title": "Xung đột",
+          "body": "Đẩy sự việc tới chỗ ai đó buộc phải chọn, và để câu chuyện tự nóng lên."
+        },
+        "04": {
+          "title": "Lên kế hoạch cú máy",
+          "body": "Điểm nhìn, nhịp và khuôn hình cùng bước lên một đường ray kiểm soát được."
+        },
+        "05": {
+          "title": "Đoạn phim thành hình",
+          "body": "Một ý tưởng đơn lẻ cứ thế đi tiếp — thành cảnh, thành trailer, thành đoạn phim liền mạch."
+        },
+        "06": {
+          "title": "Tác phẩm nở ra",
+          "body": "Mọi kết quả đều quay lại được dây chuyền và mọc ra một nhánh mới."
+        }
+      }
+    },
+    "eighth": {
+      "heading": "Sinh ra cho những bộ phim hoàn chỉnh",
+      "lead": "DramaClaw quan tâm tới chuyện một bộ phim được làm tiếp thế nào: đưa chữ vào, giữ nhân vật nhất quán, tái dùng bối cảnh, theo tiến độ từng cú máy, cả nhóm cùng bàn giao.",
+      "statementTitle": "Night Passage Protocol · Chuỗi cú máy 08",
+      "statementBody": "Một con tàu hàng không đăng ký kéo cả bí mật của thành phố chìm xuống tầng đêm.",
+      "decisions": {
+        "KEEP": {
+          "title": "Giữ",
+          "body": "Khoá nhân vật, cú máy hay đoạn phim hiện tại lại và lấy đó làm chuẩn cho những gì tiếp theo."
+        },
+        "REWRITE": {
+          "title": "Viết lại",
+          "body": "Đổi xung đột, lời thoại hay cách xử lý cú máy mà không phá bỏ một thế giới vốn đã chạy tốt."
+        },
+        "EXTEND": {
+          "title": "Kéo dài",
+          "body": "Đi tiếp từ đoạn phim hiện tại sang cảnh sau, sang một trailer, hoặc sang cả một nhánh mới."
+        },
+        "REJECT": {
+          "title": "Bỏ",
+          "body": "Lùi lại một node, chọn hướng kể khác, đưa câu chuyện trở lại đúng đường."
+        }
+      }
+    },
+    "ninth": {
+      "headingTop": "Một dòng, thẳng vào",
+      "headingAccent": "cú máy",
+      "lead": "Bạn không cần kịch bản hoàn chỉnh. Đưa ra một hướng đi và DramaClaw bóc nó thành nhân vật, xung đột, bối cảnh cùng một chuỗi cú máy mà bạn đẩy tiếp được.",
+      "featuredWork": "Luban's Craft",
+      "steps": {
+        "01": {
+          "title": "Một tiền đề",
+          "body": "Một thành phố từng chìm trong bóng tối sáng đèn trở lại, và mọi người sống sót đều nghe thấy cùng một tiếng đếm ngược."
+        },
+        "02": {
+          "title": "Thành cấu trúc",
+          "body": "Nhân vật, xung đột, bối cảnh và giới hạn kể chuyện tách ra thành những node mà bạn đẩy tiếp được."
+        },
+        "03": {
+          "title": "Thành cú máy",
+          "body": "Thứ tự cú máy, tông cảnh và nhịp được chốt lại, đoạn phim bắt đầu có một hướng để xem."
+        },
+        "04": {
+          "title": "Ra đoạn phim",
+          "body": "Một đoạn phim có chuyện, kéo dài được, dựng lại được, hoặc đưa thẳng lên tường tác phẩm."
+        }
+      }
+    },
+    "sixth": {
+      "heading": "Từng tập một, đi tới tận bản dựng",
+      "lead": "Canvas vô hạn cho phép thử nhiều tham chiếu, nhiều node, nhiều phiên bản — rồi commit kết quả về luồng chính khi bạn xác nhận, chừa lại chỗ để sáng tạo thoải mái"
+    },
+    "twelfth": {
+      "heading": "Đẩy một dòng thành cả một vũ trụ xem được",
+      "lead": "Đưa cho nó một xung đột nhân vật hay một thế giới, để DramaClaw bóc thành các node cú máy rồi cứ thế nối dài",
+      "primaryCta": "Bắt đầu sáng tạo",
+      "secondaryCta": "Đăng ký tài khoản"
+    },
+    "watchCommunity": "Xem tác phẩm của cộng đồng",
+    "watchNow": "Xem ngay",
+    "backToTop": "Lên đầu trang",
+    "hero": {
+      "headline": "Biến ý tưởng thành hiện thực",
+      "scrollHint": "Cuộn xuống"
+    },
+    "second": {
+      "title": "Từ ý tưởng thành dự án",
+      "subtitle": "Trong DramaClaw, sáng tạo không còn dừng ở một prompt và một kết quả"
+    },
+    "third": {
+      "title": "Để câu chuyện làm điểm xuất phát",
+      "subtitle": "Nhập tiểu thuyết, kịch bản hoặc văn bản theo từng tập, hệ thống tự phân tích, đặt nền cho việc trích asset, lên kế hoạch tập và bóc tách cú máy."
+    }
+  },
+  "downloadPage": {
+    "nav": {
+      "capability": "Tính năng",
+      "release": "Phiên bản",
+      "faq": "Hỏi đáp"
+    },
+    "hero": {
+      "subtitle": "Từ tiểu thuyết tới bản phim hoàn chỉnh: lên kế hoạch tập, thiết kế nhân vật, storyboard, khung đầu, tạo video và dựng bản cuối. Luồng chính đi qua dây chuyền từng bước, còn canvas bày cùng khối công việc đó dưới dạng sơ đồ node — cả hai dùng chung một bộ asset. Bản desktop lo phần media trên máy, các lần render dài và tự cập nhật.",
+      "note": "Bộ cài tải thẳng từ CDN và tự cập nhật — cài một lần là xong.",
+      "history": "Các bản phát hành cũ cho mọi nền tảng có tại"
+    },
+    "platform": {
+      "detected": "Hệ điều hành của bạn",
+      "format": "Định dạng",
+      "arch": "Kiến trúc",
+      "requirement": "Yêu cầu",
+      "mac": {
+        "name": "macOS",
+        "format": ".dmg",
+        "arch": "Apple silicon (arm64)",
+        "requirement": "macOS 12 trở lên",
+        "cta": "Tải cho macOS"
+      },
+      "windows": {
+        "name": "Windows",
+        "format": ".exe",
+        "arch": "x64",
+        "requirement": "Windows 10 trở lên",
+        "cta": "Tải cho Windows"
+      }
+    },
+    "preview": {
+      "eyebrow": "Giao diện",
+      "title": "Một dây chuyền có dẫn đường và một canvas tự do",
+      "lede": "Luồng chính bóc tiểu thuyết thành tập phim, nhân vật, storyboard, khung đầu, video và bản dựng cuối — mỗi bước một trang. Canvas chiếu bất kỳ cú máy nào lên sơ đồ node để bạn làm lại thoải mái rồi đồng bộ kết quả về. Hai bên đọc chung một bộ asset.",
+      "windowTitle": "DramaClaw — Tập 03 · Canvas",
+      "alt": "Phác thảo canvas DramaClaw bản desktop: tab tập phim ở trên, danh sách cú máy bên trái, canvas node ở giữa, bảng tham số bên phải.",
+      "caption": "Hình minh hoạ (khung nhìn canvas)"
+    },
+    "capability": {
+      "eyebrow": "Tính năng",
+      "title": "Bốn thứ chỉ bản desktop làm được",
+      "lede": "Mọi thứ bản web chạy được thì app cũng chạy. Bốn thứ dưới đây đi kèm khi bạn cài app.",
+      "items": {
+        "localFiles": {
+          "title": "Kéo thẳng file trên máy vào canvas",
+          "description": "Video, ảnh và âm thanh thả thẳng từ Finder hoặc File Explorer theo đường dẫn cục bộ — không phải tải lên trước."
+        },
+        "longTasks": {
+          "title": "Render dài không sợ đóng trình duyệt",
+          "description": "Render cả tập và tạo khung đầu hàng loạt chạy hàng chục phút ngay trong app, nên đóng tab cũng không mất công."
+        },
+        "autoUpdate": {
+          "title": "Cài một lần, luôn mới",
+          "description": "Bản mới tải ngầm và áp dụng ở lần mở kế tiếp — bạn không phải quay lại tải bộ cài nữa."
+        },
+        "localExport": {
+          "title": "File xuất nằm ngay trên ổ đĩa của bạn",
+          "description": "Bảng cú máy, khung đầu và bản dựng cuối được xếp vào thư mục trên máy theo từng tập, thay vì chất đống trong danh sách tải của trình duyệt."
+        }
+      }
+    },
+    "release": {
+      "eyebrow": "Phiên bản",
+      "title": "Phiên bản hiện tại và các thay đổi gần đây",
+      "spec": {
+        "version": "Phiên bản",
+        "pending": "Đang kiểm tra",
+        "released": "Phát hành",
+        "macValue": "12+ · Apple silicon",
+        "windowsValue": "10+ · x64",
+        "autoUpdate": "Tự cập nhật",
+        "autoUpdateValue": "Đang bật",
+        "license": "Giấy phép"
+      },
+      "checksum": {
+        "label": "SHA-512",
+        "note": "dạng base64, mỗi dòng ứng với bộ cài của nền tảng ở trên",
+        "copy": "Sao chép",
+        "copied": "Đã sao chép",
+        "pending": "Đang kiểm tra"
+      }
+    },
+    "changelog": {
+      "v132": {
+        "title": "Cài ComfyUI cục bộ đơn giản hơn, chế độ video nhất quán",
+        "description": "MiniMax H3 gom nhiều workflow vào một mục model, và các chế độ trên canvas như khung-đầu giữ nhất quán xuyên suốt khâu kiểm tra, tính phí và thực thi."
+      },
+      "v131": {
+        "title": "Danh mục media chính thức cập nhật được",
+        "description": "Trong Cài đặt có thể kiểm tra danh mục model media chính thức thủ công hoặc tự động; các lựa chọn model ảnh và video làm mới ngay khi danh mục mới có hiệu lực."
+      },
+      "v130": {
+        "title": "Kênh và năng lực model lấy từ backend",
+        "description": "Model ảnh, model video, tham số và giới hạn tham chiếu giờ lấy từ cấu hình backend. MiniMax-H3 đi kèm preset chính thức, và ComfyUI cục bộ có thể đảm nhận việc tạo nội dung."
+      },
+      "v121": {
+        "title": "Tham số media và tiến độ nhập truyện đáng tin hơn",
+        "description": "Tỉ lệ, độ phân giải và các tham số riêng của từng model được truyền nguyên vẹn với kích thước 2K/4K đã sửa đúng, còn phần nhập truyện hiển thị giai đoạn, phần trăm và thời gian đã trôi qua suốt quá trình."
+      },
+      "v120": {
+        "title": "Credits theo tính năng minh bạch, đón cả agent bên ngoài",
+        "description": "Giá từng tính năng, mức phí ước tính và lịch sử sử dụng gom về một chỗ, và các agent chạy trên máy như Claude Code có thể điều khiển DramaClaw CE qua MCP."
+      }
+    },
+    "faq": {
+      "eyebrow": "Hỏi đáp",
+      "title": "Những thắc mắc hay gặp",
+      "items": {
+        "macGatekeeper": {
+          "question": "macOS báo không xác minh được nhà phát triển, phải làm sao?",
+          "answer": "Mở Finder → Applications, tìm DramaClaw, giữ Control rồi bấm vào biểu tượng, chọn Open, sau đó xác nhận Open trong hộp thoại. Chỉ phải làm một lần; sau đó app mở bình thường."
+        },
+        "winSmartScreen": {
+          "question": "Windows báo đã bảo vệ máy của tôi, phải làm sao?",
+          "answer": "Bấm More info rồi Run anyway. SmartScreen mặc định chặn các bộ cài chưa đủ lượt tải; điều đó không nói lên bộ cài này có nguyên vẹn hay không."
+        },
+        "offline": {
+          "question": "App có cần kết nối Internet không?",
+          "answer": "Có. Tạo kịch bản, render khung đầu và dựng video đều chạy trên máy chủ đám mây; app lo phần điều phối, quản lý media và ghi kết quả xuống ổ đĩa. Các bản phim đã tải về vẫn xem được khi ngoại tuyến."
+        },
+        "update": {
+          "question": "Nâng cấp thế nào?",
+          "answer": "Bạn không cần làm gì. App kiểm tra khi mở, tải bản mới ngầm và áp dụng ở lần khởi động kế tiếp. Nếu muốn tự cài một phiên bản cụ thể, xem",
+          "linkLabel": "GitHub Releases"
+        },
+        "storage": {
+          "question": "Dự án và file xuất nằm ở đâu?",
+          "answer": "Dữ liệu dự án nằm trên đám mây theo tài khoản của bạn, nên mọi thiết bị đã đăng nhập đều thấy cùng những tập phim đó. Bảng cú máy, khung đầu và bản dựng cuối khi xuất ra thì ghi xuống ổ đĩa, và bạn đổi được đường dẫn đó trong phần cài đặt."
+        },
+        "openSource": {
+          "question": "Đây có phải mã nguồn mở không?",
+          "answer": "App dùng giấy phép Elastic-2.0: bạn được tự do sử dụng, sửa đổi và tự dựng máy chủ riêng, nhưng không được bán lại dưới dạng dịch vụ lưu trữ. Mã nguồn ở",
+          "linkLabel": "github.com/dramaclaw/dramaclaw"
+        }
+      }
+    },
+    "footer": {
+      "meta": "© 2026 CLAYMORELAB · ELASTIC-2.0 · MACOS 12+ / WINDOWS 10+"
+    }
+  },
+  "header": {
+    "partyFounding105": "庆祝建党105周年",
+    "settings": "Cài đặt",
+    "settingsWithWarning": "Cài đặt — thiếu cấu hình",
+    "settingsWarningBubble": "Thiếu thiết lập",
+    "dismissSettingsWarningBubble": "Bỏ qua nhắc nhở thiếu thiết lập",
+    "notifications": "Thông báo",
+    "account": {
+      "open": "Mở menu tài khoản",
+      "changeAvatar": "Đổi ảnh đại diện",
+      "changePassword": "Đổi mật khẩu",
+      "selectLanguage": "Chọn ngôn ngữ",
+      "languageChinese": "中文",
+      "languageEnglish": "English",
+      "languageVietnamese": "Tiếng Việt",
+      "passwordDialog": {
+        "title": "Đổi mật khẩu",
+        "description": "Đổi mật khẩu sẽ đăng xuất bạn trên mọi thiết bị. Hãy đăng nhập lại bằng mật khẩu mới.",
+        "current": "Mật khẩu hiện tại",
+        "new": "Mật khẩu mới",
+        "confirm": "Xác nhận mật khẩu mới",
+        "requirement": "Dùng ít nhất 8 ký tự và chọn mật khẩu khác mật khẩu hiện tại.",
+        "mismatch": "Hai mật khẩu mới không khớp.",
+        "unchanged": "Mật khẩu mới phải khác mật khẩu hiện tại.",
+        "currentIncorrect": "Mật khẩu hiện tại không đúng.",
+        "submit": "Đổi mật khẩu",
+        "saving": "Đang đổi…",
+        "success": "Đã đổi mật khẩu. Hãy đăng nhập lại bằng mật khẩu mới.",
+        "partialSuccess": "Đã đổi mật khẩu. Hãy đăng nhập lại; một số phiên vẫn đang được đăng xuất.",
+        "error": "Không đổi được mật khẩu. Vui lòng thử lại."
+      },
+      "avatarDialog": {
+        "title": "Đổi ảnh đại diện",
+        "description": "Chọn một ảnh làm đại diện. Ảnh vuông và rõ nét sẽ đẹp nhất.",
+        "previewHint": "Đang dùng ảnh đại diện chữ cái mặc định",
+        "choose": "Chọn ảnh",
+        "replace": "Đổi ảnh khác",
+        "fileHint": "PNG, JPG, WebP hoặc GIF",
+        "save": "Lưu ảnh đại diện",
+        "saving": "Đang lưu…",
+        "error": "Tải ảnh đại diện thất bại, vui lòng thử lại"
+      }
+    }
+  },
+  "organization": {
+    "unavailable": "Phiên bản này không hỗ trợ kiểm tra quyền truy cập theo tổ chức.",
+    "access": {
+      "title": "Quyền dùng model",
+      "loading": "Đang tải quyền dùng model",
+      "retry": "Thử lại",
+      "back": "Về danh sách dự án",
+      "available": "Tác vụ model đang dùng được",
+      "unavailable": "Tác vụ model không dùng được",
+      "reasons": {
+        "MODEL_ACCESS_DENIED": "Tài khoản này đã bị tắt quyền dùng model.",
+        "ORG_MEMBERSHIP_INACTIVE": "Tư cách thành viên của bạn trong tổ chức đang ngừng hoạt động.",
+        "ORG_SUSPENDED": "Tổ chức này đang bị tạm ngưng.",
+        "ORG_CREDENTIAL_MISSING": "Tổ chức chưa có key gateway nào khả dụng.",
+        "ORG_CREDENTIAL_DISABLED": "Key gateway của tổ chức không dùng được.",
+        "ORG_CREDENTIAL_GATEWAY_MISMATCH": "Key gateway của tổ chức đang gắn với một gateway khác. Hãy nhờ quản trị viên gắn lại.",
+        "ORG_AUTHZ_STALE": "Quyền của bạn vừa thay đổi. Hãy tải lại rồi thử tiếp.",
+        "generic": "Hiện chưa dùng được quyền model."
+      }
+    }
+  },
+  "notifications": {
+    "title": "Trung tâm thông báo",
+    "close": "Đóng trung tâm thông báo",
+    "empty": "Không có thông báo",
+    "upgrade": {
+      "title": "Đã có phiên bản {{version}}",
+      "body": "Đã có bản phát hành mới hơn từ nhà phát triển. Mở trang phát hành để xem và nâng cấp.",
+      "open": "Cập nhật",
+      "skip": "Bỏ qua phiên bản này"
+    }
+  },
+  "myBuddy": {
+    "dragHint": "Kéo để đổi vị trí",
+    "taskRunning": "Đang chạy · {{name}}",
+    "taskSuccess": "Xong · {{name}}",
+    "taskFailure": "Thất bại · {{name}}",
+    "companion": {
+      "entry": "Bạn đồng hành",
+      "title": "Chọn bạn đồng hành",
+      "titleBadgeAlt": "Người bạn OK của tôi",
+      "importCta": "Nhập bạn đồng hành",
+      "toggleVisibility": "Hiện bạn đồng hành"
+    },
+    "import": {
+      "button": "Nhập",
+      "title": "Nhập thú cưng petdex",
+      "desc": "Chọn file spritesheet.webp (bắt buộc) và pet.json (tuỳ chọn) tải từ petdex; thú cưng sẽ xuất hiện trong thư viện.",
+      "spritesheetTitle": "Bấm hoặc kéo thả spritesheet.webp",
+      "spritesheetHint": "Bắt buộc · spritesheet webp / png",
+      "jsonTitle": "Bấm hoặc kéo thả pet.json",
+      "jsonHint": "Tuỳ chọn · dùng để lấy tên",
+      "choose": "Chọn file",
+      "replace": "Thay file",
+      "gridError": "Spritesheet {{w}}×{{h}} không chia hết cho lưới {{cols}}×{{rows}} nên các khung hình sẽ bị cắt sai. Hãy dùng sheet chuẩn 8×9, hoặc khai báo đúng cols/rows trong pet.json.",
+      "hint": "Thú cưng chỉ được lưu trong trình duyệt của bạn (IndexedDB), không tải lên đâu cả; spritesheet phải theo lưới chuẩn 8×9 của petdex.",
+      "confirm": "Nhập"
+    },
+    "gallery": {
+      "title": "Chọn bạn đồng hành",
+      "tabLibrary": "Thư viện",
+      "tabMine": "Thú cưng của tôi",
+      "select": "Chọn",
+      "selected": "Đã chọn",
+      "search": "Tìm tên thú cưng…",
+      "loading": "Đang tải…",
+      "officialGroup": "Bạn đồng hành chính thức",
+      "peripheralGroup": "Bộ sưu tập bạn đồng hành",
+      "empty": "Không có thú cưng nào khớp",
+      "emptyMine": "Chưa nhập thú cưng nào — bấm Nhập để thêm"
+    },
+    "debug": {
+      "suffix": " Debug",
+      "auto": "Tự động",
+      "companionPicker": "Bạn đồng hành",
+      "festivalPreview": "Lễ hội",
+      "noFestival": "Không có lễ hội",
+      "stateSimulation": "Mô phỏng trạng thái",
+      "accessoryPreview": "Phụ kiện",
+      "triggerDiveAction": "Lặn",
+      "chestTrigger": "Kích hoạt rương",
+      "chestSingle": "Rương đơn",
+      "chestBatch": "Rương hàng loạt",
+      "triggerUpdateDialog": "Kích hoạt hộp thoại cập nhật",
+      "states": {
+        "running": "Bong bóng đang chạy",
+        "success": "Bong bóng thành công",
+        "failure": "Bong bóng thất bại",
+        "idle": "Bong bóng nhàn rỗi"
+      },
+      "accessories": {
+        "none": "Bộ đồ mới của Hoàng đế",
+        "niulai": "Niu Lai",
+        "goldenHoopStaff": "Tề Thiên Đại Thánh",
+        "littleKing": "Tiểu Vương",
+        "bubbleBalloon": "Bong bóng",
+        "cyanEnergySword": "Lưỡi kiếm năng lượng lam",
+        "mengnanWand": "Soái ca cứng cỏi",
+        "odinHammer": "Vua Búa",
+        "fireTippedSpear": "Hoả Tiêm Thương của Tam thái tử",
+        "dumbbell": "Hôm nay trời đẹp, tập tạ thôi",
+        "thumbsUp": "Like mạnh",
+        "codeLing": "Code-Ling",
+        "codeYu": "Code-Yu",
+        "codeXia": "Code-Xia",
+        "codeNing": "Code-Ning",
+        "founderMedal": "Huy chương kỷ niệm vàng",
+        "redStar": "Ngôi sao đỏ lấp lánh",
+        "darkKnightMask": "Hoàng hôn",
+        "azuMask": "Mặt nạ của Azu",
+        "redBow": "Ký ức hồng",
+        "minionGoggles": "Kính của bạn vàng",
+        "diverGoggles": "Kính lặn sâu",
+        "gourd": "Bí bảo hồ lô",
+        "judyCarrot": "Bữa trưa của thỏ",
+        "pacifier": "Đồ nghề chuẩn của em bé",
+        "wizardHat": "Mũ phù thuỷ",
+        "bambooHat": "Đại hiệp",
+        "asgardHorns": "Vì vương quốc",
+        "garySnail": "Bạn ốc sên nhỏ",
+        "captainShield": "Che chở cho bạn",
+        "lubanCompass": "La bàn Lỗ Ban",
+        "lubanTalisman": "Bùa cơ quan",
+        "redCape": "Áo choàng hộ vệ",
+        "ufoPet": "Du hành liên sao",
+        "ghostPet": "Lulu"
+      },
+      "accessoryFeedback": {
+        "none": "Đẹp trai hết nấc!",
+        "niulai": "Mẹ ơi!",
+        "goldenHoopStaff": "Bật chế độ Đại Thánh!",
+        "littleKing": "Vua giá lâm!",
+        "bubbleBalloon": "Ra công viên chơi nào",
+        "cyanEnergySword": "Heo rừng, đứng lại!",
+        "mengnanWand": "Chiến thôi!",
+        "odinHammer": "Vì Odin!",
+        "fireTippedSpear": "Nổi lửa lên!",
+        "dumbbell": "Tới giờ tập tạ!",
+        "thumbsUp": "Ngon lành!",
+        "codeLing": "Tia lửa đã bật!",
+        "codeYu": "Chế độ Ngọc!",
+        "codeXia": "Khiên phát sáng!",
+        "codeNing": "Buff tĩnh tâm!",
+        "founderMedal": "Khoe huy chương!",
+        "redStar": "Sao đỏ lấp lánh!",
+        "darkKnightMask": "Chế độ đêm!",
+        "azuMask": "Mặt nạ sẵn sàng!",
+        "redBow": "Chí mạng dễ thương!",
+        "minionGoggles": "Báo động chuối!",
+        "diverGoggles": "Sẵn sàng lặn chưa?",
+        "gourd": "Bảo bối sẵn sàng!",
+        "judyCarrot": "Đã gói bữa trưa chưa?",
+        "pacifier": "Sếp nhí!",
+        "wizardHat": "Phép thuật đã bật!",
+        "bambooHat": "Chế độ đại hiệp!",
+        "asgardHorns": "Vì vương quốc!",
+        "garySnail": "Chậm mà chắc!",
+        "captainShield": "Tôi che cho bạn!",
+        "lubanCompass": "La bàn đã kích hoạt!",
+        "lubanTalisman": "Cơ quan đã khoá!",
+        "redCape": "Chọn tôi đi!",
+        "ufoPet": "Bilu kala wugulu!",
+        "ghostPet": "Chào bạn nhé"
+      }
+    },
+    "bubbles": {
+      "walkBy": "Lẻn qua tí~",
+      "running": {
+        "queued": "Để đó tôi lo.",
+        "working": "Đang xử lý đây.",
+        "holdOn": "Tôi đang tới đây.",
+        "gears": "Bánh răng đang quay.",
+        "onIt": "Đang làm ngay.",
+        "readingRoom": "Đang đọc tình hình.",
+        "keepWindowOpen": "Cứ để mở nhé.",
+        "checkingEdges": "Đang rà các mép.",
+        "smallSteps": "Từng bước một thôi.",
+        "movingPieces": "Các mảnh đang chạy."
+      },
+      "success": {
+        "done": "Xong, gọn gàng.",
+        "nice": "Ăn điểm rồi.",
+        "landed": "Kết thúc mượt.",
+        "tidy": "Đâu vào đấy.",
+        "flag": "Bước này ổn.",
+        "cleared": "Cái này xong rồi.",
+        "goodShape": "Cái này đang ngon.",
+        "savedTrip": "Đỡ được một vòng.",
+        "noDrama": "Lần này êm ru.",
+        "oneLessThing": "Bớt được một việc."
+      },
+      "failure": {
+        "stuck": "Cái này kẹt rồi.",
+        "checking": "Để tôi xem lại.",
+        "retry": "Đã đánh dấu để chạy lại.",
+        "noted": "Tôi thấy rồi.",
+        "box": "Cái hộp nháy đèn.",
+        "hitSnag": "Vướng chỗ này rồi.",
+        "needsLook": "Cái này cần xem lại.",
+        "leftClue": "Có để lại manh mối.",
+        "tryAgainLater": "Mình thử lại được mà.",
+        "notClean": "Lần đó chưa sạch."
+      },
+      "idle": {
+        "watching": "Tôi ở đây nè.",
+        "quiet": "Bên này yên ắng.",
+        "standingBy": "Gọi tôi lúc nào cũng được.",
+        "idea": "Ý tưởng cần chút thời gian.",
+        "tinyBreak": "Tôi lảng vảng quanh đây.",
+        "noRush": "Không vội đâu.",
+        "roomBreathes": "Để trang thở một chút.",
+        "stillHere": "Vẫn online nhé.",
+        "goodPause": "Nghỉ chút cũng tốt.",
+        "mindingTop": "Đang giữ góc này.",
+        "keepRhythm": "Vẫn giữ nhịp đều.",
+        "littleCorner": "Chiếm cái góc này tí.",
+        "online": "Rảnh, nhưng vẫn online.",
+        "nextStep": "Đang chờ bước tiếp theo.",
+        "smallPatrol": "Đang đi tuần một vòng nhỏ.",
+        "softPause": "Trạng thái vẫn ổn định."
+      },
+      "dragonBoat": {
+        "leafScent": "Thoang thoảng mùi lá gói bánh.",
+        "tightWrap": "Gói từ từ thôi.",
+        "waterQuiet": "Gió thổi đều đều.",
+        "goodStroke": "Chiếc lá nhỏ đang làm nhiệm vụ.",
+        "steadyBoat": "Hôm nay mùi lá thơm dịu."
+      }
+    },
+    "actions": {
+      "idle": "Nhàn rỗi",
+      "peek": "Ngó nghiêng",
+      "countStars": "Đếm sao",
+      "sleep": "Ngủ",
+      "carryBox": "Khiêng hộp",
+      "stretch": "Vươn vai",
+      "watchMeteor": "Ngắm sao băng",
+      "readMap": "Xem bản đồ",
+      "fish": "Câu cá",
+      "blowBubbles": "Thổi bong bóng",
+      "dragonBoatPaddle": "Đua thuyền rồng",
+      "zongziCheck": "Tung bánh ú",
+      "typing": "Gõ phím",
+      "flag": "Cắm cờ",
+      "repair": "Kiểm tra hộp",
+      "walkBy": "Đi ngang qua"
+    },
+    "festivals": {
+      "dragonBoat2026": "Tết Đoan Ngọ 2026"
+    }
+  },
+  "aiAssistant": {
+    "formatCheck": {
+      "title": "Kiểm tra định dạng kịch bản",
+      "close": "Đóng",
+      "viewDetails": "Xem chi tiết",
+      "recommended": "Ví dụ kịch bản chuẩn (giữ nguyên từ khoá tiếng Anh):\nEPISODE 1\nINT. City Cafe - DAY\nCharacters: Lam Ha, Tran Mac\n△ Nắng chiều xuyên qua cửa sổ khi Lâm Hạ đặt lá thư lên bàn.\nLam Ha: Câu trả lời anh muốn nằm ngay đây.",
+      "lineLabel": "Dòng {{line}}",
+      "noIssues": "Không phát hiện vấn đề cụ thể nào"
+    },
+    "title": "Xia Director",
+    "upgrading": "Xia Director đang được nâng cấp. Hãy đón chờ nhé!",
+    "description": "Mở Xia Director bên cạnh trang sáng tác hiện tại.",
+    "toggle": "Mở rộng hoặc thu gọn Xia Director",
+    "close": "Thu gọn Xia Director",
+    "resize": "Kéo để đổi kích thước khung chat",
+    "openExternal": "Mở trong cửa sổ mới",
+    "iframeTitle": "Xia Director",
+    "newChat": "Cuộc trò chuyện mới",
+    "expandSessions": "Mở rộng danh sách phiên",
+    "collapseSessions": "Thu gọn danh sách phiên",
+    "sessionActions": "Thao tác với phiên",
+    "deleteSessionConfirm": "Xoá cuộc trò chuyện này?",
+    "noSessions": "Chưa có phiên nào",
+    "chatTitle": "Xia Director",
+    "globalScope": "Toàn cục",
+    "connected": "Đã kết nối",
+    "connecting": "Đang kết nối",
+    "reconnecting": "Đang kết nối lại",
+    "disconnected": "Đã ngắt kết nối",
+    "backendTransport": "OpenClaw / relay",
+    "emptyTitle": "Bắt đầu trò chuyện",
+    "emptyDescription": "Hỏi về tiến độ dự án, các tác vụ thất bại, hoặc nhờ trợ lý sắp xếp kế hoạch sáng tác của bạn.",
+    "syncingHistoryTitle": "Đang khởi tạo cuộc trò chuyện",
+    "syncingHistoryDescription": "Đang kết nối tới Xia Director và đồng bộ lịch sử chat. Vui lòng đợi.",
+    "disclaimer": "Xia Director có thể mắc lỗi. Hãy kiểm tra lại các chi tiết quan trọng về cốt truyện, nhân vật và asset.",
+    "placeholder": "Sau khi tải kịch bản lên, hãy nhờ Xia Director đẩy tiến độ tập phim, hình ảnh, âm thanh hoặc video hoàn chỉnh",
+    "waiting": "Đang chờ dịch vụ chat...",
+    "waitingResponse": "Đang chờ Xia Director",
+    "waitingResponses": [
+      "Đang hiểu xem bạn muốn đẩy việc gì",
+      "Đang xem lại bối cảnh cuộc trò chuyện",
+      "Đang xác định các ý chính trong yêu cầu của bạn",
+      "Đang sắp xếp thông tin liên quan",
+      "Đang dựng câu trả lời rõ ràng hơn"
+    ],
+    "waitingLongResponse": "Lần này lâu hơn bình thường, nhưng vẫn đang xử lý",
+    "waitingVeryLongResponse": "Vẫn đang chờ phản hồi. Bạn có thể chờ tiếp hoặc dừng lại",
+    "send": "Gửi",
+    "queueMessage": "Xếp tin nhắn vào hàng đợi",
+    "queuedCount": "{{count}} trong hàng đợi",
+    "queuedAttachments": "{{count}} tệp đính kèm",
+    "removeQueuedMessage": "Xoá tin nhắn khỏi hàng đợi",
+    "selectQueuedMessage": "Chọn tin nhắn trong hàng đợi",
+    "waitingStructuredRender": "Đang render",
+    "stop": "Dừng",
+    "actions": {
+      "label": "Thao tác với tin nhắn",
+      "copy": "Sao chép",
+      "copied": "Đã sao chép",
+      "readAloud": "Đọc to",
+      "details": "Xem chi tiết",
+      "pin": "Ghim",
+      "unpin": "Bỏ ghim",
+      "delete": "Xoá",
+      "more": "Thêm"
+    },
+    "search": "Tìm trong tin nhắn",
+    "clearSearch": "Xoá tìm kiếm",
+    "closeSearch": "Đóng tìm kiếm",
+    "attach": "Đính kèm file",
+    "dropFiles": "Thả để tải file lên",
+    "unsupportedDropFiles": "Chỉ hỗ trợ .txt, .md, .doc và .docx",
+    "removeAttachment": "Xoá tệp đính kèm",
+    "approvalExpires": "Hết hạn sau {{seconds}}s",
+    "allowOnce": "Cho phép một lần",
+    "allowAlways": "Luôn cho phép",
+    "deny": "Từ chối",
+    "instance": "Instance",
+    "model": "Model",
+    "noInstances": "Không có instance nào",
+    "noModels": "Không có model nào",
+    "refreshInstances": "Làm mới danh sách instance",
+    "refreshModels": "Làm mới danh sách model",
+    "compact": "Rút gọn",
+    "usage": "Mức sử dụng",
+    "pinned": "Đã ghim",
+    "clearPinned": "Bỏ ghim tất cả",
+    "messageDetail": "Chi tiết tin nhắn",
+    "closeDetail": "Đóng chi tiết",
+    "mediaDetail": "Chi tiết media",
+    "mediaDescription": "Mô tả",
+    "mediaCandidates": "Các ứng viên",
+    "raw": "Dữ liệu thô",
+    "voiceInput": "Nhập bằng giọng nói",
+    "stopVoice": "Dừng nhập bằng giọng nói",
+    "listening": "Đang nghe...",
+    "open": "Mở",
+    "download": "Tải về",
+    "copyLink": "Sao chép link",
+    "settings": "Cài đặt",
+    "closeSettings": "Đóng cài đặt",
+    "showToolEvents": "Hiện sự kiện công cụ",
+    "showThinking": "Hiện quá trình suy luận",
+    "tool": "Công cụ",
+    "historyTool": "Công cụ lịch sử",
+    "showStructuredSourceWhileStreaming": "Hiện mã JSON gốc trong lúc stream",
+    "uploadTarget": "Đích tải lên",
+    "uploadTargetOpenclaw": "Gửi tới OpenClaw",
+    "uploadTargetLocal": "Chỉ trong bảng cục bộ",
+    "ingestAutomationUploading": "Đang tải truyện lên: {{filename}}",
+    "ingestAutomationStarted": "Đã bắt đầu nhập truyện: {{filename}}",
+    "ingestAutomationFailed": "Tải lên hoặc nhập truyện thất bại: {{message}}",
+    "ingestAutomationNoProject": "Hãy mở một dự án trước khi tải truyện lên qua Xia Director.",
+    "ingestAutomationMissingFile": "Không đọc được file truyện đã tải lên. Hãy chọn lại.",
+    "attachmentOnlyPrompt": "Hãy phân tích file tôi vừa tải lên.",
+    "attachmentAnalysisUploading": "Đang tải file lên để phân tích: {{filename}}",
+    "settingsHint": "Tài khoản và đăng nhập do SuperTale quản lý. Các thiết lập này chỉ điều khiển cách hiển thị chat và hành vi tệp đính kèm.",
+    "scrollToBottom": "Về cuối",
+    "taskCompleteNotice": "✅ {{label}} đã xong. Bảo mình xem kết quả, hoặc đi tiếp bước sau.",
+    "taskFailedNotice": "{{label}} thất bại: {{reason}}\nXử lý đúng chỗ báo lỗi rồi hãy làm tiếp.",
+    "taskFailedUnknownReason": "không có lý do cụ thể nào được trả về"
+  },
+  "freezone": {
+    "chat": {
+      "title": "Xia Director",
+      "description": "Mở Xia Director bên cạnh canvas Freezone.",
+      "toggle": "Mở Xia Director trong Freezone",
+      "close": "Thu gọn Xia Director trong Freezone",
+      "resize": "Kéo để đổi kích thước Xia Director trong Freezone"
+    },
+    "canvases": {
+      "defaultSection": "Canvas mặc định",
+      "myCanvasSection": "Canvas của tôi",
+      "personalCanvasName": "Canvas cá nhân",
+      "memberCanvasesSection": "Canvas của thành viên",
+      "expandMemberCanvases": "Mở rộng canvas của thành viên",
+      "collapseMemberCanvases": "Thu gọn canvas của thành viên",
+      "emptyMemberCanvases": "Không có canvas của thành viên nào",
+      "recentSection": "Gần đây",
+      "assetsSection": "Canvas asset",
+      "episodesSection": "Canvas tập phim",
+      "otherCanvasesSection": "Canvas khác",
+      "expandOtherCanvases": "Mở rộng canvas khác",
+      "collapseOtherCanvases": "Thu gọn canvas khác",
+      "emptyOtherCanvases": "Không có canvas nào khác",
+      "ungroupedSection": "Canvas khác",
+      "episodeLabel": "Tập {{episode}}",
+      "expandAssets": "Mở rộng canvas asset",
+      "collapseAssets": "Thu gọn canvas asset",
+      "expandEpisode": "Mở rộng Tập {{episode}}",
+      "collapseEpisode": "Thu gọn Tập {{episode}}",
+      "emptyRecent": "Không có canvas nào gần đây",
+      "loading": "Đang tải...",
+      "switcher": "Đổi canvas",
+      "create": "Tạo mới",
+      "createTitle": "Tạo canvas cho dự án",
+      "createBusy": "Đang tạo",
+      "createPlaceholder": "Tên canvas mới",
+      "createNameRequired": "Hãy nhập tên canvas.",
+      "createDuplicate": "Đã có canvas tên \"{{name}}\".",
+      "createFailed": "Tạo canvas thất bại: {{message}}",
+      "createLimitTitle": "Đã chạm giới hạn canvas",
+      "createLimitReached": "Mỗi dự án tạo được tối đa {{limit}} canvas. Xoá bớt một cái để có chỗ.",
+      "createQuotaUnknownTitle": "Chưa đếm được số canvas",
+      "createQuotaUnknown": "Danh sách canvas còn đang tải. Tải xong rồi hãy thử lại.",
+      "userCreatedName": "{{user}} · {{name}}",
+      "restoreConfirm": "Đồng bộ khung nhìn luồng chính sẽ dựng lại lớp preset của canvas luồng chính này từ dữ liệu hiện tại của dự án. Các node tự thêm và đường nối thường vẫn được giữ lại. Tiếp tục?",
+      "restoreTitle": "Dựng lại lớp preset của canvas luồng chính này từ dữ liệu luồng chính hiện tại",
+      "restore": "Đồng bộ",
+      "restoreBusy": "Đang đồng bộ",
+      "restoreMenu": "Đồng bộ khung nhìn luồng chính",
+      "sourceCanvas": "Luồng chính",
+      "sourceCanvasTitle": "Quay lại canvas luồng chính gốc: {{canvasId}}",
+      "backToSource": "Quay lại canvas luồng chính gốc",
+      "conflictCopy": "Bản sao xung đột",
+      "conflictCopyDescription": "Đã lưu bản sao khôi phục khi xung đột",
+      "delete": "Xoá",
+      "deleteTitle": "Xoá canvas",
+      "deleteCurrent": "Xoá canvas này",
+      "deleteConfirm": "Xoá \"{{name}}\"? Thao tác này xoá các node và đường nối khỏi canvas này, nhưng không xoá asset ở luồng chính.",
+      "deleteBusy": "Đang xoá...",
+      "deleteFailed": "Xoá canvas thất bại: {{message}}",
+      "noConflictSnapshot": "Không có bản chụp xung đột cục bộ nào để lưu.",
+      "description": {
+        "freeWorkflowBeat": "Quy trình tự do · Tập {{episode}} / Beat {{beat}}",
+        "freeWorkflowAsset": "Quy trình tự do · {{asset}}",
+        "freeWorkflow": "Quy trình tự do",
+        "default": "Canvas mặc định",
+        "episode": "Canvas Tập {{episode}}",
+        "episodeUnknown": "Canvas tập phim",
+        "beat": "Canvas beat · Tập {{episode}} / Beat {{beat}}{{slot}}",
+        "asset": "Canvas asset · {{name}} / {{kind}}",
+        "assetUnknown": "Canvas asset · {{kind}}",
+        "assetFallback": "asset",
+        "blank": "Canvas trống"
+      },
+      "relative": {
+        "now": "Vừa xong",
+        "minutes": "{{count}} phút trước",
+        "hours": "{{count}} giờ trước",
+        "days": "{{count}} ngày trước"
+      }
+    },
+    "canvasOutline": {
+      "title": "Thành phần trên canvas",
+      "groupMembers": "{{count}} node",
+      "empty": "Canvas này chưa có node nào",
+      "duplicate": "Nhân bản",
+      "rename": "Đổi tên",
+      "download": "Tải về",
+      "locate": "Tìm trên canvas",
+      "moreActions": "Thêm thao tác",
+      "matched": "{{count}} kết quả khớp",
+      "expandAll": "Mở rộng mọi nhóm",
+      "collapseAll": "Thu gọn mọi nhóm",
+      "search": "Tìm node",
+      "closeSearch": "Đóng tìm kiếm",
+      "filter": "Lọc theo loại",
+      "noMatch": "Không có node nào khớp",
+      "types": {
+        "all": "Tất cả",
+        "text": "Văn bản",
+        "image": "Ảnh",
+        "video": "Video",
+        "storyboard": "Storyboard",
+        "beat": "Ngữ cảnh cú máy",
+        "audio": "Âm thanh",
+        "script": "Kịch bản",
+        "world": "3D / Panorama",
+        "skill": "Kỹ năng"
+      }
+    },
+    "projections": {
+      "staleCount": "{{count}} bản chiếu luồng chính có cập nhật mới",
+      "activeCount": "{{count}} bản chiếu luồng chính",
+      "sync": "Đồng bộ",
+      "syncStale": "Đồng bộ cập nhật",
+      "syncing": "Đang đồng bộ",
+      "staleBadge": "Luồng chính đã cập nhật",
+      "syncSuccess": "Đã đồng bộ bản chiếu luồng chính",
+      "syncMissingRequest": "Thiếu yêu cầu chiếu; không đồng bộ được.",
+      "syncBlocked": "Canvas chưa được lưu. Hãy xử lý xung đột trước khi đồng bộ.",
+      "remove": "Xoá bản chiếu",
+      "removing": "Đang xoá",
+      "removeSuccess": "Đã xoá bản chiếu luồng chính",
+      "removeBlocked": "Canvas chưa được lưu. Hãy xử lý xung đột trước khi xoá bản chiếu."
+    },
+    "assetPanel": {
+      "tab": {
+        "canvases": "Canvas của dự án",
+        "library": "Asset luồng chính",
+        "assets": "Thư viện asset"
+      },
+      "roles": {
+        "current_sketch": "Phác thảo",
+        "current_frame": "Khung hình",
+        "current_video": "Video",
+        "current_audio": "Âm thanh",
+        "selected_background": "Nền",
+        "director_combined": "Bản render đạo diễn"
+      },
+      "tabs": {
+        "beatAll": "Mọi beat",
+        "beatEpisode": "Beat trong tập",
+        "beatCurrent": "Beat hiện tại",
+        "characters": "Nhân vật",
+        "scenes": "Bối cảnh",
+        "props": "Đạo cụ"
+      },
+      "groups": {
+        "outputs": "Kết quả hiện tại",
+        "director": "3GS / ảnh điều khiển",
+        "characters": "Tham chiếu nhân vật",
+        "scenes": "Tham chiếu bối cảnh",
+        "props": "Tham chiếu đạo cụ",
+        "other": "Ngữ cảnh khác"
+      },
+      "empty": {
+        "beatContext": "Chưa có asset ngữ cảnh cú máy nào",
+        "category": "Nhóm này chưa có asset",
+        "noBeatContext": "Canvas này không có ngữ cảnh cú máy",
+        "beatAssets": "Cú máy này chưa có asset ngữ cảnh"
+      },
+      "episodeTitle": "Tập {{episode}}",
+      "episodeUnknown": "Tập ?",
+      "beatUnknown": "Beat ?",
+      "expandDrawer": "Mở rộng ngăn asset",
+      "collapseDrawer": "Thu gọn ngăn asset",
+      "expand": "Mở rộng",
+      "collapse": "Thu gọn",
+      "assetManager": "Trình quản lý asset",
+      "searchPlaceholder": "Tìm asset...",
+      "loadFailed": "Tải asset của dự án thất bại: {{error}}",
+      "addToCanvas": "Thêm vào canvas",
+      "add": "Thêm",
+      "replaceConfirm": "Thay “{{label}}” bằng node trên canvas?",
+      "replacing": "Đang thay…",
+      "replace": "Thay",
+      "cancel": "Huỷ",
+      "currentFrame": "Khung hình hiện tại",
+      "sentToCanvas": "Đã gửi sang canvas: {{name}}",
+      "unnamedAsset": "asset",
+      "replaceTargetUnknown": "Không xác định được đích commit cho “{{label}}” (kind={{kind}} / role={{role}})",
+      "replaceCommitted": "Đã commit vào “{{label}}”",
+      "replaceDone": "Đã thay “{{label}}” bằng node trên canvas",
+      "replaceFailed": "Thay “{{label}}” thất bại: {{error}}",
+      "directorWorld": {
+        "label": "{{scene}} / Thế giới đạo diễn",
+        "sublabel": "Chứa {{count}} nguồn đạo diễn",
+        "sourceKind": {
+          "pano360": "Ảnh 360",
+          "master": "Thế giới mặt trước",
+          "reverse": "Thế giới góc ngược",
+          "pano": "Thế giới 360",
+          "custom": "Thế giới tuỳ chỉnh",
+          "fallback": "Thế giới đạo diễn"
+        }
+      },
+      "sceneBadge": {
+        "scene_master": {
+          "label": "Góc trước",
+          "title": "Góc trước của bối cảnh"
+        },
+        "scene_reverse_master": {
+          "label": "Góc ngược",
+          "title": "Góc ngược của bối cảnh"
+        },
+        "scene_director_pano_360": {
+          "label": "Ảnh 360",
+          "title": "Ảnh toàn cảnh 360"
+        },
+        "scene_director_world": {
+          "label": "Thế giới đạo diễn",
+          "title": "Thế giới đạo diễn của bối cảnh"
+        },
+        "scene_3gs_master_ply": {
+          "label": "Thế giới mặt trước",
+          "title": "Thế giới đạo diễn 3D (mặt trước)"
+        },
+        "scene_3gs_reverse_ply": {
+          "label": "Thế giới góc ngược",
+          "title": "Thế giới đạo diễn 3D (góc ngược)"
+        },
+        "scene_3gs_pano_ply": {
+          "label": "Thế giới 360",
+          "title": "Thế giới đạo diễn 3D (360)"
+        },
+        "scene_3gs_custom_scene": {
+          "label": "Thế giới tuỳ chỉnh",
+          "title": "Thế giới đạo diễn 3D (tuỳ chỉnh)"
+        }
+      }
+    },
+    "nodeContext": {
+      "mainlineAsset": "Asset luồng chính",
+      "kind": {
+        "identity": "Tạo hình",
+        "voice": "Giọng",
+        "narrator_voice": "Giọng dẫn truyện",
+        "bgm": "BGM",
+        "sfx": "SFX",
+        "ambient_audio": "Tiếng nền",
+        "scene": "Bối cảnh",
+        "prop": "Đạo cụ",
+        "beat": "Beat",
+        "sketch": "Phác thảo",
+        "frame": "Khung hình",
+        "video": "Video",
+        "audio": "Âm thanh",
+        "director_combined": "Ảnh ghép đạo diễn",
+        "selected_background": "Nền hiện tại"
+      },
+      "binding": {
+        "background_candidate": "Ứng viên nền",
+        "sketch_candidate": "Ứng viên phác thảo",
+        "frame_candidate": "Ứng viên khung hình",
+        "selected_background": "Nền hiện tại",
+        "current_sketch": "Phác thảo hiện tại",
+        "current_frame": "Khung hình hiện tại"
+      },
+      "withEpisodeBeat": "{{label}} · Tập {{episode}}/B{{beat}}",
+      "withName": "{{label}} · {{name}}"
+    },
+    "commit": {
+      "title": "Commit vào asset luồng chính",
+      "projectLine": "Dự án: {{project}}",
+      "submit": "Commit",
+      "submitting": "Đang commit",
+      "targetIncomplete": "Đích chưa đủ thông tin",
+      "directorWorldState": "Trạng thái thế giới đạo diễn",
+      "directorWorldManifestHint": "Commit manifest thế giới đạo diễn hiện tại",
+      "modelCommitHint": "Commit thế giới 3D hiện tại vào bối cảnh trong luồng chính",
+      "loadingBeats": "Đang tải beat…",
+      "noBeats": "Không có beat nào",
+      "loadingIdentities": "Đang tải identity_id…",
+      "noIdentities": "Nhân vật này chưa có identity_id",
+      "sceneIdPlaceholder": "scene_id, ví dụ quán mì Lan Châu",
+      "sceneSlotHint": "Sẽ được ghi vào slot asset của bối cảnh này.",
+      "propIdPlaceholder": "prop_id, ví dụ thùng các-tông",
+      "propSlotHint": "Sẽ được ghi vào slot asset tham chiếu của đạo cụ này.",
+      "impactCalculating": "Đang tính mức ảnh hưởng…",
+      "impactCount": "Ảnh hưởng tới {{count}} cú máy",
+      "impactMore": "Còn {{count}} mục không hiển thị",
+      "markStaleHint": "Đánh dấu những cú máy này là cần tạo lại sau khi commit; luồng chính có thể tạo lại dựa trên dấu đó",
+      "overwriteWarning": "Thao tác này ghi đè asset sẵn có ở “{{target}}”; file gốc vẫn được giữ trong lịch sử.",
+      "sections": {
+        "targetKind": "Loại đích",
+        "targetLocation": "Vị trí đích",
+        "impact": "Xem trước ảnh hưởng",
+        "episode": "Tập",
+        "character": "Nhân vật",
+        "scene": "Bối cảnh"
+      },
+      "errors": {
+        "loadOptions": "Tải danh sách lựa chọn thất bại",
+        "loadIdentities": "Tải identity_id thất bại",
+        "incompleteTarget": "Đích chưa đủ thông tin",
+        "noWorldSource": "Khung nhìn “không nguồn” không có asset thế giới 3D nào để commit; chuyển sang một nguồn thế giới cụ thể rồi hãy commit vào slot luồng chính.",
+        "noSlotSource": "Thế giới 3D hiện tại không có asset cho slot này.",
+        "needCanvasNodeState": "Commit thế giới đạo diễn cần có trạng thái node của canvas",
+        "noDirectorWorldState": "Thế giới đạo diễn này không có trạng thái cảnh nào để commit",
+        "commitWorldSourceFirst": "Commit nguồn thế giới hiện tại vào slot luồng chính của nó trước, rồi mới commit trạng thái thế giới đạo diễn"
+      },
+      "success": {
+        "directorRender": "Đã commit asset ghép của đạo diễn: {{path}} (kèm nền sạch và metadata)",
+        "directorWorld": "Đã commit thế giới đạo diễn: {{path}}",
+        "default": "Đã commit vào {{path}}",
+        "backupSuffix": " (file cũ đã sao lưu vào {{path}})",
+        "staleSuffix": "; đã đánh dấu {{count}} cú máy cần tạo lại",
+        "directorWorldSynced": "; đã đồng bộ trạng thái thế giới đạo diễn"
+      },
+      "mediaKinds": {
+        "image": "Ảnh",
+        "video": "Video",
+        "audio": "Âm thanh",
+        "model": "Mô hình 3D"
+      },
+      "worldSources": {
+        "master": "Thế giới 3D mặt trước",
+        "reverse": "Thế giới 3D góc ngược",
+        "pano": "Thế giới 3D 360",
+        "pano360": "Ảnh 360",
+        "custom": "Thế giới 3D tuỳ chỉnh",
+        "uploaded": "Thế giới 3D đã tải lên",
+        "generic": "Thế giới 3D"
+      },
+      "kinds": {
+        "frame": "Khung đầu",
+        "sketch": "Phác thảo",
+        "director_render": "Asset ghép của đạo diễn",
+        "selected_background": "Nền hiện tại",
+        "identity": "Ảnh tạo hình nhân vật",
+        "identity_costume": "Ảnh trang phục của tạo hình",
+        "identity_portrait": "Chân dung tạo hình theo độ tuổi",
+        "portrait": "Chân dung nhân vật",
+        "scene_master": "Ảnh gốc bối cảnh",
+        "scene_reverse_master": "Ảnh bối cảnh góc ngược",
+        "scene_spatial_layout": "Bố trí không gian bối cảnh",
+        "scene_360": "Bối cảnh 360 (ĐÃ NGỪNG DÙNG — hãy dùng Director Pano 360)",
+        "scene_director_world": "Thế giới đạo diễn",
+        "scene_director_pano_360": "Director Pano 360 (ảnh toàn cảnh 3GS)",
+        "scene_3gs_active_ply": "Thế giới 3D (mục đang chọn)",
+        "scene_3gs_master_ply": "Thế giới 3D (mặt trước)",
+        "scene_3gs_reverse_ply": "Thế giới 3D (mặt sau)",
+        "scene_3gs_pano_ply": "Thế giới 3D (360)",
+        "scene_3gs_custom_scene": "Thế giới 3D (cảnh tuỳ chỉnh)",
+        "scene_3gs_collision_glb": "Khối va chạm của thế giới 3D",
+        "prop_ref": "Tham chiếu đạo cụ",
+        "video": "Video (video của beat)",
+        "beat_audio": "Âm thanh (âm thanh của beat)"
+      },
+      "shortKinds": {
+        "frame": "Khung đầu",
+        "sketch": "Phác thảo",
+        "director_render": "Ảnh ghép đạo diễn",
+        "selected_background": "Nền hiện tại",
+        "video": "Video",
+        "beat_audio": "Âm thanh",
+        "identity": "Ảnh tạo hình",
+        "identity_costume": "Trang phục tạo hình",
+        "identity_portrait": "Chân dung theo tuổi",
+        "portrait": "Chân dung",
+        "scene_master": "Ảnh gốc bối cảnh",
+        "scene_reverse_master": "Bối cảnh góc ngược",
+        "scene_spatial_layout": "Bố trí không gian bối cảnh",
+        "scene_360": "Bối cảnh 360",
+        "scene_director_world": "Thế giới đạo diễn",
+        "scene_director_pano_360": "Director Pano 360",
+        "scene_3gs_active_ply": "Thế giới 3D (mục đang chọn)",
+        "scene_3gs_master_ply": "Thế giới 3D (mặt trước)",
+        "scene_3gs_reverse_ply": "Thế giới 3D (mặt sau)",
+        "scene_3gs_pano_ply": "Thế giới 3D (360)",
+        "scene_3gs_custom_scene": "Thế giới 3D (cảnh tuỳ chỉnh)",
+        "scene_3gs_collision_glb": "Khối va chạm của thế giới 3D",
+        "prop_ref": "Tham chiếu đạo cụ"
+      },
+      "nodeLabels": {
+        "frame": "Khung hình",
+        "sketch": "Phác thảo",
+        "director_render": "Bản render đạo diễn",
+        "selected_background": "Nền hiện tại",
+        "video": "Video",
+        "beat_audio": "Âm thanh",
+        "identity": "Tạo hình",
+        "identity_costume": "Trang phục",
+        "identity_portrait": "Chân dung tạo hình",
+        "portrait": "Chân dung nhân vật",
+        "scene_master": "Góc trước",
+        "scene_reverse_master": "Góc ngược",
+        "scene_spatial_layout": "Bố trí không gian",
+        "scene_director_pano_360": "Ảnh 360",
+        "scene_3gs_master_ply": "Thế giới mặt trước",
+        "scene_3gs_reverse_ply": "Thế giới góc ngược",
+        "scene_3gs_pano_ply": "Thế giới 360",
+        "scene_3gs_custom_scene": "Thế giới tuỳ chỉnh",
+        "prop_ref": "Đạo cụ"
+      },
+      "committedNodeLabel": "Đã commit · {{label}}",
+      "batch": {
+        "title": "📤 Commit hàng loạt vào asset luồng chính",
+        "subtitle": "Dự án: {{project}} · {{total}} ảnh ({{sendable}} đẩy được / {{skipped}} bỏ qua)",
+        "hint": "Mỗi ảnh quay về đúng slot asset nó đi ra (ảnh nhập từ luồng chính được ghi lại vào slot gốc; ảnh tải lên / tạo mới / đã sửa không có gốc nên bị bỏ qua — dùng commit từng ảnh để tự chọn đích).",
+        "noProvenance": "Không có thông tin nguồn gốc (bỏ qua)",
+        "summaryReady": "Sẵn sàng commit {{count}}",
+        "summaryDone": "{{succeeded}} thành công · {{failed}} thất bại · {{skipped}} bỏ qua",
+        "doneMessage": "Commit hàng loạt xong: {{succeeded}} thành công / {{failed}} thất bại / {{skipped}} bỏ qua",
+        "done": "Xong",
+        "submit": "Commit {{count}}",
+        "submitting": "Đang commit ({{current}}/{{total}})...",
+        "retryFailed": "Thử lại {{count}} mục lỗi",
+        "status": {
+          "pending": "Đang chờ",
+          "running": "Đang commit...",
+          "ok": "✓ Xong",
+          "skipped": "Bỏ qua",
+          "failed": "✗ Lỗi"
+        }
+      },
+      "worldSource": {
+        "front": "Thế giới mặt trước",
+        "back": "Thế giới mặt sau",
+        "pano": "Thế giới 360",
+        "custom": "Thế giới tuỳ chỉnh",
+        "pano360Image": "Ảnh 360"
+      }
+    },
+    "shell": {
+      "nodeNoCommittable": "Node này không có gì để commit",
+      "canvasSaveBlocked": "Canvas chưa được lưu. Giải quyết xung đột rồi commit lại.",
+      "noAutoCommitTarget": "Node này không có đích trong luồng chính để tự commit",
+      "writingBackground": "Đang ghi nền hiện tại…",
+      "maskEditDone": "Sửa theo vùng tô xong — ảnh mới đã có trên canvas",
+      "mainlineRestored": "Khung nhìn luồng chính đã khớp với trạng thái dây chuyền hiện tại",
+      "conflict": {
+        "title": "Xung đột khi lưu canvas",
+        "detail": "Canvas này đã bị đổi ở cửa sổ khác hoặc bởi người khác. Làm mới sẽ bỏ những thay đổi chưa lưu trên máy bạn; lưu thành bản sao thì giữ lại canvas hiện tại.",
+        "snapshotHint": "Thay đổi chưa lưu của bạn đang được giữ tạm trong trình duyệt — tải bản sao lưu về trước khi quyết định có làm mới hay không.",
+        "refresh": "Làm mới",
+        "saveCopy": "Lưu thành bản sao",
+        "savingCopy": "Đang lưu...",
+        "downloadTitle": "Tải ảnh chụp thay đổi trên máy ({{nodes}} node · {{edges}} đường nối)",
+        "download": "Tải JSON trên máy"
+      },
+      "backup": {
+        "failedLabel": "Sao lưu đám mây thất bại",
+        "pendingLabel": "Đang sao lưu lên đám mây",
+        "failedDetail": "Thay đổi của bạn đã lưu trên máy, nhưng bản sao lưu đám mây chưa xong. Cứ để trang này mở — nó sẽ tự thử lại.",
+        "pendingDetail": "Thay đổi của bạn đã lưu trên máy và bản sao lưu đám mây vẫn đang đồng bộ. Bạn cứ làm tiếp."
+      },
+      "loading": "Đang tải canvas...",
+      "syncFailed": "Đồng bộ canvas thất bại",
+      "retry": "Thử lại"
+    },
+    "assetBrowser": {
+      "loading": "Đang tải…",
+      "loadFailed": "Tải thư viện asset thất bại: {{detail}}",
+      "empty": "Thư viện asset đang trống. Muốn tải lên hoặc đồng bộ từ luồng chính, mở “Thư viện asset” trên một node.",
+      "backToRoot": "Về gốc thư viện asset",
+      "folderEmpty": "“{{name}}” chưa có asset nào.",
+      "download": "Tải về",
+      "deleted": "Đã xoá {{name}}",
+      "deleteFailed": "Xoá thất bại: {{detail}}",
+      "itemFallbackName": "asset",
+      "assetName": "Tên asset",
+      "assetNamePlaceholder": "Nhập tên asset"
+    },
+    "canvasSync": {
+      "backupFailed": "Sao lưu lên đám mây thất bại. Vui lòng thử lại sau.",
+      "backupPending": "Đã lưu trên máy; bản sao lưu đám mây sẽ thử lại.",
+      "bodyOverLimit": "Dữ liệu canvas nặng {{actual}} KB, vượt giới hạn {{limit}} KB. Đã tạm dừng lưu.",
+      "dangerousEmpty": "Canvas trên máy đang trống nhưng máy chủ vẫn còn node — làm mới trước khi sửa.",
+      "dangerousEmptyBlocked": "Canvas trên máy đang trống nhưng máy chủ vẫn còn node. Đã tạm dừng tự lưu để khỏi ghi đè. Làm mới trước khi sửa.",
+      "edgesOverLimit": "Số đường nối {{actual}} vượt giới hạn {{limit}}. Đã tạm dừng lưu — bớt vài đường nối để tiếp tục.",
+      "idempotencyConflict": "Cùng một lượt lưu được gửi hai lần với nội dung khác nhau. Làm mới rồi thử lại.",
+      "localDraftStale": "Có bản nháp canvas trên máy chưa đồng bộ, nhưng bản trên máy chủ đã đổi. Lưu thành bản sao hoặc bỏ bản nháp để tiếp tục.",
+      "lockBusy": "Canvas đang bị một lượt ghi khác khoá. Vui lòng thử lại sau ít phút.",
+      "mainlineUpdatedElsewhere": "Khung nhìn luồng chính đã được cập nhật ở cửa sổ khác. Làm mới rồi thử lại.",
+      "needsMigration": "Dữ liệu canvas ở backend cần được nâng cấp. Vui lòng liên hệ quản trị viên.",
+      "nodesOverLimit": "Số node {{actual}} vượt giới hạn {{limit}}. Đã tạm dừng lưu — xoá bớt node để tiếp tục.",
+      "notRestorablePreset": "Canvas này không phải preset luồng chính khôi phục được.",
+      "payloadTooLarge": "Dữ liệu canvas vượt giới hạn của backend.",
+      "revisionConflict": "Canvas này đã bị cửa sổ hoặc người dùng khác sửa.",
+      "unsavedConflictBeforeSync": "Canvas này còn xung đột chưa xử lý. Giải quyết xong rồi hãy đồng bộ khung nhìn luồng chính."
+    },
+    "directorCommit": {
+      "layerFetchFailed": "Đọc lớp đạo diễn thất bại: {{status}}",
+      "layerNotImage": "Lớp đạo diễn không phải data URL của ảnh",
+      "layerReadFailed": "Đọc lớp đạo diễn thất bại",
+      "metaFetchFailed": "Đọc metadata của đạo diễn thất bại: {{status}}",
+      "metaInvalid": "Metadata của đạo diễn sai định dạng",
+      "missingTargetPath": "Ảnh ghép đạo diễn đã được ghi nhưng không có đường dẫn đích"
+    }
+  },
+  "theme": {
+    "toggle": "Đổi giao diện",
+    "light": "Sáng",
+    "dark": "Tối",
+    "system": "Theo hệ thống"
+  },
+  "rewards": {
+    "accessoryUnlock": {
+      "prompt": "Piko vừa tìm được thứ gì đó! Chạm để xem.",
+      "batchPrompt": "Piko vừa tìm được {{count}} thứ mới! Chạm để xem.",
+      "promptAria": "Piko tìm được phụ kiện mới, bấm để xem",
+      "batchPromptAria": "Piko tìm được {{count}} phụ kiện mới, bấm để xem",
+      "dialogEyebrow": "Piko tìm được",
+      "batchDialogEyebrow": "Piko tìm được một mẻ",
+      "dialogTitle": "Mở khoá phụ kiện mới!",
+      "batchDialogTitle": "Mở khoá {{count}} phụ kiện mới!",
+      "dialogDesc": "Nhận về rồi diện cho Piko nào.",
+      "batchDialogDesc": "Chúng đã được lưu vào kho phụ kiện của Piko để dùng sau.",
+      "claim": "Nhận",
+      "claimAll": "Nhận tất cả"
+    }
+  },
+  "credits": {
+    "balance": "Số dư credits hiện tại",
+    "availableBalance": "Số dư credits khả dụng",
+    "short": "Credits",
+    "openPanel": "Mở bảng credits",
+    "personalAccount": "Tài khoản credits cá nhân",
+    "orgAccount": "Credits được tổ chức cấp cho bạn",
+    "details": "Xem chi tiết",
+    "earned": "Nhận vào",
+    "spent": "Đã dùng",
+    "refunded": "Hoàn lại",
+    "promotions": "Khuyến mãi khả dụng",
+    "promotionCount": "{{count}} khuyến mãi có thể áp dụng",
+    "viewTransactions": "Xem lịch sử credits",
+    "back": "Quay lại",
+    "centerTitle": "Trung tâm credits",
+    "centerDescription": "Xem lại số dư tổng hợp, các khoản đã quyết toán, hoàn tiền và khuyến mãi khả dụng.",
+    "orgScopeBadge": "Credits được cấp",
+    "orgCenterDescription": "Xem phần credits mà tổ chức cấp cho bạn, kèm các khoản đã quyết toán và hoàn lại.",
+    "orgScopeNotice": "Số dư và lịch sử bên dưới là credits mà {{name}} cấp cho bạn. Mức dùng của các tác vụ sẽ trừ vào phần được cấp đó.",
+    "orgBalance": "Số dư khả dụng",
+    "dormantPersonalBalance": "Credits cá nhân (không dùng được ở đây)",
+    "dormantPersonalHint": "Số credits này nằm trong tài khoản cá nhân của bạn. Tài khoản hiện tại quyết toán bằng credits của tổ chức và sẽ không đụng tới chúng.",
+    "lowBalanceNotice": "Số dư khả dụng {{balance}} đã chạm ngưỡng nhắc {{threshold}} mà tổ chức đặt ra. Hãy liên hệ quản trị viên tổ chức để được cấp thêm.",
+    "pendingAmount": "{{amount}} credits đang chờ quyết toán",
+    "availablePromotions": "Khuyến mãi khả dụng",
+    "orgPromotionBadge": "Khuyến mãi của tổ chức",
+    "promotionDisclaimer": "Mức giảm cuối cùng phụ thuộc vào báo giá thực tế của từng tính năng, model và khu vực.",
+    "endsAt": "Kết thúc {{time}}",
+    "longTerm": "Không có ngày kết thúc",
+    "startDate": "Ngày bắt đầu",
+    "endDate": "Ngày kết thúc",
+    "projectFilter": "Lọc theo dự án",
+    "allProjects": "Tất cả dự án",
+    "featureFilter": "Lọc theo tính năng",
+    "allFeatures": "Tất cả tính năng",
+    "modelFilter": "Lọc theo model",
+    "allModels": "Tất cả model",
+    "adjustment": "Điều chỉnh credits",
+    "promotionalPrice": "Giá khuyến mãi",
+    "empty": "Chưa có hoạt động credits nào",
+    "summaryLoadFailed": "Tạm thời không xem được tổng quan credits",
+    "transactionsLoadFailed": "Tạm thời không xem được lịch sử credits",
+    "retry": "Thử lại",
+    "filtering": "Đang lọc…",
+    "filteredRecords": "{{count}} bản ghi khớp",
+    "totalRecords": "{{count}} bản ghi",
+    "previousPage": "Trang trước",
+    "nextPage": "Trang sau",
+    "pageOf": "Trang {{page}} / {{total}}",
+    "category": {
+      "all": "Tất cả",
+      "earned": "Nhận vào",
+      "spent": "Đã dùng",
+      "refunded": "Hoàn lại"
+    },
+    "status": {
+      "pending": "Chờ xử lý",
+      "confirmed": "Đã trừ",
+      "refunded": "Đã hoàn",
+      "completed": "Hoàn tất"
+    },
+    "domain": {
+      "mainline": "Luồng chính",
+      "freezone": "Freezone",
+      "all": "Luồng chính & Freezone"
+    },
+    "columns": {
+      "time": "Thời gian",
+      "feature": "Tính năng / model",
+      "project": "Dự án",
+      "status": "Trạng thái",
+      "change": "Thay đổi",
+      "balance": "Số dư sau"
+    },
+    "promotion": {
+      "active": "Khuyến mãi",
+      "discount": "Giảm {{percentOff}}%",
+      "limitedDiscount": "Giảm {{percentOff}}%, có hạn"
+    }
+  },
+  "nav": {
+    "home": "Trang chủ",
+    "sectionProject": "Dự án",
+    "sectionEpisode": "Tập phim",
+    "switchProject": "Đổi dự án",
+    "allProjects": "Tất cả dự án",
+    "collapse": "Thu gọn",
+    "creation": "Sáng tạo",
+    "production": "Sản xuất",
+    "tools": "Công cụ",
+    "creationMode": "Chế độ sáng tạo",
+    "xiaji": "Phim bộ",
+    "xiajiMenu": "Menu phim bộ",
+    "ingest": "Nguồn truyện",
+    "assets": "Thư viện asset",
+    "characters": "Nhân vật",
+    "episodes": "Studio Tập phim",
+    "script": "Kịch bản",
+    "literalScript": "Kịch bản chi tiết",
+    "sketches": "Phác thảo",
+    "audio": "Âm thanh",
+    "video": "Video",
+    "compose": "Dựng phim",
+    "styles": "Phong cách hình ảnh",
+    "tasks": "Trung tâm tác vụ",
+    "taskCenter": "Trung tâm tác vụ",
+    "aiAssistant": "Xia Director",
+    "freezone": "Freezone"
+  },
+  "characters": {
+    "title": "Nhân vật",
+    "subtitle": "Sắp xếp dàn nhân vật cho dự án này.",
+    "assetTabs": {
+      "characters": "Nhân vật",
+      "voices": "Giọng nói",
+      "scenes": "Bối cảnh",
+      "props": "Đạo cụ"
+    },
+    "assetSubtitles": {
+      "characters": "Sắp xếp dàn nhân vật cho dự án này.",
+      "voices": "Quản lý giọng người dẫn truyện mặc định của dự án này.",
+      "scenes": "Quản lý địa điểm, không gian và ghi chú môi trường của dự án này.",
+      "props": "Sắp xếp các đạo cụ và vật thể lặp lại của dự án này."
+    },
+    "assetPlaceholders": {
+      "scenes": {
+        "title": "Khu làm việc asset bối cảnh sắp ra mắt",
+        "description": "Asset bối cảnh của dự án này sẽ được quản lý tại đây sau."
+      },
+      "props": {
+        "title": "Khu làm việc asset đạo cụ sắp ra mắt",
+        "description": "Asset đạo cụ của dự án này sẽ được quản lý tại đây sau."
+      }
+    },
+    "voices": {
+      "firstPersonNarratedTitle": "Giọng người dẫn truyện ngôi thứ nhất",
+      "firstPersonNarratedDesc": "Dự án kể ở ngôi thứ nhất dùng giọng của nhân vật chính dẫn truyện \"{{name}}\". Hãy tải giọng mặc định hoặc giọng theo tạo hình lên trong phần quản lý giọng của nhân vật đó.",
+      "firstPersonNarratedMissingMain": "Dự án kể ở ngôi thứ nhất cần có nhân vật chính dẫn truyện trước. Sau đó tải giọng mặc định hoặc giọng theo tạo hình lên trong phần quản lý giọng của nhân vật đó.",
+      "openNarratorMainVoice": "Xem giọng của nhân vật dẫn truyện"
+    },
+    "autoExtract": "Tự động trích xuất",
+    "addCharacter": "Thêm nhân vật",
+    "batchOps": "Thao tác hàng loạt",
+    "batchPortraits": "Tạo toàn bộ chân dung",
+    "batchPortraitsUnavailable": "Chưa triển khai",
+    "searchPlaceholder": "Tìm nhân vật…",
+    "protagonist": "Nhân vật chính dẫn truyện",
+    "supporting": "Phụ",
+    "antagonist": "Phản diện",
+    "identitiesCount": "{{count}} tạo hình",
+    "portraitReady": "Đã có chân dung",
+    "portraitMissing": "Chưa có chân dung",
+    "stats": {
+      "total": "Nhân vật",
+      "withPortraits": "Có chân dung",
+      "identities": "Tạo hình",
+      "attempts": "Lượt yêu cầu tạo",
+      "strip": {
+        "total": "Tổng",
+        "mainCharacter": "Nhân vật chính dẫn truyện",
+        "portrait": "Chân dung",
+        "identity": "Tạo hình",
+        "voice": "Giọng nói",
+        "ariaLabel": "Thống kê nhân vật"
+      }
+    },
+    "tabs": {
+      "basics": "Thông tin cơ bản",
+      "portrait": "Chân dung",
+      "identities": "Tạo hình",
+      "voice": "Giọng nói"
+    },
+    "basics": {
+      "name": "Tên",
+      "role": "Vai trò",
+      "gender": "Giới tính",
+      "ageGroup": "Nhóm tuổi",
+      "bodyType": "Dáng người",
+      "aliases": "Tên gọi khác",
+      "aliasesHint": "Ngăn cách bằng dấu phẩy",
+      "description": "Mô tả",
+      "appearance": "Ghi chú ngoại hình",
+      "facePrompt": "Prompt khuôn mặt",
+      "facePromptHint": "vd. mặt trái xoan, mắt to"
+    },
+    "portrait": {
+      "label": "Chân dung",
+      "generate": "AI tạo",
+      "upload": "Tải lên",
+      "regenerate": "Tạo lại",
+      "attemptsBadge": "{{count}} lượt tạo",
+      "attemptsWarning": "Dùng nhiều — hãy kiểm tra lại thiết lập trước khi tạo tiếp."
+    },
+    "imageSource": {
+      "label": "Nguồn ảnh",
+      "loading": "Đang tải nguồn ảnh",
+      "saveFailed": "Cập nhật nguồn ảnh thất bại"
+    },
+    "projectStyle": {
+      "label": "Phong cách",
+      "loading": "Đang tải phong cách",
+      "configureHint": "Thiết lập phong cách của dự án ở trang nhập truyện"
+    },
+    "voiceSamples": {
+      "title": "Mẫu giọng nói (IndexTTS2)",
+      "hint": "Thường chỉ cần tải giọng mặc định. Chỉ ghi đè theo nhóm tuổi khi biến thể cần chất giọng khác.",
+      "defaultRequired": "Mặc định (bắt buộc)",
+      "ageDefaultRequired": "{{age}} (mặc định · bắt buộc)",
+      "optionalOverride": "{{age}} (ghi đè tuỳ chọn)",
+      "missingDefault": "Chưa cấu hình -> nhân vật này sẽ không nói được",
+      "inheritedDefault": "-> kế thừa giọng mặc định",
+      "missing": "Chưa cấu hình",
+      "upload": "Tải mẫu giọng lên",
+      "record": "Thu âm",
+      "trim": "Cắt còn 3-5 giây",
+      "clear": "Xoá",
+      "loading": "Đang tải mẫu giọng",
+      "loadFailed": "Tải mẫu giọng thất bại",
+      "currentDuration": "Hiện tại: khoảng {{seconds}} giây",
+      "uploaded": "Đã lưu mẫu giọng",
+      "recorded": "Đã lưu bản thu",
+      "trimmed": "Đã cắt mẫu giọng",
+      "cleared": "Đã xoá mẫu giọng",
+      "recordTitle": "Thu giọng cho \"{{slot}}\"",
+      "recordHint": "Hãy thu một đoạn rõ ràng chỉ có một người nói. Truy cập micro cần localhost hoặc HTTPS.",
+      "recordReady": "Sẵn sàng thu",
+      "requestingMic": "Đang xin quyền truy cập micro...",
+      "recording": "Đang thu; bấm dừng khi xong",
+      "recordedDuration": "Đã thu {{seconds}}s. Nghe thử trước khi lưu.",
+      "recordFailed": "Thu âm thất bại",
+      "recordUnavailable": "Trình duyệt này không hỗ trợ thu âm",
+      "recordInsecureContext": "Trang này không chạy HTTPS hay localhost nên trình duyệt đã chặn micro. Vui lòng dùng HTTPS.",
+      "recordPermissionDenied": "Micro bị từ chối quyền. Hãy cho phép truy cập micro ở thanh địa chỉ trình duyệt rồi thử lại.",
+      "recordNoDevice": "Không phát hiện micro nào. Vui lòng kiểm tra kết nối thiết bị.",
+      "recordDeviceBusy": "Micro đang được app khác sử dụng. Hãy đóng app đó rồi thử lại.",
+      "startRecord": "Bắt đầu thu",
+      "stopRecord": "Dừng",
+      "saveRecording": "Lưu",
+      "trimTitle": "Cắt giọng \"{{slot}}\"",
+      "trimHint": "Seedance 2.0 cho kết quả tốt nhất với đoạn tham chiếu 3-5 giây, rõ tiếng và chỉ một người nói.",
+      "startSeconds": "Giây bắt đầu",
+      "durationSeconds": "Thời lượng",
+      "applyTrim": "Cắt còn 3-5 giây",
+      "invalidTrim": "Giá trị cắt không hợp lệ"
+    },
+    "summary": {
+      "title": "Tổng quan",
+      "noDescription": "Chưa có mô tả. Hãy sửa các trường bên dưới.",
+      "facePromptTitle": "Prompt khuôn mặt",
+      "facePromptMissing": "Prompt khuôn mặt đang trống",
+      "ageGroupLabel": "Nhóm tuổi",
+      "bodyTypeLabel": "Dáng người",
+      "noPortrait": "Chưa có chân dung",
+      "editProfile": "Sửa hồ sơ",
+      "generateNew": "Tạo mới",
+      "uploadImage": "Tải ảnh lên"
+    },
+    "history": {
+      "open": "Xem / khôi phục lịch sử",
+      "short": "Lịch sử",
+      "title": "Lịch sử asset",
+      "description": "Xem lại các bản sao lưu trước của asset này và khôi phục bất kỳ ảnh nào làm ảnh hiện tại.",
+      "current": "Ảnh hiện tại",
+      "entries": "Lịch sử",
+      "empty": "Chưa có lịch sử",
+      "refresh": "Làm mới",
+      "restore": "Khôi phục",
+      "restoring": "Đang khôi phục",
+      "restored": "Đã khôi phục ảnh từ lịch sử"
+    },
+    "details": {
+      "title": "Chi tiết hồ sơ",
+      "subtitle": "Thay đổi sẽ áp dụng cho nhân vật này và các tạo hình phái sinh.",
+      "saveAll": "Lưu tất cả",
+      "allSaved": "Đã lưu tất cả"
+    },
+    "identities": {
+      "title": "Tạo hình / Trang phục",
+      "addNew": "Thêm tạo hình",
+      "name": "Tên tạo hình",
+      "appearance": "Ngoại hình",
+      "newNamePlaceholder": "Tên tạo hình",
+      "appearancePlaceholder": "Mô tả màu sắc, kiểu dáng, chất liệu của trang phục…",
+      "generate": "Dựng tạo hình",
+      "regenerate": "Tạo lại",
+      "upload": "Tải lên",
+      "edit": "Sửa",
+      "delete": "Xoá",
+      "costume": "Trang phục",
+      "uploadCostume": "Tải ảnh tham chiếu trang phục",
+      "replaceCostume": "Thay ảnh tham chiếu trang phục",
+      "empty": "Chưa có tạo hình nào. Hãy thêm tạo hình đầu tiên.",
+      "bodyImage": "Toàn thân",
+      "costumeImage": "Trang phục",
+      "heroEmpty": "Chưa tạo",
+      "ready": "Sẵn sàng",
+      "attempts": "{{count}} lượt tạo trong phiên này",
+      "attemptsWarn": "Số lượt tạo đang cao",
+      "noAttempts": "Chưa tạo",
+      "appearanceHeading": "Ngoại hình (prompt trang phục)",
+      "saveAppearance": "Lưu",
+      "deleteIdentity": "Xoá tạo hình",
+      "variantSuffix": " biến thể",
+      "refsTitle": "Ảnh tham chiếu & biến thể",
+      "costumeRef": "Ảnh tham chiếu trang phục",
+      "costumeRefHint": "Tuỳ chọn: tải ảnh tham chiếu lên để cố định kiểu dáng và màu sắc trang phục. Bỏ trống nếu chỉ dùng mô tả bằng chữ.",
+      "deleteCostume": "Xoá ảnh tham chiếu trang phục",
+      "costumeDeleted": "Đã xoá ảnh tham chiếu trang phục",
+      "ageVariantTitle": "Biến thể theo tuổi (tuỳ chọn)",
+      "ageVariantHint": "Chỉ dùng khi tạo hình này khác nhóm tuổi gốc của nhân vật và cần khuôn mặt riêng (vd. lúc nhỏ, lúc già).",
+      "showVariant": "Hiện thiết lập biến thể theo tuổi",
+      "hideVariant": "Ẩn thiết lập biến thể theo tuổi",
+      "inheritFromCharacter": "Kế thừa từ nhân vật",
+      "bodyTypePlaceholder": "vd. mảnh khảnh và cao",
+      "deleteImage": "Xoá ảnh",
+      "deleteImageBody": "Thao tác này chỉ xoá ảnh tạo hình đã tạo; bản ghi tạo hình vẫn được giữ lại.",
+      "imageDeleted": "Đã xoá ảnh tạo hình",
+      "portraitTitle": "Chân dung khuôn mặt của tạo hình",
+      "portraitReady": "Sẵn sàng",
+      "portraitMissing": "Chưa tạo",
+      "portraitStatus": "Chân dung tạo hình",
+      "portraitNeedsFacePrompt": "Hãy điền prompt khuôn mặt trước",
+      "attemptsConfirmNext": "Đã 2 lượt; lượt thứ 3 sẽ cần xác nhận",
+      "attemptsPassword": "Đã {{count}} lượt; lượt thứ 5 cần mật khẩu quản trị",
+      "attemptsRed": "{{count}} lượt tạo",
+      "confirmGenTitle": "Xác nhận tạo lại",
+      "confirmGenPortraitTitle": "Xác nhận tạo lại chân dung",
+      "confirmGenBody": "Đã tạo {{count}} lần liên tiếp. Vẫn tiếp tục?",
+      "renameIdentity": "Sửa tên tạo hình",
+      "renameHint": "Đổi tên cũng sẽ thay đổi các đường dẫn file liên quan.",
+      "variantOnly": "Chỉ biến thể theo tuổi",
+      "uploadPortraitTip": "Tải chân dung khuôn mặt của tạo hình (chỉ dành cho biến thể theo tuổi)",
+      "generatePortraitTip": "AI tạo chân dung khuôn mặt của tạo hình (chỉ dành cho biến thể theo tuổi)"
+    },
+    "empty": {
+      "title": "Chưa có nhân vật nào",
+      "description": "Hãy nhập truyện, rồi bấm Tự động trích xuất để lấy dàn nhân vật từ sơ đồ."
+    },
+    "drawer": {
+      "close": "Đóng",
+      "prev": "Nhân vật trước",
+      "next": "Nhân vật sau",
+      "makeMain": "Đặt làm nhân vật chính dẫn truyện",
+      "unsetMain": "Bỏ vai nhân vật chính dẫn truyện",
+      "deleteChar": "Xoá nhân vật",
+      "pickOne": "Chọn một nhân vật trong danh sách để xem chi tiết."
+    },
+    "filter": {
+      "role": "Vai trò",
+      "portrait": "Chân dung",
+      "all": "Tất cả",
+      "main": "Nhân vật chính dẫn truyện",
+      "supporting": "Vai phụ",
+      "others": "Khác",
+      "noMatch": "Không có nhân vật nào khớp."
+    },
+    "toasts": {
+      "saved": "Đã lưu",
+      "created": "Đã tạo nhân vật",
+      "deleted": "Đã xoá nhân vật",
+      "mainSet": "Đã đặt làm nhân vật chính dẫn truyện",
+      "mainUnset": "Đã bỏ vai nhân vật chính dẫn truyện",
+      "identityAdded": "Đã thêm tạo hình",
+      "identityUpdated": "Đã cập nhật tạo hình",
+      "identityDeleted": "Đã xoá tạo hình",
+      "imageUploading": "Đang tải lên…",
+      "imageGenerating": "Đang tạo…",
+      "projectDefaultQueueFull": "Hàng đợi mặc định của dự án này đã đầy",
+      "projectQueueFull": "Hàng đợi {{queue}} của dự án này đã đầy"
+    },
+    "freezone": {
+      "openCharacter": "Freezone",
+      "openCharacterTip": "Sửa asset nhân vật này trong Freezone",
+      "openPortrait": "Freezone chân dung",
+      "openPortraitTip": "Sửa asset chân dung nhân vật này trong Freezone",
+      "openIdentity": "Freezone tạo hình",
+      "openIdentityTip": "Sửa asset ảnh tạo hình này trong Freezone",
+      "opened": "Đã mở Freezone",
+      "openFailed": "Không mở được Freezone"
+    },
+    "confirm": {
+      "delete": "Xoá nhân vật \"{{name}}\"? Không thể hoàn tác.",
+      "deleteIdentity": "Xoá tạo hình \"{{name}}\"?"
+    },
+    "ageGroups": {
+      "child": "Trẻ em",
+      "young": "Thanh niên",
+      "middle": "Trung niên",
+      "elder": "Người già"
+    },
+    "identityPeriods": {
+      "earlyChildhood": "Thời thơ ấu",
+      "childhoodKid": "Thời trẻ con",
+      "childhoodChild": "Thời nhi đồng",
+      "childhoodYears": "Thời tuổi thơ",
+      "adolescence": "Thời thiếu niên",
+      "schoolYears": "Thời đi học",
+      "youngAdult": "Thời thanh niên",
+      "adulthood": "Thời trưởng thành",
+      "middleAge": "Tuổi trung niên",
+      "laterYears": "Tuổi xế chiều",
+      "workAttire": "Trang phục công việc",
+      "homeAttire": "Trang phục ở nhà",
+      "casualWear": "Trang phục thường ngày",
+      "formalWear": "Trang phục trang trọng",
+      "courtDress": "Cung trang"
+    },
+    "genders": {
+      "male": "Nam",
+      "female": "Nữ"
+    },
+    "roles": {
+      "lead": "Vai chính",
+      "supporting": "Vai phụ",
+      "villain": "Phản diện"
+    },
+    "generatePortraitTitle": "Tạo chân dung?",
+    "generatePortraitDesc": "Tạo chân dung mới từ prompt khuôn mặt",
+    "generatePortraitReplace": ". Chân dung hiện có sẽ bị thay thế",
+    "rolePlaceholder": "Vai chính / Vai phụ / Phản diện",
+    "bodyTypePlaceholder": "Trung bình / Vạm vỡ / Nhỏ nhắn…",
+    "aliasesPlaceholder": "Anh Chen, Sếp Chen",
+    "extracting": "Đang trích xuất nhân vật...",
+    "extractingEmpty": {
+      "title": "Đang trích xuất nhân vật",
+      "description": "Hệ thống đang nhận diện nhân vật từ sơ đồ. Chúng sẽ hiện ở đây khi xong."
+    },
+    "reExtractTitle": "Trích xuất lại nhân vật",
+    "reExtractDesc": "Trích xuất lại nhân vật? Thao tác này sẽ lấy lại từ sơ đồ và ghi đè dữ liệu nhân vật hiện có.",
+    "costumeAlt": "Trang phục"
+  },
+  "auth": {
+    "login": "Đăng nhập",
+    "logout": "Đăng xuất",
+    "username": "Tên đăng nhập",
+    "password": "Mật khẩu",
+    "loginButton": "Đăng nhập",
+    "loginFailed": "Sai tên đăng nhập hoặc mật khẩu",
+    "welcomeBack": "Chào mừng trở lại",
+    "signInSubtitle": "Đăng nhập để tiếp tục kiến tạo thế giới của bạn",
+    "signInEyebrow": "Đăng nhập",
+    "welcomeSub": "Cả thế giới đang chờ câu chuyện của bạn.",
+    "usernamePlaceholder": "ten.dang.nhap",
+    "passwordPlaceholder": "••••••••••",
+    "forgot": "Quên mật khẩu?",
+    "forgotHint": "Liên hệ quản trị viên workspace để đặt lại mật khẩu.",
+    "remember": "Duy trì đăng nhập trên thiết bị này",
+    "showPassword": "Hiện mật khẩu",
+    "hidePassword": "Ẩn mật khẩu",
+    "signingIn": "Đang đăng nhập…",
+    "language": "Ngôn ngữ",
+    "contactUs": "Liên hệ",
+    "learnMore": "Tìm hiểu thêm",
+    "openManual": "Mở hướng dẫn sử dụng",
+    "learnMoreToast": "Cẩm nang chính thức đang được biên soạn — hãy đón chờ nhé!",
+    "closeLogin": "Đóng hộp thoại đăng nhập",
+    "modal": {
+      "title": "Đăng nhập",
+      "subtitle": "Tiếp tục với truyện, asset và cú máy của bạn",
+      "noAccount": "Chưa có tài khoản?",
+      "applyAccount": "Đăng ký dùng thử",
+      "showcaseLabel": "Thư viện DramaClaw",
+      "showcaseEyebrow": "LÀM BẰNG DRAMACLAW",
+      "showcaseMeta": "Dây chuyền đang chạy",
+      "showcaseTitle": "Trí tưởng tượng chạy hết công suất",
+      "showcaseDescription": "Nhân vật, storyboard, âm thanh và cú máy cùng tiến trên một dây chuyền"
+    },
+    "privacy": "Quyền riêng tư",
+    "terms": "Điều khoản",
+    "docs": "Tài liệu",
+    "tagline": "Biến tiểu thuyết thành phim",
+    "github": {
+      "star": "Star"
+    },
+    "businessWechat": {
+      "shortLabel": "Doanh nghiệp",
+      "open": "Xem mã QR WeChat hợp tác",
+      "qrAlt": "Mã QR WeChat hợp tác",
+      "title": "Thêm WeChat hợp tác",
+      "subtitle": "Cấp quyền tài khoản / Hướng dẫn sử dụng",
+      "note": "Nếu là hợp tác kinh doanh, vui lòng ghi chú lại — chúng tôi sẽ ưu tiên xử lý"
+    },
+    "stage": {
+      "eyebrow": "Nền tảng sáng tác phim",
+      "headline": "Vũ Trụ DC Của Riêng Bạn",
+      "headlines": {
+        "createUniverse": "Mở Ra Vũ Trụ Sáng Tạo Của Bạn",
+        "dramaUniverse": "Mở Ra Vũ Trụ Phim Ảnh Của Bạn",
+        "storyWorld": "Kiến Tạo Thế Giới Truyện Của Bạn"
+      },
+      "headlinePrefix": "Vũ Trụ",
+      "headlineBrand": "DC",
+      "headlineSuffix": "Của Riêng Bạn",
+      "subtitlePrefix": "Vũ Trụ",
+      "subtitleBrand": "DC",
+      "subtitleSuffix": "",
+      "start": "Cảm hứng bắt đầu từ đây",
+      "sub": "NƠI MỖI TIA CẢM HỨNG GẶP GỠ SỨC MẠNH SÁNG TẠO AI DỄ DÀNG",
+      "version": "{{version}}",
+      "changelog": "Nhật ký thay đổi"
+    },
+    "community": {
+      "label": "Tác phẩm cộng đồng",
+      "heading": "DramaClaw TV",
+      "likes": "{{count}} lượt thích",
+      "openWork": "Mở tác phẩm \"{{title}}\"",
+      "works": {
+        "rainyNight": {
+          "title": "Tin Nhắn Đầu Tiên Ở Bến Xe Mưa",
+          "description": "Một người cô độc nhận được cuộc gọi làm thay đổi cả đêm ấy."
+        },
+        "emberCrown": {
+          "title": "Vương Miện Tro Tàn",
+          "description": "Một cậu bé và một con quái thú băng qua thành phố núi lửa để tìm ngai vàng đã mất."
+        },
+        "paperCity": {
+          "title": "Người Phiên Dịch Của Thành Phố Giấy",
+          "description": "Máy móc và con người trao đổi bí mật trong một thành phố biết gấp lại."
+        },
+        "neonPatrol": {
+          "title": "Tuần Tra Neon",
+          "description": "Nhóm bốn người lần theo một vụ việc lúc nửa đêm qua những con phố cyber."
+        },
+        "glassSignal": {
+          "title": "Tín Hiệu Thuỷ Tinh",
+          "description": "Một tháp phát sóng trong suốt nhận được nốt tần số thấp từ ngày mai."
+        },
+        "silentArcade": {
+          "title": "Khu Game Câm Lặng",
+          "description": "Sau giờ đóng cửa, các nhân vật game cũ bắt đầu viết lại kết thúc của mình."
+        },
+        "floatingMarket": {
+          "title": "Chợ Nổi Trên Mây",
+          "description": "Người bán trao đổi ký ức, bản đồ và những giấc mơ còn dang dở giữa tầng mây."
+        },
+        "lastTake": {
+          "title": "Cú Máy Cuối Cùng",
+          "description": "Trước khi phim trường tắt đèn, đạo diễn phải ghi lại bằng chứng."
+        }
+      }
+    },
+    "watch": {
+      "createNow": "Sáng tác ngay",
+      "previous": "Chuyển tới tác phẩm trước",
+      "next": "Chuyển tới tác phẩm sau",
+      "watchNow": "Xem ngay",
+      "play": "Phát",
+      "pause": "Tạm dừng",
+      "seek": "Tua",
+      "speed": "Tốc độ phát",
+      "quality": "1080p",
+      "mute": "Tắt tiếng",
+      "unmute": "Bật tiếng",
+      "fullscreen": "Toàn màn hình",
+      "exitFullscreen": "Thoát toàn màn hình"
+    },
+    "download": {
+      "label": "Bản desktop",
+      "primary": {
+        "mac": "macOS",
+        "windows": "Windows"
+      },
+      "aria": "Tải app desktop"
+    }
+  },
+  "project": {
+    "create": "Tạo dự án",
+    "createCard": "Dự án mới",
+    "actionsLabel": "Thao tác với dự án",
+    "name": "Tên dự án",
+    "namePlaceholder": "Nhập tên dự án của bạn",
+    "clearName": "Xoá tên dự án",
+    "nameNoChinese": "Tên dự án không được chứa ký tự tiếng Trung.",
+    "nameTooLong": "Tên dự án dài tối đa 64 ký tự.",
+    "nameInvalid": "Tên dự án chỉ được chứa chữ cái, chữ số và dấu gạch dưới.",
+    "nameExistsActive": "Đã có dự án trùng tên này. Hãy chọn tên khác.",
+    "nameExistsArchived": "Một dự án đã lưu trữ đang dùng tên này. Hãy bỏ lưu trữ nó hoặc chọn tên khác.",
+    "nameExistsDeleted": "Một dự án trùng tên đang nằm trong Thùng rác. Hãy khôi phục hoặc xoá vĩnh viễn nó trước khi tạo mới.",
+    "noProjects": "Chưa có dự án nào. Bấm để tạo mới.",
+    "dashboardTitle": "Trung tâm quản lý dự án",
+    "dashboardReturn": "Về Trung tâm quản lý dự án",
+    "dashboardSubtitle": "Quản lý các dự án phim và kịch bản của bạn.",
+    "emptyTitle": "Bắt đầu câu chuyện đầu tiên",
+    "emptyDescription": "Tạo một dự án để bắt đầu viết kịch bản, tạo phác thảo và sản xuất tập phim.",
+    "heroTitle": "Bắt đầu hành trình sáng tạo",
+    "heroDescription": "Biến câu chuyện của bạn thành video sống động bằng cách nhập kịch bản, chọn phong cách và tạo nhân vật.",
+    "heroButton": "Dự án mới",
+    "label": "Dự án",
+    "draft": "Bản nháp",
+    "searchPlaceholder": "Tìm dự án…",
+    "statusAll": "Tất cả",
+    "statusActive": "Đang hoạt động",
+    "statusArchived": "Đã lưu trữ",
+    "statusDeleted": "Thùng rác",
+    "storageSection": "Lưu trữ",
+    "pagination": {
+      "previous": "Trước",
+      "next": "Sau",
+      "pageOf": "Trang {{page}} / {{total}}",
+      "showing": "Đang hiện {{start}}–{{end}} trong {{total}}",
+      "perPage": "Mỗi trang",
+      "goToPage": "Tới trang {{page}}"
+    },
+    "sort": {
+      "label": "Sắp xếp",
+      "updatedDesc": "Cập nhật gần nhất (mới trước)",
+      "updatedAsc": "Cập nhật gần nhất (cũ trước)",
+      "nameAsc": "Tên A–Z",
+      "nameDesc": "Tên Z–A"
+    },
+    "trashRetentionHint": "Mục trong Thùng rác được giữ lại cho tới khi bạn xoá vĩnh viễn.",
+    "archivedBadge": "Đã lưu trữ",
+    "ownership": {
+      "mine": "Dự án của tôi",
+      "from": "Từ {{owner}}",
+      "unknownOwner": "người dùng khác"
+    },
+    "roleLabel": {
+      "viewer": "Người xem",
+      "editor": "Người chỉnh sửa",
+      "admin": "Quản trị",
+      "owner": "Chủ sở hữu"
+    },
+    "deletedAgo": "Đã xoá {{days}} ngày trước",
+    "deletedToday": "Đã xoá hôm nay",
+    "emptyArchived": "Không có dự án đã lưu trữ",
+    "emptyArchivedDescription": "Dự án đã lưu trữ sẽ xuất hiện ở đây. Bạn có thể bỏ lưu trữ bất cứ lúc nào.",
+    "emptyTrash": "Thùng rác trống",
+    "emptyTrashDescription": "Dự án đã xoá sẽ xuất hiện ở đây. Bạn có thể khôi phục hoặc xoá vĩnh viễn.",
+    "card": {
+      "editedAgo": "{{time}}",
+      "deletedAgo": "đã xoá {{time}}",
+      "episodes": "{{count}} tập",
+      "beats": "{{count}} beat"
+    },
+    "view": {
+      "toggle": "Hiển thị",
+      "card": "Dạng thẻ",
+      "list": "Dạng danh sách"
+    },
+    "noActiveTitle": "Không có dự án đang hoạt động",
+    "noActiveDescription": "Hãy tạo dự án mới, hoặc xem tab Đã lưu trữ và Thùng rác để tìm các dự án khác.",
+    "actions": {
+      "open": "Mở",
+      "openFreezone": "Mở trong Freezone",
+      "share": "Chia sẻ",
+      "archive": "Lưu trữ…",
+      "unarchive": "Bỏ lưu trữ",
+      "delete": "Chuyển vào Thùng rác…",
+      "restore": "Khôi phục",
+      "purge": "Xoá vĩnh viễn…"
+    },
+    "archiveDialog": {
+      "title": "Lưu trữ \"{{name}}\"?",
+      "description": "Dự án sẽ được chuyển sang mục Đã lưu trữ. Bạn có thể bỏ lưu trữ bất cứ lúc nào.",
+      "confirm": "Lưu trữ"
+    },
+    "deleteDialog": {
+      "title": "Chuyển \"{{name}}\" vào Thùng rác?",
+      "description": "Dự án sẽ được chuyển vào Thùng rác. Bạn có thể khôi phục bất cứ lúc nào trước khi xoá vĩnh viễn.",
+      "confirm": "Chuyển vào Thùng rác"
+    },
+    "purgeDialog": {
+      "title": "Xoá vĩnh viễn \"{{name}}\"?",
+      "description": "Toàn bộ kịch bản, phác thảo, âm thanh và video của dự án này sẽ bị xoá. Không thể hoàn tác.",
+      "typeHint": "Gõ tên dự án để xác nhận",
+      "confirm": "Xoá vĩnh viễn"
+    },
+    "toasts": {
+      "createFailed": "Tạo dự án thất bại. Kiểm tra lại tên hoặc thử lại sau.",
+      "archived": "Đã lưu trữ \"{{name}}\"",
+      "unarchived": "Đã bỏ lưu trữ \"{{name}}\"",
+      "deleted": "Đã chuyển \"{{name}}\" vào Thùng rác",
+      "restored": "Đã khôi phục \"{{name}}\"",
+      "purged": "Đã xoá vĩnh viễn \"{{name}}\"",
+      "undo": "Hoàn tác"
+    },
+    "title": "Dự án",
+    "newProject": "Dự án mới",
+    "newProjectTitle": "Dự án mới",
+    "open": "Mở dự án",
+    "save": "Lưu dự án",
+    "rename": "Đổi tên",
+    "renameTitle": "Đổi tên dự án",
+    "delete": "Xoá dự án",
+    "created": "Ngày tạo",
+    "modified": "Ngày sửa",
+    "updatedAt": "Cập nhật",
+    "sortBy": "Sắp xếp theo",
+    "sortDirection": "Thứ tự sắp xếp",
+    "sortByName": "Tên",
+    "sortByCreatedAt": "Ngày tạo",
+    "sortByUpdatedAt": "Ngày sửa",
+    "sortAsc": "Tăng dần",
+    "sortDesc": "Giảm dần",
+    "nodes": "Node",
+    "empty": "Chưa có dự án",
+    "emptyHint": "Bấm nút phía trên để tạo dự án mới",
+    "notFound": "Không tìm thấy dự án",
+    "notFoundDescriptionPrefix": "Không tìm thấy dự án nào dưới tài khoản hiện tại:",
+    "notFoundDescriptionSuffix": ".",
+    "backToProjects": "Về danh sách dự án",
+    "shareDialog": {
+      "title": "Chia sẻ dự án",
+      "descriptionWithOwner": "{{name}} · {{owner}}",
+      "descriptionFallback": "Quản lý thành viên dự án",
+      "currentUserFallback": "người dùng hiện tại",
+      "addMember": "Thêm thành viên",
+      "addMemberHint": "Nhập tên đăng nhập, chọn vai trò rồi thêm họ vào dự án.",
+      "copyLink": "Sao chép link",
+      "searchPlaceholder": "Tìm tên đăng nhập",
+      "alreadyInProject": "Đã ở trong dự án",
+      "limitTitle": "Đã chạm giới hạn chia sẻ",
+      "noShareableUser": "Không tìm thấy người dùng nào chia sẻ được. Người này có thể nằm ngoài phạm vi chia sẻ của dự án.",
+      "quotaUnknownTitle": "Chưa đếm được số thành viên",
+      "quotaUnknown": "Danh sách thành viên còn đang tải. Xong rồi thử lại.",
+      "limitReached": "Một dự án chỉ chia sẻ được cho tối đa {{limit}} người",
+      "memberCount": "{{count}}/{{limit}}",
+      "add": "Thêm",
+      "members": "Thành viên",
+      "owner": "Chủ sở hữu",
+      "projectOwner": "Chủ dự án",
+      "loadingMembers": "Đang tải danh sách thành viên",
+      "removeMember": "Xoá thành viên",
+      "inactive": "Ngừng hoạt động",
+      "inactiveAccessChanged": "Người dùng này hiện không truy cập được dự án",
+      "roleViewer": "Chỉ xem",
+      "roleEditor": "Được sửa và chạy tác vụ",
+      "roleAdmin": "Được quản lý thành viên chia sẻ",
+      "toastMemberUpdated": "Đã cập nhật thành viên chia sẻ",
+      "toastShareFailed": "Chia sẻ thất bại. Kiểm tra người dùng có tồn tại và bạn có quyền hay không.",
+      "toastUserOutOfScope": "Người dùng này nằm ngoài phạm vi chia sẻ của dự án.",
+      "toastUserNotFound": "Không tìm thấy người dùng",
+      "toastLinkCopied": "Đã sao chép link dự án",
+      "toastCopyFailed": "Sao chép thất bại",
+      "toastPermissionUpdated": "Đã cập nhật quyền",
+      "toastPermissionUpdateFailed": "Cập nhật quyền thất bại",
+      "toastMemberRemoved": "Đã xoá thành viên chia sẻ",
+      "toastRemoveFailed": "Xoá thất bại"
+    },
+    "role": {
+      "viewer": "Người xem",
+      "editor": "Người sửa",
+      "admin": "Quản trị",
+      "owner": "Chủ sở hữu"
+    }
+  },
+  "assets": {
+    "common": {
+      "edit": "Sửa",
+      "delete": "Xoá",
+      "generated": "đã tạo",
+      "missing": "còn thiếu",
+      "usageCount": "Dùng trong {{count}} beat",
+      "usageNone": "Chưa dùng trong beat nào",
+      "copyLink": "Sao chép link asset",
+      "linkCopied": "Đã sao chép link",
+      "appearsIn": "Xuất hiện trong các beat",
+      "beatRef": "Tập {{episode}} · Beat {{beat}}",
+      "search": "Tìm asset",
+      "searchScenes": "Tìm bối cảnh",
+      "searchProps": "Tìm đạo cụ",
+      "noMatch": "Không có asset nào khớp",
+      "jumpToAsset": "Nhảy tới asset {{name}}",
+      "sortLabel": "Sắp xếp",
+      "sortByName": "Tên",
+      "sortByUsage": "Mức sử dụng",
+      "coIdentities": "Nhân vật trong cảnh",
+      "coProps": "Đạo cụ trong cảnh"
+    },
+    "scenes": {
+      "title": "Bối cảnh",
+      "count": "{{count}} bối cảnh",
+      "build": "Dựng từ sơ đồ",
+      "buildDisabledByDerivedScenes": "Đã có bối cảnh phái sinh. Không thể dựng lại toàn bộ.",
+      "newScene": "Bối cảnh mới",
+      "newPlate": "Thêm biến thể bối cảnh",
+      "newPlateHint": "Biến thể bối cảnh là một trạng thái khác của cùng một địa điểm.",
+      "editScene": "Sửa bối cảnh",
+      "editPlate": "Sửa biến thể bối cảnh",
+      "generatedPlateName": "Tên asset",
+      "generatedPlateNamePlaceholder": "Tự sinh sau khi đặt biến thể hoặc thời gian",
+      "plateCount": "{{count}} biến thể bối cảnh",
+      "variantCount": "{{count}} biến thể",
+      "referenceCount": "{{count}} lượt dùng",
+      "selectScene": "Chọn bối cảnh {{name}}",
+      "derivedFrom": "Phái sinh từ {{base}}",
+      "emptyTitle": "Chưa có bối cảnh nào",
+      "emptyDescription": "Tạo bối cảnh mới hoặc trích xuất bối cảnh từ sơ đồ của dự án.",
+      "emptyDescriptionPerEpisode": "Với dự án có lời dẫn, bối cảnh được tạo tự động khi bạn lên kế hoạch từng tập, hoặc bạn tự thêm tay cũng được.",
+      "building": "Đang dựng bối cảnh...",
+      "buildingEmpty": {
+        "title": "Đang dựng bối cảnh",
+        "description": "Hệ thống đang trích xuất bối cảnh từ sơ đồ. Chúng sẽ hiện ở đây khi xong."
+      },
+      "confirmDelete": "Xoá bối cảnh \"{{name}}\"?",
+      "deleteTitle": "Xoá bối cảnh",
+      "deleted": "Đã xoá bối cảnh",
+      "master": "Ảnh gốc",
+      "pano": "Panorama 360",
+      "uploadMaster": "Tải ảnh gốc lên",
+      "generateMaster": "Tạo ảnh gốc",
+      "regenerateMaster": "Tạo lại ảnh gốc",
+      "deleteMaster": "Xoá ảnh gốc",
+      "reverse": "Góc ngược",
+      "generateReverse": "Tạo góc ngược",
+      "regenerateReverse": "Tạo lại góc ngược",
+      "uploadPano": "Tải lên / thay ảnh 360",
+      "generatePanoFromText": "Tạo ảnh 360",
+      "generatePanoFromMaster": "Tạo ảnh 360",
+      "generatePanoFromMasterReverse": "Tạo ảnh 360",
+      "deletePano": "Xoá ảnh 360",
+      "openPanoViewer": "Mở trình xem 360",
+      "panoCaptureDescription": "Chọn một góc nhìn 360 của bối cảnh và xuất ảnh chụp.",
+      "downloadScreenshot": "Tải ảnh chụp về",
+      "panoScreenshotDownloaded": "Đã tải ảnh chụp 360",
+      "openFreezone": "Freezone",
+      "openFreezoneTip": "Sửa bối cảnh này trong Freezone",
+      "freezoneOpened": "Đã mở Freezone cho bối cảnh",
+      "freezoneOpenFailed": "Không mở được Freezone cho bối cảnh",
+      "noMaster": "thiếu master.png",
+      "noReverse": "thiếu reverse_master.png",
+      "noPano": "thiếu pano_360.png",
+      "stage": {
+        "title": "Director World",
+        "customWorld": "Director World tuỳ chỉnh đã sẵn sàng",
+        "masterWorld": "Director World từ ảnh gốc đã sẵn sàng",
+        "reverseWorld": "Director World góc ngược đã sẵn sàng",
+        "panoWorld": "Director World 360 đã sẵn sàng",
+        "uploadCustom": "Tải lên / thay gói tuỳ chỉnh",
+        "deleteCustom": "Xoá gói tuỳ chỉnh",
+        "masterToPly": "ảnh gốc→Director World",
+        "reverseToPly": "góc ngược→Director World",
+        "panoToPly": "360→Director World",
+        "singleFaceFeature": "Chuyển ảnh đơn của bối cảnh sang SOG",
+        "panoFeature": "Chuyển panorama của bối cảnh sang SOG",
+        "confirmTitle": "Xác nhận chuyển đổi",
+        "confirmDescription": "{{feature}} sẽ chạy ngay sau khi bạn xác nhận.",
+        "confirmAction": "Xác nhận và chạy",
+        "costLoading": "Đang tải mức giá hiện tại của tổ chức",
+        "costUnavailable": "Tạm thời chưa lấy được giá. Hãy thử lại sau.",
+        "openWorld": "Mở Director World",
+        "worldNotReady": "Director World chưa sẵn sàng"
+      },
+      "fields": {
+        "name": "Tên bối cảnh",
+        "type": "Loại bối cảnh",
+        "nameRule": "Với bối cảnh gốc độc lập, chỉ cần nhập tên bối cảnh. Thêm phiên bản theo trạng thái hoặc thời gian ở khu vực biến thể của bối cảnh đang chọn.",
+        "baseScene": "Bối cảnh gốc",
+        "variant": "Biến thể",
+        "timeOfDay": "Thời điểm",
+        "environmentPrompt": "Prompt môi trường",
+        "variantPrompt": "Prompt khác biệt của biến thể",
+        "variantPromptPlaceholder": "Chỉ mô tả phần khác so với bối cảnh gốc, ví dụ mặt sàn ướt phản chiếu, tường cháy sém, hay trang trí ngày lễ.",
+        "description": "Mô tả trong truyện",
+        "variantPlaceholder": "Rò nước"
+      },
+      "environment": {
+        "front": "Phía trước",
+        "left": "Bên trái",
+        "right": "Bên phải",
+        "back": "Phía sau",
+        "light": "Ánh sáng",
+        "material": "Chất liệu / phong cách",
+        "forbidden": "Yếu tố cấm xuất hiện"
+      },
+      "types": {
+        "interior": "Nội cảnh",
+        "exterior": "Ngoại cảnh",
+        "mixed": "Nội và ngoại cảnh",
+        "other": "Khác"
+      }
+    },
+    "props": {
+      "title": "Đạo cụ",
+      "count": "{{count}} đạo cụ",
+      "newProp": "Đạo cụ mới",
+      "newPropHint": "AI trích xuất đạo cụ theo từng tập trong Studio Tập phim",
+      "editProp": "Sửa đạo cụ",
+      "emptyTitle": "Chưa có đạo cụ nào",
+      "emptyDescription": "Tạo đạo cụ mới hoặc đưa đạo cụ của tập phim lên từ trang beat.",
+      "confirmDelete": "Xoá đạo cụ \"{{name}}\"?",
+      "deleted": "Đã xoá đạo cụ",
+      "reference": "Ảnh tham chiếu",
+      "noReference": "Thiếu ảnh tham chiếu",
+      "noDescription": "Chưa có mô tả",
+      "generateReference": "Tạo ảnh tham chiếu",
+      "generatingReference": "Đang tạo...",
+      "regenerateReference": "Tạo lại ảnh tham chiếu",
+      "uploadReference": "Tải đạo cụ lên",
+      "uploadingReference": "Đang tải lên...",
+      "uploadReferenceSuccess": "Đã tải ảnh tham chiếu đạo cụ lên",
+      "openFreezone": "Freezone",
+      "openFreezoneTip": "Sửa asset đạo cụ này trong Freezone",
+      "freezoneOpened": "Đã mở Freezone cho đạo cụ",
+      "freezoneOpenFailed": "Không mở được Freezone cho đạo cụ",
+      "owner": "Chủ sở hữu",
+      "types": {
+        "weapon": "Vũ khí",
+        "accessory": "Phụ kiện",
+        "artifact": "Cổ vật",
+        "document": "Tài liệu",
+        "furniture": "Nội thất",
+        "object": "Vật thể khác"
+      },
+      "fields": {
+        "name": "Tên đạo cụ",
+        "type": "Loại đạo cụ",
+        "owner": "Chủ sở hữu",
+        "visualPrompt": "Prompt hình ảnh"
+      }
+    },
+    "narratorVoice": {
+      "heading": {
+        "firstPerson": "Giọng dẫn truyện ngôi thứ nhất",
+        "thirdPerson": "Giọng dẫn truyện ngôi thứ ba của dự án"
+      },
+      "explanation": {
+        "firstPerson": "Dẫn truyện ngôi thứ nhất dùng giọng của chính nhân vật kể; dẫn truyện ngôi thứ ba dùng giọng dẫn truyện của dự án.",
+        "thirdPerson": "Dẫn truyện ngôi thứ ba dùng một giọng chung cấp dự án cho mọi đoạn không phải thoại."
+      }
+    }
+  },
+  "time": {
+    "justNow": "vừa xong",
+    "minutesAgo": "{{count}} phút trước",
+    "hoursAgo": "{{count}} giờ trước",
+    "yesterday": "hôm qua",
+    "daysAgo": "{{count}} ngày trước",
+    "lastWeek": "tuần trước",
+    "weeksAgo": "{{count}} tuần trước",
+    "lastMonth": "tháng trước",
+    "monthsAgo": "{{count}} tháng trước",
+    "lastYear": "năm ngoái",
+    "yearsAgo": "{{count}} năm trước"
+  },
+  "common": {
+    "loading": "Đang tải...",
+    "back": "Quay lại",
+    "error": "Đã có lỗi xảy ra",
+    "novelImportRequired": "Vui lòng nhập truyện trước",
+    "insufficientCredits": "Không đủ credits. Vui lòng liên hệ quản trị viên để nạp thêm.",
+    "billingRuleNotConfigured": "Chưa cấu hình quy tắc tính phí. Vui lòng liên hệ quản trị viên để thiết lập giá credits.",
+    "billingRuleNotConfiguredShort": "Cấu hình",
+    "projectDefaultQueueFull": "Hàng đợi mặc định của dự án này đã đầy",
+    "projectQueueFull": "Hàng đợi {{queue}} của dự án này đã đầy",
+    "userDefaultQueueFull": "Bạn đã đạt giới hạn cá nhân ở hàng đợi mặc định",
+    "userQueueFull": "Bạn đã đạt giới hạn cá nhân ở hàng đợi {{queue}}",
+    "organizationDefaultQueueFull": "Hàng đợi mặc định của tổ chức đã đầy",
+    "organizationQueueFull": "Hàng đợi {{queue}} của tổ chức đã đầy",
+    "platformDefaultQueueFull": "Hàng đợi mặc định của nền tảng đã đầy",
+    "platformQueueFull": "Hàng đợi {{queue}} của nền tảng đã đầy",
+    "nodeDefaultQueueFull": "Hàng đợi mặc định của node hiện tại đã đầy",
+    "nodeQueueFull": "Hàng đợi {{queue}} của node hiện tại đã đầy",
+    "projectQueueKinds": {
+      "video": "video",
+      "world": "world",
+      "ffmpeg": "dựng phim"
+    },
+    "generationChannelPolicyBlocked": "Yêu cầu này bị chặn bởi chính sách kênh của model (không phải giới hạn tốc độ thật) — các yêu cầu tạo lại phác thảo chất lượng thấp thường bị bỏ qua. Hãy thử lại sau, hoặc nâng chất lượng tạo rồi thử lại.",
+    "generationRateLimited": "Dịch vụ model đang tạm bị giới hạn tốc độ (HTTP 429). Vui lòng thử lại sau ít phút.",
+    "refreshed": "Đã làm mới nội dung",
+    "save": "Lưu",
+    "cancel": "Huỷ",
+    "delete": "Xoá",
+    "confirm": "Xác nhận",
+    "ok": "OK",
+    "generate": "Tạo",
+    "upload": "Tải lên",
+    "stop": "Dừng",
+    "reupload": "Tải lên lại",
+    "regenerate": "Tạo lại",
+    "generateNew": "Tạo mới",
+    "regenerateSelected": "Tạo lại mục đã chọn",
+    "preview": "Xem trước",
+    "cutToPool": "Cắt vào kho",
+    "noAudio": "Không có âm thanh",
+    "noVideo": "Không có video",
+    "noBeatData": "Không có dữ liệu beat",
+    "download": "Tải về",
+    "copy": "Sao chép",
+    "comingSoon": "Sắp có",
+    "forceUse": "Vẫn dùng",
+    "use": "Dùng",
+    "confirmExecute": "Xác nhận",
+    "refresh": "Làm mới",
+    "refreshDone": "Xong",
+    "preparing": "Đang chuẩn bị...",
+    "removed": "(đã xoá)",
+    "new": "MỚI",
+    "saveStatus": {
+      "saving": "Đang lưu…",
+      "saved": "Đã lưu",
+      "savedAgo": "Đã lưu {{t}} trước",
+      "error": "Lưu thất bại",
+      "retry": "Thử lại"
+    },
+    "edit": "Sửa",
+    "close": "Đóng",
+    "success": "Thành công",
+    "search": "Tìm kiếm",
+    "play": "Phát",
+    "pause": "Tạm dừng",
+    "retry": "Thử lại",
+    "requestId": "Request ID",
+    "listSeparator": ", "
+  },
+  "ingest": {
+    "title": "Nguồn truyện",
+    "subtitle": "Tải kịch bản lên và bắt đầu hành trình sáng tạo.",
+    "dropzoneHint": "Bấm hoặc kéo thả file truyện vào đây",
+    "supportedFormats": "Hỗ trợ .txt / .md / .docx · File tối đa 512KB · Văn bản tối đa 100.000 ký tự",
+    "uploadingTitle": "Đang tải truyện lên…",
+    "uploadingHint": "Vui lòng ở lại trang này cho tới khi tải lên xong. Mạng chậm có thể mất một lúc.",
+    "inputMode": {
+      "upload": "Tải file truyện",
+      "paste": "Dán văn bản"
+    },
+    "sourceHint": {
+      "uploadActive": "File đã tải lên sẽ được nhập. Văn bản đã dán vẫn được giữ nhưng lần này không dùng tới.",
+      "pasteActive": "Văn bản đã dán sẽ được nhập. File đã tải lên vẫn được giữ nhưng lần này không dùng tới."
+    },
+    "pastePlaceholder": "Dán nội dung truyện vào đây, tối đa 1000 ký tự",
+    "startIngest": "Bắt đầu nhập",
+    "saveSettings": "Lưu cài đặt",
+    "settingsSaved": "Đã lưu cài đặt dự án",
+    "settingsSaveFailed": "Lưu cài đặt dự án thất bại",
+    "processing": "Đang xử lý...",
+    "elapsed": "Đã trôi qua {{time}}",
+    "projectSettings": "Cài đặt dự án",
+    "advancedSettings": "Cài đặt nâng cao",
+    "visualStyle": "Phong cách hình ảnh",
+    "narrationStyle": "Ngôi kể",
+    "ethnicity": "Sắc tộc mặc định cho nhân vật không xác định",
+    "rhythm": "Nhịp phim",
+    "ttsProvider": "Nhà cung cấp TTS",
+    "ttsVoice": "Giọng TTS",
+    "videoBackend": "Engine video",
+    "videoResolution": "Độ phân giải video",
+    "selectPlaceholder": "Chọn",
+    "firstPerson": "Ngôi thứ nhất (nhân vật tự kể)",
+    "thirdPerson": "Ngôi thứ ba (người dẫn truyện)",
+    "uploadSuccess": "Đã tải lên",
+    "status": {
+      "uploaded": "Đã tải lên",
+      "importing": "Đang nhập",
+      "completed": "Đã nhập xong",
+      "stopped": "Đã dừng",
+      "failed": "Nhập thất bại"
+    },
+    "previewHeading": "Xem trước cấu trúc truyện",
+    "knowledgeGraph": {
+      "title": "Sơ đồ tri thức",
+      "stats": "{{nodes}} node · {{edges}} mối quan hệ",
+      "connections": "{{count}} liên kết",
+      "relationships": "Mối quan hệ",
+      "interactionHint": "Kéo để di chuyển · Cuộn để phóng to · Chọn một node để xem chi tiết",
+      "truncated": "Đang hiện các mối quan hệ cốt lõi",
+      "zoomIn": "Phóng to",
+      "zoomOut": "Thu nhỏ",
+      "resetView": "Đặt lại khung nhìn",
+      "expand": "Mở rộng sơ đồ",
+      "loadFailed": "Sơ đồ tri thức tạm thời không khả dụng",
+      "loadFailedHint": "Dữ liệu sơ đồ của bạn vẫn nguyên vẹn. Hãy thử tải lại sau ít phút."
+    },
+    "scriptDetails": "Chi tiết kịch bản",
+    "previewGenerating": "Đang tạo bản xem trước cấu trúc...",
+    "restoredFilename": "Truyện đã nhập",
+    "reimport": "Nhập lại",
+    "reimportSourceMissing": "Không còn file gốc đã tải lên. Hãy tải lại file trước khi nhập.",
+    "statFilename": "Tên file",
+    "statTotalChars": "Tổng số ký tự",
+    "statBillableChars": "Số ký tự tính phí",
+    "creditPerChars": "{{credits}} credits / {{chars}} ký tự",
+    "statChaptersDetected": "Số chương nhận diện được",
+    "statEpisodesEstimated": "Số tập ước tính",
+    "episodesUnit": "tập",
+    "tableChapterNo": "Chương",
+    "tableTitle": "Tiêu đề",
+    "tableCharCount": "Số chữ",
+    "moreChapters": "… và {{count}} chương nữa",
+    "reuploadConfirm": {
+      "title": "Xác nhận nhập lại",
+      "description": "Nhập lại sẽ dựng lại sơ đồ tri thức và có thể ảnh hưởng tới kết quả ở các bước sau như nhân vật, tập phim, kịch bản và video. Bạn có chắc muốn nhập lại truyện/kịch bản không?",
+      "confirm": "Xác nhận nhập lại"
+    },
+    "logsPanel": "Log nhập truyện",
+    "logCompleted": "Nhập xong",
+    "fileDeleted": "Đã xoá file",
+    "buildHint": "Dựng sơ đồ ngữ nghĩa trước, sau đó tạo nhân vật và tập phim ở các trang tương ứng.",
+    "emptyPreview": "Chưa có nội dung để xem trước. Hãy tải file lên để xem cấu trúc.",
+    "chapterTitleFallback": "Chương {{n}}",
+    "novelFormat": {
+      "button": "Hướng dẫn định dạng phim tinh phẩm",
+      "title": "Định dạng phim tinh phẩm",
+      "intro": "Kịch bản phim tinh phẩm cần có ranh giới tập và phân cảnh rõ ràng. DramaClaw tách kịch bản theo dòng đầu cảnh trước khi tạo hình ảnh, lời thoại và âm thanh cho từng dòng; hệ thống không tự bịa ra điểm ngắt cảnh cho văn xuôi không có tiêu đề.",
+      "standardStatus": "Chuẩn · sẵn sàng nhập",
+      "standardStatusHint": "Hỗ trợ nhiều định dạng thông dụng trong ngành. Metadata đầy đủ về bối cảnh, thời gian và INT/EXT sẽ được phân tích chính xác.",
+      "warningStatus": "Có thể sửa · vẫn cho nhập",
+      "warningStatusHint": "Ranh giới phân cảnh đã rõ, nhưng metadata bối cảnh, thời gian hoặc INT/EXT còn thiếu và sẽ được chuẩn hoá tự động.",
+      "blockingStatus": "Không xác định được ranh giới phân cảnh · bị chặn",
+      "blockingStatusHint": "Chỉ bị chặn khi các chương không hợp lệ, hoặc phim tinh phẩm không có dòng đầu cảnh nào nhận diện được.",
+      "specLabel": "Dòng đầu cảnh đầy đủ được hỗ trợ",
+      "repairableLabel": "Định dạng có thể tự bổ sung",
+      "repairableHint": "Cả hai cảnh dưới đây đều nhận ra được, nhưng mỗi cảnh thiếu một thứ: “SCENE 1 - TITLE” không có mốc thời gian lẫn dấu INT/EXT, còn “INT./EXT.” thì không quy về được một giá trị nội hay ngoại. Chỉ cần một trong hai là cả kịch bản tụt xuống mức “sửa được” — vẫn cho nhập kèm cảnh báo và phần thiếu được điền ở bước sau. File gốc không bao giờ bị viết lại.",
+      "rulesLabel": "Quy tắc viết",
+      "ruleEpisode": "Mỗi tập bắt đầu bằng một dòng riêng “EPISODE 1” (“CHAPTER 1” cũng được, kịch bản tiếng Trung thì “第N集”); nhiều tập thì liệt kê lần lượt theo thứ tự. Giữ nguyên từ khoá tiếng Anh/tiếng Trung — bộ phân tích không nhận từ khoá tiếng Việt.",
+      "ruleScene": "Mỗi phân cảnh phải có dòng đầu cảnh hoàn chỉnh của riêng nó: INT./EXT. + địa điểm + “ - ” + thời gian, ví dụ “INT. SEOUL SUBWAY STATION - NIGHT”. Đừng chỉ điền cho cảnh đầu tiên của tập. Giữ nguyên INT./EXT. và DAY/NIGHT bằng tiếng Anh — bộ phân tích khớp từng chữ.",
+      "ruleCharacters": "Dùng đúng nhãn “Characters:” (hoặc “人物：”) rồi liệt kê tên các nhân vật thực sự có mặt trong cảnh, ngăn cách bằng dấu phẩy; không ghi tạo hình hay chỉ dẫn diễn xuất ở dòng này.",
+      "ruleBody": "Mỗi dòng chỉ một hành động hoặc một cú máy; hỗ trợ cả ký hiệu hành động “△” và “▲”. Không gộp nhiều cú máy hay nhiều người nói vào một dòng.",
+      "ruleDialogue": "Viết lời thoại dạng “TênNhânVật: lời thoại”. Chỉ thêm chỉ dẫn diễn xuất ngắn trong ngoặc đơn khi thật cần, và dùng “TênNhânVật OS: lời thoại” cho độc thoại nội tâm (OS giữ nguyên tiếng Anh).",
+      "ruleLocationChange": "Tạo dòng đầu cảnh mới mỗi khi đổi địa điểm. Hỗ trợ cả thứ tự Địa điểm-Thời gian-INT/EXT lẫn Địa điểm-INT/EXT-Thời gian.",
+      "exampleLabel": "Đoạn ví dụ",
+      "ruleTimeTokens": "Mốc thời gian viết ngay trong dòng đầu cảnh. Ở định dạng tiếng Anh, bộ phân tích chỉ nhận đúng bảy từ khoá: DAY / NIGHT / MORNING / AFTERNOON / EVENING / DAWN / DUSK — viết nguyên văn, không dịch. Viết thứ khác (MIDNIGHT, LATE NIGHT, giờ đồng hồ trần) làm cả dòng đầu cảnh không nhận ra được, mất luôn ranh giới cảnh.",
+      "ruleClockTime": "Đừng nhét giờ đồng hồ vào tên địa điểm. Khi cần giờ chính xác, viết thêm một dòng riêng “Time: 11:47 PM” ngay dưới dòng đầu cảnh — địa điểm vẫn được đọc là “Seoul Subway Station” còn thời gian được chuẩn hoá thành đêm."
+    },
+    "sceneHeaders": {
+      "missing": "Không nhận diện được dòng đầu cảnh nào, nên hệ thống không biết mỗi cảnh bắt đầu từ đâu.",
+      "missingFix": "Hãy làm theo ví dụ phía trên: mở đầu bằng “Episode N”, rồi đặt cho mỗi phân cảnh một tiêu đề riêng gồm số cảnh, địa điểm, thời gian và INT/EXT trước phần nhân vật, hành động và lời thoại. Giữ nguyên các từ khoá tiếng Anh/tiếng Trung trong ví dụ.",
+      "repairable": "Đã nhận diện được ranh giới phân cảnh, nhưng một số tiêu đề thiếu thời gian, bối cảnh hoặc INT/EXT. Vẫn có thể nhập, phần metadata thiếu sẽ được bổ sung khi lên kế hoạch phân cảnh.",
+      "repairableFix": "Dựa theo ví dụ phía trên để bổ sung địa điểm, thời gian hoặc INT/EXT còn thiếu. Bạn cũng có thể nhập tiếp mà không cần sửa file gốc.",
+      "open": "Xem các phân cảnh của {{chapter}}",
+      "rowCount_one": "{{count}} phân cảnh",
+      "rowCount_other": "{{count}} phân cảnh",
+      "count_one": "{{count}} phân cảnh",
+      "count_other": "{{count}} phân cảnh",
+      "scene": "Cảnh {{number}}",
+      "characters": "Nhân vật",
+      "characterSeparator": ", ",
+      "unknownLocation": "Không nhận diện được bối cảnh của phân cảnh",
+      "empty": "Chương này không có nội dung phân cảnh",
+      "unparsedBody": "Phần văn bản nằm ngoài các phân cảnh nhận diện được"
+    },
+    "chapterDetails": {
+      "open": "Xem nội dung của {{chapter}}",
+      "description": "Xem trước nội dung chương",
+      "sceneHeaders": "Phân cảnh",
+      "body": "Nội dung",
+      "empty": "Không có nội dung chương",
+      "emptyScene": "Phân cảnh này không có nội dung"
+    },
+    "projectType": "Loại dự án",
+    "projectTypeLocked": "Loại dự án bị khoá sau khi nhập. Nhập lại để đổi.",
+    "projectTypes": {
+      "narrated": "Có lời dẫn",
+      "drama": "Phim tinh phẩm"
+    },
+    "visualStyles": {
+      "anime": "Anime",
+      "chinesePeriodDrama": "Cổ trang Trung Hoa",
+      "guomanFantasy": "Tiên hiệp Quốc mạn 3D",
+      "postApocalyptic": "Hậu tận thế",
+      "realistic": "Hiện đại tả thực",
+      "republicanEraDrama": "Dân Quốc"
+    },
+    "ethnicities": {
+      "chinese": "Trung Quốc",
+      "japanese": "Nhật Bản",
+      "korean": "Hàn Quốc",
+      "western": "Phương Tây",
+      "mixed": "Lai"
+    },
+    "stopped": "Đã dừng",
+    "formatCheck": {
+      "slot": {
+        "location": "địa điểm",
+        "time": "mốc thời gian",
+        "interiorExterior": "dấu INT/EXT"
+      },
+      "slotSeparator": ", ",
+      "placeholder": {
+        "location": "[ĐỊA ĐIỂM]",
+        "time": "[DAY/NIGHT]",
+        "interiorExterior": "[INT/EXT]"
+      },
+      "suggestionLabeled": "{{header}}; Location: {{location}}, {{time}}, {{interiorExterior}}",
+      "untitledChapter": "Chương chưa đặt tên",
+      "summary": {
+        "missingSceneHeaders": "Phim tinh phẩm bắt buộc phải có dòng đầu cảnh: hệ thống không biết mỗi cảnh bắt đầu ở đâu. Bổ sung rồi nhập lại.",
+        "noChapters": "Không tìm thấy chương nào dùng được hay phần nội dung nào nhận ra được, nên không dựng cấu trúc kịch bản được.",
+        "repairableSceneHeaders": "Đã nhận ra ranh giới các cảnh; phần thông tin cảnh còn thiếu sẽ được điền vào ở bước lên kế hoạch bối cảnh.",
+        "formatRisks_one": "Tải lên thành công, nhưng phát hiện {{count}} rủi ro định dạng có thể ảnh hưởng tới việc nhận diện cảnh.",
+        "formatRisks_other": "Tải lên thành công, nhưng phát hiện {{count}} rủi ro định dạng có thể ảnh hưởng tới việc nhận diện cảnh.",
+        "passed": "Tải lên thành công và kịch bản đã qua kiểm tra định dạng."
+      },
+      "issue": {
+        "sceneHeaderMissingSlots": {
+          "message": "Dòng đầu cảnh “{{header}}” còn thiếu {{missing}}.",
+          "fix": "Điền nốt phần còn thiếu theo đúng cảnh thật — ví dụ “{{suggestion}}”."
+        },
+        "missingSceneHeaders": {
+          "message": "Không nhận ra dòng đầu cảnh nào, nên hệ thống không biết mỗi cảnh bắt đầu ở đâu.",
+          "fix": "Viết theo định dạng chuẩn: mỗi tập mở đầu bằng “EPISODE N”, mỗi cảnh có một dòng đầu cảnh riêng dạng “INT./EXT. địa điểm - DAY/NIGHT”, rồi mới tới nhân vật, hành động và lời thoại. Ví dụ: EPISODE 1 / INT. City Cafe - DAY. Các từ khoá EPISODE, INT., EXT., DAY, NIGHT phải viết đúng nguyên văn tiếng Anh — bộ phân tích khớp từng chữ, dịch sang tiếng Việt là hỏng."
+        },
+        "nonstandardSceneHeaders": {
+          "message": "Đã nhận ra ranh giới các cảnh, nhưng một số thông tin cảnh chưa đầy đủ.",
+          "fix": "Hệ thống đã nhận ra ranh giới các cảnh và sẽ điền hoặc chuẩn hoá phần địa điểm, thời gian, INT/EXT còn thiếu ở bước lên kế hoạch bối cảnh."
+        },
+        "sceneHeadersMissingTime": {
+          "message": "Một số dòng đầu cảnh không ghi rõ mốc thời gian, nên time_of_day và việc kế thừa biến thể bối cảnh có thể không ổn định.",
+          "fix": "Thêm mốc thời gian rõ ràng vào dòng đầu cảnh. Chỉ bảy giá trị này được chấp nhận: DAY, NIGHT, MORNING, AFTERNOON, EVENING, DAWN, DUSK. Dù thiếu thì ranh giới cảnh vẫn được giữ và chuẩn hoá ở bước sau."
+        },
+        "missingInteriorExterior": {
+          "message": "Dòng đầu cảnh không có dấu INT/EXT.",
+          "fix": "Thêm INT hoặc EXT vào đầu dòng, dạng “INT. địa điểm - DAY”."
+        },
+        "sparseSceneHeaders": {
+          "message": "Có quá ít dòng đầu cảnh, nên các cảnh nối tiếp và việc kế thừa thời gian có thể không ổn định.",
+          "fix": "Mỗi cảnh viết một dòng đầu cảnh."
+        },
+        "tooFewDialogueLines": {
+          "message": "Tìm được quá ít dòng thoại dùng được. Nếu đây là đoạn câm hoặc thiên về hành động thì vẫn nhập được.",
+          "fix": "Bổ sung các dòng thoại nhận diện được, theo dạng “Tên nhân vật: lời thoại”."
+        },
+        "multiSpeakerLines": {
+          "message": "Nhiều dòng nhét mấy người nói hoặc mấy dấu hai chấm vào cùng một dòng. Hệ thống sẽ cố chuẩn hoá theo kịch bản hạng B, nhưng mỗi dòng một lời thoại vẫn tốt hơn.",
+          "fix": "Viết lại sao cho mỗi dòng chỉ chứa một lời thoại của một người."
+        },
+        "ambiguousSpeakers": {
+          "message": "Nhiều người nói không rõ là ai (“anh ta”, “cô ấy”, “đối phương”, “giọng trong điện thoại”), nên việc xác định danh tính có thể không ổn định.",
+          "fix": "Thay những người nói mơ hồ như “anh ta” hay “cô ấy” bằng tên nhân vật thật."
+        },
+        "manyLongDialogues": {
+          "message": "Có nhiều dòng thoại đơn quá dài, dễ sinh ra đoạn thoại quá dài trong một đơn vị ở bước sau.",
+          "fix": "Tách bớt những dòng dài nhất để rút ngắn độ dài mỗi lời thoại."
+        },
+        "duplicateChapterNumber": {
+          "message": "Trùng số chương {{number}}: {{title}}.",
+          "fix": "Kiểm tra xem trong phần nội dung có câu nào trông giống tiêu đề chương không, để một chương khỏi bị cắt thành nhiều chương."
+        },
+        "nonIncreasingChapterNumber": {
+          "message": "Số chương đi từ {{previous_number}} lùi về hoặc lặp lại {{number}}.",
+          "fix": "Kiểm tra xem số chương có tăng dần không, hoặc xác nhận rằng câu chữ giống tiêu đề trong phần nội dung không bị nhầm thành tiêu đề chương."
+        },
+        "notScreenplayLike": {
+          "message": "Văn bản đọc giống văn xuôi tiểu thuyết hơn là kịch bản chia cảnh. Kiểm tra này không chặn việc nhập, nhưng kết quả dựng cấu trúc có thể kém hơn.",
+          "fix": "Nếu đây là văn xuôi tiểu thuyết, hãy đổi loại dự án sang Có lời dẫn. Nếu là kịch bản, hãy bổ sung các dòng đầu cảnh."
+        }
+      }
+    }
+  },
+  "video": {
+    "voiceSelect": "Giọng đọc",
+    "defaultVoice": "Giọng mặc định",
+    "generateAllTTS": "Tạo toàn bộ TTS",
+    "generateAudio": "Tạo âm thanh",
+    "audioGenerating": "Đang tạo âm thanh...",
+    "generateAllVideos": "Tạo toàn bộ video",
+    "globalOptimize": "Tối ưu toàn cục",
+    "videoGenerating": "Đang tạo video...",
+    "addSubtitles": "Thêm phụ đề",
+    "composeVideo": "Dựng video",
+    "composing": "Đang dựng...",
+    "composeHint": "Thiết lập tuỳ chọn rồi bấm \"Dựng video\" để xuất bản phim hoàn chỉnh",
+    "export": "Xuất file",
+    "downloadSRT": "Tải SRT",
+    "downloadZIP": "Tải ZIP",
+    "audioTab": "Âm thanh",
+    "videoTab": "Video",
+    "composeTab": "Dựng phim",
+    "globalOptimizeStarted": "Đã bắt đầu tác vụ tối ưu toàn cục",
+    "ttsComplete": "Đã tạo xong TTS",
+    "ttsPreview": "Nghe thử",
+    "ttsPreviewPlaying": "Đang phát thử..."
+  },
+  "sketches": {
+    "assignColors": "Gán màu",
+    "batchSketches": "Phác thảo hàng loạt",
+    "generateSketches": "Tạo phác thảo",
+    "generating": "Đang tạo phác thảo...",
+    "noSketches": "Chưa có phác thảo. Bấm \"Tạo phác thảo\" để bắt đầu.",
+    "gridGallery": "Thư viện lưới",
+    "noGrids": "Chưa có lưới nào",
+    "beatThumbnails": "Ảnh thu nhỏ theo beat"
+  },
+  "tasks": {
+    "taskCount": "{{count}} tác vụ",
+    "noTasks": "Không có tác vụ",
+    "cancelled": "Đã huỷ tác vụ",
+    "cleared": "Đã xoá các tác vụ hoàn tất",
+    "deleted": "Đã xoá tác vụ",
+    "clearCompleted": "Xoá tác vụ đã hoàn tất",
+    "taskDetail": "Chi tiết tác vụ",
+    "resultLog": "Log kết quả",
+    "logs": "Log",
+    "status": {
+      "submitting": "Đang gửi",
+      "queued": "Trong hàng đợi",
+      "pending": "Chờ xử lý",
+      "starting": "Đang khởi động",
+      "running": "Đang chạy",
+      "completed": "Hoàn tất",
+      "failed": "Thất bại",
+      "cancelled": "Đã huỷ"
+    },
+    "open": "Mở",
+    "allProjects": "Tất cả dự án (+{{count}})",
+    "currentOnly": "Chỉ dự án hiện tại ({{count}} dự án khác)",
+    "types": {
+      "build_characters": "Dựng nhân vật",
+      "ingest_fast": "Nhập truyện nhanh",
+      "build_episodes": "Lên kế hoạch tập phim",
+      "character_portrait": "Chân dung nhân vật",
+      "identity_image": "Ảnh tạo hình",
+      "identity_portrait": "Chân dung tạo hình",
+      "script_writer": "Viết kịch bản",
+      "literal_script_writer": "Kịch bản chi tiết",
+      "director_notes": "Lên kế hoạch cảnh quay",
+      "identity_planner": "Lên kế hoạch tạo hình",
+      "episode_scene_planner": "Lên kế hoạch phân cảnh",
+      "episode_prop_planner": "Lên kế hoạch đạo cụ",
+      "content_rewriter": "AI viết lại",
+      "sketch_generation": "Tạo phác thảo",
+      "batch_sketch": "Phác thảo hàng loạt",
+      "sketch_regen": "Tạo lại phác thảo",
+      "grid_preview": "Xem trước lưới",
+      "batch_render": "Render hàng loạt",
+      "grid_regenerate": "Tạo lại lưới",
+      "audio_generation": "Tạo âm thanh",
+      "audio_generation_indextts2": "Tạo âm thanh IndexTTS2",
+      "video_generation": "Tạo video",
+      "single_video": "Video đơn lẻ",
+      "global_optimize_video": "Tối ưu video toàn cục",
+      "selected_regen": "Tạo lại mục đã chọn",
+      "compose_episode": "Dựng video",
+      "freezone_image_reverse_prompt": "Đảo ngược prompt từ ảnh",
+      "build_scenes": "Dựng bối cảnh",
+      "build_props": "Dựng đạo cụ",
+      "beat_video_prompt": "Tạo prompt",
+      "scene_reference_asset": "Ảnh tham chiếu bối cảnh",
+      "prop_reference_asset": "Ảnh tham chiếu đạo cụ",
+      "director_control_to_sketch": "Khung đạo diễn sang phác thảo",
+      "sketch_grid_generation": "Tạo lưới phác thảo",
+      "mainline_sketch_from_context": "Tạo phác thảo",
+      "mainline_frame_from_context": "Render khung storyboard",
+      "indextts2_audio_generation": "Tạo âm thanh",
+      "freezone_video_gen": "Video Freezone",
+      "stage_asset": "Asset bối cảnh",
+      "freezone_gen": "Tạo trong Freezone",
+      "freezone_edit": "Sửa trong Freezone",
+      "freezone_mask_edit": "Sửa theo vùng tô",
+      "freezone_extract": "Trích khung hình",
+      "freezone_analyze": "Phân tích video",
+      "freezone_video_story": "Đọc video",
+      "freezone_video_erase": "Xoá vật thể khỏi video",
+      "freezone_video_upscale": "Upscale video",
+      "freezone_audio_separate": "Tách âm thanh",
+      "freezone_video_compose": "Dựng video",
+      "freezone_text_translate": "Dịch phụ đề",
+      "freezone_text_generate": "AI tạo văn bản",
+      "freezone_story_script": "Tạo kịch bản truyện",
+      "freezone_script_to_video_plan": "Kịch bản sang kế hoạch video",
+      "freezone_audio_speech": "Tạo giọng đọc",
+      "freezone_audio_eleven_music": "Tạo nhạc",
+      "freezone_image_to_3gs": "Ảnh sang thế giới 3D"
+    },
+    "cancelRunning": {
+      "title": "Dừng tác vụ",
+      "fallbackMessage": "Tác vụ đã bắt đầu chạy. Dừng bây giờ sẽ không hoàn lại số credits đã dùng. Vẫn dừng chứ?",
+      "confirm": "Dừng tác vụ",
+      "keepRunning": "Tiếp tục chạy",
+      "continued": "Tác vụ vẫn chạy tiếp"
+    },
+    "stageAssetSteps": {
+      "pano_from_master": "Toàn cảnh từ ảnh gốc",
+      "pano_from_text": "Toàn cảnh từ chữ",
+      "pano_sharp": "Toàn cảnh sang SOG",
+      "single_face_sharp": "Một mặt sang SOG",
+      "voxel_world_from_360": "Toàn cảnh sang voxel",
+      "scene_360": "Tạo ảnh toàn cảnh 360",
+      "upload_package": "Tải gói bối cảnh lên",
+      "splat_collision": "Tạo lưới va chạm"
+    },
+    "chatLabel": {
+      "sceneKind": {
+        "master": "ảnh gốc tham chiếu",
+        "spatial_layout": "tham chiếu bố trí không gian",
+        "reverse_master": "tham chiếu góc ngược",
+        "fallback": "tham chiếu bối cảnh",
+        "named": "{{scene}} — {{kind}}"
+      },
+      "beatRange": "Beat {{ranges}}",
+      "sketchGrid": "Lưới phác thảo {{index}}/{{total}}",
+      "sketch": "Phác thảo",
+      "episodePrefixed": "Tập {{episode}} · {{label}}",
+      "withBeats": "{{label}} ({{beats}})",
+      "identityPortraitNamed": "{{character}} — chân dung tạo hình “{{identity}}”",
+      "identityPortrait": "Chân dung tạo hình {{name}}",
+      "characterPortraitNamed": "Chân dung {{character}}",
+      "characterPortrait": "Chân dung nhân vật",
+      "identityImageNamed": "{{character}} — ảnh tạo hình “{{identity}}”",
+      "identityImage": "Ảnh tạo hình {{name}}",
+      "unknownCharacter": "Nhân vật",
+      "withEpisodeBeat": "{{label}} (Tập {{episode}}, Beat {{beat}})",
+      "withEpisode": "{{label}} (Tập {{episode}})"
+    },
+    "progress": {
+      "ingest": {
+        "reading": "Đang đọc và kiểm tra văn bản gốc...",
+        "validated": "Văn bản gốc đã hợp lệ",
+        "chunking": "Đang cắt văn bản gốc...",
+        "planning": "Đang ghi nhận kế hoạch phân tích...",
+        "saving": "Đang lưu kết quả nhập...",
+        "complete": "Nhập xong"
+      },
+      "pipeline": {
+        "normalizingScenes": "AI đang chuẩn hoá các khối cảnh trong kịch bản..."
+      },
+      "script": {
+        "start": "Đang tạo kịch bản...",
+        "beatVideoPromptStart": "Đang tạo prompt video cho beat {{beatNum}}",
+        "beatVideoPromptSaved": "Đã lưu prompt video cho beat {{beatNum}}"
+      },
+      "submitting": "Đang gửi tác vụ…",
+      "queued": "Tác vụ đã vào hàng đợi",
+      "characters": {
+        "chunking": "Đang cắt văn bản gốc…",
+        "nothingToAnalyze": "Không có gì để phân tích",
+        "extracting": "Đang trích nhân vật theo từng đoạn…",
+        "noResults": "Không trích được kết quả nào",
+        "enrichingAppearance": "Đang điền ngoại hình nhân vật…",
+        "publishing": "Đang đưa nhân vật vào dự án…",
+        "repairingAppearance": "Đang bù chỗ thiếu trong ngoại hình nhân vật có sẵn…",
+        "recordingEvidence": "Đang ghi nhận bằng chứng nhân vật…",
+        "complete": "Trích nhân vật xong"
+      },
+      "scenes": {
+        "notNeeded": "Không cần dựng sẵn bối cảnh nào",
+        "extractingFromHeadings": "Đang trích bối cảnh nền từ dòng đầu cảnh…",
+        "noResults": "Không trích được kết quả nào",
+        "normalizing": "Đang gom các cách viết khác nhau của cùng một địa điểm…",
+        "saving": "Đang lưu bối cảnh mới…",
+        "complete": "Trích bối cảnh xong"
+      },
+      "props": {
+        "perEpisode": "Đạo cụ được tạo theo từng tập"
+      },
+      "started": "Tác vụ đã bắt đầu",
+      "cancelled": "Tác vụ đã huỷ"
+    },
+    "log": {
+      "ingest": {
+        "readingFile": "Đang đọc file: {{path}}",
+        "readComplete": "Đã đọc file: {{charCount}} ký tự",
+        "chunked": "Cắt theo quy tắc cố định xong: {{chunkCount}} đoạn ({{sectionType}})",
+        "planReused": "Dùng lại kế hoạch phân tích sẵn có: {{runId}}",
+        "planRecorded": "Đã ghi nhận kế hoạch phân tích: {{runId}}",
+        "sourceSaved": "Đã lưu văn bản gốc"
+      },
+      "source": {
+        "loading": "Đang nạp văn bản gốc từ file...",
+        "loaded": "Đã nạp văn bản gốc: {{charCount}} ký tự"
+      },
+      "pipeline": {
+        "legacyRecall": "Kiểm tra đối chứng theo luật tìm được {{sceneCount}} khối cảnh: {{sceneNames}}"
+      },
+      "characters": {
+        "emptyChunks": "⚠️ Văn bản gốc không tạo ra đoạn nào",
+        "chunked": "Cắt theo quy tắc cố định: {{chunkCount}} đoạn ({{sectionType}})",
+        "reusingChunks": "Dùng lại {{cachedCount}} đoạn đã xong, chỉ tính lại {{pendingCount}} đoạn",
+        "reusingAdjudication": "Dùng lại kết quả chốt lần trước: {{characterCount}} nhân vật, không gọi model",
+        "noEvidence": "⚠️ Không trích được nhân vật nào có bằng chứng trong văn bản gốc; giữ nguyên dữ liệu nhân vật hiện có",
+        "merged": "Đã gộp thành {{candidateCount}} nhân vật ứng viên",
+        "published": "Đã thêm {{addedCount}} nhân vật, bỏ qua {{skippedCount}} nhân vật đã có",
+        "repaired": "Đã điền prompt khuôn mặt cho {{repairedCount}} nhân vật có sẵn"
+      },
+      "scenes": {
+        "deferred": "Bối cảnh của dự án có lời dẫn được tạo khi cần ở bước lên kế hoạch tập",
+        "noHeadings": "⚠️ Không trích được bối cảnh nào từ dòng đầu cảnh; giữ nguyên dữ liệu bối cảnh hiện có",
+        "published": "Đã thêm {{addedCount}} bối cảnh, sửa {{repairedCount}} mô tả tạm, bỏ qua {{skippedCount}} bối cảnh đã có"
+      },
+      "props": {
+        "deferred": "Đạo cụ được tạo khi cần ở bước lên kế hoạch tập"
+      }
+    },
+    "toast": {
+      "scenesBuildQueued": "Tác vụ dựng bối cảnh đã vào hàng đợi"
+    }
+  },
+  "taskCenter": {
+    "actions": {
+      "cancel": "Huỷ",
+      "cancelConfirm": "Huỷ tác vụ này?",
+      "clearCompleted": "Xoá mục đã xong",
+      "openOrigin": "Mở trang gốc",
+      "copyId": "Sao chép Task ID",
+      "downloadLogs": "Tải log về",
+      "retryHint": "Thử lại từ trang gốc"
+    },
+    "detail": {
+      "currentStatus": "Trạng thái hiện tại",
+      "debugInfo": "Thông tin debug",
+      "tabs": {
+        "overview": "Tổng quan",
+        "logs": "Log"
+      },
+      "meta": {
+        "type": "Loại",
+        "project": "Dự án",
+        "episode": "Tập phim",
+        "scope": "Phạm vi",
+        "beat": "Beat",
+        "status": "Trạng thái",
+        "progress": "Tiến độ",
+        "createdAt": "Tạo lúc",
+        "updatedAt": "Cập nhật lúc",
+        "completedAt": "Hoàn tất lúc",
+        "taskId": "Task ID",
+        "providerTaskId": "Task ID phía nhà cung cấp"
+      },
+      "result": {
+        "label": "Kết quả"
+      },
+      "error": {
+        "label": "Lỗi"
+      },
+      "logs": {
+        "placeholder": "Chưa có log nào."
+      }
+    },
+    "io": {
+      "background": "Nền",
+      "backgroundCandidate": "Ứng viên nền",
+      "beatContext": "Ngữ cảnh beat",
+      "currentBackground": "Nền hiện tại",
+      "currentSketch": "Phác thảo hiện tại",
+      "currentSketchCandidate": "Ứng viên phác thảo hiện tại",
+      "currentStoryboard": "Storyboard hiện tại",
+      "directorComposite": "Ảnh ghép đạo diễn",
+      "inputReference": "Tham chiếu đầu vào",
+      "masterReverse": "Ảnh gốc + góc ngược",
+      "pano360": "Ảnh toàn cảnh 360°",
+      "sceneMasterReverse": "Ảnh gốc bối cảnh + góc ngược",
+      "sketchBackgroundIdentityProps": "Phác thảo + nền + tạo hình/đạo cụ",
+      "sketchCandidate": "Ứng viên phác thảo",
+      "storyboardCandidate": "Ứng viên storyboard"
+    },
+    "panel": {
+      "open": "Mở Trung tâm tác vụ",
+      "close": "Đóng",
+      "filters": {
+        "all": "Tất cả",
+        "running": "Đang chạy",
+        "failed": "Thất bại",
+        "done": "Đã xong"
+      },
+      "empty": "Không có tác vụ",
+      "emptyFiltered": "Không có tác vụ",
+      "selectPrompt": "Chọn một tác vụ để xem chi tiết."
+    },
+    "relative": {
+      "justNow": "vừa xong"
+    },
+    "status": {
+      "submitting": "Đang gửi",
+      "queued": "Trong hàng đợi",
+      "pending": "Chờ xử lý",
+      "starting": "Đang khởi động",
+      "running": "Đang chạy",
+      "completed": "Hoàn tất",
+      "failed": "Thất bại",
+      "cancelled": "Đã huỷ"
+    },
+    "statusBar": {
+      "idle": "Rảnh",
+      "connecting": "Đang kết nối…",
+      "connected": "Đã kết nối",
+      "reconnecting": "Đang kết nối lại…",
+      "polling": "Đang thăm dò…",
+      "failed": "Kết nối thất bại",
+      "offline": "Ngoại tuyến",
+      "running": "{{count}} đang chạy",
+      "lastDone": "Gần nhất: {{label}} {{relative}}",
+      "generationRunning": "Đang tạo",
+      "generationComplete": "Hoàn tất",
+      "progress": "Tiến độ {{percent}}%",
+      "openHint": "Bấm để mở",
+      "closeHint": "Bấm để thu gọn"
+    },
+    "title": "Trung tâm tác vụ",
+    "toast": {
+      "completed": "{{label}} đã hoàn tất",
+      "failed": "{{label}} thất bại: {{error}}",
+      "canceled": "Đã huỷ {{label}}",
+      "copied": "Đã sao chép Task ID"
+    }
+  },
+  "pikoMiniGame": {
+    "statusEntry": "Giải lao cùng Piko",
+    "statusTooltip": "Chơi một ván Piko một phút",
+    "libraryTitle": "Giải lao cùng Piko",
+    "librarySubtitle": "Chọn một trò chơi",
+    "title": "Piko một chút, bắt lại cảm hứng",
+    "idleHint": "Nhấn Space để bắn",
+    "countdownHint": "Sẵn sàng chưa nào~",
+    "start": "Bắt đầu",
+    "playAgain": "Chơi lại",
+    "backToWork": "Quay lại làm việc",
+    "backToLibrary": "Về danh sách trò chơi",
+    "audioOn": "Bật âm thanh trò chơi Piko",
+    "audioOff": "Tắt âm thanh trò chơi Piko",
+    "score": "Năng lượng ý tưởng {{score}}",
+    "energy": "Năng lượng",
+    "ultimateReady": "Năng lượng đầy. Nhấn Q",
+    "timeLeft": "{{seconds}}s",
+    "activePowerUp": "{{powerUp}} đang hiệu lực",
+    "resultMeta": "Piko đã bắt được {{caught}} mảnh cảm hứng",
+    "result": {
+      "maxCombo": "Combo cao nhất",
+      "powerUps": "Vật phẩm tăng lực",
+      "score": "Ý tưởng"
+    },
+    "insight": {
+      "combo": "Nhịp của bạn đã trở lại. Storyboard sẽ trôi mượt hơn đấy.",
+      "jelly": "Bạn đã chậm nhịp lại. Đây là lúc tốt để đẩy đều tay.",
+      "burst": "Canh thời điểm bùng nổ rất chuẩn. Hãy bắt đầu từ các điểm nhấn.",
+      "rain": "Bạn đã hứng được cơn mưa ý tưởng. Làm hàng loạt sẽ rất trôi.",
+      "flow": "Động cơ đã nóng máy lại. Đẩy nốt một phần nhỏ nào.",
+      "soft": "Giải lao xong rồi. Không cần ép não đâu."
+    },
+    "powerUps": {
+      "magnet": "Sao nam châm",
+      "rapid": "Kẹo tăng tốc",
+      "jelly": "Thạch thời gian"
+    },
+    "feedback": {
+      "combo": "Đã bắt đúng nhịp combo",
+      "wild": "Bạn đã bắt được cơn bão ý tưởng",
+      "burst": "Điểm bùng nổ sáng rực",
+      "rain": "Cơn mưa ý tưởng đã đổ xuống",
+      "high": "Cảm hứng đã nạp đầy",
+      "medium": "Đèn đã sáng trở lại",
+      "soft": "Đã reset xong"
+    },
+    "float": {
+      "combo": "Combo x{{count}}",
+      "comboBoost": "Nhân đôi ý tưởng trong 3s",
+      "burst": "Bùng nổ cảm hứng",
+      "rain": "Mưa ý tưởng",
+      "rush": "Nước rút cuối",
+      "energyReady": "Năng lượng đầy. Nhấn Q",
+      "powerUp": {
+        "magnet": "Sao nam châm đang hút ý tưởng",
+        "rapid": "Kẹo tăng tốc đã kích hoạt",
+        "jelly": "Thạch thời gian đã làm chậm sân chơi"
+      },
+      "ultimate": "Bùng nổ ý tưởng"
+    },
+    "memory": {
+      "title": "Lật hình trí nhớ",
+      "hint": "Ghép các lá bài có cùng ký hiệu",
+      "moves": "Lượt lật",
+      "movesValue": "{{moves}} lượt lật",
+      "score": "{{score}} điểm",
+      "roundMeta": "Vòng {{round}} / {{total}}",
+      "scan": "Quét ý tưởng",
+      "scanUsed": "Đã dùng lượt quét",
+      "streak": "Chuỗi ghép x{{streak}}",
+      "nextRound": "Vòng sau",
+      "cardHidden": "Lá bài úp",
+      "cardVisible": "Lá bài {{value}}",
+      "completed": "Đã ghép hết các cặp",
+      "resultMeta": "{{moves}} nước · tổng {{score}} điểm"
+    },
+    "breakout": {
+      "title": "Phá gạch",
+      "canvasLabel": "Bàn chơi Phá gạch",
+      "hint": "Di chuyển thanh đỡ bằng chuột hoặc cảm ứng, hoặc dùng phím mũi tên hay A và D",
+      "start": "Bắt đầu chơi",
+      "ready": "Phá sạch mọi viên gạch",
+      "lifeLost": "Cố lên nào!",
+      "waveClear": "Đợt tiếp theo tới rồi!",
+      "won": "Đã phá hết gạch!",
+      "lost": "Thua rồi",
+      "score": "Điểm {{score}}",
+      "wave": "Đợt {{wave}} / {{total}}",
+      "lives": "Mạng {{lives}}"
+    },
+    "stackGame": {
+      "title": "Xếp đi, đừng hoảng",
+      "canvasLabel": "Bàn chơi Xếp đi, đừng hoảng",
+      "hint": "Di ngang để ngắm, rồi bấm chuột hoặc nhấn Space để thả. Cân bằng ăn đứt chiều cao",
+      "start": "Bắt đầu xếp",
+      "ready": "Vững đã, cao tính sau",
+      "lost": "Rồi, giờ thì hoảng được",
+      "levelClear": "Chồng đó trụ được!",
+      "won": "Piko lên tới đỉnh rồi!",
+      "wonHint": "Ba cái tháp lung lay, thế mà cái nào cũng đứng vững",
+      "score": "{{score}} điểm",
+      "progress": "Đã xếp {{current}} / {{target}}",
+      "level": "Cấp {{level}} / {{total}}",
+      "nextLevel": "Xếp tiếp",
+      "result": "Điểm cuối {{score}}",
+      "assistReady": "Còn một cú đẩy nhẹ",
+      "assistUsed": "Đã dùng cú đẩy",
+      "feedback": {
+        "perfect": "Thả chuẩn ×{{streak}}",
+        "steady": "Vẫn đứng vững",
+        "assist": "Piko đẩy lại cho rồi",
+        "danger": "Nghiêng rồi kìa!"
+      }
+    },
+    "flying": {
+      "title": "Piko bay",
+      "canvasLabel": "Bàn chơi Piko bay",
+      "hint": "Nhấn Space, mũi tên lên, hoặc chạm để lái Piko chui qua các cổng năng lượng",
+      "start": "Bắt đầu bay",
+      "ready": "Sẵn sàng cất cánh",
+      "lost": "Piko đâm vào cổng năng lượng",
+      "score": "Điểm bay {{score}}",
+      "precision": "Chuẩn xác x{{streak}}",
+      "shieldReady": "Khiên sẵn sàng",
+      "shieldUsed": "Đã dùng khiên"
+    },
+    "leap": {
+      "title": "Piko nhảy",
+      "canvasLabel": "Bàn chơi Piko nhảy",
+      "hint": "Giữ Space, chuột hoặc chạm để tích lực, thả ra để nhảy sang mảnh ý tưởng tiếp theo",
+      "start": "Bắt đầu nhảy",
+      "ready": "Sẵn sàng cho cú nhảy tiếp theo",
+      "lost": "Piko đáp trượt rồi",
+      "score": "Điểm nhảy {{score}}",
+      "combo": "Combo đáp giữa ×{{combo}}",
+      "centerHint": "Đáp đúng giữa để được điểm thưởng",
+      "rescueReady": "Lá cứu hộ sẵn sàng",
+      "feedback": {
+        "perfect": "Tiếp đất hoàn hảo",
+        "spring": "Bật nhún",
+        "rescue": "Lá cứu hộ"
+      },
+      "chargeHint": "Giữ để tích lực · thả ra để nhảy",
+      "result": "Bạn được {{score}} điểm"
+    }
+  },
+  "literalScript": {
+    "generating": "Đang tạo kịch bản chi tiết...",
+    "noScript": "Chưa có kịch bản chi tiết. Bấm \"Tạo\" để dựng từ nguồn truyện.",
+    "beatCount": "{{count}} beat"
+  },
+  "episode": {
+    "stage": {
+      "script": "Kịch bản",
+      "sketch": "Phác thảo",
+      "audio": "Âm thanh",
+      "video": "Video",
+      "compose": "Dựng phim"
+    },
+    "rail": {
+      "itemAria": "Tập {{n}}: {{title}}"
+    },
+    "nav": {
+      "script": "Kịch bản",
+      "shots": "Cú máy",
+      "compose": "Dựng phim",
+      "text": "Văn bản",
+      "sketch": "Phác thảo",
+      "render": "Render",
+      "audio": "Âm thanh",
+      "video": "Video"
+    },
+    "script": {
+      "rhythmDuration": "Theo thời lượng",
+      "rhythmLiteral": "Từng dòng một",
+      "rhythmDurationHint": "Chia cảnh theo thời lượng mục tiêu",
+      "rhythmLiteralHint": "Mỗi dòng nguồn thành một beat",
+      "identityLabel": "Tạo hình:",
+      "editIdentityLabel": "Sửa tạo hình:",
+      "identityRequired": "Hãy lên kế hoạch tạo hình cho tập này trước khi tạo kịch bản.",
+      "identityNotPlanned": "Chưa lên kế hoạch · Tới trang lập kế hoạch →",
+      "identityPickManually": "Tự chọn",
+      "identityCount": "Đã chọn {{count}} tạo hình",
+      "planIdentitiesNew": "Đã tạo {{count}} tạo hình mới",
+      "planIdentitiesResolved": "Đã tái sử dụng {{count}} tạo hình sẵn có",
+      "planIdentitiesNone": "Không nhận diện được tạo hình nào — hãy chắc chắn đã nhập văn bản nguồn và kế hoạch tập phim",
+      "targetLines": "Số dòng mục tiêu",
+      "minCharsPerLine": "Ký tự tối thiểu/dòng",
+      "maxCharsPerLine": "Ký tự tối đa/dòng",
+      "aiRewrite": "AI viết lại",
+      "aiRewriteTitle": "AI viết lại?",
+      "aiRewriteDesc": "Tạo lời dẫn từ văn bản nguồn và các tham số. Bản chuyển thể hiện có sẽ bị ghi đè.",
+      "rawLabel": "Bản gốc · Chỉ đọc (từ lúc nhập truyện)",
+      "rawActionLabel": "Xem bản gốc",
+      "noRawText": "Không có văn bản gốc. Hãy liên kết nội dung nguồn của tập này ở bước Nhập truyện trước.",
+      "sourceTextLabel": "Văn bản nguồn của beat",
+      "sourceTextLabelNarrated": "Bản AI viết lại / bản gốc",
+      "sourceTextLabelDrama": "Bản gốc",
+      "sourceTextMeta": "Chỉnh sửa tự động lưu, tổng cộng {{count}} dòng",
+      "sourceTextPlaceholder": "Thêm văn bản nguồn của tập phim dùng để tạo beat theo từng dòng.",
+      "sourceTextPlaceholderNarrated": "Bấm AI viết lại để tạo lời dẫn, hoặc sửa bản gốc trước khi tạo kịch bản.",
+      "sourceTextPlaceholderDrama": "Bản gốc được dùng để tạo kịch bản và có thể sửa trực tiếp.",
+      "linePreviewLabel": "Xem trước cách tách dòng",
+      "lineCount": "{{count}} dòng",
+      "noSourceLines": "Chưa tạo dòng nào",
+      "assetPlanningTitle": "Lên kế hoạch asset",
+      "storySummary": "Tóm tắt câu chuyện",
+      "noStorySummary": "Chưa có tóm tắt câu chuyện",
+      "keyEvents": "Sự kiện then chốt",
+      "noKeyEvents": "Chưa có sự kiện then chốt",
+      "cliffhanger": "Nút thắt cuối tập",
+      "noCliffhanger": "Chưa có nút thắt cuối tập",
+      "scenes": "Bối cảnh",
+      "props": "Đạo cụ",
+      "noScenes": "Chưa lên kế hoạch bối cảnh",
+      "noProps": "Chưa lên kế hoạch đạo cụ",
+      "planScenes": "Lên kế hoạch bối cảnh",
+      "replanScenes": "Lên lại kế hoạch bối cảnh",
+      "planProps": "Lên kế hoạch đạo cụ",
+      "replanProps": "Lên lại kế hoạch đạo cụ",
+      "identities": "Tạo hình",
+      "noIdentities": "Chưa lên kế hoạch tạo hình",
+      "planIdentities": "Lên kế hoạch tạo hình",
+      "replanIdentities": "Lên lại kế hoạch tạo hình",
+      "identityCharactersRequired": "Hãy dựng nhân vật từ sơ đồ tri thức trước",
+      "identityCharactersBuilding": "Đang dựng nhân vật; lên kế hoạch tạo hình sẽ mở khi xong",
+      "identityCharactersLoading": "Đang kiểm tra dữ liệu nhân vật",
+      "sceneCatalogBuilding": "Đang dựng bối cảnh; lên kế hoạch bối cảnh sẽ mở khi xong",
+      "sceneCatalogLoading": "Đang kiểm tra tiến độ dựng bối cảnh",
+      "propInGlobal": "Đã có trong thư viện đạo cụ chung",
+      "propCheckingGlobal": "Đang kiểm tra thư viện đạo cụ chung",
+      "promoteProp": "Thêm vào thư viện đạo cụ chung",
+      "promotePropTitle": "Thêm vào thư viện đạo cụ chung: {{name}}",
+      "promotePropName": "Tên đạo cụ chung",
+      "promotePropType": "Loại đạo cụ",
+      "promoteVisualPrompt": "Prompt hình ảnh",
+      "promoteOwner": "Chủ sở hữu",
+      "promoteSubmit": "Thêm vào thư viện chung",
+      "promoteSuccess": "Đã thêm vào thư viện đạo cụ chung",
+      "scenePlanComplete": "Đã lên kế hoạch {{count}} bối cảnh",
+      "propPlanComplete": "Đã lên kế hoạch {{count}} đạo cụ",
+      "previewTitle": "Xem trước kịch bản",
+      "previewCount": "{{count}} Beat",
+      "previewLoading": "Đang tải kịch bản...",
+      "previewEmptyTitle": "Chưa có kịch bản",
+      "previewEmpty": "Chưa có beat kịch bản nào. Hãy tạo kịch bản để xem trước tại đây.",
+      "previewSpeaker": "Người nói",
+      "previewNoSpeaker": "Không có người nói",
+      "previewDialogueLine": "Lời thoại",
+      "previewNarrationLine": "Lời dẫn",
+      "previewNoNarration": "Không có lời",
+      "previewVisualDescription": "Mô tả hình ảnh",
+      "previewNoVisualDescription": "Chưa có mô tả hình ảnh",
+      "adaptedLabel": "Bản chuyển thể · Tự động lưu",
+      "clearAdapted": "Xoá bản chuyển thể",
+      "adaptedPlaceholder": "Bấm AI viết lại để tạo, hoặc tự viết các câu lời dẫn ngắn. Tự động lưu khi rời khỏi ô.",
+      "summaryLabel": "Tóm tắt · Chỉ đọc (do AI tạo)",
+      "noSummary": "Chưa có tóm tắt",
+      "adaptedCleared": "Đã xoá bản chuyển thể",
+      "minGtMax": "Số ký tự tối thiểu không được lớn hơn tối đa",
+      "rewrite": "Viết lại",
+      "clearAdaptedTitle": "Xoá bản chuyển thể?",
+      "clearAdaptedDesc": "Sau khi xoá, việc tạo beat theo từng dòng sẽ dùng thẳng văn bản gốc. Không thể hoàn tác.",
+      "clearButton": "Xoá",
+      "generateRewrite": "AI viết lại",
+      "rewriteTargetBeats": "Số dòng mục tiêu",
+      "rewriteBeatCharsMin": "Ký tự tối thiểu/dòng",
+      "rewriteBeatCharsMax": "Ký tự tối đa/dòng",
+      "generateScript": "Tạo kịch bản",
+      "generateLineByLine": "Tạo theo từng dòng",
+      "rewriteComplete": "AI đã viết lại xong",
+      "scriptReviewPassed": "Đã tạo xong kịch bản",
+      "scriptReviewFailed": "Kịch bản chưa qua vòng rà soát. Hãy tạo lại: {{summary}}",
+      "modeLabel": "Chế độ hiện tại:",
+      "modeLiteral": "Mỗi dòng một Beat",
+      "sourceWorkbenchHint": "Văn bản nguồn tự động lưu ở bên phải",
+      "reviewIssuesFallback": "Vẫn còn vấn đề chưa xử lý"
+    },
+    "beat": {
+      "badge": "Beat {{n}}",
+      "openDrawer": "Mở chi tiết beat {{n}}",
+      "jumpTo": "Tới {{stage}}",
+      "select": "Chọn",
+      "deselect": "Bỏ chọn",
+      "noSketch": "Chưa có phác thảo",
+      "noRender": "Chưa render",
+      "noNarration": "(Không có lời dẫn)",
+      "stale": "Đã cũ",
+      "clickToView": "Bấm vào một beat để xem chi tiết",
+      "noMatching": "Không có beat nào khớp",
+      "sectionText": "Văn bản",
+      "sectionSketch": "Phác thảo",
+      "sectionRender": "Render",
+      "sectionAudio": "Âm thanh",
+      "sectionVideo": "Video",
+      "edited": "Đã sửa",
+      "notEdited": "Chưa sửa",
+      "selected": "Đã chọn",
+      "notSelected": "Chưa chọn",
+      "rendered": "Đã render",
+      "notRendered": "Chưa render",
+      "generated": "Đã tạo",
+      "notGenerated": "Chưa tạo",
+      "deleteManualShot": "Xoá",
+      "deleteManualShotTitle": "Xoá cú máy thủ công?",
+      "deleteManualShotDesc": "Xoá cú máy thủ công Beat #{{n}}? Các beat phía sau sẽ được đánh số lại.",
+      "deleteManualShotSuccess": "Đã xoá cú máy thủ công Beat #{{n}}",
+      "deleteManualShotFailed": "Xoá cú máy thủ công thất bại",
+      "insertBefore": "Chèn cú máy thủ công trước Beat #{{n}}",
+      "insertBeforeShort": "Trước",
+      "insertAfter": "Chèn cú máy thủ công sau Beat #{{n}}",
+      "insertAfterShort": "Sau",
+      "openFreezone": "Mở XiPaint Beat Workbench",
+      "openFreezoneTip": "Sửa trong Freezone",
+      "openFreezoneFailed": "Không mở được XiPaint",
+      "markedProps": "Đạo cụ {{count}}",
+      "detectedProps": "Đạo cụ nhận diện được {{count}}"
+    },
+    "drawer": {
+      "script": "Kịch bản",
+      "sketch": "Phác thảo",
+      "audio": "Âm thanh",
+      "video": "Video",
+      "close": "Đóng (Esc)"
+    },
+    "workbench": {
+      "aspectSwitch": {
+        "title": "Đổi tỉ lệ khung hình?",
+        "desc": "Đổi tỉ lệ khung hình sẽ không kéo giãn hay làm biến dạng các phác thảo, ảnh tham chiếu và video đã tạo — chúng vẫn giữ tỉ lệ gốc. Muốn đưa những asset đó về tỉ lệ mới thì phải tạo lại. Tiếp tục?",
+        "confirm": "Vẫn đổi"
+      },
+      "pool": {
+        "rebuildIndex": "Dựng lại chỉ mục",
+        "rebuildSuccess": "Đã dựng lại chỉ mục kho ảnh: {{count}} ảnh",
+        "rebuildFailed": "Dựng lại chỉ mục kho ảnh thất bại"
+      },
+      "endOfBeats": "—— Hết danh sách ——",
+      "endOfBeatsCount": "Tổng cộng {{count}} beat",
+      "jumpTo": "Tới {{stage}}",
+      "save": "Lưu",
+      "regenerate": "Tạo lại",
+      "retry": "Thử lại",
+      "cancel": "Huỷ",
+      "generate": "Tạo",
+      "preview": "Xem trước",
+      "view": {
+        "display": "Hiển thị",
+        "selectedCount": "Đã chọn {{count}}",
+        "clear": "Bỏ chọn",
+        "totalShots": "{{count}} cú máy",
+        "activeBeat": "Beat {{n}}",
+        "noMatchingBeats": "Không có beat nào khớp",
+        "selectionHint": "Chọn các beat để tạo lại phác thảo và render hàng loạt",
+        "batchRegenSketch": "Tạo lại phác thảo",
+        "batchRegenRender": "Render lại",
+        "dragToResize": "Kéo để chỉnh tỉ lệ bề ngang trái/phải"
+      },
+      "text": {
+        "narration": "Lời thoại",
+        "narrationPlaceholder": "Nhập lời cần đọc",
+        "type": "Loại",
+        "silence": "Không lời",
+        "dialogue": "Lời thoại",
+        "narrationLabel": "Lời dẫn",
+        "location": "Bối cảnh",
+        "locationPlaceholder": "Chọn bối cảnh",
+        "locationNone": "(chưa xác định)",
+        "sceneVariant": "Biến thể bối cảnh",
+        "timeOfDay": "Thời điểm trong ngày",
+        "timeOfDayPlaceholder": "Ngày / Đêm",
+        "visualDescription": "Mô tả hình ảnh",
+        "identities": "Tạo hình",
+        "noCharacter": "Không có nhân vật",
+        "identityDetectionRequired": "Chưa nhận diện hoặc đánh dấu tạo hình. Nếu cảnh không có nhân vật nào, hãy chọn \"Không có nhân vật\".",
+        "props": "Đạo cụ",
+        "noProp": "Không có đạo cụ",
+        "videoMode": "Chế độ video",
+        "keyframePrompt": "Prompt keyframe",
+        "videoPrompt": "Prompt video",
+        "firstFrame": "Khung đầu",
+        "keyframe": "Keyframe",
+        "speaker": "Người nói",
+        "narrator": "Người dẫn truyện",
+        "projectNarrator": "Người dẫn truyện của dự án",
+        "speakerPlaceholder": "ID tạo hình (vd. Chen_monk), bắt buộc với lời thoại",
+        "speakerRequired": "Hãy chọn người nói",
+        "identitiesNotPlanned": "Tập này chưa lên kế hoạch tạo hình. Hãy sang trang Kịch bản để thiết lập.",
+        "propsNotPlanned": "Tập này chưa lên kế hoạch đạo cụ. Hãy sang trang Kịch bản để thiết lập.",
+        "more": "Thêm",
+        "saveFailed": "Lưu thất bại",
+        "noSceneVariant": "Không có biến thể"
+      },
+      "insertManual": {
+        "titleBeforeFirst": "Chèn cú máy thủ công trước beat đầu tiên",
+        "titleAfter": "Chèn cú máy thủ công sau beat {{n}}",
+        "audioType": "Loại cú máy",
+        "audioTypeSilence": "Không lời",
+        "audioTypeNarration": "Lời dẫn",
+        "audioTypeDialogue": "Lời thoại",
+        "narration": "Lời thoại / lời dẫn",
+        "narrationPlaceholder": "Nhập lời thoại hoặc lời dẫn cần đọc",
+        "narrationRequired": "Hãy nhập lời thoại hoặc lời dẫn",
+        "silentHint": "Cú máy không lời sẽ không tạo âm thanh",
+        "speaker": "Người nói",
+        "speakerPlaceholder": "Chọn hoặc nhập tạo hình của người nói",
+        "speakerRequired": "Hãy chọn người nói",
+        "narrator": "Người dẫn truyện",
+        "projectNarrator": "Người dẫn truyện của dự án",
+        "visualDescription": "Mô tả hình ảnh",
+        "visualPlaceholder": "Mô tả trong một câu những gì máy quay cần thể hiện",
+        "visualRequired": "Bắt buộc phải có mô tả hình ảnh",
+        "type": "Loại",
+        "typeManual": "Thủ công",
+        "location": "Địa điểm",
+        "locationPlaceholder": "Chọn địa điểm",
+        "locationNone": "(không có)",
+        "timeOfDay": "Thời điểm trong ngày",
+        "timeOfDayPlaceholder": "Chọn thời điểm",
+        "timeOfDayNone": "(không có)",
+        "duration": "Thời lượng (giây)",
+        "identities": "Tạo hình",
+        "identitiesPlaceholder": "Ngăn cách bằng dấu phẩy (vd. {{example}}); để trống để tự nhận diện từ mô tả hình ảnh",
+        "identitiesPlaceholderEmpty": "ID tạo hình ngăn cách bằng dấu phẩy; để trống để tự nhận diện",
+        "submit": "Chèn",
+        "success": "Đã chèn cú máy thủ công",
+        "sceneVariant": "Biến thể",
+        "noSceneVariant": "Không có biến thể",
+        "props": "Đạo cụ",
+        "propsPlaceholder": "Ngăn cách bằng dấu phẩy (vd. {{example}}); để trống để tự nhận diện từ mô tả hình ảnh",
+        "propsPlaceholderEmpty": "ID đạo cụ ngăn cách bằng dấu phẩy; để trống để tự nhận diện"
+      },
+      "audio": {
+        "narrationEmpty": "Chưa có lời dẫn — beat này không tạo được âm thanh. Hãy điền nội dung trước.",
+        "previewing": "Đang nghe thử",
+        "previewFailed": "Nghe thử thất bại",
+        "regenerated": "Đã tạo lại Beat #{{n}}",
+        "regenFailed": "Tạo lại thất bại",
+        "defaultLabel": "Mặc định",
+        "defaultVoice": "Giọng mặc định",
+        "overrideLabel": "Ghi đè",
+        "inheritPlaceholder": "Kế thừa",
+        "inheritDefault": "Kế thừa mặc định của tập phim",
+        "customVoiceId": "voice_id tuỳ chỉnh",
+        "preview": "Nghe thử",
+        "generating": "Đang tạo...",
+        "genFailed": "Tạo thất bại",
+        "notGenerated": "Chưa tạo",
+        "regenTitle": "Tạo lại âm thanh?",
+        "regenDesc": "Tạo lại lồng tiếng TTS cho Beat #{{n}}.",
+        "configureVoiceAction": "Thiết lập",
+        "beatNarrationVoice": "Âm thanh lời dẫn của beat này",
+        "beatNarrationVoiceUpload": "Tải âm thanh cho beat",
+        "beatNarrationVoiceUploaded": "Đã tải âm thanh lời dẫn của beat lên",
+        "prereqHintCharacters": ". Hãy sang trang Nhân vật để tải giọng người dẫn truyện lên.",
+        "prereqHintVoices": ". Hãy sang Asset > Giọng nói để tải lên hoặc cắt một giọng dẫn truyện mặc định."
+      },
+      "video": {
+        "started": "Đã bắt đầu tạo video cho Beat #{{n}}",
+        "regenFailed": "Tạo lại thất bại",
+        "model": "Model",
+        "generating": "Đang tạo...",
+        "genFailed": "Tạo thất bại",
+        "notGenerated": "Chưa tạo",
+        "genTitle": "Tạo video?",
+        "genDesc": "Đã kiểm tra lại ảnh tham chiếu và prompt. Tiến hành tạo đoạn video cho Beat #{{n}}.",
+        "regenTitle": "Tạo lại video?",
+        "regenDesc": "Tạo lại đoạn video cho Beat #{{n}}.",
+        "noteDefault": "Mặc định",
+        "noteNarration": "Khuyến nghị dùng lời dẫn",
+        "noteDialogue": "Cú máy có lời thoại",
+        "candidateCount": "Các phiên bản trước ({{count}})",
+        "currentBadge": "Hiện tại",
+        "switched": "Beat #{{n}} đã chuyển sang phiên bản khác",
+        "switchFailed": "Chuyển thất bại",
+        "seedance2Prompt": "Prompt chủ thể của Seedance2.0",
+        "seedance2Ready": "Đã cấu hình",
+        "seedance2Missing": "Còn thiếu",
+        "seedance2Saved": "Đã lưu cấu hình Seedance2",
+        "seedance2Inspector": "Seedance2 Inspector",
+        "seedance2PreviewMode": "Chế độ xem trước Seedance2",
+        "mediaStatus": "Trạng thái media",
+        "promptStatus": "Trạng thái prompt",
+        "videoVersions": "Phiên bản video ({{count}})",
+        "renderReady": "Render",
+        "audioReady": "Âm thanh",
+        "videoReady": "Video",
+        "seedance2References": "Ảnh tham chiếu",
+        "seedance2Voice": "Giọng nói",
+        "seedance2ReferenceStats": "{{selected}} đã gửi / {{missing}} còn thiếu",
+        "seedance2TextOverlay": "Chữ trên màn hình",
+        "seedance2AtReferences": "Tham chiếu @",
+        "seedance2MentionCandidates": "Các tham chiếu khả dụng",
+        "seedance2ReferenceDetails": "Chi tiết tham chiếu",
+        "seedance2ReferenceSent": "Đã gửi",
+        "seedance2ReferenceMissing": "Thiếu file",
+        "seedance2ReferenceUnused": "Chưa dùng",
+        "seedance2ReferenceFallback": "Thiếu ảnh",
+        "seedance2ReferenceImage": "Ảnh tham chiếu",
+        "seedance2ReferenceEmpty": "Chưa có tham chiếu nào. Hãy tải lên một ảnh hoặc file âm thanh làm tham chiếu thủ công.",
+        "seedance2AssetUpload": "Tải asset lên",
+        "seedance2AssetUploaded": "Đã tải tham chiếu Seedance2 lên",
+        "seedance2AssetDelete": "Xoá",
+        "seedance2AssetDeleted": "Đã xoá tham chiếu Seedance2",
+        "seedance2AssetCrop": "Cắt",
+        "seedance2AssetCropped": "Đã cắt tham chiếu Seedance2",
+        "seedance2AssetCropTitle": "Cắt tham chiếu Seedance2",
+        "seedance2AssetAudioTrim": "Cắt âm thanh",
+        "seedance2AssetAudioTrimTitle": "Cắt âm thanh tham chiếu Seedance2",
+        "seedance2AssetAudioTrimHint": "Seedance 2.0 cho kết quả tốt nhất với mẫu giọng rõ tiếng, chỉ một người nói, dài 3-5 giây.",
+        "seedance2AssetAudioTrimStart": "Bắt đầu (giây)",
+        "seedance2AssetAudioTrimDuration": "Thời lượng (giây)",
+        "seedance2AssetAudioTrimApply": "Cắt còn 3-5 giây",
+        "seedance2AssetAudioTrimInvalid": "Thiết lập cắt không hợp lệ",
+        "seedance2AssetAudioTrimmed": "Đã cắt âm thanh tham chiếu Seedance2",
+        "seedance2CropWidth": "Chiều rộng",
+        "seedance2CropHeight": "Chiều cao",
+        "seedance2ModeLabels": {
+          "first_frame": "Chế độ khung đầu",
+          "first_last_frame": "Chế độ khung đầu–khung cuối",
+          "multimodal_reference": "Chế độ nhiều tham chiếu"
+        },
+        "mode": "Chế độ tạo",
+        "duration": "Thời lượng",
+        "resolution": "Độ phân giải",
+        "ratio": "Tỉ lệ khung hình",
+        "generateAudio": "Tạo âm thanh",
+        "returnLastFrame": "Trả về khung cuối",
+        "returnLastFramePending": "Đang chờ khung cuối",
+        "humanReview": "Kiểm duyệt bởi người",
+        "generateVideo": "Tạo video",
+        "preview": {
+          "render": "Render",
+          "sketch": "Phác thảo",
+          "audio": "Âm thanh",
+          "video": "Video"
+        },
+        "previewMissing": {
+          "render": "Chưa có khung render",
+          "sketch": "Chưa có phác thảo",
+          "audio": "Chưa có âm thanh",
+          "video": "Chưa có video"
+        },
+        "seedance2PromptGuidance": "Hướng dẫn viết cho AI",
+        "seedance2GuidanceSubject": "Chủ thể",
+        "seedance2GuidanceScene": "Bối cảnh",
+        "seedance2GuidanceLighting": "Ánh sáng",
+        "seedance2GuidanceCamera": "Máy quay",
+        "seedance2GuidanceStyle": "Phong cách",
+        "seedance2GuidanceNoSubtitle": "Không phụ đề",
+        "seedance2GuidanceSubjectTemplate": "Subject: Define the primary character or object, its current action and state, and avoid competing focal subjects.",
+        "seedance2GuidanceSceneTemplate": "Scene: Describe the spatial background, location relationships, key props, and environmental materials while staying consistent with the references.",
+        "seedance2GuidanceLightingTemplate": "Lighting: Describe the key light, tonal layers, color temperature, and atmosphere while avoiding unintended flicker.",
+        "seedance2GuidanceCameraTemplate": "Camera: Specify shot size, viewpoint, movement speed, and direction so the camera move is clear and executable.",
+        "seedance2GuidanceStyleTemplate": "Style: Define visual texture, period, color direction, and realism to prevent style drift.",
+        "seedance2GuidanceNoSubtitleTemplate": "No subtitles: Do not generate any text or subtitles; keep the frame visually clean.",
+        "seedance2SceneOptimizeLabels": {
+          "anime": "Anime",
+          "realistic": "Tả thực"
+        },
+        "seedance2GeneratePrompt": "AI tối ưu",
+        "seedance2PromptGenerated": "Đã tối ưu prompt Seedance2",
+        "seedance2PromptGeneratedOtherBeat": "Đã tối ưu prompt chủ thể và lưu ngược về beat #{{n}}",
+        "seedance2PromptGenerateFailed": "Tạo prompt Seedance2 thất bại",
+        "videoPrompt": "Prompt video",
+        "keyframePrompt": "Prompt video của riêng beat",
+        "generateBeatVideoPrompt": "Tạo prompt cho beat này",
+        "beatVideoPromptGenerated": "Đã tạo prompt video cho beat này",
+        "beatVideoPromptGenerateStarted": "Đã bắt đầu tạo prompt video cho beat này",
+        "beatVideoPromptGenerateFailed": "Tạo prompt video cho beat này thất bại",
+        "beatVideoPromptRequired": "Beat #{{n}} chưa có prompt video. Hãy tạo prompt cho beat này trước.",
+        "seedance2PromptRequired": "Beat #{{n}} chưa có prompt chính của Seedance2.0. Hãy điền vào hoặc chạy AI tối ưu trước.",
+        "seedance2OverlayEnabled": "Bật",
+        "seedance2OverlayKind": "Kiểu",
+        "seedance2OverlayKindAdCopy": "Chữ quảng cáo",
+        "seedance2OverlayKindSubtitle": "Phụ đề",
+        "seedance2OverlayKindSpeechBubble": "Bong bóng thoại",
+        "seedance2OverlayPlacement": "Vị trí đặt",
+        "seedance2OverlayTiming": "Thời điểm",
+        "seedance2OverlayStyle": "Kiểu chữ",
+        "seedance2OverlayContent": "Nội dung chữ",
+        "seedance2OverlaySpeaker": "Người nói",
+        "seedance2OverlaySpeakerNone": "Không có",
+        "narratorVoice": "Giọng người dẫn truyện",
+        "narratorVoiceMissing": "Thiếu giọng",
+        "narratorVoiceLoading": "Đang tải giọng người dẫn truyện",
+        "narratorVoiceLoadFailed": "Tải giọng người dẫn truyện thất bại",
+        "narratorVoiceMissingDetail": "Chưa cấu hình giọng người dẫn truyện cho dự án kể ngôi thứ ba",
+        "narratorVoiceUpload": "Tải lên",
+        "narratorVoiceRecord": "Thu âm",
+        "narratorVoiceProjectAudio": "Âm thanh của dự án",
+        "narratorVoiceTrim": "Cắt",
+        "narratorVoiceDelete": "Xoá",
+        "narratorVoiceUploaded": "Đã lưu giọng người dẫn truyện",
+        "narratorVoiceSaved": "Đã lưu bản thu giọng người dẫn truyện",
+        "narratorVoiceCopied": "Đã sao chép làm giọng người dẫn truyện",
+        "narratorVoiceTrimmed": "Đã cắt giọng người dẫn truyện",
+        "narratorVoiceDeleted": "Đã xoá giọng người dẫn truyện",
+        "narratorVoiceRecordTitle": "Thu giọng người dẫn truyện",
+        "narratorVoiceRecordHint": "Hãy thu 10-20 giây lời nói rõ ràng.",
+        "narratorVoiceRecordReady": "Sẵn sàng thu",
+        "narratorVoiceRequestingMic": "Đang xin quyền micro",
+        "narratorVoiceRecording": "Đang thu",
+        "narratorVoiceRecorded": "Đã thu {{seconds}}s",
+        "narratorVoiceRecordFailed": "Thu âm thất bại",
+        "narratorVoiceRecordUnavailable": "Trình duyệt này không hỗ trợ thu âm",
+        "narratorVoiceRecordStart": "Bắt đầu",
+        "narratorVoiceSaveRecording": "Lưu bản thu",
+        "narratorVoiceProjectAudioTitle": "Chọn âm thanh của dự án",
+        "narratorVoiceSourcesLoading": "Đang tải âm thanh của dự án",
+        "narratorVoiceNoSources": "Chưa có âm thanh nào của dự án dùng được",
+        "narratorVoiceTrimTitle": "Cắt giọng người dẫn truyện",
+        "narratorVoiceTrimHint": "Seedance 2.0 cho kết quả tốt nhất với đoạn tham chiếu 3-5 giây, rõ tiếng và chỉ một người nói.",
+        "narratorVoiceTrimStart": "Giây bắt đầu",
+        "narratorVoiceTrimDuration": "Số giây thời lượng",
+        "narratorVoiceTrimApply": "Cắt còn 3-5 giây",
+        "narratorVoiceTrimInvalid": "Giá trị cắt không hợp lệ",
+        "narratorVoiceUse": "Dùng",
+        "seedance2SubjectPromptGenerated": "Đã tối ưu prompt chủ thể",
+        "grokVideoInspector": "Grok Video Inspector",
+        "happyHorseInspector": "HappyHorse Inspector",
+        "grokPromptLabel": "Prompt Grok",
+        "subjectPromptLabel": "Prompt chủ thể",
+        "generateGrokPrompt": "Tạo prompt Grok",
+        "generateSubjectPrompt": "Tạo prompt chủ thể",
+        "seedance2CropTitleWithAspect": "Cắt {{aspect}}",
+        "seedance2CropDragHandle": "Di chuyển vùng cắt"
+      },
+      "sketch": {
+        "switched": "Đã đổi phác thảo",
+        "switchFailed": "Đổi thất bại",
+        "forcedUse": "Đã ép dùng phác thảo này",
+        "forceFailed": "Ép dùng thất bại",
+        "regenStarted": "Đã bắt đầu tạo lại",
+        "regenFailed": "Tạo lại thất bại",
+        "verifyGate": "Cổng kiểm tra:",
+        "verifyLabel": "Tính nhất quán của phác thảo",
+        "verifyDrawerTitle": "12.9 Kiểm tra tính nhất quán của phác thảo",
+        "currentSketch": "Phác thảo hiện tại",
+        "generating": "Đang tạo",
+        "genFailed": "Tạo thất bại",
+        "notGenerated": "Chưa có phác thảo — hãy kích hoạt tạo hàng loạt ở phía trên",
+        "candidateHint": "Phác thảo ứng viên, chưa được chốt từ kho",
+        "candidateCount": "Ứng viên ({{count}})",
+        "regenThisBeat": "Tạo lại beat này",
+        "staleBatch": "Phác thảo hàng loạt đã cũ",
+        "currentBadge": "Hiện tại",
+        "staleBadge": "Đã cũ",
+        "colorBindings": "Gán màu",
+        "reassignColors": "Gán lại màu",
+        "identityColors": "Tạo hình",
+        "propColors": "Đạo cụ",
+        "aiDetectResults": "Kết quả AI",
+        "aiDetectResultCounts": "{{beats}} beat / {{identities}} tạo hình / {{props}} đạo cụ",
+        "openGridGallery": "Lưới phác thảo",
+        "noCandidates": "Kho chưa có ứng viên nào. Hãy dùng thanh tạo hàng loạt phía trên.",
+        "versionMismatch": "Phiên bản phác thảo không khớp",
+        "versionMismatchDesc": "Phác thảo này được tạo từ một kịch bản cũ hơn. Cách gán màu cho nhân vật có thể đã thay đổi. Vẫn ép dùng chứ?",
+        "generateNow": "Tạo ngay",
+        "generateTitle": "Tạo phác thảo ngay?",
+        "generateDesc": "Tạo phác thảo cho Beat #{{n}}. Phác thảo mới sẽ vào kho ứng viên.",
+        "regenTitle": "Tạo lại phác thảo?",
+        "regenDesc": "Tạo lại phác thảo cho Beat #{{n}}. Phác thảo mới sẽ vào kho ứng viên.",
+        "poseEdit": "Chỉnh tư thế",
+        "poseTitle": "Trình sửa phác thảo Beat {{n}}",
+        "poseCharacters": "Nhân vật trong khung",
+        "posePreset": "Tư thế dựng sẵn",
+        "poseApplyPreset": "Áp dụng tư thế dựng sẵn",
+        "poseSelect": "Chọn/kéo",
+        "poseColorPen": "Bút màu",
+        "poseInk": "Bút mực",
+        "poseEraser": "Tẩy",
+        "poseWidth": "Độ dày nét",
+        "poseUndo": "Hoàn tác",
+        "poseReset": "Đặt lại tư thế",
+        "poseAddToFrame": "Thêm",
+        "poseRemoveFromFrame": "Bỏ ra",
+        "poseClear": "Xoá nét vẽ",
+        "poseSaved": "Đã lưu chỉnh sửa phác thảo",
+        "cropEdit": "Cắt và lưu",
+        "cropTitle": "Cắt phác thảo Beat {{n}}",
+        "cropWidth": "Chiều rộng",
+        "cropHeight": "Chiều cao",
+        "cropSaved": "Đã lưu phác thảo đã cắt",
+        "directorControl": "Asset Director tổng hợp",
+        "directorControlFile": "Combined + env-only + metadata",
+        "convertDirectorControl": "Chuyển thành phác thảo",
+        "convertDirectorStarted": "Đã bắt đầu tác vụ Direct Render sang phác thảo",
+        "convertDirectorFailed": "Không khởi động được Direct Render sang phác thảo",
+        "openDirectorWorld": "Director World",
+        "openDirectorWorldTip": "Mở Beat này trong Director World",
+        "openDirectorWorldFailed": "Không mở được Beat này trong Director World",
+        "chooseBackground": "Nền",
+        "chooseBackgroundTip": "Chọn nền riêng cho beat này",
+        "chooseBackgroundFailed": "Chọn nền riêng cho beat thất bại",
+        "chooseBackgroundSaved": "Đã lưu nền riêng cho beat",
+        "backgroundDialogTitle": "Nền của Beat {{n}}",
+        "backgroundDialogDesc": "Chỉ ảnh hưởng tới phác thảo và render của riêng beat này. Chế độ hàng loạt vẫn dùng ảnh gốc của bối cảnh.",
+        "backgroundMissing": "Chưa có ảnh nền",
+        "backgroundCurrent": "Hiện tại",
+        "backgroundSnapshotUse": "Dùng bản chụp",
+        "openFreezone": "Sửa trong Freezone",
+        "openFreezoneTip": "Sửa phác thảo của beat này trong Freezone",
+        "freezoneOpened": "Đã mở Freezone cho phác thảo",
+        "freezoneOpenFailed": "Không mở được Freezone cho phác thảo",
+        "cropTitleWithAspect": "Cắt {{aspect}}",
+        "cropDragHandle": "Di chuyển vùng cắt"
+      },
+      "sketchGrid": {
+        "title": "Lưới phác thảo",
+        "titleWithCount": "Lưới phác thảo ({{count}} lưới)",
+        "gridCount": "{{count}} lưới",
+        "gridLabel": "Lưới #{{n}}",
+        "cellCount": "{{count}} ô",
+        "noPreview": "Không có bản xem trước",
+        "generateGrid": "Tạo/Tạo lại",
+        "regenStarted": "Đã bắt đầu Lưới #{{n}}",
+        "regenFailed": "Tạo lưới thất bại",
+        "uploadGrid": "Tải lưới lên",
+        "uploadSuccess": "Đã tải Lưới #{{n}} lên",
+        "uploadFailed": "Tải lưới lên thất bại",
+        "exportPrompt": "Xuất prompt",
+        "promptTitle": "Prompt của Lưới #{{n}}",
+        "promptContent": "Nội dung prompt",
+        "promptFailed": "Xuất prompt thất bại",
+        "copySuccess": "Đã sao chép prompt",
+        "cut": "Cắt vào kho",
+        "cutSuccess": "Đã cắt Lưới #{{n}}",
+        "cutFailed": "Cắt lưới thất bại",
+        "unknownScene": "Bối cảnh không rõ"
+      },
+      "render": {
+        "generateNew": "Tạo mới",
+        "switched": "Đã đổi bản render",
+        "switchFailed": "Đổi thất bại",
+        "forcedUse": "Đã ép dùng bản render này",
+        "forceFailed": "Ép dùng thất bại",
+        "regenStarted": "Đã bắt đầu tạo lại",
+        "regenFailed": "Tạo lại thất bại",
+        "versionMismatch": "Phiên bản render không khớp",
+        "versionMismatchDesc": "Bản render này được tạo từ một kịch bản cũ hơn. Nội dung có thể không nhất quán. Vẫn ép dùng chứ?",
+        "regenTitle": "Render lại?",
+        "regenDesc": "Render lại cho Beat #{{n}}. Bản render mới sẽ vào kho ứng viên.",
+        "openFreezone": "Sửa trong Freezone",
+        "openFreezoneTip": "Sửa bản render của beat này trong Freezone",
+        "freezoneOpened": "Đã mở trình sửa Freezone",
+        "freezoneOpenFailed": "Không mở được trình sửa Freezone",
+        "backgroundTitle": "Ảnh nền tham chiếu khi render",
+        "backgroundCurrent": "Hiện tại: {{label}}",
+        "backgroundHint": "Áp màu sắc/chất liệu lên phác thảo mà không đổi bố cục.",
+        "backgroundRenderInput": "Đầu vào render: {{label}}",
+        "backgroundMissing": "Không tìm thấy ảnh tham chiếu",
+        "backgroundOpen360": "Mở Director World",
+        "backgroundDirectorWorldDescription": "Căn khung cú máy trong Director World rồi ghi vào khung Director combined của cú máy hiện tại.",
+        "backgroundAnchorLabels": {
+          "directorEnvOnly": "Ảnh chụp cảnh trong Director World",
+          "master": "Bối cảnh chính diện",
+          "reverse": "Bối cảnh góc ngược"
+        },
+        "backgroundCropAction": "Cắt {{label}}",
+        "backgroundCropTitle": "Cắt ảnh chụp {{label}}",
+        "backgroundCropFallbackTitle": "Cắt ảnh chụp",
+        "backgroundUpload": "Tải ảnh tham chiếu bên ngoài lên",
+        "backgroundUploaded": "Đã tải ảnh nền tham chiếu khi render lên",
+        "backgroundUploadFailed": "Tải ảnh nền tham chiếu khi render lên thất bại",
+        "backgroundSaved": "Đã đổi ảnh nền tham chiếu khi render",
+        "backgroundSaveFailed": "Lưu ảnh nền tham chiếu khi render thất bại",
+        "backgroundCropSave": "Lưu phần đã cắt",
+        "backgroundCropTitleWithAspect": "Cắt {{aspect}}",
+        "backgroundCropDragHandle": "Di chuyển vùng cắt",
+        "relightLabel": "Đổi ánh sáng sang {{timeOfDay}}",
+        "relightLabelDefaultTime": "thời điểm đã chỉ định",
+        "relightTooltip": "Đổi ánh sáng: chiếu sáng lại cú máy theo thời điểm trong ngày của beat mà không đổi cấu trúc bối cảnh.",
+        "lockedLightTooltip": "Khoá ánh sáng: dùng đúng ánh sáng vốn có của ảnh bối cảnh; không đổi sáng.",
+        "lockedLightLabel": "Khoá ánh sáng"
+      },
+      "renderGrid": {
+        "title": "Lưới render",
+        "titleWithCount": "Lưới render ({{count}} lưới)",
+        "gridCount": "{{count}} lưới",
+        "rebuildIndex": "Dựng lại chỉ mục",
+        "rebuildSuccess": "Đã dựng lại chỉ mục: {{count}} ảnh",
+        "rebuildFailed": "Dựng lại chỉ mục thất bại",
+        "noIndexedGrids": "Chưa có chỉ mục Lưới render. Hãy chạy Render trước hoặc dựng lại chỉ mục kho ảnh.",
+        "gridLabel": "Lưới #{{n}}",
+        "cellCount": "{{count}} ô",
+        "noPreview": "Không có bản xem trước",
+        "cut": "Cắt vào kho",
+        "regenStarted": "Đã bắt đầu Lưới #{{n}}",
+        "regenFailed": "Tạo lại lưới thất bại",
+        "uploadGrid": "Tải lưới lên",
+        "uploadSuccess": "Đã tải Lưới #{{n}} lên",
+        "uploadFailed": "Tải lưới lên thất bại",
+        "exportPrompt": "Xuất prompt",
+        "promptTitle": "Prompt của Lưới #{{n}}",
+        "promptContent": "Nội dung prompt",
+        "promptFailed": "Xuất prompt thất bại",
+        "copySuccess": "Đã sao chép prompt",
+        "cutSuccess": "Đã cắt Lưới #{{n}}",
+        "cutFailed": "Cắt lưới thất bại"
+      },
+      "batch": {
+        "narrationIncompatible": "Model này chỉ hỗ trợ cú máy có lời thoại ({{count}} beat lời dẫn không tương thích)",
+        "toolbar": "Thanh công cụ tạo nội dung",
+        "globalOptimizeStarted": "Đã bắt đầu tối ưu toàn cục",
+        "rewriteScriptTitle": "Viết lại toàn bộ kịch bản?",
+        "rewriteScriptDesc": "Tạo lại lời dẫn của mọi beat từ văn bản gốc/bản chuyển thể. Nội dung hiện có và các dấu \"đã cũ\" của phác thảo sẽ bị ảnh hưởng.",
+        "rewriteScript": "Viết lại toàn bộ kịch bản",
+        "genSketchTitle": "Tạo toàn bộ phác thảo?",
+        "genSketchDesc": "Tạo phác thảo cho mọi beat. Phác thảo hiện có sẽ không bị ghi đè; bản mới sẽ vào kho ứng viên.",
+        "genSketch": "Tạo toàn bộ phác thảo",
+        "genSketchShort": "Toàn bộ phác thảo",
+        "autoSelectTitle": "Tự động chọn tất cả?",
+        "autoSelectDesc": "Tự động chọn phác thảo tốt nhất trong kho ứng viên cho mọi beat.",
+        "autoSelect": "Tự động chọn tất cả",
+        "insertManualBeforeFirst": "Trước cú máy đầu tiên",
+        "insertManualBeforeFirstShort": "Trước cú máy đầu",
+        "insertManualBeforeFirstTooltip": "Chèn một cú máy thủ công trước beat đầu tiên",
+        "genMissingManualTitle": "Bù các phác thảo còn thiếu?",
+        "genMissingManualDesc": "Tạo hàng loạt phác thảo cho các cú máy thủ công mới chèn trong tập này mà chưa có phác thảo, gom nhóm theo bối cảnh.",
+        "genMissingManual": "Bù phác thảo",
+        "genMissingManualShort": "Cú máy mới",
+        "genMissingManualTooltip": "Tạo phác thảo cho các cú máy thủ công mới chèn trong tập này mà chưa có phác thảo, gom nhóm theo bối cảnh",
+        "genMissingManualEmpty": "Không có cú máy thủ công nào thiếu phác thảo",
+        "genMissingManualDispatched": "Đã gửi {{count}} tác vụ phác thảo cho cú máy thủ công",
+        "autoCombine": "Vẽ lại hàng loạt",
+        "genRender": "Render cả tập",
+        "genRenderShort": "Toàn bộ render",
+        "genRenderTitle": "Render cả tập?",
+        "genRenderDesc": "Tạo các lưới Render cho cả tập theo quy trình Kế hoạch render chuẩn. Cần có phác thảo và kết quả AI nhận diện tạo hình trước.",
+        "genRenderTooltip": "Mở Kế hoạch render cho cả tập (chế độ generate_grid chuẩn)",
+        "batchRenderStarted": "Đã bắt đầu render",
+        "aiDetect": "AI nhận diện",
+        "aiDetectTooltip": "Dùng thị giác AI để nhận diện nhân vật được tô màu nào xuất hiện trong từng phác thảo",
+        "aiDetectRunning": "AI đang nhận diện nhân vật...",
+        "aiDetectSuccess": "AI nhận diện xong: {{beats}} beat, {{ids}} tạo hình, {{props}} đạo cụ",
+        "aiDetectEmpty": "AI không nhận diện được gì",
+        "aiDetectReview": "Hãy xem lại từng beat; bổ sung tạo hình hoặc đạo cụ còn thiếu ở mục Thêm nếu AI bỏ sót.",
+        "reassignColors": "Gán lại màu",
+        "reassignColorsTitle": "Gán lại màu cho phác thảo?",
+        "reassignColorsDesc": "Thao tác này sẽ gán lại màu cho phác thảo của tập này dựa trên các tạo hình hiện có trong kịch bản. Phác thảo hiện có có thể hiển thị dấu màu không nhất quán.",
+        "reassignColorsTooltip": "Gán lại màu dựa trên tạo hình trong kịch bản (chạy lại nhiều lần vẫn cho kết quả như nhau)",
+        "reassignColorsSuccess": "Đã gán lại màu cho {{count}} tạo hình và {{propCount}} đạo cụ",
+        "genAudioTitle": "Tạo toàn bộ âm thanh?",
+        "genAudioDesc": "Tạo lồng tiếng TTS cho mọi beat còn thiếu âm thanh.",
+        "genAudio": "Tạo toàn bộ âm thanh",
+        "genAudioShort": "Toàn bộ âm thanh",
+        "genAudioUnavailableForVideoModel": "Model video hiện tại không cần tạo âm thanh riêng cho cả tập",
+        "videoModel": "Model video",
+        "sketchSettingsLabel": "Cài đặt phác thảo",
+        "renderSettingsLabel": "Cài đặt render",
+        "videoSettingsLabel": "Cài đặt video",
+        "genVideoTitle": "Tạo toàn bộ video?",
+        "genVideoDesc": "Tạo đoạn video cho mọi beat còn thiếu video. Cần có phác thảo/bản render và âm thanh trước.",
+        "genVideo": "Tạo toàn bộ video",
+        "genVideoShort": "Toàn bộ video",
+        "aiOptimizeTitle": "Tạo prompt video cho mọi beat?",
+        "aiOptimizeDesc": "Dùng SuperPower phân tích phác thảo của tập này và tạo prompt video cho toàn bộ beat.",
+        "aiOptimize": "Tạo prompt video cho mọi beat",
+        "aiOptimizeShort": "Prompt toàn bộ beat",
+        "selectedCount": "Đã chọn {{count}} beat",
+        "clearSelection": "Bỏ chọn",
+        "batchRegen": "Tạo lại hàng loạt",
+        "sketch": "Phác thảo",
+        "render": "Render",
+        "audio": "Âm thanh",
+        "video": "Video",
+        "singleRegen": "Vẽ lại riêng lẻ",
+        "regenSketchSingleTitle": "Vẽ lại riêng lẻ phác thảo của {{count}} beat?",
+        "regenSketchSingleDesc": "Tách #{{beats}} thành các tác vụ phác thảo 1×1 theo tỉ lệ khung hình hiện tại.",
+        "regenSketchTitle": "Tạo lại phác thảo cho {{count}} beat ({{mode}})?",
+        "regenSketchDesc": "Tạo lại phác thảo cho #{{beats}}. Phác thảo mới sẽ vào kho ứng viên.",
+        "regenSketchDescBatch": "Sẽ chạy thành {{batches}} lô.",
+        "regenRenderTitle": "Render lại {{count}} beat ({{mode}})?",
+        "regenRenderDesc": "Render lại #{{beats}}. Bản render mới sẽ vào kho ứng viên.",
+        "regenRenderDescBatch": "Sẽ chạy thành {{batches}} lô.",
+        "genBatchAudioTitle": "Tạo âm thanh cho {{count}} beat?",
+        "genBatchAudioDesc": "Gửi một tác vụ âm thanh IndexTTS2 cho #{{beats}}.",
+        "genBatchAudio": "Tạo âm thanh cho {{count}} beat",
+        "genBatchVideoTitle": "Tạo video cho {{count}} beat?",
+        "genBatchVideoDesc": "Tạo đoạn video cho #{{beats}} lần lượt từng cái. Cần có phác thảo/bản render và âm thanh.",
+        "genBatchVideo": "Tạo video cho {{count}} beat",
+        "batchHint": "Chế độ khuyến nghị đang được làm nổi bật. Âm thanh gửi một tác vụ bất đồng bộ cho các beat đã chọn; video vẫn chạy lần lượt từng beat.",
+        "dispatched": "Đã gửi {{count}} beat → {{mode}}",
+        "dispatchedBatch": " × {{batches}} lô",
+        "dispatchFailed": "Gửi tác vụ thất bại",
+        "sketchGroupRunning": "Nhóm phác thảo tương ứng đang chạy rồi",
+        "sketchGroupSkippedRunning": "Đã bỏ qua {{count}} nhóm phác thảo đang chạy",
+        "sketchSameSceneRequired": "Tạo lại phác thảo chỉ dùng được các beat cùng một bối cảnh; bối cảnh hiện tại: {{scenes}}",
+        "sketchSceneMissingRequired": "Các beat đã chọn chưa gán bối cảnh nên không kiểm tra được điều kiện cùng bối cảnh: #{{beats}}. Hãy lên kế hoạch hoặc gán bối cảnh trước.",
+        "sketchDispatchQueue": "Hàng gửi tạo lại phác thảo",
+        "sketchDispatchQueued": "Đã xếp {{count}} beat vào hàng cho {{mode}}",
+        "sketchDispatchDuplicate": "Các beat này đã nằm trong thẻ gửi tạo lại phác thảo ở phía trên: #{{beats}}. Hãy dùng nút Tạo nhóm ở đó hoặc xoá thẻ đi trước.",
+        "sketchDispatchOverlap": "Các beat này đã được thẻ gửi tạo lại phác thảo ở phía trên sử dụng: #{{beats}}. Hãy dùng nút Tạo nhóm ở đó hoặc xoá thẻ đi trước.",
+        "sketchDispatchRun": "Tạo nhóm",
+        "sketchTaskStatus": "Trạng thái tác vụ: {{status}}",
+        "sketchUsageTitle": "Mức dùng yêu cầu tạo phác thảo",
+        "sketchUsageToday": "Hôm nay {{count}}",
+        "sketchUsageTotal": "Tổng cộng {{count}}",
+        "imageGuardConfirmTitle": "Tiếp tục tạo?",
+        "imageGuardLockedTitle": "Chốt chặn khi tạo ảnh",
+        "operatorPasswordPlaceholder": "Mật khẩu người vận hành",
+        "operatorPasswordError": "Mật khẩu không đúng",
+        "audioDispatched": "Đã gửi tác vụ âm thanh IndexTTS2 cho {{count}} beat",
+        "audioSuccess": "Đã tạo âm thanh cho {{ok}} beat",
+        "audioPartial": "Âm thanh: {{ok}} thành công, {{fail}} thất bại",
+        "videoSuccess": "Đã tạo video cho {{ok}} beat",
+        "videoPartial": "Video: {{ok}} thành công, {{fail}} thất bại",
+        "batchRegenSketchSuccess": "Đã bắt đầu tạo lại phác thảo cho {{count}} beat",
+        "batchRegenRenderSuccess": "Đã bắt đầu render lại {{count}} beat",
+        "episodeFreezone": "Freezone của tập",
+        "episodeFreezoneTooltip": "Mở tập này trong Freezone",
+        "episodeFreezoneOpened": "Đã mở Freezone của tập",
+        "episodeFreezoneOpenFailed": "Không mở được Freezone của tập"
+      },
+      "verify": {
+        "notRun": "Chưa chạy",
+        "running": "Đang chạy",
+        "passed": "Đạt",
+        "failed": "Không đạt",
+        "status": "Trạng thái: {{state}}",
+        "notGenerated": "Báo cáo này chưa được tạo. Việc kiểm tra sẽ tự chạy tại cổng tương ứng trong quy trình, hoặc sau các thao tác hàng loạt ở tab Cú máy.",
+        "charPassed": "✓ Đạt",
+        "charFailed": "⚠ Không đạt",
+        "faceScore": "Khuôn mặt {{score}}",
+        "clothingScore": "Trang phục {{score}}",
+        "jumpBeat": "Nhảy tới beat {{n}}"
+      },
+      "actionPanel": {
+        "episodeFreezone": "Canvas của tập",
+        "episodeFreezoneTooltip": "Mở asset của tập này trong canvas",
+        "episodeFreezoneOpened": "Đã mở canvas của tập",
+        "episodeFreezoneOpenFailed": "Không mở được canvas của tập"
+      }
+    },
+    "state": {
+      "ready": "Sẵn sàng",
+      "missing": "Chờ xử lý",
+      "generating": "Đang tạo",
+      "failed": "Thất bại"
+    },
+    "health": {
+      "allReady": "Sẵn sàng",
+      "blocked": "Chưa sẵn sàng",
+      "readyRatio": "{{ready}}/{{total}}",
+      "blockedCount": "{{count}} đang vướng",
+      "composeReady": "Sẵn sàng",
+      "composeBlocked": "Thiếu {{count}}",
+      "beatCount": "{{count}} beat"
+    },
+    "compose": {
+      "blocked": "Còn thiếu:",
+      "exportSrt": "Xuất SRT",
+      "exportZip": "Xuất ZIP",
+      "composeEpisode": "Dựng tập phim",
+      "recomposeEpisode": "Dựng lại",
+      "composeTitle": "Xác nhận dựng 「{{title}}」",
+      "composeDesc": "Nối toàn bộ các đoạn video của beat thành một tập phim hoàn chỉnh. Việc này có thể mất vài phút.",
+      "composeDescSubtitles": " (có phụ đề)",
+      "composeDescBgm": " (có nhạc nền)",
+      "composeConfirm": "Bắt đầu dựng",
+      "composeCancel": "Huỷ",
+      "composing": "Đang dựng",
+      "composeFinal": "Bản dựng cuối",
+      "downloadVideo": "Tải video về",
+      "composingProgress": "Đang dựng...",
+      "notComposed": "Chưa dựng",
+      "composeHint": "Hãy chắc chắn mọi beat đều đã có phác thảo, âm thanh và video. Bấm \"Dựng tập phim\" để tạo. Xong rồi thì xem trước và tải về ở đây, hoặc xuất SRT/ZIP ở góc trên bên phải.",
+      "beats": "Beat",
+      "duration": "Thời lượng ước tính",
+      "options": "Tuỳ chọn",
+      "resolution": "Độ phân giải",
+      "resolution720": "720p",
+      "resolution1080": "1080p",
+      "videoCount": "Video: {{ready}}/{{total}}",
+      "beatsReady": "beat đã sẵn sàng",
+      "blockerTitle": "Còn {{count}} beat chưa sẵn sàng",
+      "blockerHint": "Bấm vào thẻ để nhảy tới beat đó",
+      "readyToCompose": "Mọi beat đã sẵn sàng — bấm \"Dựng tập phim\" ở góc trên bên phải để bắt đầu",
+      "subtitlesOn": "có phụ đề",
+      "subtitlesOff": "không phụ đề",
+      "durationApprox": "~{{value}}",
+      "durationUnknown": "chưa rõ thời lượng",
+      "planDot": " · ",
+      "finalPreview": "Xem trước bản cuối",
+      "episodeHeader": "Tập {{n}}",
+      "noClips": "Không có đoạn video nào để dựng",
+      "noClipsHint": "Hãy tạo video cho các beat của tập này trước, rồi quay lại đây để dựng bản cuối.",
+      "blockerCount": "{{count}} beat chưa sẵn sàng",
+      "blockerSubtitle": "Các beat sau vẫn còn thiếu asset. Hãy hoàn thiện chúng trước khi dựng.",
+      "missingItemSeparator": ", ",
+      "missingItems": "Còn thiếu: {{items}}",
+      "beatLabel": "Beat"
+    },
+    "gate": {
+      "scriptIdentitiesRequired": "Tập này chưa lên kế hoạch tạo hình nào. Hãy chọn tạo hình nhân vật ở bảng nguồn trước.",
+      "seedanceDialogueOnly": "Seedance 1.5 chỉ hỗ trợ cú máy có lời thoại ({{n}} beat lời dẫn không tương thích)"
+    },
+    "list": {
+      "subtitle": "Lên kế hoạch các tập và đưa từng tập tới video hoàn chỉnh.",
+      "backToEpisodes": "Về danh sách tập phim",
+      "episodeNumber": "Tập {{n}}",
+      "switchEpisode": "Đổi tập",
+      "episodeSwitchSummary": "{{lines}} dòng nguồn · {{identities}} tạo hình · {{scenes}} bối cảnh · {{props}} đạo cụ",
+      "planEpisodes": "Lên kế hoạch tập phim",
+      "replanEpisodes": "Lên lại kế hoạch",
+      "replanTitle": "Lên lại kế hoạch tập phim?",
+      "replanDesc": "Các tập sẽ được tạo lại từ cấu trúc chương. Dữ liệu tập phim hiện có có thể bị ảnh hưởng.",
+      "noEpisodes": "Chưa có tập phim nào",
+      "noEpisodesHint": "Hãy tải và nhập truyện trước, rồi bấm \"Lên kế hoạch tập phim\" để tạo các tập từ cấu trúc chương.",
+      "planning": "Đang lên kế hoạch tập phim",
+      "refresh": "Làm mới",
+      "refreshed": "Đã làm mới danh sách tập",
+      "selectedEpisodeSummary": "{{lines}} dòng nguồn · {{beats}} Beat · {{identities}} tạo hình · {{scenes}} bối cảnh · {{props}} đạo cụ · {{status}}",
+      "scriptReady": "Kịch bản đã sẵn sàng",
+      "scriptPending": "Kịch bản đang chờ",
+      "stats": {
+        "totalEpisodes": "Số tập",
+        "completedEpisodes": "Đã xong",
+        "totalCharacters": "Nhân vật",
+        "totalIdentities": "Tạo hình",
+        "totalScenes": "Bối cảnh",
+        "totalProps": "Đạo cụ",
+        "totalKeyEvents": "Sự kiện then chốt"
+      },
+      "identityCount": "{{count}} tạo hình",
+      "shotCount": "{{count}} cú máy",
+      "sceneCount": "{{count}} bối cảnh",
+      "propCount": "{{count}} đạo cụ",
+      "noIdentities": "Chưa lên kế hoạch tạo hình",
+      "noScenes": "Chưa lên kế hoạch bối cảnh",
+      "noProps": "Chưa lên kế hoạch đạo cụ",
+      "planIdentities": "Lên kế hoạch tạo hình",
+      "replanIdentities": "Lên lại kế hoạch tạo hình",
+      "identityCharactersRequired": "Hãy dựng nhân vật từ sơ đồ tri thức trước",
+      "identityCharactersBuilding": "Đang dựng nhân vật; lên kế hoạch tạo hình sẽ mở khi xong",
+      "identityCharactersLoading": "Đang kiểm tra dữ liệu nhân vật",
+      "sceneCatalogBuilding": "Đang dựng bối cảnh; lên kế hoạch bối cảnh sẽ mở khi xong",
+      "sceneCatalogLoading": "Đang kiểm tra tiến độ dựng bối cảnh",
+      "planScenes": "Lên kế hoạch bối cảnh",
+      "replanScenes": "Lên lại kế hoạch bối cảnh",
+      "planProps": "Lên kế hoạch đạo cụ",
+      "replanProps": "Lên lại kế hoạch đạo cụ",
+      "viewDetails": "Xem chi tiết"
+    },
+    "beats": {
+      "genFailed": "Tạo thất bại",
+      "loading": "Đang tải…",
+      "noBeatsTitle": "Chưa có beat nào",
+      "noBeats": "Chưa có beat nào — hãy tạo kịch bản trước",
+      "generateBeats": "Tạo beat",
+      "generateBeatsTitle": "Tạo beat?",
+      "generateBeatsDesc": "Tách bản chuyển thể (hoặc văn bản gốc) theo từng dòng thành các beat, làm cơ sở cho phác thảo, âm thanh và video."
+    },
+    "sketchPlan": {
+      "title": "Kế hoạch phác thảo ({{beats}} beat → {{grids}} lưới)",
+      "subtitle": "Hệ thống đã tự gom nhóm theo bối cảnh. Xác nhận để gửi các tác vụ phác thảo.",
+      "confirm": "Xác nhận {{grids}} lưới phác thảo"
+    },
+    "renderPlan": {
+      "title": "Kế hoạch render ({{beats}} beat → {{grids}} lưới)",
+      "subtitle": "Hệ thống đã tự gom nhóm theo bối cảnh và số nhân vật. Xác nhận để bắt đầu.",
+      "strategy": "Chiến lược lập kế hoạch",
+      "strategyLocation": "Gom theo bối cảnh",
+      "strategyNaive": "Xếp tuần tự",
+      "forceOneByOne": "Render riêng từng cái · độ trung thực cao nhất (1×1 mỗi beat)",
+      "confirm": "Xác nhận {{grids}} lưới",
+      "planning": "Đang lập kế hoạch render…",
+      "unavailable": "Không có kế hoạch render nào",
+      "openDialog": "Render lại mục đã chọn ({{count}})",
+      "dispatched": "Đã bắt đầu render",
+      "featureDisabled": "Render V2 đang tắt. Hãy dùng tạo lại theo từng beat.",
+      "unknownLocation": "bối cảnh không rõ",
+      "split": "Tách",
+      "mergeNext": "Gộp với cái sau",
+      "stale": {
+        "input": "Đầu vào đã thay đổi (nhân vật hoặc nội dung beat). Vui lòng xác nhận lại.",
+        "plan": "Logic lập kế hoạch đã cập nhật. Vui lòng xác nhận lại."
+      },
+      "errors": {
+        "invalidBeats": "Các beat đã chọn không thuộc tập phim này",
+        "noBeats": "Tập này chưa có beat nào"
+      },
+      "paddingCount": "+{{count}} ô trống"
+    },
+    "renderSettings": {
+      "model": "Model render",
+      "modelPlaceholder": "Chọn model"
+    },
+    "sketchSettings": {
+      "model": "Model phác thảo",
+      "modelPlaceholder": "Chọn model phác thảo",
+      "aspectRatio": "Tỉ lệ",
+      "wide16x9": "16:9",
+      "aspectChangeHint": "Đổi tỉ lệ khung hình chỉ ảnh hưởng tới nội dung tạo mới; asset đã có phải tạo lại mới cập nhật theo tỉ lệ mới."
+    },
+    "sketches": {
+      "selectFailed": "Chọn thất bại"
+    },
+    "video": {
+      "switchFailed": "Đổi video thất bại"
+    }
+  },
+  "audioType": {
+    "narration": "Lời dẫn",
+    "dialogue": "Lời thoại",
+    "silence": "Cảnh không lời",
+    "action": "Cảnh hành động"
+  },
+  "styles": {
+    "createStyle": "Tạo phong cách",
+    "projectDefault": "Mặc định của dự án",
+    "preset": "Dựng sẵn",
+    "custom": "Tuỳ chỉnh",
+    "customPreviewEmpty": "Chưa tải lên ảnh tham chiếu",
+    "uploadedPreview": "Xem trước ảnh tham chiếu đã tải lên",
+    "analyzingPreview": "Đang phân tích ảnh tham chiếu…",
+    "styleIdRequiredBeforeUpload": "Nhập Style ID trước khi tải ảnh tham chiếu lên",
+    "unsupportedPreviewType": "Hãy dùng ảnh PNG, JPEG, WebP hoặc GIF.",
+    "jsonFormatError": "JSON không hợp lệ",
+    "jsonChangesApplied": "Đã áp dụng thay đổi JSON",
+    "styleSaved": "Đã lưu phong cách",
+    "setAsDefault": "Đặt \"{{name}}\" làm mặc định của dự án",
+    "confirmDelete": "Xoá phong cách tuỳ chỉnh \"{{name}}\"?",
+    "deleted": "Đã xoá",
+    "unsaved": "Chưa lưu",
+    "labelField": "Nhãn hiển thị",
+    "labelPlaceholder": "vd. Phong cách Anime",
+    "projectStyleSection": "Cấu hình phong cách của dự án",
+    "styleDirective": "Chỉ dẫn phong cách",
+    "avoidDirective": "Chỉ dẫn cần tránh",
+    "styleTag": "Style tag",
+    "styleTagHint": "Định danh phong cách ngắn gọn, được chèn vào khi render",
+    "styleTagPlaceholder": "vd. ANIME",
+    "configJson": "Cấu hình (JSON)",
+    "structuredEdit": "Sửa theo cấu trúc",
+    "jsonEdit": "Sửa JSON",
+    "save": "Lưu",
+    "alreadyDefault": "Đã là mặc định của dự án",
+    "applyToProject": "Áp dụng cho dự án",
+    "delete": "Xoá",
+    "selectStyle": "Chọn một phong cách",
+    "selectStyleHint": "Chọn phong cách ở bên trái để xem hoặc sửa. Bản dựng sẵn chỉ đọc; bản tuỳ chỉnh thì sửa được.",
+    "noStyles": "Chưa có phong cách nào",
+    "noStylesHint": "Bấm \"Tạo phong cách\" để AI tự phân tích từ ảnh tham chiếu, hoặc tự thiết lập chỉ dẫn phong cách cho dự án.",
+    "createTitle": "Tạo phong cách tuỳ chỉnh",
+    "createHint": "Tải ảnh tham chiếu lên để AI phân tích, hoặc tự thiết lập chỉ dẫn phong cách cho dự án.",
+    "styleId": "Style ID",
+    "styleIdHint": "Chữ thường + dấu gạch dưới",
+    "styleIdPlaceholder": "cyberpunk_v1",
+    "nameField": "Tên",
+    "namePlaceholder": "Cyberpunk",
+    "aiAnalyze": "AI phân tích ảnh tham chiếu (tuỳ chọn)",
+    "reupload": "Tải lên lại",
+    "uploadRef": "Tải ảnh tham chiếu",
+    "aiExtractedHint": "Tham số do AI trích xuất (sửa được sau khi tạo)",
+    "noStylesAvailable": "Không có phong cách nào. Bấm góc trên bên phải để tạo.",
+    "paramsExtracted": "Đã trích xuất tham số phong cách",
+    "idNameRequired": "Nhập ID và tên",
+    "styleCreated": "Đã tạo phong cách",
+    "renameTitle": "Đổi tên phong cách"
+  },
+  "identityPicker": {
+    "title": "Chọn tạo hình nhân vật",
+    "empty": "Chưa có nhân vật nào. Hãy tạo nhân vật và tạo hình ở trang Nhân vật trước.",
+    "aiPlan": "AI gợi ý tạo hình",
+    "defaultIdentity": "Mặc định"
+  },
+  "composeGate": {
+    "beatCount": "{{count}} beat",
+    "goFix": "Sửa →"
+  },
+  "region": {
+    "picker": {
+      "label": "Chọn khu vực",
+      "placeholder": "Chọn một khu vực",
+      "required": "Hãy chọn khu vực trước"
+    },
+    "badge": {
+      "label": "Khu vực hiện tại"
+    },
+    "switch": {
+      "confirm": {
+        "title": "Đổi khu vực cần đăng nhập lại",
+        "body": "Bạn sẽ bị đăng xuất khỏi khu vực hiện tại; các việc đang chờ sẽ bị huỷ. Tiếp tục?",
+        "cta": "Đổi khu vực và đăng xuất"
+      }
+    },
+    "edge": {
+      "no_region": "Chưa chọn khu vực; đang chuyển tới trang đăng nhập"
+    },
+    "lockdown": {
+      "banner": "Khu vực đã đổi ở tab khác, đang tải lại…"
+    },
+    "empty": {
+      "title": "Không tải được danh sách khu vực",
+      "body": "Kiểm tra kết nối mạng rồi thử lại.",
+      "retry": "Thử lại"
+    }
+  },
+  "titleBar": {
+    "back": "Quay lại",
+    "switchToEnglish": "English",
+    "switchToChinese": "中文",
+    "minimize": "Thu nhỏ",
+    "maximize": "Phóng to",
+    "close": "Đóng"
+  },
+  "canvas": {
+    "storyboardGroup": {
+      "headerCount": "Storyboard · {{count}} node",
+      "label": "Nhóm storyboard",
+      "aspect": "Tỉ lệ",
+      "cols": "Lưới",
+      "colsOption": "{{cols}} cột",
+      "index": "Số thứ tự",
+      "stitch": "Ghép",
+      "stitchComingSoon": "Tính năng ghép sắp có",
+      "convertToPlain": "Chuyển thành nhóm thường",
+      "ungroup": "Bỏ nhóm",
+      "localUpload": "Tải lên từ máy",
+      "fromHistory": "Chọn từ lịch sử",
+      "imageOnlyHint": "Nhóm storyboard chỉ nhận ảnh",
+      "uploadFailed": "Tải lên thất bại, vui lòng thử lại"
+    },
+    "backToNodes": {
+      "hint": "Khung nhìn hiện tại không có node nào. Bấm nút để quay lại phần nội dung của bạn.",
+      "button": "Về vùng có node"
+    },
+    "zoom": {
+      "menuLabel": "Tuỳ chọn thu phóng",
+      "inputLabel": "Mức thu phóng",
+      "zoomIn": "Phóng to",
+      "zoomOut": "Thu nhỏ",
+      "fitView": "Vừa màn hình",
+      "zoomToPercent": "Thu phóng tới {{percent}}%"
+    },
+    "bookmarks": {
+      "setCurrent": "Lưu vị trí tại đây (ghi đè)",
+      "setNew": "Lưu vị trí tại đây",
+      "deleteCurrent": "Xoá vị trí này",
+      "clearAll": "Xoá toàn bộ vị trí",
+      "jumpTooltip": "Vị trí {{digit}}",
+      "emptyTooltip": "Vị trí {{digit}} (bấm để lưu khung nhìn hiện tại)"
+    },
+    "addImage": "Thêm ảnh",
+    "splitStoryboard": "Tách ô lưới",
+    "generate": "Tạo",
+    "generationProgress": "Đang tạo {{percent}}%",
+    "analysisProgress": "Đang phân tích {{percent}}%",
+    "generating": "Đang tạo",
+    "analyzing": "Đang phân tích",
+    "emptyHintDescription": "Nhấp đúp để thêm node, giữ chuột trái để quét chọn",
+    "emptyHintBeforeTab": "Nhấn ",
+    "emptyHintAfterTab": " hoặc nhấp đúp để tạo node",
+    "nodePlacement": {
+      "previewHint": "Di chuyển để chọn vị trí đặt",
+      "confirmHint": "Bấm để đặt",
+      "cancelHint": "Esc để huỷ"
+    },
+    "crossProjectAssets": {
+      "success": "Đã sao chép {{count}} asset media vào dự án này",
+      "partialFailure": "Sao chép thất bại {{count}} asset media; các node bị ảnh hưởng đã được đánh dấu — xoá rồi dán lại",
+      "copying": "Đang chép asset…",
+      "failedPlaceholder": "Chép asset thất bại. Xoá node này rồi dán lại.",
+      "removeNode": "Bỏ node"
+    },
+    "emptyHintChips": {
+      "textToVideo": "Text to Video",
+      "imageBackground": "Đổi nền ảnh",
+      "firstFrameVideo": "Khung đầu thành video",
+      "audioToVideo": "Audio to Video",
+      "templates": "Mẫu dựng sẵn"
+    },
+    "toolbar": {
+      "zoomIn": "Phóng to",
+      "zoomOut": "Thu nhỏ",
+      "fitView": "Vừa khung nhìn",
+      "lock": "Khoá canvas",
+      "unlock": "Mở khoá canvas",
+      "organize": "Sắp xếp / định vị canvas",
+      "organizeShortcut": "⌥⇧F",
+      "toolMove": "Di chuyển",
+      "toolHand": "Bàn tay",
+      "toolGroupLabel": "Công cụ trỏ trên canvas",
+      "hideEdges": "Ẩn đường nối",
+      "showEdges": "Hiện đường nối"
+    },
+    "quickbar": {
+      "addNode": "Thêm node",
+      "history": "Lịch sử",
+      "shortcuts": "Phím tắt",
+      "help": "Trung tâm trợ giúp",
+      "viewManual": "Xem hướng dẫn sử dụng",
+      "helpMenu": {
+        "tutorial": "Hướng dẫn"
+      }
+    },
+    "trackpad": {
+      "enable": "Bật kéo canvas bằng trackpad",
+      "disable": "Tắt kéo canvas bằng trackpad"
+    },
+    "history": {
+      "title": "Asset trong lịch sử",
+      "tabs": {
+        "image": "Ảnh",
+        "video": "Video",
+        "audio": "Âm thanh",
+        "world": "World Model"
+      },
+      "sortDesc": "Mới nhất trước",
+      "sortAsc": "Cũ nhất trước",
+      "batch": "Chọn",
+      "selectedCount": "Đã chọn {{n}}",
+      "searchPlaceholder": "Tìm trong prompt…",
+      "searchPlaceholderName": "Tìm theo tên…",
+      "clearSearch": "Xoá tìm kiếm",
+      "noMatch": "Không có asset lịch sử nào khớp",
+      "noMatchOtherTabs": "Tab này không có kết quả — thử {{tabs}}",
+      "empty": "Chưa có asset nào trong lịch sử",
+      "unknownDate": "Không rõ ngày",
+      "view": "Xem",
+      "play": "Phát",
+      "pause": "Tạm dừng",
+      "use": "Dùng",
+      "delete": "Xoá",
+      "deleteConfirmTitle": "Xoá asset lịch sử này?",
+      "deleteConfirmDescription": "Asset này sẽ bị xoá vĩnh viễn khỏi Asset trong lịch sử. Nội dung đã dùng trên canvas không bị ảnh hưởng.",
+      "deleteConfirmAction": "Xoá",
+      "deleteFailed": "Xoá thất bại. Vui lòng thử lại.",
+      "promptTitle": "Prompt",
+      "viewFullPrompt": "Xem toàn bộ prompt",
+      "batchDownload": "Tải về",
+      "batchUse": "Dùng",
+      "selectAll": "Chọn tất cả",
+      "deselectAll": "Bỏ chọn tất cả",
+      "downloading": "Đang tải về…"
+    },
+    "shortcuts": {
+      "title": "Phím tắt",
+      "groups": {
+        "create": "Tạo",
+        "zoom": "Thu phóng",
+        "move": "Di chuyển canvas",
+        "other": "Khác"
+      },
+      "devices": {
+        "keyboard": "Bàn phím",
+        "trackpad": "Trackpad",
+        "mouse": "Chuột"
+      },
+      "actions": {
+        "group": "Nhóm lại",
+        "copy": "Sao chép",
+        "paste": "Dán",
+        "openNodePanel": "Node mới",
+        "closeAddNodePanel": "Đóng bảng thêm node",
+        "cancelNodePlacement": "Huỷ đặt node",
+        "multiSelect": "Chọn nhiều",
+        "duplicateNode": "Nhân bản node",
+        "zoomIn": "Phóng to",
+        "zoomOut": "Thu nhỏ",
+        "fitView": "Vừa màn hình",
+        "panCanvas": "Kéo canvas",
+        "boxSelect": "Quét chọn node",
+        "organize": "Sắp xếp canvas",
+        "undo": "Hoàn tác",
+        "redo": "Làm lại",
+        "delete": "Xoá",
+        "toggleMinimap": "Bật/tắt bản đồ thu nhỏ"
+      },
+      "gestures": {
+        "clickNode": "+ bấm vào node",
+        "dragNode": "+ kéo node",
+        "middleDrag": "Kéo chuột giữa",
+        "leftDrag": "Kéo chuột trái",
+        "holdLeftDrag": "Giữ chuột trái rồi kéo",
+        "twoFingerSwipe": "Vuốt hai ngón",
+        "spaceDrag": "Giữ Space rồi kéo",
+        "panCanvasAll": "Giữ Space rồi kéo / vuốt hai ngón trackpad / chuột giữa"
+      },
+      "keys": {
+        "space": "Space"
+      }
+    },
+    "contextMenu": {
+      "upload": "Tải lên",
+      "addNode": "Thêm node",
+      "undo": "Hoàn tác",
+      "redo": "Làm lại",
+      "paste": "Dán"
+    },
+    "assetLibrary": {
+      "title": "Thư viện asset",
+      "resyncTitle": "Tự đồng bộ khi mở. Nếu luồng chính vừa thêm nhân vật, bối cảnh hay đạo cụ, bấm để đồng bộ lại.",
+      "close": "Đóng",
+      "allAssets": "Tất cả asset",
+      "searchAssets": "Tìm asset",
+      "searchPlaceholder": "Tìm trong phạm vi hiện tại",
+      "clearSearch": "Xoá tìm kiếm",
+      "categories": "Nhóm asset",
+      "uploading": "Đang tải lên…",
+      "uploadFailed": "Tải lên thất bại",
+      "remove": "Bỏ",
+      "viewDetails": "Xem chi tiết asset",
+      "bulkSelected_one": "Đã chọn {{count}} (chỉ xoá được asset tải lên từ máy)",
+      "bulkSelected_other": "Đã chọn {{count}} (chỉ xoá được asset tải lên từ máy)",
+      "rename": "Đổi tên",
+      "sendToCanvas": "Gửi sang canvas",
+      "prevPage": "Trang trước",
+      "nextPage": "Trang sau",
+      "pageSize": "Số mục mỗi trang",
+      "projectNotReady": "Dự án chưa sẵn sàng",
+      "deleteEntryTitle": "Xoá asset",
+      "deleteEntryDescription": "Xoá “{{name}}”? Không hoàn tác được.",
+      "delete": "Xoá",
+      "downloadFailed": "Tải về thất bại: {{detail}}",
+      "bulkDeleteTitle": "Xoá hàng loạt",
+      "bulkDeleteDescription": "Xoá {{count}} asset đã chọn? Không hoàn tác được.",
+      "bulkDeleteFailed": "{{count}} mục xoá không thành công: {{detail}}",
+      "deleteFolderTitle": "Xoá thư mục",
+      "deleteFolderDescriptionWithItems": "Xoá thư mục “{{name}}”? {{count}} asset bên trong cũng bị xoá theo. Không hoàn tác được.",
+      "deleteFolderDescription": "Xoá thư mục “{{name}}”?",
+      "uncategorized": "Chưa phân nhóm",
+      "allCategories": "Tất cả nhóm",
+      "subtitle": "Sắp xếp, tái sử dụng và tải lên asset của dự án",
+      "syncMainline": "Đồng bộ luồng chính",
+      "exitBulkDelete": "Thoát xoá hàng loạt",
+      "bulkDeleteHint": "Chọn nhiều asset đã tải lên để xoá",
+      "newFolder": "Thư mục mới",
+      "uploadAssets": "Tải asset lên",
+      "folders": "Thư mục",
+      "categoryAria": "Nhóm {{label}}",
+      "dropToUpload": "Thả để tải lên “{{label}}”",
+      "loadFailed": "Tải không thành công: {{detail}}",
+      "openDetails": "Mở chi tiết asset",
+      "deselect": "Bỏ chọn",
+      "markForDelete": "Đánh dấu để xoá",
+      "maxSelectable": "Chọn tối đa {{count}}",
+      "select": "Chọn",
+      "viewDetailsAria": "Xem chi tiết {{name}}",
+      "assetFallbackName": "asset",
+      "unnamed": "(Chưa đặt tên)",
+      "emptySearchTitle": "Không có asset nào khớp",
+      "emptyAllTitle": "Chưa có asset nào",
+      "emptyCategoryTitle": "Nhóm này chưa có asset",
+      "emptySearchHint": "Thử từ khoá khác, hoặc xoá tìm kiếm để xem tất cả",
+      "emptyAllHint": "Tải file lên, hoặc đồng bộ nhân vật, bối cảnh và đạo cụ từ luồng chính",
+      "emptyCategoryHint": "Đổi nhóm, hoặc tải lên asset hợp với nhóm này",
+      "uploadFirst": "Tải asset đầu tiên lên",
+      "deleteSelected": "Xoá mục đã chọn",
+      "confirm": "Xác nhận",
+      "folderAria": "Thư mục {{label}}",
+      "folderMoreAria": "Thêm thao tác cho {{label}}",
+      "changeCover": "Đổi ảnh bìa",
+      "pageAria": "Trang {{page}}",
+      "perPage": "{{size}} / trang",
+      "itemCount_one": "{{count}} asset",
+      "itemCount_other": "{{count}} asset",
+      "upload": {
+        "title": "Tải asset lên",
+        "subtitle": "Chọn file và nơi lưu — asset đã tải lên dùng lại được trong cả dự án",
+        "pickLocalFiles": "Chọn file trên máy",
+        "pickFiles": "Chọn file",
+        "dropHint": "Thả file vào đây, hoặc bấm để chọn",
+        "supports": "Hỗ trợ {{list}}",
+        "listSeparator": ", ",
+        "unsupportedRejected": "Đã bỏ qua {{count}} file có định dạng không hỗ trợ",
+        "selectedCount": "Đã chọn {{count}}",
+        "addMore": "Thêm nữa",
+        "removeFile": "Bỏ {{name}}",
+        "settings": "Thiết lập tải lên",
+        "settingsHint": "Bắt buộc chọn nơi lưu; thẻ có thể thêm sau",
+        "destination": "Nơi lưu",
+        "pickDestination": "Chọn nơi lưu",
+        "chooseFolder": "Chọn thư mục",
+        "projectLibrary": "Thư viện asset của dự án",
+        "create": "Tạo mới",
+        "tag": "Thẻ",
+        "optional": "tuỳ chọn",
+        "pickTag": "Chọn thẻ",
+        "choose": "Chọn",
+        "submit": "Tải lên",
+        "submitCount": "Tải lên {{count}}"
+      },
+      "category": {
+        "other": "Khác",
+        "character": "Nhân vật",
+        "scene": "Bối cảnh",
+        "prop": "Đạo cụ",
+        "style": "Phong cách",
+        "audio": "Âm thanh"
+      },
+      "source": {
+        "upload": "Tải lên",
+        "character": "Nhân vật",
+        "scene": "Bối cảnh",
+        "prop": "Đạo cụ"
+      },
+      "folder": {
+        "mainline": "Luồng chính"
+      },
+      "media": {
+        "image": "Ảnh",
+        "video": "Video",
+        "audio": "Âm thanh"
+      },
+      "preview": {
+        "closeAria": "Đóng chi tiết asset",
+        "dialogAria": "Chi tiết asset",
+        "mainlineHint": "Asset đồng bộ từ luồng chính phải sửa ngay tại nội dung luồng chính sinh ra nó"
+      },
+      "cover": {
+        "title": "Đổi ảnh bìa",
+        "titleWithFolder": "Đổi ảnh bìa · {{name}}",
+        "empty": "Thư mục này chưa có ảnh — tải lên một ảnh rồi mới đặt được bìa.",
+        "pickAria": "Dùng {{name}} làm ảnh bìa"
+      },
+      "audioPlay": "Phát",
+      "audioPause": "Tạm dừng",
+      "audioProgress": "Tiến độ phát",
+      "folderDialog": {
+        "fieldLabel": "Tên thư mục",
+        "placeholder": "Nhập tên thư mục",
+        "createHint": "Tạo xong là dùng ngay được để xếp và tải asset vào",
+        "renameHint": "Tên mới hiện ra khắp thư viện asset"
+      }
+    },
+    "referencePick": {
+      "kind": {
+        "text": "văn bản",
+        "image": "ảnh",
+        "video": "video",
+        "audio": "âm thanh"
+      },
+      "rejectKind": "Node {{kind}} chưa dùng làm tham chiếu được",
+      "rejectGeneric": "Node này không dùng làm tham chiếu được",
+      "noTargets": "Chưa có node nào trên canvas dùng làm tham chiếu được",
+      "chip": "Tham chiếu",
+      "chipTitleWithExternal": "Thêm tham chiếu: một node trên canvas, hoặc một file trên máy",
+      "chipTitleCanvasOnly": "Chọn một node trên canvas làm tham chiếu",
+      "sourceCanvas": "Từ canvas",
+      "sourceCanvasHint": "Bấm vào một node trên canvas",
+      "sourceExternal": "Từ file",
+      "sourceExternalHint": "Tải một file asset từ máy này lên",
+      "bannerTitle": "Chọn một tham chiếu trên canvas",
+      "exit": "Thoát chế độ chọn",
+      "deselect": "Bỏ chọn",
+      "select": "Chọn {{label}}"
+    },
+    "capabilities": {
+      "candidateResultTitle": "{{name}} · bản ứng viên",
+      "candidateHint": "Bộ tạo ứng viên · chỉ thành asset sau khi Commit",
+      "freePrompt": "Prompt tự do",
+      "common": {
+        "inputs": {
+          "base_ref": {
+            "label": "Tham chiếu chính",
+            "description": "Ảnh nối vào đầu tiên được dùng làm nền để sửa; không có ảnh thì quay về chế độ text-to-image."
+          },
+          "extra_refs": {
+            "label": "Tham chiếu phụ"
+          }
+        },
+        "params": {
+          "style": {
+            "label": "Phong cách",
+            "options": {
+              "supertale_production": "Chuẩn dựng SuperTale",
+              "cinematic_realistic": "Điện ảnh tả thực",
+              "clean_sketch": "Phác thảo nét sạch",
+              "spiderverse_mixed": "Đa chất liệu"
+            }
+          },
+          "notes": {
+            "label": "Ghi chú thêm"
+          },
+          "scene_id": {
+            "label": "Scene ID"
+          },
+          "prop_id": {
+            "label": "Prop ID"
+          }
+        }
+      },
+      "real_scene_sketch_repair": {
+        "name": "Sửa phác thảo cảnh thực",
+        "shortName": "Phác thảo cảnh",
+        "description": "Sửa phác thảo cảnh thực của beat hiện tại dựa trên khung điều khiển của Director World cùng tham chiếu bối cảnh/tạo hình.",
+        "inputs": {
+          "3gs_combined": {
+            "label": "Ảnh ghép đạo diễn 3GS",
+            "description": "Ảnh nối vào đầu tiên làm nền, quyết định góc máy, không gian và bố cục."
+          },
+          "scene_refs": {
+            "label": "Tham chiếu bối cảnh / tạo hình / đạo cụ",
+            "description": "Các ảnh nối vào sau được dùng làm tham chiếu để sửa và bám ngữ nghĩa."
+          }
+        },
+        "preserve": {
+          "camera": "Góc máy / bố cục gốc",
+          "layout": "Đồ đạc, tường, cửa ra vào và cửa sổ",
+          "identity": "Màu tạo hình nhân vật",
+          "props": "Màu và vị trí đạo cụ",
+          "street_mood": "Không khí đời sống đường phố"
+        },
+        "modify": {
+          "deblur": "Khử nhoè / hậu cảnh bị nhoè nhoẹt",
+          "distortion": "Sửa méo / kéo giãn do 3GS",
+          "furniture_detail": "Dọn lại kết cấu đồ đạc",
+          "actor_blocks": "Diễn viên dạng khối → nét nhân vật sạch",
+          "staging_blocks": "Khối dựng cảnh → vật thể thật"
+        },
+        "params": {
+          "shot_type": {
+            "label": "Cỡ cảnh",
+            "options": {
+              "closeup": "Cận cảnh",
+              "medium_closeup": "Trung cận",
+              "medium": "Trung cảnh",
+              "wide": "Toàn cảnh"
+            }
+          },
+          "angle": {
+            "label": "Góc máy",
+            "options": {
+              "eye_level": "Ngang tầm mắt",
+              "high": "Góc cao",
+              "low": "Góc thấp",
+              "over_shoulder": "Qua vai",
+              "reverse": "Góc ngược"
+            }
+          },
+          "lens": {
+            "label": "Ống kính",
+            "options": {
+              "24mm": "24mm góc rộng",
+              "35mm": "35mm tự nhiên",
+              "50mm": "50mm tiêu chuẩn",
+              "85mm": "85mm nén cảnh"
+            }
+          },
+          "lighting": {
+            "label": "Ánh sáng",
+            "options": {
+              "dim_street_warm": "Đèn đường ấm, tối",
+              "mixed_neon": "Neon nóng lạnh pha nhau",
+              "window_daylight": "Sáng tự nhiên qua cửa sổ",
+              "hard_toplight": "Đèn đỉnh gắt"
+            }
+          },
+          "preserve": {
+            "label": "Bắt buộc giữ"
+          },
+          "modify": {
+            "label": "Trọng tâm cần sửa"
+          },
+          "notes": {
+            "label": "Yêu cầu thêm",
+            "description": "ví dụ: tô màu cả những dáng người xám ở hậu cảnh; giữ nguyên kết cấu gỗ của cái bàn."
+          }
+        }
+      },
+      "portrait_from_ref": {
+        "name": "Tạo hình nhân vật từ ảnh mẫu",
+        "shortName": "Tạo hình",
+        "description": "Tạo bản ứng viên chân dung / tạo hình từ một ảnh mẫu, rồi Commit vào asset nhân vật.",
+        "inputs": {
+          "ref_image": {
+            "label": "Ảnh mẫu",
+            "description": "Ảnh mẫu dùng để lấy dáng mặt, thần thái, trang phục hoặc tư thế."
+          },
+          "identity_ref": {
+            "label": "Ảnh tạo hình sẵn có",
+            "description": "Khi sửa một tạo hình đã có, nối ảnh tạo hình chuẩn vào làm tham chiếu để giữ nhất quán."
+          }
+        },
+        "params": {
+          "character": {
+            "label": "Nhân vật",
+            "description": "Chỉ dùng để dựng prompt; đích ghi về được xác nhận lúc Commit."
+          },
+          "age_band": {
+            "label": "Nhóm tuổi",
+            "options": {
+              "young": "Trẻ",
+              "middle": "Trung niên",
+              "old": "Cao tuổi"
+            }
+          },
+          "portrait_style": {
+            "label": "Phong cách asset",
+            "options": {
+              "clean_production_portrait": "Chân dung sản xuất nét sạch",
+              "cinematic_identity": "Ảnh tạo hình kiểu điện ảnh",
+              "character_reference_sheet": "Bảng tham chiếu nhân vật"
+            }
+          },
+          "preserve": {
+            "label": "Giữ nguyên",
+            "options": {
+              "face": "Khuôn mặt và ngũ quan",
+              "hair": "Kiểu tóc",
+              "temperament": "Thần thái",
+              "outfit": "Hướng trang phục"
+            }
+          },
+          "outfit": {
+            "label": "Ghi chú trang phục"
+          },
+          "notes": {
+            "label": "Yêu cầu thêm"
+          }
+        }
+      },
+      "character_multi_view_candidate": {
+        "name": "Nhân vật nhiều góc nhìn",
+        "shortName": "Nhiều góc",
+        "description": "Tạo bản ứng viên 3 góc / 4 góc / lưới 9 ô từ ảnh nhân vật, rồi Commit vào asset tạo hình hoặc chân dung.",
+        "inputs": {
+          "character_ref": {
+            "label": "Ảnh mẫu nhân vật",
+            "description": "Giữ dáng mặt, kiểu tóc, trang phục và thần thái nhất quán."
+          },
+          "style_ref": {
+            "label": "Tham chiếu phong cách / tư thế",
+            "description": "Tuỳ chọn, bổ sung phong cách vẽ, tư thế hoặc chi tiết trang phục."
+          }
+        },
+        "params": {
+          "character": {
+            "label": "Nhân vật",
+            "description": "Tên nhân vật đích."
+          },
+          "layout": {
+            "label": "Bố cục",
+            "options": {
+              "three_view": "3 góc",
+              "four_view": "4 góc",
+              "nine_grid": "Lưới 9 ô"
+            }
+          },
+          "view_focus": {
+            "label": "Góc nhìn",
+            "options": {
+              "front": "Chính diện",
+              "side": "Nghiêng",
+              "back": "Sau lưng",
+              "expression": "Biểu cảm",
+              "pose": "Tư thế",
+              "outfit": "Chi tiết trang phục"
+            }
+          },
+          "notes": {
+            "label": "Yêu cầu thêm"
+          }
+        }
+      },
+      "scene_master_candidate": {
+        "name": "Ứng viên ảnh gốc bối cảnh",
+        "shortName": "Ảnh gốc cảnh",
+        "description": "Tạo hoặc sửa một ứng viên ảnh gốc bối cảnh, rồi Commit vào slot scene_master."
+      },
+      "scene_360_candidate": {
+        "name": "Ứng viên bối cảnh 360",
+        "shortName": "Cảnh 360",
+        "description": "Tạo ứng viên ảnh toàn cảnh tỉ lệ 2:1, rồi Commit vào slot Director Pano 360."
+      },
+      "prop_ref_candidate": {
+        "name": "Ứng viên tham chiếu đạo cụ",
+        "shortName": "Tham chiếu đạo cụ",
+        "description": "Tạo ứng viên reference_3view cho đạo cụ, rồi Commit vào slot prop_ref."
+      },
+      "render_repair_candidate": {
+        "name": "Ứng viên sửa bản render",
+        "shortName": "Sửa render",
+        "description": "Sửa bản render của beat hiện tại / ứng viên render đạo diễn, rồi Commit vào slot của beat.",
+        "params": {
+          "repair_focus": {
+            "label": "Trọng tâm cần sửa"
+          }
+        }
+      },
+      "video_start_frame_candidate": {
+        "name": "Ứng viên khung đầu video",
+        "shortName": "Khung đầu",
+        "description": "Tạo ứng viên khung đầu video từ bản render / khung trích xuất / ảnh mẫu, rồi Commit vào slot khung hình (khung đầu video và khung đầu của beat là cùng một file).",
+        "params": {
+          "motion_setup": {
+            "label": "Thiết lập chuyển động"
+          }
+        }
+      }
+    },
+    "cameraMovement": {
+      "title": "Chuyển động máy",
+      "loading": "Đang tải…",
+      "empty": "Không có mẫu chuyển động máy nào",
+      "noPreview": "Không có xem trước",
+      "presets": {
+        "fixed": "Máy cố định",
+        "follow": "Bám theo",
+        "spiral-up": "Xoắn ốc lên",
+        "spiral-down": "Xoắn ốc xuống",
+        "tilt-up": "Tilt lên",
+        "tilt-down": "Tilt xuống",
+        "pan-left": "Pan trái",
+        "pan-right": "Pan phải",
+        "crane-up": "Crane lên",
+        "crane-down": "Crane xuống",
+        "truck-left": "Truck trái",
+        "truck-right": "Truck phải",
+        "dolly-in": "Dolly vào",
+        "dolly-out": "Dolly ra",
+        "zoom-in": "Zoom vào",
+        "zoom-out": "Zoom ra",
+        "dolly-zoom": "Dolly zoom",
+        "orbit": "Orbit",
+        "roll": "Roll",
+        "fpv": "FPV",
+        "drone": "Drone",
+        "aerial": "Flycam trên cao",
+        "handheld": "Cầm tay"
+      },
+      "clear": "Bỏ chọn",
+      "apply": "Áp dụng"
+    },
+    "paintTools": {
+      "brush": "Cọ",
+      "rect": "Hình chữ nhật",
+      "eraser": "Tẩy",
+      "brushSize": "Cỡ cọ",
+      "thickness": "Cỡ",
+      "undo": "Hoàn tác",
+      "redo": "Làm lại",
+      "undoShort": "Hoàn tác",
+      "redoShort": "Làm lại",
+      "reset": "Đặt lại",
+      "loadSourceFailed": "Tải ảnh gốc thất bại",
+      "loadingSource": "Đang tải ảnh gốc...",
+      "noProject": "URL hiện tại không có dự án nên không gửi được",
+      "aspect": "Tỉ lệ",
+      "aspectOriginal": "Nguyên bản",
+      "resolution": "Độ phân giải",
+      "count": "Số lượng",
+      "countValue": "{{n}}"
+    },
+    "eraseOverlay": {
+      "displayName": "Xoá vật thể",
+      "close": "Đóng công cụ xoá",
+      "needMask": "Tô lên vùng muốn xoá trước đã",
+      "submit": "Gửi lệnh xoá"
+    },
+    "redrawOverlay": {
+      "displayName": "Vẽ lại",
+      "maskedDisplayName": "Inpaint",
+      "submitMasked": "Inpaint",
+      "submitWhole": "Vẽ lại toàn bộ",
+      "needPromptOrMask": "Nhập prompt, hoặc tô vùng cần inpaint",
+      "clearMask": "Xoá vùng tô",
+      "exit": "Thoát vẽ lại",
+      "promptPlaceholderMasked": "Mô tả vùng đã tô cần biến thành gì, ví dụ đổi hậu cảnh này thành trời hoàng hôn",
+      "promptPlaceholderWhole": "Mô tả cách vẽ lại ảnh này, ví dụ giữ nguyên bố cục, đổi hậu cảnh thành sa mạc lúc hoàng hôn",
+      "targetAspect": "Tỉ lệ đích"
+    },
+    "annotateEditor": {
+      "ellipse": "Hình elip",
+      "arrow": "Mũi tên",
+      "text": "Chữ",
+      "pan": "Kéo ảnh",
+      "panHint": "Kéo ảnh đi (hoặc giữ Space rồi kéo)",
+      "fitWindow": "Vừa khung",
+      "color": "Màu",
+      "clear": "Xoá hết"
+    },
+    "nodeMenu": {
+      "referenceGenerate": "Tạo từ node này",
+      "skillCount": "{{count}} kỹ năng"
+    },
+    "multiSelect": {
+      "arrange": "Sắp xếp",
+      "duplicate": "Nhân bản",
+      "batchDownload": "Tải tất cả",
+      "group": "Nhóm lại",
+      "mergeStoryboard": "Gộp thành storyboard",
+      "mergeStoryboardHint": "Nhóm storyboard chỉ nhận node ảnh, tối đa 25 node",
+      "deleteAllLocked": "Mọi node đã chọn đều bị khoá theo luồng chính nên không xoá được",
+      "deleteCount": "Xoá {{count}} node",
+      "batchDelete": "Xoá tất cả",
+      "arrangeGrid": "Xếp lưới",
+      "arrangeHorizontal": "Xếp ngang",
+      "arrangeVertical": "Xếp dọc"
+    },
+    "nodeToolbar": {
+      "mainlineLocked": "Bản chiếu từ luồng chính · đã khoá",
+      "openWorkbench": "Mở bàn làm việc",
+      "openingWorkbench": "Đang mở...",
+      "beatContext": "Ngữ cảnh cú máy",
+      "beatContextHint": "Tạo hoặc nhảy tới node ngữ cảnh cú máy của asset này; không tự vẽ đường nối",
+      "beatContextName": "Ngữ cảnh cú máy · Tập {{episode}}/B{{beat}}",
+      "audioSuffix": "có tiếng",
+      "silentSuffix": "không tiếng",
+      "groupBackground": "Nền của nhóm",
+      "backgroundColor": "Màu nền",
+      "noColor": "Không màu",
+      "arrangeMode": "Cách sắp xếp",
+      "arrangeGrid": "Lưới",
+      "arrangeHorizontal": "Ngang",
+      "arrangeVertical": "Dọc",
+      "commitHint": "Ghi nội dung của node này về asset trong luồng chính"
+    },
+    "style": {
+      "chip": "Phong cách",
+      "chipLoading": "Phong cách · đang tải",
+      "chipLoadingTitle": "Đang tải danh sách phong cách",
+      "chipFailed": "Phong cách · tải lỗi",
+      "chipFailedTitle": "Danh sách phong cách không tải được — bấm để thử lại. Phong cách bạn đã chọn vẫn được gửi kèm lượt tạo.",
+      "chipMissing": "Phong cách · không còn",
+      "chipMissingTitle": "Phong cách này đã ngừng dùng — bấm để chọn cái khác.",
+      "thumbAria": "Phong cách {{label}}",
+      "clear": "Bỏ phong cách",
+      "select": "Chọn phong cách",
+      "change": "Đổi phong cách",
+      "placeholderNone": "Chưa chọn phong cách",
+      "placeholderLoading": "Đang tải…",
+      "placeholderFailed": "Tải danh sách phong cách thất bại — bấm để thử lại",
+      "placeholderMissing": "Phong cách này không còn — bấm để chọn cái khác",
+      "noImageUpstream": "Chưa nối node ảnh nào vào"
+    },
+    "styleGallery": {
+      "title": "Thư viện phong cách",
+      "all": "Tất cả",
+      "other": "Khác",
+      "sampleAlt": "Ảnh mẫu {{index}} của {{label}}",
+      "detailAria": "Xem chi tiết {{label}}",
+      "useAria": "Dùng {{label}}",
+      "loading": "Đang tải…",
+      "empty": "Chưa có mẫu phong cách nào"
+    },
+    "commitHint": {
+      "title": "Khi commit, kết quả này được ghi về slot nào trong luồng chính",
+      "sketch": "phác thảo",
+      "frame": "khung hình",
+      "typed": "Tập {{episode}} / beat {{beat}} · ứng viên {{candidate}} · nằm ở node này, khi commit sẽ thành {{promoted}}",
+      "untyped": "Ứng viên luồng chính · gắn với Tập {{episode}} / beat {{beat}} · nằm ở node này, khi commit slot được khớp theo ngữ cảnh",
+      "free": "Ứng viên tự do · nằm ở node này, khi commit bạn tự chọn asset đích"
+    },
+    "cameraPicker": {
+      "title": "Máy quay",
+      "body": "Thân máy",
+      "lens": "Ống kính",
+      "focal": "Tiêu cự",
+      "aperture": "Khẩu độ",
+      "clear": "Bỏ chọn",
+      "prev": "Trước",
+      "next": "Sau",
+      "loading": "Đang tải…"
+    },
+    "groupColor": {
+      "red": "Đỏ",
+      "orange": "Cam",
+      "yellow": "Vàng",
+      "green": "Xanh lá",
+      "cyan": "Xanh lơ",
+      "blue": "Xanh dương",
+      "purple": "Tím",
+      "pink": "Hồng",
+      "gray": "Xám"
+    },
+    "videoClip": {
+      "exit": "Thoát cắt video",
+      "subtitleTodo": "Phụ đề (chưa hỗ trợ)",
+      "extractingFrames": "Đang trích khung hình…",
+      "framesFailed": "Tải khung hình thất bại",
+      "dragStart": "Kéo để chỉnh điểm vào",
+      "dragEnd": "Kéo để chỉnh điểm ra",
+      "muteTodo": "Tắt tiếng (chưa hỗ trợ)",
+      "loopTodo": "Lặp lại (chưa hỗ trợ)",
+      "submitting": "Đang cắt…",
+      "submit": "Áp dụng đoạn cắt"
+    },
+    "mentionReplace": {
+      "empty": "Không có asset nào để thay vào",
+      "kindMaterialsAria": "Asset {{kind}}",
+      "materials": "Asset trên canvas",
+      "referenced": "Đang tham chiếu"
+    },
+    "splitEditor": {
+      "cellCount": "Số ô tạo ra",
+      "cellHeight": "Chiều cao ô (px)",
+      "cellWidth": "Chiều rộng ô (px)",
+      "cols": "Số cột",
+      "layoutError": "Đường ngăn quá dày, phần trích ra còn quá ít. Giảm độ dày hoặc bớt số hàng/cột.",
+      "lineThickness": "Độ dày đường ngăn",
+      "params": "Thiết lập lưới",
+      "rows": "Số hàng"
+    },
+    "nodeHistory": {
+      "current": "Hiện tại",
+      "daysAgo": "{{count}} ngày trước",
+      "hoursAgo": "{{count}} giờ trước",
+      "minutesAgo": "{{count}} phút trước",
+      "refresh": "Làm mới lịch sử",
+      "secondsAgo": "{{count}} giây trước",
+      "title": "Lịch sử"
+    },
+    "imagePipeline": {
+      "convertFailed": "Chuyển đổi ảnh thất bại",
+      "downloadFailed": "Không tải được dữ liệu ảnh",
+      "emptyResult": "Không có ảnh nào dùng được trả về",
+      "fileReadFailed": "Đọc file thất bại",
+      "loadFailed": "Tải ảnh thất bại",
+      "localReadFailed": "Không đọc được dữ liệu ảnh trên máy",
+      "unparsableResult": "Không phân tích được kết quả thành ảnh"
+    },
+    "resumeGeneration": {
+      "failedWithMessage": "Tạo thất bại: {{message}}",
+      "imageFailed": "Tạo ảnh thất bại",
+      "noImageResult": "Lượt tạo không trả về kết quả nào",
+      "noVideoResult": "Lượt tạo video không trả về kết quả nào",
+      "noWorldUrl": "Tạo thất bại: không tìm thấy URL thế giới 3D trong task.result",
+      "taskGone": "Tác vụ tạo đã kết thúc hoặc không còn tồn tại",
+      "videoFailed": "Tạo video thất bại"
+    },
+    "fileDrop": {
+      "aria": "Thả file để thêm vào canvas",
+      "hint": "Node tương ứng được tạo ngay tại vị trí này",
+      "title": "Thả vào canvas"
+    },
+    "tools": {
+      "annotate": "Chú thích",
+      "crop": "Cắt ảnh",
+      "splitStoryboard": "Cắt rời storyboard"
+    },
+    "cropTool": {
+      "ratioCustom": "Tuỳ chỉnh",
+      "ratioEmpty": "Nhập tỉ lệ, ví dụ 3:2 hoặc 1.5",
+      "ratioFree": "Tự do",
+      "ratioInvalid": "Định dạng tỉ lệ không hợp lệ",
+      "ratioOriginal": "Nguyên bản",
+      "ratioPlaceholder": "Nhập tỉ lệ, ví dụ 3:2 hoặc 1.5",
+      "targetRatio": "Tỉ lệ đích"
+    },
+    "toolProcessor": {
+      "unsupportedTool": "Loại công cụ không được hỗ trợ",
+      "canvasInitFailed": "Khởi tạo canvas thất bại",
+      "gridSizeInvalid": "Số hàng và số cột của lưới phải lớn hơn 0",
+      "lineTooThick": "Đường ngăn quá dày nên không cắt được storyboard"
+    },
+    "selectedBackground": {
+      "candidateEdgeLabel": "Ứng viên nền hiện tại",
+      "missingProject": "Thiếu dự án",
+      "candidateCreateFailed": "Tạo node ứng viên nền hiện tại thất bại",
+      "commitSuccess": "Đã đặt nền hiện tại"
+    },
+    "videoReference": {
+      "limitImage": "Một node video tham chiếu được tối đa {{limit}} ảnh",
+      "limitVideo": "Một node video tham chiếu được tối đa {{limit}} video",
+      "limitAudio": "Một node video tham chiếu được tối đa {{limit}} đoạn âm thanh",
+      "limitTotal": "Một node video tham chiếu được tối đa {{limit}} asset"
+    },
+    "mentionChip": {
+      "doubleClickReplace": "Bấm đúp để thay tham chiếu này",
+      "clickToPlay": "{{label}} · bấm để phát",
+      "replace": "Thay tham chiếu"
+    },
+    "naming": {
+      "copySuffix": "{{name}} - Bản sao",
+      "panoCaptureGroup": "Ảnh chụp toàn cảnh ({{total}})",
+      "group": "Nhóm {{index}}",
+      "storyboardGroup": "Nhóm storyboard {{index}}",
+      "storyboardFrame": "Khung storyboard",
+      "externalAssetGroup": "Asset bên ngoài"
+    },
+    "viewportHint": {
+      "focused": "Đang tập trung vào node đã chọn",
+      "returnToNode": "Về lại node"
+    },
+    "controls": {
+      "snapAlignOn": "Bật bắt dính khi căn chỉnh",
+      "snapAlignOff": "Tắt bắt dính khi căn chỉnh",
+      "fpsOn": "Hiện FPS",
+      "fpsOff": "Ẩn FPS",
+      "minimap": "Bản đồ thu nhỏ của canvas"
+    },
+    "assetReplace": {
+      "dropToReplace": "Thả để thay asset này",
+      "dragHint": "Kéo vào một asset cùng loại bên trái để thay thế",
+      "handleHint": "Giữ và kéo vào thư viện asset để thay một asset cùng loại",
+      "handleLabel": "Thay asset"
+    },
+    "reference": {
+      "detach": "Gỡ tham chiếu này",
+      "mention": "Nhắc tới \"{{name}}\" trong prompt"
+    },
+    "common": {
+      "regenerate": "Tạo lại"
+    },
+    "modelParams": {
+      "title": "Tham số model",
+      "defaultOption": "Mặc định"
+    },
+    "multiConnect": {
+      "label": "Nối vùng chọn",
+      "hint": "Nối vùng chọn: bấm để tạo một node phía sau nối vào mọi node đã chọn, hoặc kéo thả lên một node có sẵn"
+    },
+    "spawnPlus": {
+      "referenceThisNode": "Tạo từ node này",
+      "connectIntoThisNode": "Nối vào node này"
+    },
+    "edge": {
+      "disconnect": "Ngắt nối"
+    },
+    "addNodePanel": {
+      "skillCount": "{{count}} kỹ năng"
+    },
+    "generation": {
+      "missingProjectParam": "URL hiện tại không có tham số dự án",
+      "missingProjectRetry": "URL hiện tại không có dự án nên không thử lại được"
+    },
+    "imageModel": {
+      "modeEdit": "Sửa ảnh",
+      "modeGenerate": "Tạo ảnh",
+      "noneAvailable": "Không có model nào dùng được"
+    },
+    "skillParams": {
+      "aspectRatio": "Tỉ lệ khung hình",
+      "quality": "Chất lượng"
+    },
+    "mainline": {
+      "chainAlreadyBound": "Chuỗi này đã gắn với {{bound}}, không nhận thêm {{incoming}}",
+      "imageRoleTaken": "Ảnh này đã gắn với vai trò {{existing}} trong luồng chính, không nhận thêm {{candidate}}",
+      "roleBoundElsewhere": "{{role}} đã gắn với một ảnh khác. Ngắt liên kết đó trước đã."
+    },
+    "assetDrop": {
+      "fallbackNodeLabel": "Node"
+    }
+  },
+  "tool": {
+    "crop": "Cắt ảnh",
+    "annotate": "Chú thích",
+    "split": "Tách ô"
+  },
+  "toolDialog": {
+    "suffix": "",
+    "noProcessableImage": "Node hiện tại không có ảnh nào để xử lý",
+    "processFailed": "Xử lý thất bại",
+    "processing": "Đang xử lý...",
+    "apply": "Áp dụng",
+    "confirm": "Xác nhận",
+    "splitDiscardHint": "(vùng màu đỏ là pixel đường phân cách sẽ bị loại khi tách)",
+    "cropResultTitle": "Kết quả cắt ảnh",
+    "annotateResultTitle": "Kết quả chú thích"
+  },
+  "nodeToolbar": {
+    "aiEdit": "Sửa bằng AI",
+    "panorama": "Panorama",
+    "generateDirectorWorld": "Tạo thế giới 3DGS",
+    "generatePanoDirectorWorld": "Tạo thế giới 3DGS 360",
+    "addPanoToDirectorWorld": "Thêm vào Director World",
+    "connectImageSource": "Nối một ảnh đầu vào",
+    "normalImage": "Ảnh thường",
+    "image360": "Ảnh 360",
+    "multiDimension": "Đa góc nhìn",
+    "multiDimensionPrompt": "Generate multi-angle views of the same subject (front, 3/4 side, profile, back) while keeping style, lighting, and materials consistent.",
+    "relight": "Đổi ánh sáng",
+    "relightPrompt": "Keep the composition and subject unchanged; redesign the lighting only — adjust direction, color temperature, and contrast for a more cinematic look.",
+    "hd": "HD",
+    "hdPrompt": "Upscale this image to high definition: sharpen details and textures, remove noise and compression artifacts, while preserving the original composition, palette, and subject features.",
+    "outpaint": "Mở rộng khung",
+    "outpaintPrompt": "Naturally extend the canvas outward (outpainting): fill in plausible surroundings, lighting, and background while keeping the original subject, style, and atmosphere consistent.",
+    "repaint": "Vẽ lại",
+    "repaintPrompt": "Keep the subject and composition; repaint the image overall to improve quality and consistency, while preserving subject features, palette, and style.",
+    "erase": "Xoá vật thể",
+    "erasePrompt": "Erase distracting or unwanted elements from the image (clutter, text, watermarks) and seamlessly inpaint the occluded regions, keeping subject and background style consistent.",
+    "matting": "Tách nền",
+    "mattingPrompt": "Cut out the subject and replace the background with a clean transparent (or solid) backdrop, preserving fine edge details (hair strands, semi-transparent regions) realistically.",
+    "rotate": "Xoay",
+    "reupload": "Tải lên lại",
+    "copy": "Sao chép",
+    "copyText": "Sao chép văn bản",
+    "copyErrorReport": "Sao chép lỗi",
+    "copied": "Đã sao chép",
+    "download": "Tải về",
+    "ungroup": "Bỏ nhóm",
+    "saveAs": "Lưu thành...",
+    "noDownloadPresetPathsHint": "Chưa có thư mục lưu nhanh. Dùng thư mục tải về mặc định.",
+    "storyboardLine": "Ô {{index}}: {{content}}",
+    "gridMenu": {
+      "trigger": "Lưới",
+      "multiCameraGrid": "Đa máy quay 3x3",
+      "multiCameraGridPrompt": "From this image, generate a 3x3 grid of multi-camera views covering front, left/right 3/4, profiles, back, and varied tilt angles, keeping the subject, style, lighting, and materials fully consistent.",
+      "plotFourGrid": "Diễn tiến cốt truyện 2x2",
+      "plotFourGridPrompt": "From this image, project the next plot beats and generate a 2x2 grid of consecutive frames within the same scene, preserving character design, spatial relationships, lighting, and overall style.",
+      "faceThreeView": "Ba góc khuôn mặt",
+      "faceThreeViewPrompt": "From this character face, generate front, 3/4, and full profile three-view sheets, keeping hairstyle, facial proportions, skin tone, gaze, and expression style consistent on a clean neutral background.",
+      "productThreeView": "Ba góc sản phẩm",
+      "productThreeViewPrompt": "From this product, generate front, side, and top three-view sheets, keeping materials, colors, proportions, and details accurate on a clean neutral background suitable for product display.",
+      "serialStoryboard25": "Storyboard 25 ô",
+      "serialStoryboard25Prompt": "From this image, generate a coherent 25-cell storyboard covering a full narrative beat (setup-development-climax-resolution), keeping character design, scene setting, shot style, and atmosphere consistent.",
+      "cinematicLightCorrection": "Chỉnh sáng điện ảnh",
+      "cinematicLightCorrectionPrompt": "Apply cinematic light grading: refine key/fill light relationship, adjust color temperature, contrast, and highlight/shadow layering for added volume and cinematic feel, while keeping subject and composition unchanged.",
+      "characterThreeView": "Ba góc nhân vật",
+      "characterThreeViewPrompt": "From this character, generate front, side, and back full-body three-view sheets, keeping costume, accessories, body proportions, and overall style consistent on a unified neutral background suitable for character sheets.",
+      "frameProjection3sLater": "Dự đoán khung +3s",
+      "frameProjection3sLaterPrompt": "Project the state 3 seconds after this frame: continue character motion, expression, camera position, and environmental lighting naturally, while keeping character design and visual style consistent.",
+      "frameProjection5sEarlier": "Dựng lại khung -5s",
+      "frameProjection5sEarlierPrompt": "Reconstruct the state 5 seconds before this frame: infer the initiating actions, expressions, spatial relationships, and camera position, while keeping character design and visual style consistent.",
+      "confirmBar": {
+        "close": "Đóng",
+        "submit": "Tạo",
+        "cost": "Chi phí tính toán"
+      }
+    },
+    "video": {
+      "clip": "Cắt đoạn",
+      "hd": "HD",
+      "analyze": "Phân tích",
+      "separateAudioVideo": "Tách tiếng/hình",
+      "subtitleRemoval": "Xoá phụ đề",
+      "subtitleRemovalTip": "Xoá phụ đề bằng AI — chỉ hỗ trợ tiếng Trung & tiếng Anh",
+      "subtitleRemovalSmart": "Xoá thông minh",
+      "subtitleRemovalBox": "Xoá theo vùng chọn",
+      "fullscreen": "Toàn màn hình",
+      "notImplementedYet": "Sắp có",
+      "requiresVideo": "Hãy tải video lên trước"
+    },
+    "audio": {
+      "requiresAudio": "Chưa có âm thanh nào để tải về",
+      "downloadAs": "Tải về dạng {{format}}",
+      "m4aSourceOnlyHint": "chỉ khi nguồn là m4a",
+      "m4aSourceOnly": "Nguồn không phải m4a nên không chuyển sang m4a được",
+      "downloadFailed": "Tải âm thanh thất bại"
+    }
+  },
+  "multiAngleEditor": {
+    "title": "Trình chỉnh đa góc nhìn",
+    "horizontal": "Ngang",
+    "vertical": "Dọc",
+    "zoom": "Cỡ cảnh",
+    "promptToggle": "Prompt bổ sung",
+    "promptPlaceholder": "Tuỳ chọn: thêm chi tiết về tông cảm xúc, phong cách hoặc bố cục…",
+    "reset": "Đặt lại",
+    "submit": "Tạo",
+    "presets": {
+      "custom": "Tuỳ chỉnh",
+      "fisheye": "Fisheye",
+      "tilted": "Dutch tilt",
+      "frontTopDown": "Front high angle",
+      "frontBottomUp": "Front low angle",
+      "panoramaTopDown": "Bird's-eye",
+      "backView": "Back view"
+    },
+    "zoomLevels": {
+      "extreme_close_up": "Extreme close-up",
+      "close_up": "Close-up",
+      "medium_close": "Medium close-up",
+      "medium": "Medium",
+      "full_body": "Full body",
+      "wide": "Wide",
+      "extreme_wide": "Extreme wide"
+    },
+    "horizontalLabels": {
+      "front": "Front",
+      "frontRight": "Front-right 3/4",
+      "right": "Right side",
+      "backRight": "Back-right 3/4",
+      "back": "Back",
+      "backLeft": "Back-left 3/4",
+      "left": "Left side",
+      "frontLeft": "Front-left 3/4"
+    },
+    "verticalLabels": {
+      "lookDown": "Top-down / god view",
+      "highAngle": "High angle",
+      "eyeLevel": "Eye-level",
+      "lowAngle": "Low angle",
+      "lookUp": "Worm's-eye"
+    },
+    "promptIntro": "From the reference image, render the same subject under these camera conditions:",
+    "promptHorizontal": "- Horizontal orbit: {{deg}}° ({{description}})",
+    "promptVertical": "- Vertical pitch: {{deg}}° ({{description}})",
+    "promptZoom": "- Shot framing: {{zoom}}",
+    "promptPreset": "- Lens preset: {{preset}}",
+    "promptExtra": "- Extra: {{text}}",
+    "promptExtraDefault": "- Extra: preserve additional detail, mood and stylistic nuance.",
+    "promptOutro": "Keep the subject's costume, accessories, overall style, and lighting consistent with the original; only the camera angle and framing should change.",
+    "qualityPicker": {
+      "title": "Chất lượng"
+    }
+  },
+  "scene360": {
+    "label": "Panorama 360°",
+    "exit": "Thoát panorama",
+    "submit": "Tạo"
+  },
+  "upscaleEditor": {
+    "title": "Upscale HD",
+    "providerLabel": "Nhà cung cấp",
+    "modelLabel": "Model",
+    "qualityLabel": "Chất lượng",
+    "scaleLabel": "Hệ số phóng",
+    "submit": "Tạo",
+    "cancel": "Huỷ",
+    "preset": {
+      "general": "Tổng quát"
+    },
+    "modelPicker": {
+      "provider": "Nhà cung cấp",
+      "model": "Model",
+      "empty": "Không có model khả dụng"
+    },
+    "qualityPicker": {
+      "title": "Chất lượng"
+    }
+  },
+  "rotateEditor": {
+    "title": "Xoay & lật",
+    "exit": "Thoát xoay & lật",
+    "angleLabel": "Góc xoay",
+    "angleSuffix": "°",
+    "rotate90": "Xoay 90° theo chiều kim đồng hồ",
+    "mirrorH": "Lật ngang",
+    "mirrorV": "Lật dọc",
+    "save": "Lưu",
+    "saving": "Đang lưu...",
+    "resultTitle": "Kết quả xoay"
+  },
+  "outpaintEditor": {
+    "title": "Mở rộng khung",
+    "exit": "Thoát mở rộng khung",
+    "submit": "Tạo",
+    "aspectLabel": "Tỉ lệ khung hình",
+    "qualityLabel": "Độ phân giải",
+    "numImagesLabel": "Số biến thể",
+    "numImages": "{{count}}",
+    "aspect": {
+      "original": "Gốc",
+      "s1_1": "1:1",
+      "s4_3": "4:3",
+      "s3_4": "3:4",
+      "s16_9": "16:9",
+      "s9_16": "9:16"
+    },
+    "modelPicker": {
+      "provider": "Nhà cung cấp",
+      "model": "Model",
+      "empty": "Không có model khả dụng"
+    }
+  },
+  "lightEditor": {
+    "title": "Trình chỉnh ánh sáng",
+    "previewMode": {
+      "perspective": "Phối cảnh",
+      "front": "Chính diện"
+    },
+    "tabs": {
+      "global": "Toàn cục",
+      "smart": "Thông minh"
+    },
+    "smartToggle": "Chế độ thông minh",
+    "smartPlaceholder": "Mô tả ánh sáng bạn muốn, ví dụ: nắng sớm dịu chiếu từ phía trước bên trái, tông ấm kiểu điện ảnh.",
+    "smartUploadReference": "Tải ảnh tham chiếu",
+    "smartPresets": "Preset ánh sáng",
+    "brightness": "Độ sáng",
+    "color": "Nhiệt độ màu",
+    "mainLight": "Nguồn sáng chính",
+    "rimLight": "Viền sáng",
+    "rimLightOn": "Bật",
+    "rimLightOff": "Tắt",
+    "directions": {
+      "left": "Left",
+      "top": "Top",
+      "right": "Right",
+      "front": "Front",
+      "bottom": "Bottom",
+      "back": "Back"
+    },
+    "presets": {
+      "overexposedFilm": "Phim cháy sáng",
+      "blueBacklight": "Ngược sáng xanh",
+      "rembrandt": "Rembrandt",
+      "cyberpunk": "Cyberpunk",
+      "psychedelicSunset": "Hoàng hôn ảo giác",
+      "mysteriousDark": "Tối bí ẩn",
+      "goldenHour": "Giờ vàng",
+      "nolanCool": "Xám lạnh kiểu Nolan"
+    },
+    "presetPrompts": {
+      "overexposedFilm": "High-contrast overexposed film look — bright highlights, gentle grain, nostalgic warm cast.",
+      "blueBacklight": "Strong blue backlight from behind the subject, glowing rim around silhouette, overall cool palette.",
+      "rembrandt": "Classic Rembrandt lighting: single 45°/45° key, telltale triangle highlight on the shadow-side cheek, background falls off.",
+      "cyberpunk": "Cyberpunk neon — magenta and cyan neon sources, wet reflections, moody glow.",
+      "psychedelicSunset": "Psychedelic sunset gradient — purple-red to orange sky temperature, soft lens flare.",
+      "mysteriousDark": "Low-key mysterious lighting — vast shadows with a single side light grazing the subject, smoky atmosphere.",
+      "goldenHour": "Golden-hour warm light — low-angle golden sun raking across one side, soft rim glow.",
+      "nolanCool": "Nolan-style cool grey — desaturated blue-grey light, hard contrast, cinematic realism."
+    },
+    "reset": "Đặt lại",
+    "submit": "Tạo",
+    "promptIntro": "Keep composition, subject and materials unchanged. Re-light the image with these instructions:",
+    "promptBrightness": "- Brightness: {{value}}%",
+    "promptColor": "- Light color: {{color}}",
+    "promptMainLight": "- Main light direction: {{direction}}",
+    "promptRimLight": "- Rim light: on (soft contour around the subject)",
+    "promptSmart": "- Style description: {{text}}",
+    "promptOutro": "Preserve subject features, wardrobe and background details. Only redesign lighting, shadow and color temperature.",
+    "qualityPicker": {
+      "title": "Chất lượng"
+    }
+  },
+  "modelPicker": {
+    "provider": "Nhà cung cấp",
+    "model": "Model",
+    "empty": "Không có model khả dụng"
+  },
+  "modelParams": {
+    "provider": "Nhà cung cấp",
+    "model": "Model",
+    "providerKeyRequiredTitle": "Cần API key của nhà cung cấp",
+    "providerKeyRequiredDesc": "{{provider}} chưa được cấu hình. Vui lòng thêm API key trong Cài đặt trước khi dùng.",
+    "goConfigure": "Đi tới cấu hình",
+    "autoAspectRatio": "Tự động",
+    "quality": "Chất lượng",
+    "aspectRatio": "Tỉ lệ khung hình",
+    "enableWebSearch": "Bật tìm kiếm web",
+    "otherParams": "Tham số khác",
+    "extraOptions": "Tuỳ chọn bổ sung",
+    "thinkingLevel": "Mức suy luận",
+    "thinkingLevelDesc": "Chỉ áp dụng cho fal Nano Banana 2. Mức suy luận cao sẽ tốn thêm chi phí.",
+    "thinkingDisabled": "Tắt",
+    "thinkingMinimal": "Tiêu chuẩn",
+    "thinkingHigh": "Cao",
+    "noModelsAvailable": "Quản trị viên chưa cấu hình model tạo ảnh nào"
+  },
+  "node": {
+    "menu": {
+      "uploadImage": "Tải tài nguyên lên",
+      "image": "Ảnh",
+      "aiImageGeneration": "Ảnh AI",
+      "storyboard": "Kết quả tách ô",
+      "storyboardGen": "Lưới nhiều biến thể",
+      "beatContext": "Ngữ cảnh cú máy",
+      "textAnnotation": "Văn bản",
+      "video": "Video",
+      "audio": "Âm thanh",
+      "videoStory": "Video Story",
+      "script": "Kịch bản",
+      "pano360Viewer": "Góc nhìn 360°",
+      "threeDWorld": "Thế giới 3D",
+      "sectionAddNode": "Thêm node",
+      "sectionAddResource": "Thêm tài nguyên",
+      "sectionSkillNode": "Node kỹ năng",
+      "placeholderVideo": "Video",
+      "placeholderVideoCompose": "Dựng video",
+      "placeholderAudio": "Âm thanh",
+      "placeholderScript": "Kịch bản",
+      "betaTag": "Beta",
+      "videoCompose": "Dựng video"
+    },
+    "imageNode": {
+      "title": "Node ảnh",
+      "prompt": "Prompt",
+      "model": "Model",
+      "size": "Kích thước",
+      "aspectRatio": "Tỉ lệ khung hình",
+      "referenceImages": "Ảnh tham chiếu",
+      "noImage": "Chưa có ảnh",
+      "dragImage": "Kéo thả hoặc bấm để tải ảnh lên",
+      "resultAlt": "Ảnh kết quả",
+      "generatedAlt": "Ảnh đã tạo",
+      "waitingResult": "Đang chờ ảnh kết quả",
+      "waitingResultDelayed": "Đã chờ {{minutes}} phút mà chưa có kết quả. Vẫn đang chờ...",
+      "selectToEdit": "Chọn node này và nhập prompt bên dưới để tạo hoặc sửa ảnh",
+      "generationFailed": "Tạo thất bại",
+      "requestId": "Request ID",
+      "copyRequestId": "Sao chép Request ID",
+      "requestIdCopied": "Đã sao chép",
+      "resolution": "Độ phân giải ảnh"
+    },
+    "directorControlBundle": {
+      "badge": "Bộ Director tổng hợp",
+      "tooltip": "Asset Director tổng hợp đầy đủ gồm ảnh ghép, ảnh chỉ có môi trường và metadata. Ảnh thu nhỏ hiển thị ảnh ghép."
+    },
+    "imageEdit": {
+      "promptRequired": "Vui lòng nhập prompt",
+      "apiKeyRequired": "Nhà cung cấp phía backend chưa được cấu hình",
+      "resultTitle": "Ảnh kết quả",
+      "promptPlaceholder": "Mô tả bất cứ thứ gì bạn muốn tạo hoặc chỉnh sửa",
+      "noModelAvailable": "Quản trị viên chưa cấu hình model tạo ảnh nào",
+      "tryLabel": "Thử:",
+      "referenceGroupLabel": "Nhóm tham chiếu asset",
+      "imageNodeBadge": "Node ảnh",
+      "moreRefs": "+{{count}} tham chiếu nữa",
+      "connectRefTitle": "Kéo một ảnh từ thư viện asset vào, hoặc bấm AI Edit trên một node ảnh để tự nối",
+      "connectRef": "Nối một ảnh tham chiếu",
+      "suggest": {
+        "img2imgPrompt": "Generate a cleaner, more refined version based on the reference image, keeping the subject identity and composition.",
+        "img2img": "Ảnh sang ảnh",
+        "upscalePrompt": "Restore the reference image in high definition — sharpen detail, edges and texture while keeping the content unchanged.",
+        "upscale": "Upscale",
+        "cameraPrompt": "Camera movement: a slow push-in, subject held steady, cinematic quality."
+      },
+      "focusPrompt": "Rút gọn prompt",
+      "modes": {
+        "text_to_image": "Chữ sang ảnh",
+        "all_reference": "Tham chiếu đa năng",
+        "image_reference": "Tham chiếu ảnh",
+        "image_to_image": "Ảnh sang ảnh",
+        "image_to_video": "Ảnh sang video",
+        "first_last_frame": "Khung đầu & khung cuối"
+      },
+      "markButton": "Đánh dấu",
+      "cameraButton": "Máy quay",
+      "assetLibraryTitle": "Chọn một tham chiếu từ thư viện asset (nhân vật / bối cảnh / đạo cụ)",
+      "assetLibrary": "Thư viện asset",
+      "insertRef": "Chèn {{label}}"
+    },
+    "imageGen": {
+      "contextPalette": {
+        "button": "Bảng màu bối cảnh",
+        "actors": "Màu diễn viên",
+        "props": "Màu đạo cụ",
+        "empty": "Node này không có dữ liệu màu ngữ cảnh cú máy"
+      },
+      "aspect": {
+        "auto": "Tự động"
+      },
+      "quality": {
+        "low": "Thấp",
+        "medium": "Tiêu chuẩn",
+        "high": "Cao"
+      },
+      "assetReferenceGroup": "Nhóm tham chiếu asset",
+      "missingContext": "Thiếu dự án hoặc ngữ cảnh cú máy",
+      "album": {
+        "expand": "Mở album",
+        "expandCount": "Mở {{count}} ảnh đã tạo",
+        "heading": "Album · {{count}}",
+        "setAsMain": "Bấm để đặt làm ảnh chính",
+        "applyToCanvas": "Đặt ảnh này lên canvas thành một node ảnh riêng",
+        "applyToCanvasLabel": "Thêm vào canvas",
+        "download": "Tải ảnh này về",
+        "mainImage": "Ảnh chính",
+        "generating": "Đang tạo…"
+      },
+      "upload": "Tải ảnh lên",
+      "uploading": "Đang tải lên",
+      "uploadingEllipsis": "Đang tải lên…",
+      "removeReference": "Bỏ ảnh tham chiếu",
+      "history": {
+        "generatingNew": "Đang tạo ảnh mới…",
+        "back": "Quay lại"
+      },
+      "emptyState": {
+        "tryLabel": "Thử:",
+        "imageToImageTitle": "Thêm một node ảnh phía trên để làm tham chiếu",
+        "imageToImage": "Ảnh sang ảnh"
+      },
+      "cropBackgroundTitle": "Cắt một vùng 16:9 từ {{source}} và ghi vào selected_background.png của beat này",
+      "cropBackground": "📐 Cắt nền",
+      "assetLibraryTitle": "Chọn một ảnh tham chiếu từ thư viện asset (nhân vật / bối cảnh / đạo cụ)",
+      "assetLibrary": "Thư viện asset",
+      "fromUpstream": "Từ node phía trên · {{name}}",
+      "dropReference": "Thôi tham chiếu asset này",
+      "promptPlaceholderUpstream": "Nội dung từ node phía trên đã được nối vào — viết thêm chi tiết cho prompt…",
+      "promptPlaceholder": "Mô tả tấm ảnh bạn muốn, dùng @ để tham chiếu asset",
+      "translatePrompt": "Dịch prompt (Trung ↔ Anh)",
+      "generate": "Tạo",
+      "param": {
+        "quality": "Chất lượng",
+        "resolution": "Độ phân giải",
+        "aspect": "Tỉ lệ khung hình"
+      },
+      "camera": "Máy quay",
+      "countValue": "×{{count}}"
+    },
+    "beatContextNode": {
+      "heading": "Ngữ cảnh cú máy",
+      "standaloneTitle": "Ngữ cảnh cú máy tuỳ chỉnh",
+      "openWorkbench": "Mở bàn làm việc",
+      "openingWorkbench": "Đang mở...",
+      "syncToMainline": "Đồng bộ về luồng chính",
+      "unset": "Chưa đặt",
+      "fields": {
+        "visual": "Khung hình mở đầu",
+        "scene": "Bối cảnh",
+        "time": "Thời điểm",
+        "identities": "Tạo hình xuất hiện",
+        "props": "Đạo cụ xuất hiện"
+      },
+      "placeholders": {
+        "visual": "Chưa đặt; bấm để nhập khung hình mở đầu"
+      },
+      "empty": {
+        "noCharacter": "Không có nhân vật nào xuất hiện",
+        "noProp": "Không có đạo cụ nào xuất hiện"
+      },
+      "stale": "Đã xoá",
+      "assets": {
+        "background": "Nền",
+        "sketch": "Phác thảo",
+        "frame": "Cú máy",
+        "selected": "Đã chọn",
+        "unselected": "Chưa chọn",
+        "exists": "Đã có",
+        "missing": "Còn thiếu"
+      },
+      "status": {
+        "standaloneLocalOnly": "Bối cảnh tuỳ chỉnh; chỉ dùng trên canvas này.",
+        "syncError": "Đồng bộ thất bại: {{message}}",
+        "unknownError": "Lỗi không xác định",
+        "syncing": "Đang đồng bộ về luồng chính...",
+        "stale": "Thay đổi cục bộ chưa được đồng bộ về luồng chính; các kỹ năng vẫn dùng node này.",
+        "fresh": "Ngữ cảnh đã đồng bộ; các kỹ năng dùng node này.",
+        "missingTargetForSync": "Thiếu dự án/tập/beat — không đồng bộ về luồng chính được.",
+        "missingTargetForLocal": "Thiếu dự án/tập/beat — không cập nhật ngữ cảnh cục bộ được."
+      },
+      "palette": {
+        "identityColor": "Màu tạo hình",
+        "propColor": "Màu đạo cụ",
+        "actorColors": "Màu diễn viên",
+        "propColors": "Màu đạo cụ"
+      },
+      "mention": {
+        "identity": "Nhân vật",
+        "prop": "Đạo cụ"
+      }
+    },
+    "upload": {
+      "uploadedAlt": "Tài nguyên đã tải lên",
+      "hint": "Kéo vào đây hoặc bấm tải lên để thêm ảnh hoặc video",
+      "uploadImage": "Tải ảnh lên",
+      "uploading": "Đang tải lên",
+      "uploadAsset": "Tải asset lên"
+    },
+    "audio": {
+      "uploadTypeError": "Vui lòng tải lên file âm thanh",
+      "uploadLocalTitle": "Tải âm thanh từ máy",
+      "uploading": "Đang tải lên",
+      "uploadAudio": "Tải âm thanh lên",
+      "replaceAudioTitle": "Thay âm thanh",
+      "replace": "Thay"
+    },
+    "storyboardNode": {
+      "title": "Kết quả tách ô",
+      "frames": "Số ô",
+      "rows": "Số hàng",
+      "cols": "Số cột",
+      "frameIndex": "Khung {{index}}"
+    },
+    "storyboardGen": {
+      "rowsShort": "H",
+      "colsShort": "C",
+      "frameCount": "{{count}} biến thể",
+      "ratioModeOverall": "Tổng thể",
+      "ratioModeCell": "Từng ô",
+      "cellAspectRatio": "Tỉ lệ ô",
+      "overallAspectRatio": "Tỉ lệ tổng thể",
+      "requestAspectRatio": "Tỉ lệ yêu cầu",
+      "framePlaceholder": "Mô tả biến thể {{index}}",
+      "gridPreviewTitle": "Xem trước lưới",
+      "noImageModelConfigured": "Quản trị viên chưa cấu hình model ảnh nào nên chưa tạo được",
+      "needOneFrameDescription": "Mô tả ít nhất một ô ứng viên",
+      "generateFailed": "Tạo thất bại"
+    },
+    "operationPanel": {
+      "expand": "Mở rộng",
+      "collapse": "Thu gọn"
+    },
+    "textNode": {
+      "tryHint": "Thử:",
+      "modes": {
+        "writing": "Viết nội dung",
+        "textToVideo": "Text to Video",
+        "imageToPrompt": "Image to Prompt",
+        "textToMusic": "Nhân bản giọng",
+        "textToMusicGen": "Text to Music"
+      },
+      "placeholder": "Viết một câu chuyện, một cảnh hoặc ý tưởng nhân vật. Ví dụ: trong một nhà ga cũ giữa đêm mưa, một lá thư đến muộn làm thay đổi lựa chọn của tất cả mọi người.",
+      "generatePlaceholder": "Mô tả câu chuyện, bối cảnh, nhân vật, lời thoại hoặc ý tưởng bạn muốn tạo…",
+      "generateText": "Tạo văn bản bằng AI",
+      "modelPickerHint": "Chọn một model",
+      "submit": "Gửi",
+      "translate": "Dịch (zh ↔ en)",
+      "group": {
+        "textToVideo": "Nhóm chữ sang video",
+        "imageToPrompt": "Nhóm ảnh sang prompt",
+        "textToMusic": "Nhóm chữ sang nhạc",
+        "cloneAudio": "Nhóm nhân bản giọng"
+      },
+      "detachUpstreamImage": "Gỡ tham chiếu này"
+    },
+    "videoUpscale": {
+      "title": "Upscale video",
+      "nodeTitle": "HD",
+      "placeholder": "Thiết lập các tham số bên dưới để tạo video HD",
+      "panel": {
+        "title": "Upscale video",
+        "resolution": "Độ phân giải",
+        "frameInterpolation": "Nội suy khung hình",
+        "frameInterpolationNone": "Không",
+        "frameInterpolationLockedHint": "Bản cơ bản chỉ hỗ trợ chế độ không nội suy",
+        "denoise": "Khử nhiễu",
+        "denoiseNone": "Tắt",
+        "submit": "Tạo video HD"
+      }
+    },
+    "videoNode": {
+      "uploading": "Đang tải lên...",
+      "generating": "Đang tạo...",
+      "noVideo": "Chưa có video",
+      "upload": "Tải lên",
+      "clickToUpload": "Bấm hoặc kéo thả để tải video lên",
+      "resolution": "Độ phân giải video",
+      "tabs": {
+        "textToVideo": "Text to Video",
+        "allReference": "Tham chiếu đa năng",
+        "imageToVideo": "Image to Video",
+        "firstFrame": "Khung đầu",
+        "firstLastFrame": "Khung đầu/cuối",
+        "imageReference": "Ảnh tham chiếu",
+        "videoEdit": "Sửa video"
+      },
+      "placeholder": "Mô tả video bạn muốn tạo.",
+      "referenceDocument": {
+        "file": "File tham chiếu",
+        "removeFile": "Bỏ file tham chiếu",
+        "linkPlaceholder": "URL công khai",
+        "unsupportedType": "Loại file không hỗ trợ. Chấp nhận: {{types}}",
+        "fileTooLarge": "File tham chiếu phải từ 100MB trở xuống (hiện tại: {{size}}MB)",
+        "fileUnsupported": "Model này không hỗ trợ tham chiếu bằng file",
+        "linkUnsupported": "Model này không hỗ trợ tham chiếu bằng liên kết web",
+        "invalidLink": "Nhập một URL HTTP/HTTPS công khai hợp lệ",
+        "fileLinkConflict": "Không dùng đồng thời file tham chiếu và liên kết web"
+      },
+      "submit": "Gửi",
+      "submitBusy": "Đang tạo, vui lòng đợi",
+      "partialBatchFailed": "Đã tạo {{ok}}/{{total}}, phần còn lại thất bại",
+      "humanReviewErrors": {
+        "assetFetchFailed": "Không truy cập được ảnh tham chiếu {{index}}. Hãy tải lên lại rồi thử lại.",
+        "assetExpired": "Link của ảnh tham chiếu {{index}} đã hết hạn. Hãy tải lên lại.",
+        "unsupportedImage": "Ảnh tham chiếu {{index}} có định dạng hoặc kích thước không được hỗ trợ.",
+        "contentRejected": "Ảnh tham chiếu {{index}} không qua được kiểm duyệt nội dung. Hãy thử ảnh khác.",
+        "reviewTimeout": "Kiểm duyệt ảnh tham chiếu quá thời gian chờ. Hãy thử lại sau.",
+        "unknownReviewError": "Ảnh tham chiếu {{index}} không qua kiểm duyệt và dịch vụ không nêu lý do. Hãy thử ảnh khác hoặc liên hệ quản trị viên."
+      },
+      "aspect": {
+        "title": "Tỉ lệ khung hình",
+        "auto": "Tự động"
+      },
+      "quality": {
+        "title": "Chất lượng"
+      },
+      "duration": {
+        "title": "Thời lượng"
+      },
+      "sceneOptimize": {
+        "title": "Phong cách",
+        "options": {
+          "anime": "Anime",
+          "realistic": "Tả thực"
+        }
+      },
+      "audio": {
+        "title": "Tạo âm thanh",
+        "on": "Bật",
+        "off": "Tắt",
+        "durationTooShort": "Mỗi đoạn âm thanh phải dài ít nhất {{min}} giây: {{clips}}. Hãy thay hoặc dùng đoạn dài hơn rồi thử lại.",
+        "durationTooLong": "Mỗi đoạn âm thanh chỉ được dài tối đa {{max}} giây: {{clips}}. Hãy cắt bớt hoặc dùng đoạn ngắn hơn rồi thử lại.",
+        "durationTotalTooShort": "Tổng các đoạn âm thanh phải dài ít nhất {{min}} giây, hiện là {{total}} giây: {{clips}}. Hãy thêm hoặc kéo dài âm thanh rồi thử lại.",
+        "durationTotalTooLong": "Tổng các đoạn âm thanh chỉ được dài tối đa {{max}} giây, hiện là {{total}} giây: {{clips}}. Hãy cắt bớt hoặc bỏ bớt đoạn rồi thử lại.",
+        "clipDuration": "{{label}} ({{seconds}}s)",
+        "clipSeparator": ", ",
+        "clipFallbackLabel": "Âm thanh {{index}}"
+      },
+      "referenceDuration": {
+        "videoFallbackLabel": "Video {{index}}",
+        "videoTooShort": "Mỗi đoạn video phải dài ít nhất {{min}} giây: {{clips}}. Hãy thay hoặc kéo dài rồi thử lại.",
+        "videoTooLong": "Mỗi đoạn video chỉ được dài tối đa {{max}} giây: {{clips}}. Hãy cắt bớt hoặc thay đoạn khác rồi thử lại.",
+        "videoTotalTooShort": "Tổng các đoạn video phải dài ít nhất {{min}} giây, hiện là {{total}} giây: {{clips}}. Hãy thêm hoặc kéo dài video rồi thử lại.",
+        "videoTotalTooLong": "Tổng các đoạn video chỉ được dài tối đa {{max}} giây, hiện là {{total}} giây: {{clips}}. Hãy cắt bớt hoặc bỏ bớt video rồi thử lại."
+      },
+      "count": {
+        "format": "{{count}}"
+      },
+      "frame": {
+        "captureCurrent": "Chụp khung hiện tại",
+        "captureFirst": "Chụp khung đầu",
+        "captureLast": "Chụp khung cuối",
+        "capturing": "Đang chụp...",
+        "titleFirst": "Khung đầu",
+        "titleLast": "Khung cuối",
+        "titleCurrent": "Khung hiện tại"
+      },
+      "subtitleErase": {
+        "exit": "Thoát",
+        "submit": "Gửi",
+        "tools": {
+          "rect": "Hình chữ nhật",
+          "undo": "Hoàn tác",
+          "redo": "Làm lại",
+          "reset": "Đặt lại"
+        }
+      },
+      "player": {
+        "play": "Phát",
+        "pause": "Tạm dừng",
+        "mute": "Tắt tiếng",
+        "unmute": "Bật tiếng"
+      },
+      "cta": {
+        "allReference": "Tham chiếu đa năng",
+        "imageReference": "Tham chiếu ảnh",
+        "firstFrame": "Video từ khung đầu",
+        "imageToVideo": "Ảnh sang video",
+        "firstLastFrame": "Video từ khung đầu & khung cuối"
+      },
+      "spawn": {
+        "firstFrame": "Khung đầu",
+        "lastFrame": "Khung cuối",
+        "referenceImage": "Ảnh tham chiếu",
+        "imageReferenceGroup": "Nhóm tham chiếu ảnh",
+        "firstFrameGroup": "Nhóm video từ khung đầu",
+        "imageToVideoGroup": "Nhóm ảnh sang video",
+        "allReferenceGroup": "Nhóm tham chiếu đa năng",
+        "firstLastFrameGroup": "Nhóm video từ khung đầu & khung cuối"
+      },
+      "clip": {
+        "displayName": "Cắt đoạn",
+        "noUrl": "Cắt xong nhưng không trả về URL video",
+        "failed": "Cắt thất bại: {{detail}}"
+      },
+      "videoEdit": {
+        "imageLimit": "Sửa video hỗ trợ tối đa {{limit}} ảnh tham chiếu; đã dùng {{limit}} ảnh đầu ({{ignored}} ảnh bị bỏ qua)"
+      },
+      "allReference": {
+        "happyHorseUnsupported": "HappyHorse không hỗ trợ tham chiếu đa năng. Chuyển sang chữ-sang-video hoặc ảnh-sang-video.",
+        "modelUnsupported": "Model này không hỗ trợ tham chiếu đa năng. Đổi model hoặc chọn chế độ tạo khác."
+      },
+      "generation": {
+        "noResult": "Lượt tạo video không trả về kết quả nào",
+        "failed": "Tạo video thất bại",
+        "faceBlockedMessage": "Asset có mặt người thật và bị chính sách an toàn nội dung chặn. Bật “Kiểm duyệt asset người thật” bên dưới rồi thử lại (kiểm duyệt có thể lâu hơn và không chắc qua).",
+        "faceBlockedTitle": "Asset bị chặn"
+      },
+      "album": {
+        "expand": "Mở album",
+        "expandCount": "Mở {{count}} kết quả đã tạo",
+        "heading": "Album · {{count}}",
+        "setAsMain": "Bấm để đặt làm video chính",
+        "applyToCanvas": "Đặt video này lên canvas thành một node video riêng",
+        "applyToCanvasLabel": "Thêm vào canvas",
+        "download": "Tải video này về",
+        "mainVideo": "Video chính",
+        "generating": "Đang tạo…"
+      },
+      "history": {
+        "generatingNew": "Đang tạo video mới…",
+        "back": "Quay lại"
+      },
+      "error": {
+        "requestId": "Request ID"
+      },
+      "emptyState": {
+        "tryLabel": "Thử:"
+      },
+      "videoLoadFailed": "Tải video thất bại"
+    },
+    "pano360": {
+      "captureGroup2x2": "Bộ ảnh chụp toàn cảnh (4)",
+      "captureGroup4x3": "Bộ ảnh chụp toàn cảnh (12)",
+      "snapCurrent": "Chụp góc nhìn hiện tại",
+      "snap2x2": "Chụp 4 góc",
+      "snap4x3": "Chụp 12 góc",
+      "useAsBackground": "Dùng làm nguồn nền (ghi vào selected_background của beat này)",
+      "resetView": "Đặt lại góc nhìn",
+      "zoomOut": "Thu nhỏ",
+      "zoomIn": "Phóng to",
+      "panLeft": "Xoay trái",
+      "panRight": "Xoay phải",
+      "panUp": "Ngẩng lên",
+      "panDown": "Cúi xuống",
+      "enterFullscreen": "Vào toàn màn hình",
+      "fov": "FOV",
+      "sphereCorrection": "Hiệu chỉnh cầu",
+      "lockViewTitle": "Ghi góc nhìn hiện tại vào các tham số hiệu chỉnh",
+      "lockView": "Khoá góc nhìn hiện tại",
+      "front": "Hướng chính",
+      "setFrontYawTitle": "Đặt góc yaw hiện tại làm hướng chính",
+      "effectsAndExport": "Hiệu ứng & xuất",
+      "planetMode": "Hành tinh nhỏ",
+      "copyCorrectionJsonTitle": "Sao chép frontYaw, tham số hiệu chỉnh và FOV hiện tại dưới dạng JSON",
+      "copyCorrectionJson": "Chép JSON hiệu chỉnh",
+      "dir": {
+        "front": "Trước",
+        "right": "Phải",
+        "back": "Sau",
+        "left": "Trái"
+      },
+      "pitch": {
+        "up": "Trên",
+        "level": "Ngang",
+        "down": "Dưới"
+      },
+      "status": {
+        "initFailed": "Photo Sphere Viewer khởi tạo thất bại: {{detail}}",
+        "ready": "Sẵn sàng",
+        "loaded": "Đã tải xong",
+        "loadFailed": "Tải thất bại",
+        "loadFailedDetail": "Tải thất bại: {{detail}}",
+        "loading": "Đang tải…",
+        "frontSet": "Đã đặt góc nhìn hiện tại làm hướng chính: {{yaw}}°",
+        "jsonCopied": "Đã chép JSON hiệu chỉnh vào clipboard",
+        "jsonNoClipboard": "Đã tạo JSON hiệu chỉnh (không dùng được clipboard — xem console)",
+        "snapDone": "Đã chụp góc nhìn hiện tại",
+        "snapFailed": "Chụp thất bại",
+        "snapFailedDetail": "Chụp thất bại: {{detail}}",
+        "notInShotContext": "Không ở trong ngữ cảnh cú máy — không đặt làm nguồn nền được",
+        "backgroundSet": "Đã đặt nền hiện tại",
+        "backgroundSubmitted": "Đã tạo và gửi ứng viên nền",
+        "setFailedDetail": "Không đặt được: {{detail}}",
+        "capturing": "Đang chụp ({{count}})…",
+        "uploadingCount": "Đang tải lên ({{count}})…",
+        "capturedCount": "Đã chụp {{count}} ảnh"
+      },
+      "currentView": "Góc nhìn hiện tại",
+      "currentBackground": "Nền hiện tại",
+      "metaViewer": "Trình xem tự do 360°",
+      "metaWaiting": "Đang chờ ảnh toàn cảnh từ node phía trên",
+      "connectUpstream": "Nối một node ảnh phía trên để xem ảnh toàn cảnh",
+      "collapsePanel": "Thu gọn bảng điều khiển",
+      "expandPanel": "Mở bảng điều khiển",
+      "reset": "Đặt lại",
+      "setAsCurrentView": "Đặt làm góc nhìn hiện tại",
+      "exitPlanet": "Thoát hành tinh nhỏ"
+    },
+    "videoModel": {
+      "reason": {
+        "videoUnsupported": "Model này không nhận asset video",
+        "audioUnsupported": "Model này không nhận asset âm thanh",
+        "singleImageOnly": "Model này chỉ nhận 1 ảnh mỗi lượt",
+        "imagesOnly": "Model này chỉ nhận asset ảnh",
+        "grokImagesOnly": "Grok Video Channel chỉ nhận asset ảnh",
+        "grokImageLimit": "Grok Video Channel hỗ trợ tối đa 1 khung đầu và 7 ảnh tham chiếu",
+        "maxImages": "Model này hỗ trợ tối đa {{count}} asset ảnh",
+        "maxVideos": "Model này hỗ trợ tối đa {{count}} asset video",
+        "maxAudios": "Model này hỗ trợ tối đa {{count}} asset âm thanh"
+      }
+    },
+    "scriptNode": {
+      "action": {
+        "fromScript": "Storyboard từ kịch bản",
+        "fromVideoRef": "Storyboard từ video tham chiếu",
+        "fromCharacter": "Storyboard từ nhân vật"
+      },
+      "actionGroup": "Nhóm {{action}}",
+      "column": {
+        "shot_no": "Số cú máy",
+        "duration": "Thời lượng",
+        "visual_description": "Mô tả hình ảnh",
+        "character_1": "Nhân vật 1",
+        "character_description_1": "Mô tả nhân vật 1",
+        "character_image_1": "Ảnh nhân vật 1",
+        "character_2": "Nhân vật 2",
+        "character_description_2": "Mô tả nhân vật 2",
+        "character_image_2": "Ảnh nhân vật 2",
+        "reference": "Tham chiếu",
+        "shot": "Cỡ cảnh",
+        "character_action": "Hành động nhân vật",
+        "emotion": "Cảm xúc",
+        "scene_tags": "Thẻ bối cảnh",
+        "lighting_mood": "Ánh sáng & không khí",
+        "sound": "Âm thanh",
+        "dialogue": "Lời thoại",
+        "shot_prompt": "Prompt cú máy",
+        "video_motion_prompt": "Prompt chuyển động video"
+      },
+      "error": {
+        "missingProject": "Thiếu tham số dự án",
+        "missingInput": "Mô tả câu chuyện trong prompt, hoặc nối một node video / ảnh nhân vật vào"
+      },
+      "spawn": {
+        "screenplay": "Kịch bản",
+        "character": "Nhân vật {{index}}"
+      },
+      "retry": "Thử lại",
+      "tryLabel": "Thử:",
+      "shotCount": "{{count}} cú máy",
+      "close": "Đóng",
+      "defaultTitle": "Kịch bản storyboard",
+      "scriptView": "Xem dạng kịch bản",
+      "fullscreen": "Toàn màn hình",
+      "uploadFailed": "Tải lên thất bại",
+      "promptPlaceholder": "Mô tả câu chuyện, hoặc thêm tham chiếu nhân vật / video — phần storyboard cứ để hệ thống dựng",
+      "translate": "Dịch (Trung ↔ Anh)",
+      "generate": "Tạo",
+      "referenceFallback": "Tham chiếu {{index}}",
+      "uploadImage": "Bấm để tải ảnh lên",
+      "replaceImage": "Thay ảnh",
+      "removeImage": "Bỏ ảnh",
+      "closePreview": "Đóng xem trước"
+    },
+    "audioPanel": {
+      "musicLength": {
+        "30s": "30 giây",
+        "1m": "1 phút",
+        "2m": "2 phút",
+        "3m": "3 phút",
+        "4m": "4 phút",
+        "5m": "5 phút",
+        "10m": "10 phút"
+      },
+      "promptLabel": {
+        "music": "Mô tả bản nhạc",
+        "speech": "Văn bản cần đọc"
+      },
+      "promptPlaceholder": {
+        "music": "Mô tả bản nhạc bạn muốn: phong cách, nhạc cụ, tốc độ, tâm trạng…",
+        "speech": "Văn bản cần đọc"
+      },
+      "emotionLabel": "Gợi ý cách diễn",
+      "emotionOptional": "(tuỳ chọn, viết tự do)",
+      "emotionPlaceholder": "ví dụ căng thẳng, thì thào, hơi sợ",
+      "voiceMissing": "Cấu hình hoặc chọn một giọng trước đã",
+      "translate": "Dịch (Trung ⇄ Anh)",
+      "voiceSettings": "Thiết lập giọng",
+      "advancedSettings": "Thiết lập nâng cao",
+      "generate": "Tạo",
+      "help": "Trợ giúp",
+      "musicDuration": "Độ dài bản nhạc",
+      "musicDurationHelp": "Đặt độ dài bài hát. Ở chế độ tự động thì lời được giữ nguyên vẹn; khi đã đặt độ dài thì khớp đúng độ dài đó được ưu tiên trước.",
+      "forceInstrumental": "Chỉ nhạc không lời",
+      "forceInstrumentalHelp": "Bắt buộc ra bản nhạc không lời, không có giọng hát.",
+      "respectSections": "Tôn trọng độ dài từng đoạn",
+      "respectSectionsHelp": "Bám sát chiến lược thời lượng của từng đoạn nhạc.",
+      "voiceLoading": "Đang tải…",
+      "copied": "Đã sao chép",
+      "copyFailed": "Sao chép thất bại",
+      "copyVoiceRef": "Sao chép tham chiếu giọng",
+      "switchVoice": "Đổi giọng"
+    },
+    "voiceRef": {
+      "projectNarrator": "Người dẫn truyện của dự án",
+      "userCustom": "Giọng tuỳ chỉnh",
+      "characterDefault": "{{name}} (giọng mặc định)",
+      "characterAgeGroup": "{{name}} ({{slot}})",
+      "identity": "{{id}} (giọng riêng)",
+      "identityResolved": "{{id}} (đã xác định)",
+      "character": "Nhân vật",
+      "ageGroup": "Nhóm tuổi",
+      "identityFallback": "Tạo hình"
+    },
+    "voiceModal": {
+      "title": "Chọn giọng",
+      "close": "Đóng",
+      "tab": {
+        "library": "Thư viện giọng",
+        "mine": "Giọng của tôi"
+      },
+      "searchLibrary": "Tìm trong thư viện giọng",
+      "searchMine": "Tìm trong giọng của tôi",
+      "loading": "Đang tải…",
+      "empty": "Không có giọng nào",
+      "emptyMine": "Chưa có giọng nào — nhân bản một giọng để bắt đầu.",
+      "clone": "Nhân bản một giọng",
+      "uploading": "Đang tải lên…",
+      "selected": "Đã chọn",
+      "select": "Chọn",
+      "missingProject": "URL hiện tại thiếu tham số dự án",
+      "loadFailed": "Tải danh sách giọng thất bại",
+      "pickAudioFile": "Chọn một file âm thanh (mp3 / wav / m4a / aac / ogg / webm)",
+      "fileTooLarge": "Âm thanh mẫu phải dưới {{limit}}MB (hiện tại {{size}}MB) — nén hoặc cắt bớt rồi thử lại",
+      "uploadNetworkError": "Tải lên thất bại: mất kết nối (file âm thanh lớn dễ bị đứt — giữ dưới {{limit}}MB rồi thử lại)",
+      "uploadFailed": "Tải lên thất bại",
+      "perPage": "{{count}} / trang",
+      "jumpTo": "Tới trang",
+      "pageSuffix": "trang",
+      "totalCount": "Tổng {{count}}"
+    },
+    "storyboard": {
+      "exportCanvasInitFailed": "Khởi tạo canvas xuất file thất bại",
+      "emptyCell": "Trống",
+      "editCell": "Sửa ô này",
+      "replaceFromInput": "Thay bằng ảnh đầu vào",
+      "cellNotePlaceholder": "Mô tả ô {{no}}",
+      "inputImageLabel": "Ảnh {{index}}",
+      "noEditableImage": "Ô này không có ảnh nào sửa được",
+      "cellTitle": "Ô {{index}}",
+      "createEditNodeFailed": "Tạo node chỉnh sửa thất bại",
+      "noExportableImages": "Không có ảnh nào để xuất",
+      "exportFailed": "Xuất thất bại",
+      "cellNoExportableImage": "Ô này không có ảnh nào để xuất",
+      "untitledProject": "Dự án chưa đặt tên",
+      "projectFallback": "dự án",
+      "packFailed": "Tải gói về thất bại",
+      "noInputImages": "Không có ảnh đầu vào",
+      "showFrameIndex": "Hiện số thứ tự ô",
+      "showFrameNote": "Hiện mô tả ô",
+      "imageFit": "Cách vừa ảnh",
+      "imageFitCover": "Lấp đầy ô",
+      "imageFitContain": "Vừa trọn ảnh",
+      "notePlacement": "Vị trí chú thích",
+      "notePlacementOverlay": "Đè lên ảnh",
+      "notePlacementBottom": "Dưới ảnh",
+      "frameIndexPrefix": "Tiền tố số thứ tự",
+      "cellGap": "Khoảng cách",
+      "fontSize": "Cỡ chữ (%)",
+      "backgroundColor": "Màu nền",
+      "textColor": "Màu chữ",
+      "exportSettings": "Thiết lập xuất file",
+      "gridSummary": "{{rows}} x {{cols}} | {{count}} ô",
+      "packing": "Đang đóng gói…",
+      "pack": "Tải cả gói",
+      "exporting": "Đang xuất…",
+      "mergeGrid": "Gộp thành lưới"
+    },
+    "displayName": {
+      "uploadNode": "Asset đã tải lên",
+      "imageNode": "Ảnh AI",
+      "imageGenNode": "Node ảnh",
+      "exportImageNode": "Ảnh kết quả",
+      "beatContextNode": "Ngữ cảnh cú máy",
+      "textAnnotationNode": "Chữ",
+      "groupNode": "Nhóm",
+      "storyboardNode": "Khung hình đã trích",
+      "storyboardGenNode": "Biến thể storyboard",
+      "videoNode": "Video",
+      "audioNode": "Âm thanh",
+      "videoStoryNode": "Video có chuyện",
+      "videoComposeNode": "Dựng video",
+      "scriptNode": "Bộ tạo kịch bản",
+      "pano360ViewerNode": "Trình xem toàn cảnh 360°",
+      "threeDWorldNode": "Thế giới 3D",
+      "skillNode": "Kỹ năng",
+      "styleNode": "Phong cách"
+    },
+    "exportResult": {
+      "generic": "Ảnh kết quả",
+      "storyboardGenOutput": "Kết quả storyboard",
+      "storyboardSplitExport": "Xuất khung hình",
+      "storyboardFrameEdit": "Kết quả một khung hình",
+      "matte": "Kết quả tách nền",
+      "upscale": "Đã upscale"
+    },
+    "audioNode": {
+      "empty": "Chưa có âm thanh",
+      "noVoiceConfigured": "Chưa cấu hình giọng",
+      "generateFailed": "Tạo thất bại",
+      "selectVoiceFirst": "Cấu hình hoặc chọn một giọng trước đã"
+    },
+    "videoStory": {
+      "columns": {
+        "shotNumber": "Số cú máy",
+        "startTime": "Bắt đầu",
+        "endTime": "Kết thúc",
+        "duration": "Thời lượng",
+        "visualDescription": "Mô tả hình ảnh",
+        "narrative": "Lời dẫn",
+        "shotSize": "Cỡ cảnh",
+        "cameraAngle": "Góc máy",
+        "cameraMovement": "Chuyển động máy",
+        "focalAndDof": "Tiêu cự & độ sâu trường ảnh",
+        "lighting": "Ánh sáng",
+        "backgroundMusic": "Nhạc nền",
+        "voiceAndSfx": "Giọng / SFX",
+        "imagePrompt": "Prompt ảnh",
+        "videoMotionPrompt": "Prompt chuyển động video",
+        "keyframeUrl": "Keyframe"
+      },
+      "emptyTitle": "Không phát hiện cú máy nào",
+      "emptyDetail": "Phản hồi không chứa dòng cú máy nào dùng được. Phản hồi thô được giữ bên dưới để bạn xem API trả về những gì.",
+      "viewRaw": "Xem phản hồi thô",
+      "rawEmpty": "(trống)",
+      "parseFailed": "Phân tích thất bại",
+      "parsing": "Đang phân tích…",
+      "rowCount": "{{count}} cú máy",
+      "rowCountTotal": "Tổng {{count}} cú máy",
+      "fullscreen": "Toàn màn hình",
+      "close": "Đóng",
+      "unknownError": "Lỗi không rõ"
+    },
+    "videoOps": {
+      "referenceGroupLabel": "Nhóm tham chiếu asset",
+      "upstreamPlaceholder": "Nội dung từ node phía trên đã tự gắn vào — viết thêm chi tiết cho prompt…",
+      "humanReviewTitle": "Bật khi tư liệu có mặt người thật. Kiểm duyệt có thể lâu hơn và không chắc được duyệt.",
+      "humanReviewLabel": "Kiểm duyệt người thật",
+      "translateTitle": "Dịch prompt (Trung ⇄ Anh)",
+      "modes": {
+        "textToVideo": "Chữ sang video",
+        "firstFrame": "Khung đầu",
+        "imageToVideo": "Ảnh sang video",
+        "imageReference": "Tham chiếu nhiều ảnh",
+        "firstLastFrame": "Khung đầu & khung cuối",
+        "videoEdit": "Sửa video",
+        "allReference": "Tham chiếu đa năng",
+        "current": "chế độ hiện tại"
+      },
+      "refKind": {
+        "image": "Ảnh",
+        "video": "Video",
+        "audio": "Âm thanh"
+      },
+      "refUnit": {
+        "image": "ảnh",
+        "video": "đoạn"
+      },
+      "overCap": "Tham chiếu {{kind}} vượt giới hạn của {{mode}} ({{cap}} {{unit}}); asset này sẽ không được dùng trong lượt tạo lần này.",
+      "slot": {
+        "firstFrame": "Khung đầu",
+        "lastFrame": "Khung cuối"
+      },
+      "chip": {
+        "imageFallback": "Tham chiếu {{index}}",
+        "videoFallback": "Tham chiếu video {{index}}",
+        "audioFallback": "Tham chiếu âm thanh {{index}}"
+      },
+      "modeDisabled": {
+        "hasVideoUseVideoEdit": "Đang nối một node video — hãy dùng “Sửa video”",
+        "hasImagePickMode": "Đang nối một node ảnh — chọn “Khung đầu”, “Ảnh sang video” hoặc “Tham chiếu ảnh”",
+        "hasVideoNoFirstFrame": "Đang nối một node video — “Khung đầu” không dùng được",
+        "hasVideoNoImageToVideo": "Đang nối một node video — “Ảnh sang video” không dùng được",
+        "needOneImage": "Nối một node ảnh vào (đúng 1 node)",
+        "firstFrameSingleImage": "“Khung đầu” chỉ nhận một ảnh",
+        "imageToVideoSingleImage": "“Ảnh sang video” chỉ nhận một ảnh",
+        "imageToVideoSingleImageUseRef": "“Ảnh sang video” chỉ nhận một ảnh — hãy dùng “Tham chiếu ảnh” thay thế",
+        "hasVideoNoImageReference": "Đang nối một node video — “Tham chiếu ảnh” không dùng được",
+        "needImages1to9": "Nối các node ảnh vào (1–9 node)",
+        "imageReferenceMax9": "“Tham chiếu ảnh” hỗ trợ tối đa 9 ảnh",
+        "needOneVideo": "Nối một node video vào (đúng 1 node)",
+        "videoEditSingleVideo": "“Sửa video” chỉ nhận đúng 1 node video được nối",
+        "happyHorseUnsupported": "HappyHorse không hỗ trợ chế độ này",
+        "modelNoVideoEdit": "Model này không hỗ trợ “Sửa video”",
+        "videoUpstreamAllRefOrEdit": "Khi phía trên là video, chỉ dùng được “Tham chiếu đa năng” hoặc “Sửa video”",
+        "videoUpstreamAllRefOnly": "Khi phía trên là video, chỉ dùng được “Tham chiếu đa năng”",
+        "hasImageOrAudioRefs": "Không dùng được khi đang tham chiếu asset ảnh/âm thanh",
+        "moreThanTwoImages": "Không dùng được khi phía trên có hơn 2 ảnh"
+      }
+    },
+    "threeDWorld": {
+      "upstreamNodeFallback": "Node phía trên",
+      "directorWorld": "Thế giới đạo diễn",
+      "captureReadFailed": "Không đọc được ảnh chụp 3GS",
+      "captureSizeFailed": "Không đọc được kích thước ảnh chụp 3GS",
+      "refImageTitle": "Ảnh tham chiếu từ node phía trên",
+      "refImageAlt": "Tham chiếu ảnh từ node phía trên",
+      "refImagePreviewAlt": "Xem trước tham chiếu ảnh từ node phía trên",
+      "refImageFallback": "Ảnh {{index}}",
+      "noProject": "Không xác định được dự án hiện tại",
+      "textTo3dUnsupported": "Chữ sang 3D chưa được nối — hãy nối một node ảnh vào",
+      "pano360Label": "Ảnh 360",
+      "pano3dgsLabel": "3DGS 360",
+      "image3dgsLabel": "3DGS từ ảnh",
+      "worldUrlMissing": "Không tìm thấy URL thế giới 3D trong task.result",
+      "generateFailed": "Tạo thất bại: {{message}}",
+      "notInBeatContext": "Không ở trong ngữ cảnh cú máy — không đặt được nền hiện tại",
+      "combinedNoProject": "Không có dự án — không lưu được ảnh ghép đạo diễn của canvas",
+      "combinedBundleMissing": "Ảnh ghép đạo diễn thiếu combined/env_only/frame_meta",
+      "combinedUrlMissing": "Ảnh ghép đạo diễn của canvas thiếu URL ảnh",
+      "combinedLabel": "Ảnh ghép đạo diễn",
+      "envOnlyLabel": "Chỉ hậu cảnh",
+      "captureGroupName": "Kết quả thế giới đạo diễn",
+      "captureOutputFailed": "Đưa ảnh chụp thế giới đạo diễn ra canvas thất bại",
+      "captureLabel": "Thế giới đạo diễn {{kind}}",
+      "thumbAlt": "Ảnh thu nhỏ của thế giới đạo diễn",
+      "directorCaptureReadFailed": "Không đọc được ảnh chụp thế giới đạo diễn",
+      "directorCaptureSizeFailed": "Không đọc được kích thước ảnh chụp thế giới đạo diễn",
+      "directorElement": "Phần tử đạo diễn",
+      "directorExportLabel": "Xuất thế giới đạo diễn"
+    }
+  },
+  "viewer": {
+    "imageAlt": "Ảnh",
+    "prev": "Trước",
+    "next": "Sau",
+    "reset": "Đặt lại khung nhìn",
+    "noPanoManifest": "Không có manifest 360 nào",
+    "videoTitleFallback": "Video",
+    "videoSeek": "Tiến độ video",
+    "mute": "Tắt tiếng",
+    "unmute": "Bật tiếng",
+    "fullscreen": "Toàn màn hình",
+    "threeD": {
+      "title": "Director World",
+      "description": "Tải asset Director World từ manifest cùng nguồn gốc.",
+      "noManifest": "Không có manifest Director World nào",
+      "initializing": "Đang khởi tạo PlayCanvas...",
+      "anonymousActor": "Diễn viên vô danh {{n}}",
+      "anonymousProp": "Đạo cụ vô danh {{n}}",
+      "stagingMarker": "Điểm đánh dấu của đạo diễn",
+      "captureFailed": "Chụp Director World thất bại",
+      "sceneStage": "Director World của bối cảnh",
+      "close": "Đóng",
+      "sourcePickerLabel": "Nguồn thế giới",
+      "emptySource": "Không có nguồn",
+      "panoSuffix": "ảnh 360",
+      "panoSourceStatus": "Nguồn 360: căn khung bên trong quả cầu và đặt các thành phần đạo diễn",
+      "panoSourceHint": "Nguồn 360 · yaw / góc nhìn / chụp · diễn viên, đạo cụ và dàn cảnh vẫn là thành phần đạo diễn trong thế giới",
+      "openDirectorWorldTitle": "Mở Director World",
+      "openingDirectorWorld": "Đang mở...",
+      "directorWorld": "Director World",
+      "enterDirectorWorld": "Vào Director World",
+      "quickActions": "Thao tác nhanh",
+      "emptyWorldReady": "Thế giới đạo diễn trống",
+      "sceneDirectorWorldDescription": "Tải asset Director World của bối cảnh từ manifest cùng nguồn gốc.",
+      "beatDirectorWorld": "Director World của cú máy",
+      "beatDirectorWorldDescription": "Mở Director World với ngữ cảnh cú máy hiện tại.",
+      "selectedBackgroundDirectorWorldDetail": "Xuất kết quả env/combined/meta",
+      "selectedBackgroundCommitSuccess": "Đã đặt làm nền hiện tại",
+      "selectedBackgroundOutputLabel": "Nền hiện tại",
+      "currentBackgroundSource": "Nguồn nền hiện tại",
+      "downstreamCurrentBackground": "Nền hiện tại phía sau",
+      "savedEnvOnlyBackground": "Nền env-only đã lưu hiện tại",
+      "noSelectedBackground": "Chưa có nền hiện tại",
+      "noEnvOnlyBackground": "Chưa có nền env-only nào được lưu",
+      "cropDirectorBackground": "Chụp nền đạo diễn",
+      "cropDirectorBackgroundDetail": "Chọn {{aspects}} từ nền đạo diễn",
+      "cropMaster": "Cắt ảnh gốc",
+      "cropMasterDetail": "Chọn {{aspects}} từ ảnh gốc",
+      "cropReverse": "Cắt ảnh góc ngược",
+      "cropReverseDetail": "Chọn {{aspects}} từ ảnh góc ngược",
+      "backgroundCropperTitle": "Chọn một vùng {{aspect}} làm nguồn nền{{source}}",
+      "backgroundCropperDescription": "Kéo vùng chọn với tỉ lệ {{aspect}} đã khoá. Xác nhận sẽ gửi nó qua node nền hiện tại về beat ở luồng chính.",
+      "backgroundCropperGenerated": "Đã tạo nền hiện tại và ghi về luồng chính",
+      "useAsBackgroundSource": "Dùng làm nguồn nền",
+      "selectedBackgroundSourceHint": "Thao tác này cập nhật node đầu ra trước. Node preset của luồng chính tự động commit; node do người dùng tạo cần xác nhận tại node đầu ra.",
+      "directorCombinedDirectorWorldDetail": "Xuất khung điều khiển tổng hợp",
+      "directorCombinedSourceTitle": "Nguồn Director combined",
+      "directorCombinedSourceHint": "Bạn cũng có thể nối một ảnh tuỳ ý vào nguồn Director combined, rồi bấm Gửi để ghi ra cùng kết quả.",
+      "directorCombinedOutputLabel": "Khung Director combined · Tập {{episode}}/B{{beat}}",
+      "directorCombinedCommitSuccess": "Đã đặt asset Director tổng hợp cho Tập {{episode}}/B{{beat}}",
+      "directorCombinedMissingContext": "Thiếu bối cảnh dự án hoặc cú máy",
+      "directorControlBundleMissing": "Thiếu ảnh env-only và metadata cho asset Director tổng hợp. Hãy gửi lại từ Director World.",
+      "directorControlCommitted": "Đã commit asset Director tổng hợp: {{path}} (bao gồm env-only và metadata).",
+      "canvasSaveConflictBeforeCommit": "Canvas chưa được lưu. Hãy xử lý xung đột trước khi commit.",
+      "panoSetAsSelectedBackground": "Đặt làm nền hiện tại",
+      "panoOutputToCanvasNode": "Xuất ra node trên canvas",
+      "outputToCanvasNodeSuccess": "Đã xuất ra node trên canvas",
+      "panoDownloadCurrentView": "Tải khung nhìn hiện tại",
+      "exportControlFrameStarting": "Đang xuất khung điều khiển...",
+      "exportControlFrameSuccess": "Đã xuất asset Director tổng hợp: {{path}} (bao gồm env-only và metadata).",
+      "exportControlLayer": "Xuất lớp điều khiển",
+      "actionActorTitle": "Diễn viên",
+      "actionPresetsValue": "{{count}} preset",
+      "actionActorSub": "Duyệt các diễn viên tạo được / chuột phải để tạo",
+      "actionPropTitle": "Đạo cụ",
+      "actionPropSub": "Duyệt các đạo cụ tạo được / chuột phải để tạo",
+      "actionStagingTitle": "Dàn cảnh AI",
+      "actionStagingValue": "{{count}} dàn cảnh",
+      "actionStagingSub": "Duyệt dàn cảnh / chuột phải để AI tạo",
+      "actionExportTitle": "Xuất file",
+      "actionExportValue": "combined + env + meta",
+      "actionExportSub": "Xuất ba file",
+      "stageInteractive": "Director World đang tương tác",
+      "stageClickToEnter": "Bấm vào cảnh để vào Director World",
+      "stageTabFullscreen": "Tab để toàn màn hình",
+      "stageTabRestore": "Tab để về mặc định",
+      "stageExitInteraction": "Esc để thoát tương tác",
+      "stageStatusStrip": "{{state}} · cú máy {{aspect}} · {{status}}",
+      "stageShortcutHint": "1/2 duyệt diễn viên/đạo cụ tạo được · 3 duyệt dàn cảnh · 4 xuất combined/env/meta · chuột phải để tạo · C chọn tâm ngắm · F dời tới tâm ngắm · M gắn vào tâm ngắm · phím mũi tên/IJKL/UO dịch nhẹ · R/T xoay · -/+ đổi cỡ · Esc thoát",
+      "shortcuts": {
+        "toggle": "Phím tắt",
+        "title": "Phím tắt Director World",
+        "subtitle": "Bấm vào cảnh để vào Director World trước khi dùng phím tắt.",
+        "close": "Đóng",
+        "select": "Duyệt các diễn viên, đạo cụ và dàn cảnh tạo được",
+        "place": "Chọn tâm ngắm, dời tới tâm ngắm, đặt xuống đất, gắn kết",
+        "nudge": "Dịch nhẹ vị trí vật thể đang chọn",
+        "transform": "Xoay, đổi cỡ và duyệt tư thế diễn viên",
+        "camera": "Đưa camera ra sau, đối diện hoặc nhìn vào vật thể đang chọn",
+        "saveExport": "Lưu trạng thái đạo diễn / xuất khung điều khiển",
+        "safeDelete": "Xoá an toàn vật thể đang chọn",
+        "system": "Ẩn bảng điều khiển / thoát tương tác"
+      },
+      "directorWorldDescription": "Tải nguồn SOG hoặc panorama 360 cùng nguồn gốc.",
+      "sections": {
+        "stage": "Sân khấu",
+        "add": "Thêm",
+        "selection": "Đang chọn",
+        "output": "Đầu ra"
+      },
+      "sourceCalibration": {
+        "title": "Hiệu chỉnh thế giới",
+        "sogHint": "Chỉnh vị trí, góc và tỉ lệ của nguồn thế giới hiện tại; diễn viên, đạo cụ và dàn cảnh vẫn nằm trên mặt sàn ngang.",
+        "panoHint": "Chỉnh vị trí, hướng và tỉ lệ của quả cầu 360; diễn viên, đạo cụ và dàn cảnh vẫn nằm trên mặt sàn ngang.",
+        "directionBall": "Quả cầu định hướng",
+        "directionValue": "Yaw {{yaw}}°, pitch {{pitch}}°",
+        "xOffset": "Trái / phải {{value}}",
+        "yOffset": "Độ cao {{value}}",
+        "zOffset": "Trước / sau {{value}}",
+        "pitch": "Pitch {{value}}°",
+        "yaw": "Yaw {{value}}°",
+        "roll": "Roll {{value}}°",
+        "scale": "Tỉ lệ thế giới {{value}}",
+        "advanced": "Hiệu chỉnh nâng cao",
+        "expand": "Mở rộng",
+        "collapse": "Thu gọn",
+        "reset": "Đặt lại hiệu chỉnh thế giới",
+        "resetStatus": "Đã đặt lại hiệu chỉnh thế giới"
+      },
+      "frameAspect": "Khung hình",
+      "speed": "Tốc độ {{value}}x",
+      "axes": "Trục toạ độ",
+      "collision": "Va chạm",
+      "resetCamera": "Đặt lại camera",
+      "worldHeightStatus": "Độ cao Director World {{value}}",
+      "actor": "Diễn viên",
+      "prop": "Đạo cụ",
+      "staging": "Dàn cảnh",
+      "actorIdentity": "Tạo hình diễn viên",
+      "currentCreate": "Đang tạo: {{type}}",
+      "nextAnonymousActor": "Diễn viên tiếp theo: {{label}} · {{color}}",
+      "nextAnonymousProp": "Đạo cụ tiếp theo: {{label}} · {{color}}",
+      "actorPose": "Tư thế diễn viên",
+      "shapeHint": "Gợi ý hình khối",
+      "stagingShapeHint": "Hình khối dàn cảnh",
+      "pauseAction": "Tạm dừng",
+      "runAction": "Chạy",
+      "propColor": "Màu đạo cụ",
+      "stagingName": "Tên dàn cảnh",
+      "selectedStagingName": "Tên dàn cảnh đang chọn",
+      "stagingColor": "Màu dàn cảnh",
+      "aiStagingPrompt": "Hãy cho BuilderGPT biết bạn muốn thêm đạo cụ dàn cảnh nào (ví dụ: ngựa, kiệu, chồng thùng gỗ):",
+      "aiStagingDefault": "staging prop",
+      "aiPlaceholder": "Vật giữ chỗ do AI tạo",
+      "localPlaceholder": "Vật giữ chỗ cục bộ",
+      "scale": "Tỉ lệ {{value}}",
+      "placeAtCrosshair": "Đặt diễn viên tại tâm ngắm",
+      "noBeatPalette": "Beat này chưa nhận diện được tạo hình / đạo cụ nào; Director World sẽ không tự dựng tạo hình tuỳ tiện.",
+      "noBeatActorPalette": "Chưa gán màu cho diễn viên nên không tạo được diễn viên. Hãy gán màu ở Beat trên luồng chính trước.",
+      "noBeatPropPalette": "Chưa gán màu cho đạo cụ nên không tạo được đạo cụ. Hãy gán màu ở Beat trên luồng chính trước.",
+      "noSelection": "Chưa chọn gì",
+      "moveToCrosshair": "Dời tới tâm ngắm",
+      "mountSelected": "Gắn vào mục tiêu ở tâm ngắm",
+      "unmountSelected": "Tháo gắn kết",
+      "mountedSuffix": "đã gắn",
+      "ground": "Đặt xuống đất",
+      "rotateLeft": "Xoay trái",
+      "rotateRight": "Xoay phải",
+      "deleteSelected": "Xoá vật đang chọn",
+      "downloadCombined": "Tải file combined",
+      "downloadEnvOnly": "Tải file env_only",
+      "useEnvAsBackground": "Dùng env_only làm nền",
+      "submitCurrentViewAsBackground": "Gửi khung nhìn hiện tại làm nền",
+      "submitCurrentViewAsDirectorCombined": "Gửi khung nhìn hiện tại làm Director combined",
+      "outputCurrentViewAsDirectorCombined": "Xuất khung nhìn hiện tại thành Director combined",
+      "saveScene": "Lưu Director World",
+      "clearScene": "Xoá cảnh đã lưu",
+      "outputHint": "combined giữ nguyên phần che khuất của diễn viên/đạo cụ; env_only ẩn diễn viên/đạo cụ để làm nền cho Beat hiện tại.",
+      "counts": "{{actor}} diễn viên / {{prop}} đạo cụ / {{staging}} dàn cảnh",
+      "sourceBadge": "PLY {{sourceKind}} · Asset đầu vào được tải qua tài nguyên tĩnh OpenResty cùng nguồn gốc",
+      "shortcutHint": "Chuột phải / Shift+chuột trái để đặt · Chuột trái để chọn · 1/2/3 đổi công cụ · P lưu trạng thái đạo diễn · F dời tới tâm ngắm · M gắn vào tâm ngắm · G đặt xuống đất · R/T xoay · H vừa khung nhìn",
+      "beatOverlay": {
+        "title": "Lớp phủ cú máy",
+        "currentBeat": "Cú máy hiện tại {{beat}}",
+        "inheritedFromBeat": "Chưa lưu; đang tạm dùng cú máy {{beat}}",
+        "sameSceneBeats": "Các cú máy cùng bối cảnh",
+        "copyFlow": "Nguồn sao chép: cú máy {{sourceBeat}} -> cú máy hiện tại {{targetBeat}}",
+        "saveCurrent": "Lưu trạng thái đạo diễn của cú máy này",
+        "copySelected": "Sao chép nguồn vào cú máy hiện tại",
+        "copySelectedSuccess": "Đã sao chép cú máy {{sourceBeat}} vào cú máy hiện tại {{targetBeat}}"
+      },
+      "skillDefinitions": {
+        "freezone_sketch_from_context": {
+          "name": "Phác thảo từ nền hiện tại",
+          "description": "Tạo ứng viên phác thảo cho luồng chính từ ngữ cảnh cú máy và nền hiện tại."
+        },
+        "freezone_sketch_from_director_combined": {
+          "name": "Phác thảo từ Director combined",
+          "description": "Tạo ứng viên phác thảo cho luồng chính từ ngữ cảnh cú máy và ảnh Director combined."
+        },
+        "freezone_frame_from_context": {
+          "name": "Khung hình từ ngữ cảnh cú máy",
+          "description": "Render ứng viên khung hình cho luồng chính từ ngữ cảnh cú máy, phác thảo và ảnh tham chiếu."
+        },
+        "freezone_set_selected_background": {
+          "name": "Đặt nền hiện tại",
+          "description": "Đặt nền cho cú máy hiện tại từ một nguồn ảnh chỉ định, không gọi model tạo ảnh."
+        },
+        "freezone_set_director_combined": {
+          "name": "Đặt Director combined",
+          "description": "Đặt asset Director tổng hợp cho cú máy hiện tại từ một nguồn ảnh chỉ định, không gọi model tạo ảnh."
+        },
+        "freezone_scene_360": {
+          "name": "Tạo panorama 360",
+          "description": "Tạo ứng viên panorama bối cảnh tỉ lệ 2:1 từ ảnh gốc của bối cảnh."
+        }
+      },
+      "skillInputLabels": {
+        "beat_context": "Ngữ cảnh cú máy",
+        "sketch": "Phác thảo",
+        "background": "Nền",
+        "identity": "Tạo hình diễn viên",
+        "prop": "Đạo cụ",
+        "scene": "Prompt bối cảnh",
+        "scene_master": "Ảnh gốc bối cảnh",
+        "scene_reverse_master": "Góc ngược bối cảnh",
+        "director_combined": "Director combined",
+        "source_image": "Ảnh nguồn",
+        "frame": "Khung hình"
+      },
+      "skillOutputLabels": {
+        "current_sketch_candidate": "Ứng viên phác thảo",
+        "current_frame_candidate": "Ứng viên khung hình",
+        "scene_360_candidate": "Ứng viên panorama 360",
+        "selected_background": "Nền hiện tại",
+        "director_combined": "Director combined",
+        "review_report": "Báo cáo rà soát"
+      },
+      "skillParametersTitle": "Tham số",
+      "skillParameterLabels": {
+        "freezone_sketch_from_context": {
+          "aspect_ratio": "Tỉ lệ"
+        },
+        "freezone_frame_from_context": {
+          "quality": "Chất lượng",
+          "background_reference_mode": "Chế độ tham chiếu nền"
+        }
+      },
+      "skillParameterOptions": {
+        "freezone_sketch_from_context": {
+          "aspect_ratio": {
+            "2_3": "Dọc 2:3",
+            "16_9": "Ngang 16:9"
+          }
+        },
+        "freezone_frame_from_context": {
+          "quality": {
+            "low": "Thấp",
+            "medium": "Trung bình",
+            "high": "Cao"
+          },
+          "background_reference_mode": {
+            "material_only": "Chỉ lấy diện mạo",
+            "scene_anchor": "Neo theo bối cảnh"
+          }
+        }
+      },
+      "skillRequirement": {
+        "required": "Bắt buộc",
+        "optional": "Tuỳ chọn"
+      },
+      "skillCardinality": {
+        "single": "Đơn",
+        "multi": "Nhiều"
+      },
+      "skillInputUnbound": "Chưa gán",
+      "skillInputNoCharacter": "Không có nhân vật",
+      "skillInputNoProp": "Không có đạo cụ",
+      "skillInputFromBeatContext": "Ngữ cảnh cú máy",
+      "skillInputDragHint": "kéo một asset vào đây",
+      "sourceKinds": {
+        "master": "Thế giới từ ảnh gốc",
+        "reverse": "Thế giới góc ngược",
+        "pano": "Thế giới 360",
+        "uploaded": "Thế giới đã tải lên",
+        "custom": "Thế giới tuỳ chỉnh"
+      },
+      "shapeHints": {
+        "box": "Hộp / vật nhỏ",
+        "generic_large": "Vật dàn cảnh cỡ lớn",
+        "pile": "Đống chất",
+        "quadruped_mount": "Thú bốn chân cưỡi được",
+        "wheeled_artillery": "Khí tài có bánh",
+        "long_vehicle": "Xe dài / cỗ xe",
+        "sports_car": "Xe thể thao",
+        "flying_craft": "Phương tiện bay"
+      },
+      "statusMessages": {
+        "noActorPreset": "Chưa gán màu cho diễn viên; hãy gán màu ở Beat trên luồng chính trước",
+        "actorPreset": "Preset diễn viên: {{label}}",
+        "noPropPreset": "Chưa gán màu cho đạo cụ; hãy gán màu ở Beat trên luồng chính trước",
+        "propPreset": "Preset đạo cụ: {{label}}",
+        "aiStagingSelected": "Đã chọn dàn cảnh AI",
+        "sceneSaved": "Đã lưu cảnh Director World",
+        "sceneCleared": "Đã xoá cảnh đã lưu",
+        "deleteNeedsShift": "Nhấn Shift+Delete để xoá vật đang chọn",
+        "engine": {
+          "splatCorrupt": "Không phân tích được file thế giới 3D (gói .sog hỏng, hoặc URL trả về thứ không phải file). Kiểm tra URL có truy cập được và file có nguyên vẹn không, rồi thử lại.",
+          "splatUnreachable": "Tải asset thế giới 3D thất bại (URL không truy cập được hoặc đã hết hạn). Làm mới hoặc tạo lại rồi thử lại.",
+          "splatDecode": "Giải mã file thế giới 3D thất bại (định dạng không hỗ trợ hoặc file hỏng).",
+          "splatGeneric": "Tải thế giới 3D thất bại. Vui lòng thử lại.",
+          "ready": "PlayCanvas đã sẵn sàng. Đang chờ thế giới 3D…",
+          "emptyWorld": "Thế giới đạo diễn trống · đặt vật thể lên mặt sàn ngang",
+          "noWorldSource": "Không có asset thế giới 3D nào được cung cấp.",
+          "loadingWorld": "Đang tải thế giới 3D…",
+          "loadingWorldPercent": "Đang tải thế giới 3D… {{percent}}%",
+          "worldLoaded": "Đã tải xong thế giới 3D",
+          "worldLoadedGaussians": "Đã tải xong thế giới 3D · {{count}} gaussian",
+          "panoCleared": "Đã xoá môi trường 360.",
+          "panoLoading": "Đang tải môi trường 360…",
+          "panoFailed": "Tải môi trường 360 thất bại: {{message}}",
+          "panoLoaded": "Đã tải xong môi trường 360 · nhìn thẳng từ bên trong quả cầu",
+          "collisionLoading": "Đang tải GLB va chạm: {{url}}",
+          "collisionFailed": "Tải va chạm thất bại, quay về y=0: {{message}}",
+          "collisionMissingApi": "Asset va chạm không có instantiateRenderEntity, bỏ qua",
+          "collisionLoaded": "Đã tải GLB va chạm (khung dây gỡ lỗi), meshInstances={{count}}"
+        }
+      },
+      "skillStatus": {
+        "generating": "Đang tạo...",
+        "submit": "Gửi",
+        "queued": "Trong hàng đợi...",
+        "starting": "Đang khởi động...",
+        "running": "Đang chạy...",
+        "outputs": "Đầu ra",
+        "missingSource": "Thiếu nguồn",
+        "missingSkill": "Không tìm thấy kỹ năng: {{id}}",
+        "emptySkillId": "skill_id trống"
+      },
+      "markerKinds": {
+        "actor": "Diễn viên",
+        "prop": "Đạo cụ",
+        "staging": "Dàn cảnh"
+      },
+      "actorColor": "Màu diễn viên",
+      "skillProviderLabels": {
+        "freezone_mainline": "Kỹ năng luồng chính",
+        "agent": "Kỹ năng agent",
+        "tool": "Kỹ năng công cụ",
+        "workflow": "Kỹ năng workflow"
+      },
+      "poses": {
+        "standing": "Đứng",
+        "talking": "Đang nói",
+        "arms_crossed": "Khoanh tay",
+        "sitting": "Ngồi",
+        "eating": "Đang ăn",
+        "crouching": "Ngồi xổm",
+        "kneeling": "Quỳ",
+        "lying": "Nằm / gục",
+        "walking": "Đi bộ",
+        "running": "Chạy",
+        "pointing": "Chỉ tay",
+        "holding": "Cầm đồ",
+        "interacting": "Tương tác",
+        "fighting": "Đánh nhau",
+        "sword": "Cầm vũ khí"
+      },
+      "skillMissingBeatContext": "Thiếu ngữ cảnh cú máy",
+      "skillNoSelectedBackgroundOutput": "Không tìm thấy node kết quả nền hiện tại",
+      "skillMissingProjectOrBeat": "Thiếu dự án hoặc ngữ cảnh cú máy",
+      "skillSelectedBackgroundOutputUnavailable": "Node kết quả nền hiện tại không dùng được",
+      "skillNoMasterImage": "Bối cảnh này chưa có ảnh gốc",
+      "skillNoReverseImage": "Bối cảnh này chưa có ảnh góc ngược",
+      "skillNoDirectorBackground": "Beat này chưa có nền đạo diễn",
+      "skillFallbackTitle": "Kỹ năng",
+      "skillLoading": "Đang tải kỹ năng…",
+      "skillUnknown": "Kỹ năng không rõ",
+      "sceneRestored": "Đã khôi phục cảnh lưu gần nhất"
+    },
+    "purpose": {
+      "freezone": "Freezone",
+      "asset": "Chụp asset luồng chính",
+      "beat": "Sản xuất beat luồng chính",
+      "mainline": "Dây chuyền luồng chính"
+    },
+    "pano": {
+      "dialogTitle": "Khuôn hình 360",
+      "dialogDescription": "Chọn tỉ lệ khung và góc nhìn, rồi ghi ảnh chụp về đích của nó.",
+      "capture": "Chụp",
+      "captureNoun": "ảnh chụp",
+      "resetView": "Đặt lại",
+      "notReady": "Trình xem 360 chưa sẵn sàng",
+      "contextSaveTarget": "Lưu vào selected_background",
+      "contextDownloadOnly": "Mục bối cảnh chỉ tải về, không bao giờ ghi đè bản mới nhất",
+      "fovPresets": {
+        "fisheye": "Mắt cá 160°",
+        "wide": "Góc rộng 120°",
+        "standard": "Tiêu chuẩn 70°",
+        "tele": "Tele 8°"
+      },
+      "lockCurrentView": "Hiệu chỉnh theo góc nhìn hiện tại",
+      "enterPlanet": "Hành tinh nhỏ",
+      "exitPlanet": "Thoát hành tinh nhỏ",
+      "copyParamsJson": "Chép JSON tham số",
+      "saving": "Đang lưu",
+      "saveCorrection": "Lưu hiệu chỉnh",
+      "showGuides": "Hiện đường gióng",
+      "hideGuides": "Ẩn đường gióng",
+      "resetCropFrame": "Đặt lại khung chụp",
+      "setFrontFromView": "Đặt góc hiện tại làm hướng chính",
+      "resetCorrection": "Đặt lại hiệu chỉnh",
+      "saved": "Đã lưu {{name}}",
+      "noPathReturned": "Không có đường dẫn nào được trả về",
+      "captureList": "Ảnh đã chụp",
+      "clearCaptureList": "Xoá danh sách ảnh chụp",
+      "captureN": "Ảnh chụp {{id}}",
+      "downloadCaptureN": "Tải ảnh chụp {{id}}"
+    }
+  },
+  "split": {
+    "title": "Tách ô lưới",
+    "rows": "Số hàng",
+    "cols": "Số cột",
+    "preview": "Xem trước",
+    "split": "Tách"
+  },
+  "ai": {
+    "provider": "Nhà cung cấp AI",
+    "model": "Model",
+    "prompt": "Prompt",
+    "generating": "Đang tạo...",
+    "success": "Tạo thành công",
+    "error": "Tạo thất bại"
+  },
+  "settings": {
+    "title": "Cài đặt",
+    "close": "Đóng",
+    "navigationLabel": "Nhóm cài đặt",
+    "statusConfigured": "{{page}} đã được cấu hình",
+    "statusNotConfigured": "{{page}} chưa được cấu hình",
+    "secretSavedBadge": "Đã lưu",
+    "secretSavedPlaceholder": "Đã lưu · {{preview}} (nhập giá trị mới để thay thế)",
+    "pages": {
+      "models": "Model & Kênh",
+      "storage": "Lưu trữ media"
+    },
+    "modelConfig": {
+      "title": "Cấu hình model",
+      "description": "Chọn gateway chính thức, tự cấu hình NewAPI, hoặc kết hợp dịch vụ cục bộ với dịch vụ chính thức.",
+      "baseUrlHint": "Runtime CE tự động cấu hình URL của Local NewAPI.",
+      "effectiveBadge": "Đang dùng: {{channel}}",
+      "guide": "Hướng dẫn cấu hình",
+      "loading": "Đang tải…",
+      "requestFailed": "Yêu cầu thất bại, vui lòng thử lại.",
+      "activateMode": "Đặt làm chế độ đang dùng",
+      "configureBeforeActivate": "Hãy cấu hình chế độ này trước khi kích hoạt.",
+      "modeActivated": "{{mode}} đang được sử dụng.",
+      "statusConfigured": "Đã cấu hình",
+      "statusNotConfigured": "Chưa cấu hình",
+      "statusActive": "Đang dùng",
+      "gatewayWarningIconLabel": "Chưa cấu hình model gateway",
+      "gatewayNotConfiguredImpact": "Model gateway đang dùng chưa được cấu hình. Mọi lệnh gọi model văn bản, ảnh, video và âm thanh đều sẽ thất bại; hãy cấu hình kênh chính thức hoặc khởi tạo Local NewAPI trước khi tạo nội dung.",
+      "modes": {
+        "official": "Chính thức",
+        "custom": "Tuỳ chỉnh",
+        "hybrid": "Kết hợp cục bộ + chính thức"
+      },
+      "fields": {
+        "baseUrl": "URL New API",
+        "gatewayBaseUrl": "URL gateway",
+        "apiKey": "API Key",
+        "sqlDsn": "DSN cơ sở dữ liệu",
+        "sqlitePath": "Đường dẫn SQLite",
+        "adminUsername": "Tên đăng nhập quản trị"
+      },
+      "official": {
+        "description": "Nhập API Key của kênh chính thức trên nền tảng, rồi lưu lại.",
+        "save": "Lưu & bật",
+        "enable": "Chuyển sang kênh chính thức",
+        "saved": "Đã lưu và chuyển sang kênh chính thức.",
+        "enabled": "Đã chuyển sang kênh chính thức.",
+        "missingFields": "Vui lòng điền API Key.",
+        "registerLink": "Đăng ký tại RelayClaw",
+        "mediaCatalogTitle": "Danh mục model media chính thức",
+        "mediaCatalogStatus": "Phiên bản {{version}} · {{count}} model · {{source}}",
+        "mediaCatalogSources": {
+          "bundled": "Đi kèm app",
+          "remote": "Cập nhật trực tuyến"
+        },
+        "mediaCatalogAutoUpdate": "Tự động cập nhật model chính thức",
+        "mediaCatalogAutoUpdateHint": "Kiểm tra và áp dụng các bản cập nhật danh mục tương thích mỗi khi mở Cài đặt.",
+        "mediaCatalogCheckNow": "Kiểm tra cập nhật",
+        "mediaCatalogUpdated": "Danh mục model media chính thức đã được cập nhật.",
+        "mediaCatalogUpToDate": "Danh mục model media chính thức đã là mới nhất.",
+        "mediaCatalogCheckFailed": "Không kiểm tra được danh mục model media chính thức. Hãy thử lại sau."
+      },
+      "custom": {
+        "description": "CE dùng một NewAPI cục bộ chạy trên SQLite. DramaClaw sẽ tự kết nối cơ sở dữ liệu, tạo runtime token và bật kênh cục bộ.",
+        "init": "Khởi tạo Local NewAPI",
+        "repair": "Kiểm tra & sửa",
+        "initialized": "Local NewAPI đã sẵn sàng.",
+        "localStatusTitle": "Local NewAPI",
+        "localReady": "Đã cấu hình runtime token",
+        "localNeedsInit": "Cần khởi tạo",
+        "sqliteReady": "Cơ sở dữ liệu SQLite đã sẵn sàng; không cần cấu hình đường dẫn cơ sở dữ liệu.",
+        "sqliteWaiting": "Đang chờ dịch vụ NewAPI cục bộ tạo cơ sở dữ liệu SQLite của nó.",
+        "databaseTitle": "Cơ sở dữ liệu NewAPI",
+        "databaseDescription": "Dùng để tìm tài khoản quản trị và điền access_token; với SQLite thì đặt sqlDsn=local kèm đường dẫn tuyệt đối tới file one-api.db đã có.",
+        "databaseConfigured": "Đã cấu hình cơ sở dữ liệu",
+        "databaseNotConfigured": "Chưa cấu hình cơ sở dữ liệu",
+        "setupAdminTitle": "Thiết lập quản trị viên lần đầu",
+        "setupAdminDescription": "Nếu Local NewAPI là bản mới, hãy đặt mật khẩu cho tài khoản quản trị root. Nếu nó đã được khởi tạo, hãy để trống và chạy phần kiểm tra.",
+        "setupPassword": "Mật khẩu thiết lập",
+        "setupConfirmPassword": "Xác nhận mật khẩu",
+        "setupPasswordPlaceholder": "Ít nhất 8 ký tự",
+        "setupConfirmPasswordPlaceholder": "Nhập lại lần nữa",
+        "setupPasswordOnlyOnce": "Tên đăng nhập và mật khẩu này chỉ được gửi tới NewAPI của bạn khi tạo quản trị viên đầu tiên trên một bản NewAPI mới tinh. Nếu NewAPI đã khởi tạo rồi, việc nhập mật khẩu ở đây sẽ không đổi mật khẩu quản trị hiện có. DramaClaw không lưu mật khẩu này và không dùng nó cho các thao tác về sau; hãy tự giữ lại để đăng nhập bảng quản trị NewAPI sau khi thiết lập lần đầu.",
+        "setupRequired": "Local NewAPI chưa được khởi tạo. Hãy nhập mật khẩu thiết lập kèm xác nhận rồi thử lại.",
+        "setupAlreadyInitializedPasswordIgnored": "NewAPI của bạn đã được khởi tạo trước đó. Lần chạy này không gọi endpoint thiết lập của NewAPI và không đổi mật khẩu quản trị hiện có; mật khẩu bạn nhập đã bị bỏ qua và xoá đi.",
+        "setupPasswordMissingUsername": "Hãy nhập tên đăng nhập quản trị.",
+        "setupPasswordIncomplete": "Hãy nhập cả mật khẩu thiết lập lẫn phần xác nhận.",
+        "setupPasswordTooShort": "Mật khẩu thiết lập phải dài ít nhất 8 ký tự.",
+        "setupPasswordMismatch": "Hai lần nhập mật khẩu thiết lập không khớp nhau."
+      },
+      "quick": {
+        "title": "Thiết lập khuyến nghị",
+        "description": "Sau khi Local NewAPI được khởi tạo, dùng một profile duy nhất để cấu hình kênh nhà cung cấp, model theo tính năng, embedding và ánh xạ model media.",
+        "recommended": "Khuyến nghị",
+        "custom": "Cấu hình của tôi",
+        "active": "Đang dùng",
+        "upstreamKey": "API Key phía nhà cung cấp",
+        "upstreamKeyPlaceholder": "Nhập API Key của nhà cung cấp model",
+        "channelKeysTitle": "API Key của các kênh",
+        "keyHint": "Key được nhập riêng cho từng kênh và không bao giờ được lưu trong JSON của profile. Hãy để trống nếu nhà cung cấp đó đã có key được lưu.",
+        "savedKeyPlaceholder": "Đã lưu · {{preview}} (nhập giá trị mới để thay thế)",
+        "fixJsonFirst": "Hãy sửa JSON của profile trước. Các ô nhập key của kênh sẽ hiện ở đây sau khi JSON phân tích thành công.",
+        "editJson": "Xem hoặc sửa JSON của profile",
+        "jsonHint": "Mục channels khai báo các nhà cung cấp. Model theo tính năng, embedding và từng model media đều chọn một kênh qua trường channel. Hiện chưa hỗ trợ trùng nhà cung cấp.",
+        "recommendedJsonHint": "Profile khuyến nghị là mẫu chỉ đọc dựng sẵn. Hãy chuyển sang Cấu hình của tôi để sửa và lưu profile riêng.",
+        "apply": "Lưu & áp dụng tất cả",
+        "applyHint": "Ghi trọn bộ thiết lập một lần. Dùng Cài đặt nâng cao bên dưới nếu muốn sửa từng phần.",
+        "applying": "Đang xử lý: {{step}}",
+        "applied": "Thiết lập khuyến nghị đã được lưu và bật.",
+        "initializeFirst": "Hãy khởi tạo Local NewAPI trước, rồi áp dụng profile sau khi cơ sở dữ liệu và quyền quản trị của nó đã sẵn sàng.",
+        "comfyConfig": "Cấu hình ComfyUI",
+        "comfyTemplateHint": "Chỉ nạp mẫu MiniMax H3 cục bộ khi thực sự cần. Việc mở chế độ Kết hợp sẽ không tự tạo kênh ComfyUI.",
+        "loadComfyTemplate": "Nạp mẫu MiniMax H3",
+        "advanced": "Cài đặt nâng cao",
+        "invalidJson": "JSON của profile không hợp lệ: {{message}}",
+        "missingKeys": "Thiếu API Key phía nhà cung cấp cho kênh: {{channels}}",
+        "steps": {
+          "initialize": "Khởi tạo Local NewAPI",
+          "channel": "Lưu kênh nhà cung cấp",
+          "features": "Lưu model theo tính năng",
+          "embedding": "Lưu embedding",
+          "media": "Lưu model media"
+        }
+      },
+      "featureModels": {
+        "title": "Ánh xạ model theo nghiệp vụ",
+        "description": "Gán model từ nhà cung cấp cho các tính năng hiểu văn bản, tạo nội dung và hiểu hình ảnh. Tính năng chưa gán sẽ dùng mặc định của backend.",
+        "channelsTitle": "Kênh nhà cung cấp",
+        "channelsDescription": "Chỉ thêm những nhà cung cấp bạn cần, rồi cấu hình key và Base URL ghi đè (tuỳ chọn). Mỗi nhà cung cấp chỉ thêm được một lần.",
+        "addChannelShort": "Thêm",
+        "manageChannels": "Quản lý kênh",
+        "removeChannelShort": "Xoá",
+        "channelCatalogTitle": "Quản lý kênh nhà cung cấp",
+        "channelCatalogDescription": "Xem các kênh mà RelayClaw CE hỗ trợ cùng năng lực của chúng, rồi thêm hoặc bỏ nhà cung cấp cho model của bạn.",
+        "channelCatalogSearch": "Tìm theo tên hoặc ID kênh",
+        "channelCapabilityFilter": "Lọc theo năng lực của kênh",
+        "channelCapabilities": "Năng lực",
+        "channelDescription": "Mô tả",
+        "channelAction": "Thao tác",
+        "channelUnavailable": "Không khả dụng",
+        "noCapabilityData": "Không có dữ liệu năng lực",
+        "noMatchingChannels": "Không có kênh nào khớp.",
+        "channelTypesLoading": "Đang tải danh sách kênh nhà cung cấp…",
+        "channelTypesLoadFailed": "Tải danh sách kênh nhà cung cấp thất bại. Hãy kiểm tra RelayClaw CE có đang chạy không rồi thử lại.",
+        "retryChannelTypes": "Tải lại",
+        "removeChannelTitle": "Xoá kênh nhà cung cấp?",
+        "removeChannelConfirm": "Xoá “{{provider}}” sẽ xoá luôn {{featureCount}} ánh xạ model nghiệp vụ, {{mediaCount}} ánh xạ model media và {{embeddingCount}} cấu hình embedding. Thay đổi có hiệu lực ngay với cấu hình hiện tại.",
+        "capabilities": {
+          "all": "Mọi năng lực",
+          "text": "Văn bản",
+          "vision": "Thị giác",
+          "embedding": "Embedding",
+          "rerank": "Rerank",
+          "image": "Ảnh",
+          "video": "Video",
+          "audio": "Âm thanh"
+        },
+        "saveChannels": "Lưu các kênh",
+        "channelsSaved": "Đã lưu thiết lập kênh nhà cung cấp vào máy.",
+        "comfyWorkflows": "Workflow ComfyUI",
+        "comfyWorkflowHint": "Thêm nhiều workflow dạng API Format vào cùng một model. RelayClaw sẽ lo phần định tuyến workflow. API key là tuỳ chọn.",
+        "comfyAddWorkflow": "Thêm workflow",
+        "comfyExpandWorkflow": "Mở rộng",
+        "comfyCollapseWorkflow": "Thu gọn",
+        "comfyModelName": "Tên model",
+        "comfyModelPlaceholder": "Tên model, vd. MiniMax-H3",
+        "comfyWorkflowId": "Workflow ID",
+        "comfyWorkflowJson": "JSON của workflow",
+        "comfyWorkflowIdPlaceholder": "Workflow ID, vd. minimax-h3-t2v",
+        "comfyDuplicateWorkflow": "Workflow ID không được trùng nhau.",
+        "comfyInvalidWorkflow": "Workflow phải là một đối tượng JSON hợp lệ.",
+        "replaceComfyModelTitle": "Chuyển sang model MiniMax H3?",
+        "replaceComfyModelConfirm": "Kênh ComfyUI này đang gắn với {{currentModel}}. Nạp mẫu sẽ chuyển nó sang {{nextModel}} và cập nhật các thiết lập model media do workflow quản lý. Tiếp tục?",
+        "replaceComfyModel": "Chuyển và nạp",
+        "clearComfy": "Xoá cấu hình ComfyUI",
+        "clearComfyTitle": "Xoá cấu hình ComfyUI?",
+        "clearComfyConfirm": "Thao tác này sẽ xoá kênh ComfyUI, các workflow và những ánh xạ model media liên quan khỏi cài đặt cục bộ lẫn NewAPI. Các dự án hiện có và media đã tạo sẽ không bị xoá.",
+        "comfyCleared": "Đã xoá cấu hình ComfyUI.",
+        "channelsSaveHint": "Thao tác này chỉ lưu preset kênh cục bộ của CE, chưa sửa ngay các kênh NewAPI hiện có. Lần lưu ánh xạ model kế tiếp sẽ cập nhật kênh NewAPI theo các preset này. Nếu muốn thay key của một kênh NewAPI ngay bây giờ, hãy dùng nút cập nhật trên kênh đó.",
+        "syncChannel": "Cập nhật kênh NewAPI",
+        "syncChannelHint": "Cập nhật ngay key và Base URL của kênh NewAPI hiện có cho nhà cung cấp này mà không đụng tới các ánh xạ model.",
+        "channelSynced": "Đã cập nhật kênh NewAPI.",
+        "channelProvider": "Nhà cung cấp",
+        "upstreamKey": "API Key phía nhà cung cấp",
+        "baseUrlOverride": "Ghi đè Base URL",
+        "baseUrlPlaceholder": "Thường để trống; sẽ dùng preset của nhà cung cấp",
+        "removeChannel": "Xoá kênh",
+        "noChannelsHint": "Chưa thêm kênh nhà cung cấp nào. Hãy thêm kênh trước, rồi chọn kênh đó cho model theo tính năng.",
+        "noChannels": "Hãy thêm một kênh nhà cung cấp trước.",
+        "noChannelsShort": "Chưa có kênh",
+        "colFeature": "Tính năng",
+        "colProvider": "Kênh đã cấu hình",
+        "colUpstreamModel": "Model phía nhà cung cấp",
+        "colModel": "Model phía nhà cung cấp",
+        "upstreamModelPlaceholder": "Nhập model phía nhà cung cấp, vd. qwen-plus",
+        "save": "Lưu ánh xạ",
+        "saveRow": "Lưu",
+        "savedOne": "Đã lưu kênh cho tính năng này.",
+        "applyToAll": "Áp dụng cho tất cả",
+        "bulkModelPlaceholder": "Điền hàng loạt model phía nhà cung cấp, vd. qwen-plus",
+        "bulkMissingModel": "Hãy nhập model phía nhà cung cấp cần áp dụng trước.",
+        "bulkApplied": "Đã điền {{count}} bản nháp model. Bấm Lưu ánh xạ để ghi chúng vào NewAPI.",
+        "saveHint": "Ghi các kênh NewAPI, nhóm theo từng nhà cung cấp.",
+        "saved": "Đã lưu {{count}} kênh.",
+        "savedPartial": "Xong: {{succeeded}} thành công, {{failed}} thất bại.",
+        "noMappings": "Hãy điền tên model phía nhà cung cấp cho ít nhất một tính năng trước.",
+        "missingBaseUrl": "Hãy điền URL New API trước.",
+        "missingKeys": "Thiếu key phía nhà cung cấp cho: {{providers}}",
+        "textModelsTitle": "Hiểu & tạo văn bản",
+        "multimodalModelsTitle": "Model hiểu hình ảnh",
+        "visionRequiredHint": "Tính năng này gửi ảnh tới model phía nhà cung cấp. Hãy chọn một model đa phương thức hỗ trợ đầu vào ảnh / hiểu hình ảnh; model chỉ xử lý văn bản có thể lỗi khi chạy.",
+        "multimodalRequiredBadge": "Cần model đa phương thức",
+        "cogneeDescription": "Việc nhập truyện và truy xuất tri thức cần cả model hiểu nội dung lẫn model embedding; hai thứ này hợp thành kho tri thức truyện Cognee.",
+        "groups": {
+          "xiahua": "XiaHua",
+          "xialiao": "XiaLiao",
+          "xiatan": "XiaTang",
+          "xiajing": "XiaJing",
+          "xiadao": "XiaDao",
+          "xiage": "XiaGe",
+          "novelImport": "XiaLiao · Kho tri thức truyện (Cognee)"
+        },
+        "features": {
+          "HERMES": "Model chat của AI Director",
+          "GLOBAL_VIDEO_OPTIMIZER": "Tối ưu prompt video từ hình ảnh",
+          "SEEDANCE2_PROMPT_COMPOSER": "Soạn prompt tạo video",
+          "GLOBAL_VIDEO_IDENTITY_DETECTOR": "Nhận diện dấu hiệu nhân vật và đạo cụ trong phác thảo",
+          "IDENTITY_PLANNER_CAST": "Lên kế hoạch dàn nhân vật cho tập phim",
+          "IDENTITY_PLANNER_ANALYSIS": "Phân tích tạo hình nhân vật",
+          "IDENTITY_PLANNER_APPEARANCE": "Tạo diện mạo riêng cho từng tạo hình",
+          "LITERAL_BEAT_META": "Tách và chú thích cú máy theo từng dòng",
+          "EPISODE_SCENE_PLANNER": "Lên kế hoạch phân cảnh cho tập phim",
+          "EPISODE_PROP_PLANNER": "Lên kế hoạch đạo cụ cho tập phim",
+          "CHARACTER_BUILD": "Trích và chốt nhân vật từ văn bản gốc",
+          "SCENE_BUILD": "Phân tích và làm giàu mô tả bối cảnh",
+          "FREEZONE_TRANSLATION": "Dịch prompt Trung/Anh",
+          "FREEZONE_TEXT_WRITER": "Tạo văn bản bằng AI",
+          "FREEZONE_STORY_SCRIPT": "Tạo kịch bản truyện",
+          "FREEZONE_VISION": "Phân tích nội dung ảnh và video",
+          "STYLE_ANALYZER": "Phân tích phong cách tuỳ chỉnh từ ảnh tham chiếu",
+          "CONTENT_REWRITER": "Viết lại văn bản gốc thành lời dẫn video ngắn",
+          "SCREENPLAY_NORMALIZER": "Phân tích phân cảnh khi lên kế hoạch phim",
+          "EPISODE_SCENE_RECONCILE": "Đối chiếu và bổ sung asset bối cảnh gốc",
+          "NARRATED_SCENE_ASSET": "Lên kế hoạch asset bối cảnh cho phim có lời dẫn",
+          "STAGING_PROP": "Lên kế hoạch đạo cụ tạm thời trong Director World",
+          "COGNEE": "① Hiểu nội dung & trích xuất tri thức (LLM)"
+        }
+      },
+      "embeddingModel": {
+        "title": "② Vector hoá & tìm kiếm ngữ nghĩa (Embedding)",
+        "description": "Vector hoá văn bản để tìm kiếm ngữ nghĩa trong kho tri thức. Số chiều của model tuỳ chỉnh được gắn cố định khi tạo mỗi dự án.",
+        "colProvider": "Kênh đã cấu hình",
+        "colUpstreamModel": "Model phía nhà cung cấp",
+        "colDimension": "Số chiều",
+        "colBatchSize": "Kích thước lô",
+        "defaultProvider": "Chọn kênh",
+        "upstreamModelPlaceholder": "Nhập model embedding phía nhà cung cấp, vd. text-embedding-3-large",
+        "batchSizePlaceholder": "Mặc định 10",
+        "dimensionWarning": "Số chiều được gắn cố định vào model embedding tuỳ chỉnh khi tạo dự án; thay đổi ở đây về sau chỉ ảnh hưởng tới dự án mới. Hãy xoá và dựng lại sơ đồ trước khi đổi model hoặc số chiều của một dự án đã có. Để trống kích thước lô thì dùng mặc định chính thức là 10.",
+        "saveHint": "Khi lưu, hệ thống ghi ánh xạ NewAPI và lưu số chiều cùng kích thước lô (tuỳ chọn) vào cấu hình cục bộ của CE.",
+        "noChannelsHint": "Hãy thêm kênh nhà cung cấp ở phía trên trước khi cấu hình model embedding.",
+        "save": "Lưu cấu hình embedding",
+        "saved": "Đã lưu cấu hình model embedding.",
+        "noChannels": "Hãy thêm một kênh nhà cung cấp trước.",
+        "missingProvider": "Hãy chọn kênh nhà cung cấp cho embedding.",
+        "missingModel": "Hãy nhập tên model embedding phía nhà cung cấp.",
+        "invalidDimension": "Số chiều embedding phải là một số nguyên dương.",
+        "invalidBatchSize": "Hãy nhập kích thước lô embedding hợp lệ."
+      },
+      "mediaModels": {
+        "title": "Model tạo ảnh / video / âm thanh",
+        "description": "Danh sách model lấy từ cấu hình cục bộ tuỳ chỉnh hiện tại. Hãy thêm model ảnh hoặc video và cấu hình các năng lực hiển thị trong XiaHua.",
+        "addModel": "Thêm model",
+        "addModelTitle": "Thêm model media",
+        "editModelTitle": "Sửa model media",
+        "editCapabilities": "Sửa năng lực",
+        "removeModel": "Xoá model",
+        "colActions": "Thao tác",
+        "modelId": "Model ID",
+        "displayName": "Tên hiển thị",
+        "mediaType": "Loại media",
+        "sortOrder": "Thứ tự sắp xếp",
+        "enabled": "Bật trong XiaHua",
+        "capabilitiesJson": "JSON cấu hình năng lực",
+        "commonCapabilities": "Năng lực trong XiaHua",
+        "resolutionOptions": "Độ phân giải",
+        "ratioOptions": "Tỉ lệ khung hình",
+        "customOptionPlaceholder": "Nhập giá trị tuỳ chỉnh, ngăn cách bằng dấu phẩy",
+        "addCustomOption": "Thêm giá trị tuỳ chỉnh",
+        "qualityOptions": "Mức chất lượng ảnh (ngăn cách bằng dấu phẩy)",
+        "minDuration": "Thời lượng tối thiểu (giây)",
+        "maxDuration": "Thời lượng tối đa (giây)",
+        "referenceImageMax": "Giới hạn số ảnh tham chiếu",
+        "referenceVideoMax": "Giới hạn số video tham chiếu",
+        "referenceAudioMax": "Giới hạn số file âm thanh tham chiếu",
+        "referenceFileMax": "Giới hạn file tham chiếu",
+        "referenceLinkMax": "Giới hạn liên kết tham chiếu",
+        "referenceFileTypes": "Loại file (ngăn cách bằng dấu phẩy)",
+        "referenceAudioMinSeconds": "Tối thiểu mỗi đoạn âm thanh (giây)",
+        "referenceAudioMaxSeconds": "Tối đa mỗi đoạn âm thanh (giây)",
+        "referenceAudioTotalMinSeconds": "Tổng âm thanh tối thiểu (giây)",
+        "referenceAudioTotalMaxSeconds": "Tổng âm thanh tối đa (giây)",
+        "referenceVideoMinSeconds": "Tối thiểu mỗi đoạn video (giây)",
+        "referenceVideoMaxSeconds": "Tối đa mỗi đoạn video (giây)",
+        "referenceVideoTotalMinSeconds": "Tổng video tối thiểu (giây)",
+        "referenceVideoTotalMaxSeconds": "Tổng video tối đa (giây)",
+        "humanReview": "Hỗ trợ kiểm duyệt bởi người",
+        "supportedModes": "Chế độ tạo video",
+        "capabilitiesHint": "Dùng chung hợp đồng cấu hình với danh mục media của bản EE. Hãy lưu cấu hình đầy đủ để áp dụng trong XiaHua.",
+        "applyModelEdit": "Áp dụng vào cấu hình",
+        "missingModelFields": "Hãy nhập Model ID và tên hiển thị, rồi chọn nhà cung cấp.",
+        "invalidCapabilitiesJson": "Cấu hình năng lực phải là một đối tượng JSON hợp lệ.",
+        "colType": "Loại",
+        "colModel": "Model ID",
+        "colProvider": "Kênh đã cấu hình",
+        "colUpstreamModel": "Model phía nhà cung cấp",
+        "defaultProvider": "Dùng mặc định",
+        "officialOnly": "Chỉ kênh chính thức",
+        "upstreamModelPlaceholder": "Mặc định là {{model}}",
+        "saveHint": "Khi lưu, hệ thống ghi vào NewAPI và lưu ánh xạ vào máy.",
+        "save": "Lưu cấu hình ảnh / video / âm thanh",
+        "saveVideo": "Lưu cấu hình video",
+        "saved": "Đã lưu ánh xạ model ảnh / video / âm thanh.",
+        "noMappings": "Hãy chọn kênh cho ít nhất một model ảnh / video / âm thanh trước.",
+        "noChannelsHint": "Hãy thêm kênh nhà cung cấp ở phía trên trước khi chọn kênh cho model ảnh / video / âm thanh.",
+        "types": {
+          "image": "Ảnh",
+          "video": "Video",
+          "audio": "Âm thanh"
+        }
+      }
+    },
+    "mediaStorage": {
+      "title": "Image host / Lưu trữ media",
+      "description": "Cấu hình nơi trung chuyển media tham chiếu tạm thời mà NewAPI/các model dùng, qua Aliyun OSS hoặc Cloudinary.",
+      "fullyManagedUpload": "Tải asset lên có quản lý toàn phần",
+      "provider": "Nhà cung cấp",
+      "providerAliyunOss": "Aliyun OSS",
+      "providerCloudinary": "Cloudinary (Miễn phí)",
+      "providerHint": "Với nhà cung cấp này, nên tắt 「Tải asset lên có quản lý toàn phần」; gói miễn phí có hạn mức băng thông nên chỉ dùng cho chỉnh sửa / tải lên điểm-điểm.",
+      "currentPlan": "Phương án tải lên hiện tại",
+      "status": "Cấu hình hiện tại",
+      "source": "Nguồn: {{source}}",
+      "configured": "Đã cấu hình",
+      "notConfigured": "Chưa cấu hình",
+      "warningIconLabel": "Chưa cấu hình lưu trữ media tham chiếu",
+      "notConfiguredImpact": "Chưa cấu hình lưu trữ media tham chiếu. Các luồng chỉ có chữ và text-to-image thường vẫn chạy được; nhưng những tính năng cần tải ảnh tham chiếu từ máy lên sẽ thất bại, gồm ảnh tham chiếu XiaHua, ảnh tham chiếu nhân vật, ảnh tạo hình, image-to-image, khung đầu của video và image-to-video. Hãy cấu hình Aliyun OSS hoặc Cloudinary.",
+      "showSecret": "Hiện",
+      "hideSecret": "Ẩn",
+      "fieldsHint": "Giá trị đã lưu được cất trong CSDL cài đặt CE cục bộ; AccessKey đầy đủ không được trả về. Hãy để trống các thông tin đã lưu và chỉ nhập những trường bạn muốn thay.",
+      "save": "Lưu cấu hình OSS",
+      "saveCloudinary": "Lưu cấu hình Cloudinary",
+      "saveSuccess": "Đã lưu cấu hình OSS",
+      "cloudinarySaveSuccess": "Đã lưu cấu hình Cloudinary",
+      "saveFailed": "Lưu cấu hình OSS thất bại",
+      "cloudinaryFieldsHint": "Giá trị đã lưu được cất trong CSDL cài đặt CE cục bộ; API Key / Secret đầy đủ không được trả về. Hãy để trống các thông tin đã lưu và chỉ nhập những trường bạn muốn thay. API Folder là tuỳ chọn; để trống thì sẽ tải lên thư mục gốc của Cloudinary.",
+      "cloudinaryRegisterLink": "Đăng ký tài khoản Cloudinary",
+      "testUpload": "Thử tải lên",
+      "testUploadPlaceholder": "Chức năng thử tải lên sắp có",
+      "validation": {
+        "ttlSeconds": "TTL của signed URL phải lớn hơn 0"
+      },
+      "fields": {
+        "cloudName": "Cloud Name",
+        "apiKey": "API Key",
+        "apiSecret": "API Secret",
+        "apiFolder": "API Folder (tuỳ chọn)",
+        "materialsRoot": "Thư mục gốc chứa tư liệu",
+        "accessKeyId": "AccessKey ID",
+        "accessKeySecret": "AccessKey Secret",
+        "bucket": "Bucket",
+        "endpoint": "Endpoint / Region",
+        "ttlSeconds": "TTL của signed URL (giây)"
+      }
+    },
+    "codexBridge": {
+      "title": "Cầu nối Codex cục bộ",
+      "badge": "localhost",
+      "description": "Cứ để app desktop chạy; kết nối từ trình duyệt sẽ tự động ghép cặp với access token của Codex.",
+      "statusLabel": "Trạng thái",
+      "statusConnected": "Dịch vụ cục bộ đã kết nối",
+      "authLabel": "Xác thực",
+      "authReady": "Đã tạo token"
+    },
+    "providers": "API Key",
+    "providersDesc": "Cấu hình API key của các nhà cung cấp AI",
+    "pricing": "Giá cả",
+    "pricingDesc": "Quản lý cách hiển thị giá của node, quy đổi tỉ giá và ước tính theo gói credits.",
+    "providerGuideText": "Mỗi nhà cung cấp khác nhau về năng lực model, tốc độ hàng đợi, độ ổn định và giá. Hãy đổi nhà cung cấp tuỳ theo công việc, và làm theo tham số khuyến nghị của từng bên.",
+    "doNotShowAgain": "Không hiện lại nữa",
+    "appearance": "Giao diện",
+    "appearanceDesc": "Tuỳ chỉnh giao diện ứng dụng",
+    "experimental": "Thử nghiệm",
+    "experimentalDesc": "Các công tắc bật/tắt tính năng thử nghiệm hoặc ưu tiên thấp.",
+    "about": "Giới thiệu",
+    "aboutDesc": "Thông tin ứng dụng",
+    "general": "Chung",
+    "generalDesc": "Cài đặt chung",
+    "apiKey": "API Key",
+    "model": "Model",
+    "enterApiKey": "Nhập API Key",
+    "nanoBananaProModel": "Model Nano Banana Pro",
+    "nanoBananaProModelDesc": "Đổi endpoint Nano Banana Pro cho nhà cung cấp này. Nếu một endpoint lỗi, hãy thử endpoint khác. Xem <modelListLink>danh sách model</modelListLink> để biết chi tiết.",
+    "addProvider": "Thêm nhà cung cấp",
+    "providerPpioName": "PPIO",
+    "comingSoon": "Sắp có...",
+    "radiusPreset": "Bo góc",
+    "radiusPresetDesc": "Điều khiển kiểu bo góc chung cho các bảng, ô nhập và node.",
+    "radiusCompact": "Gọn",
+    "radiusDefault": "Mặc định",
+    "radiusLarge": "Bo tròn",
+    "themeTone": "Tông màu giao diện",
+    "themeToneDesc": "Chọn tông trung tính, ấm hoặc lạnh cho cả giao diện sáng và tối.",
+    "toneNeutral": "Trung tính",
+    "toneWarm": "Ấm",
+    "toneCool": "Lạnh",
+    "edgeRoutingMode": "Kiểu đường nối",
+    "edgeRoutingModeDesc": "Đổi kiểu đường nối giữa các node, gồm cả đường vuông góc tự động né node.",
+    "edgeRoutingSpline": "Đường cong",
+    "edgeRoutingOrthogonal": "Vuông góc",
+    "edgeRoutingSmartOrthogonal": "Né thông minh (vuông góc)",
+    "accentColor": "Màu nhấn",
+    "accentColorDesc": "Dùng cho nút bấm, viền khi chọn và các điểm nhấn tương tác.",
+    "resetAccentColor": "Đặt lại",
+    "downloadPresetPaths": "Thư mục tải về dựng sẵn",
+    "downloadPresetPathsDesc": "Dùng cho menu tải về trên thanh công cụ node để lưu nhanh (tối đa 8 thư mục).",
+    "storyboardGenKeepStyleConsistent": "Giữ các biến thể trong lưới bám theo ảnh tham chiếu",
+    "storyboardGenKeepStyleConsistentDesc": "Khi bật, prompt của lưới nhiều biến thể sẽ được nối thêm \"图片风格与参考图保持一致\".",
+    "storyboardGenDisableTextInImage": "Không cho chữ mô tả xuất hiện trong biến thể lưới",
+    "storyboardGenDisableTextInImageDesc": "Khi bật, prompt của lưới nhiều biến thể sẽ được nối thêm \"禁止添加描述文本\".",
+    "ignoreAtTagWhenCopyingAndGenerating": "Bỏ qua thẻ @ khi sao chép/lưu văn bản",
+    "ignoreAtTagWhenCopyingAndGeneratingDesc": "Khi bật, văn bản sao chép và metadata nhúng trong lưới sẽ bỏ các thẻ kiểu \"@图1\"; còn yêu cầu tạo ảnh chỉ bỏ dấu \"@\" và giữ lại \"图1\".",
+    "useUploadFilenameAsNodeTitle": "Dùng tên file tải lên làm tiêu đề node",
+    "useUploadFilenameAsNodeTitleDesc": "Khi bật, ảnh mới tải lên sẽ mặc định lấy tên file làm tiêu đề node (vẫn sửa được bằng cách nhấp đúp).",
+    "downloadPathPlaceholder": "Nhập đường dẫn thư mục, vd. /Users/name/Pictures/BeatWorkbench hoặc D:\\\\Images\\\\BeatWorkbench",
+    "addPath": "Thêm đường dẫn",
+    "chooseFolder": "Chọn thư mục",
+    "noDownloadPresetPaths": "Chưa có đường dẫn dựng sẵn nào",
+    "providerApiKeyGuidePrefix": "Đầu tiên",
+    "providerRegisterLink": "bấm vào đây để đăng ký",
+    "providerApiKeyGuideMiddle": ", sau đó",
+    "getApiKeyLink": "bấm vào đây để lấy API key",
+    "missingAnyApiKeyMessage": "Nhà cung cấp phía backend chưa được cấu hình.",
+    "openProvidersSettings": "Xem các nhà cung cấp",
+    "aboutAppName": "Beat Workbench",
+    "aboutIntro": "Bàn làm việc tạo ứng viên, thử nghiệm ảnh tự do và commit asset của SuperTale.",
+    "aboutVersionLabel": "Phiên bản",
+    "aboutVersionUnknown": "Không rõ",
+    "aboutAuthorLabel": "Tác giả",
+    "aboutAuthor": "痕继痕迹",
+    "aboutRepositoryLabel": "Kho mã nguồn",
+    "autoCheckUpdateOnLaunch": "Tự kiểm tra cập nhật khi khởi động",
+    "autoCheckUpdateOnLaunchDesc": "Kiểm tra cập nhật một lần mỗi khi mở app.",
+    "enableUpdateDialog": "Bật hộp thoại cập nhật",
+    "enableUpdateDialogDesc": "Hiện hộp thoại riêng khi phát hiện phiên bản mới.",
+    "enableStoryboardGenGridPreviewShortcut": "Bật phím tắt xem trước lưới",
+    "enableStoryboardGenGridPreviewShortcutDesc": "Khi bật, giữ Ctrl + Alt + Shift rồi bấm Tạo ở lưới nhiều biến thể sẽ tạo một node xem trước lưới mà không gửi yêu cầu tới AI.",
+    "showStoryboardGenAdvancedRatioControls": "Hiện điều khiển tỉ lệ lưới nâng cao",
+    "showStoryboardGenAdvancedRatioControlsDesc": "Khi bật, hiện thông tin tỉ lệ ô/tổng thể và công tắc chuyển chế độ Tổng thể/Từng ô. Khi tắt, lưới nhiều biến thể mặc định dùng chế độ tỉ lệ theo ô.",
+    "storyboardGenAutoInferEmptyFrame": "Tự suy đoán biến thể để trống",
+    "storyboardGenAutoInferEmptyFrameDesc": "Khi bật, các ô lưới để trống sẽ tự động được nối thêm \"依据之前的内容进行推测\" khi dựng prompt tạo ảnh.",
+    "showNodePrice": "Hiện giá của node trên thanh tiêu đề",
+    "showNodePriceDesc": "Liên tục ước tính chi phí của lần chạy hiện tại dựa trên model, độ phân giải và các tuỳ chọn bổ sung đã chọn.",
+    "priceDisplayCurrencyMode": "Đơn vị tiền hiển thị",
+    "priceDisplayCurrencyModeDesc": "Ở chế độ tự động, tiếng Trung dùng CNY còn tiếng Anh dùng USD.",
+    "priceCurrencyAuto": "Theo ngôn ngữ",
+    "priceCurrencyCny": "CNY",
+    "priceCurrencyUsd": "USD",
+    "usdToCnyRate": "Tỉ giá USD sang CNY",
+    "usdToCnyRateDesc": "Chỉ dùng để quy đổi giá hiển thị giữa USD và CNY. Không làm thay đổi mức tính phí thật của nhà cung cấp.",
+    "preferDiscountedPrice": "Ưu tiên giá đã giảm",
+    "preferDiscountedPriceDesc": "Hiện tại chỉ áp dụng cho KIE. Mức giá nội địa đã giảm thường phải liên hệ riêng với KIE để được cấp; khi bật, phần ước tính sẽ ưu tiên dùng mức giá đó.",
+    "grsaiCreditTier": "Gói credits GRSAI",
+    "grsaiCreditTierDesc": "GRSAI tính phí theo credits, nên mức ước tính cho mỗi lần chạy sẽ thay đổi theo gói bạn nạp.",
+    "grsaiCreditTierOption": "{{price}} CNY / {{credits}} credits",
+    "checkUpdateNow": "Kiểm tra cập nhật ngay",
+    "checkingUpdate": "Đang kiểm tra cập nhật...",
+    "checkUpdateHasUpdate": "Đã phát hiện phiên bản mới.",
+    "checkUpdateUpToDate": "Bạn đang dùng phiên bản mới nhất.",
+    "checkUpdateFailed": "Kiểm tra cập nhật thất bại. Vui lòng thử lại sau."
+  },
+  "pricing": {
+    "nativePrice": "Giá gốc nhà cung cấp: {{value}}",
+    "originalPrice": "Giá niêm yết: {{value}}",
+    "pointsCost": "Credits: {{count}}",
+    "grsaiTier": "Gói: {{price}} CNY / {{credits}} credits"
+  },
+  "update": {
+    "dialogTitle": "Đã có bản cập nhật",
+    "dialogDescription": "Đã có phiên bản mới. Bạn có muốn tải về ngay không?",
+    "goToQuarkDownload": "Tải qua Quark",
+    "goToGithubDownload": "GitHub Releases",
+    "versionLine": "Hiện tại: {{currentVersion}}, Mới nhất: {{latestVersion}}",
+    "ignoreRule": "Quy tắc bỏ qua nhắc nhở",
+    "ignoreTodayVersion": "Hôm nay không nhắc phiên bản này nữa",
+    "ignoreThisVersionForever": "Không bao giờ nhắc phiên bản này",
+    "ignoreAllForever": "Không bao giờ nhắc cập nhật",
+    "applyIgnore": "Áp dụng"
+  },
+  "errorDialog": {
+    "detailsTitle": "Chi tiết lỗi",
+    "copyReport": "Sao chép báo cáo lỗi",
+    "technicalDetails": "Chi tiết kỹ thuật",
+    "serviceConfigTitle": "Dịch vụ tạo nội dung chưa được cấu hình",
+    "openRouterConfigMessage": "Model này cần OpenRouter, nhưng API key phía backend chưa được cấu hình. Vui lòng liên hệ quản trị viên.",
+    "stillRunningTitle": "Vẫn đang tạo",
+    "stillRunningMessage": "Lần tạo này lâu hơn bình thường. Trang đã ngừng chờ, nhưng tác vụ vẫn chạy ngầm — hãy tải lại sau để lấy kết quả, hoặc xem tiến độ trong Trung tâm tác vụ."
+  },
+  "videoCompose": {
+    "title": "Dựng video",
+    "export": "Xuất file",
+    "exporting": "Đang xuất…",
+    "exportLocation": "Xuất tới",
+    "exportToLocal": "Tải về máy",
+    "exportToCanvas": "Xuất ra canvas",
+    "exportDialog": {
+      "title": "Cài đặt xuất file",
+      "location": "Xuất tới",
+      "resolution": "Độ phân giải",
+      "format": "Định dạng"
+    },
+    "cover": {
+      "button": "Đặt ảnh bìa",
+      "title": "Ảnh bìa",
+      "tabFrame": "Chọn khung hình",
+      "tabUpload": "Tải lên",
+      "uploadHint": "Bấm hoặc kéo thả để tải ảnh lên",
+      "reupload": "Chọn ảnh khác",
+      "uploading": "Đang tải lên…",
+      "captureFailed": "Không chụp được khung hình hiện tại",
+      "error": "Đặt ảnh bìa thất bại"
+    },
+    "clipLoading": "Đang tải video…",
+    "speedPrefix": "Tốc độ",
+    "moveToNewTrack": "Chuyển sang hàng mới",
+    "fullscreenPlay": "Phát toàn màn hình",
+    "play": "Phát",
+    "pause": "Tạm dừng",
+    "emptyPreview": "Timeline đang trống — hãy nối và thêm các đoạn video",
+    "trackEmpty": "Thả các đoạn video vào đây",
+    "removeClip": "Xoá đoạn",
+    "moveLeft": "Dời sang trái",
+    "moveRight": "Dời sang phải",
+    "mute": "Tắt tiếng",
+    "unmute": "Bật tiếng",
+    "kind": {
+      "video": "Video",
+      "audio": "Âm thanh"
+    },
+    "error": {
+      "prefix": "Dựng video thất bại",
+      "noUrl": "Dựng xong nhưng không trả về URL video",
+      "overlap": "Các đoạn video bị chồng thời gian, phần dựng chưa hỗ trợ điều này. Hãy tách các đoạn bị chồng ra hoặc xoá bớt một đoạn rồi xuất lại."
+    },
+    "node": {
+      "hint": "Nối ít nhất {{min}} node video để mở được",
+      "counts": "Video {{video}} · Âm thanh {{audio}}",
+      "open": "Mở phần dựng video",
+      "reopen": "Mở lại",
+      "resultName": "Video đã dựng"
+    },
+    "undo": "Hoàn tác",
+    "redo": "Làm lại",
+    "split": "Cắt đôi",
+    "splitLeft": "Cắt phía trái",
+    "splitRight": "Cắt phía phải",
+    "speed": "Tốc độ",
+    "speedMultiplier": "Tốc độ",
+    "duration": "Thời lượng",
+    "volume": "Âm lượng",
+    "duplicate": "Nhân bản đoạn",
+    "resetToUpstream": "Nhập lại từ node nguồn",
+    "snap": "Bám dính",
+    "zoom": "Thu phóng",
+    "zoomIn": "Phóng to",
+    "zoomOut": "Thu nhỏ"
+  },
+  "modelTaskAccess": {
+    "blocked": {
+      "MODEL_ACCESS_DENIED": "Tài khoản này đã bị tắt quyền dùng model. Hãy liên hệ quản trị viên tổ chức.",
+      "ORG_MEMBERSHIP_INACTIVE": "Tư cách thành viên của bạn trong tổ chức đang ngừng hoạt động. Hãy liên hệ quản trị viên tổ chức.",
+      "ORG_SUSPENDED": "Tổ chức này đang bị tạm ngưng nên không tạo nội dung được.",
+      "ORG_CREDENTIAL_MISSING": "Tổ chức chưa gắn key gateway nào. Hãy nhờ quản trị viên tổ chức gắn key.",
+      "ORG_CREDENTIAL_DISABLED": "Key gateway của tổ chức không dùng được. Hãy liên hệ quản trị viên tổ chức.",
+      "ORG_CREDENTIAL_GATEWAY_MISMATCH": "Key gateway của tổ chức đang gắn với một gateway khác. Hãy nhờ quản trị viên tổ chức gắn lại.",
+      "ORG_AUTHZ_STALE": "Quyền của bạn vừa thay đổi. Hãy tải lại rồi thử tiếp.",
+      "generic": "Hiện chưa tạo nội dung được. Hãy tải lại trang hoặc liên hệ quản trị viên tổ chức."
+    }
+  },
+  "character": {
+    "main": {
+      "drama": {
+        "label": "Nhân vật chính",
+        "makeMain": "Đặt làm nhân vật chính",
+        "unsetMain": "Bỏ nhân vật chính",
+        "mainSet": "Đã đặt làm nhân vật chính",
+        "mainUnset": "Đã bỏ nhân vật chính"
+      },
+      "narrated": {
+        "label": "Nhân vật dẫn truyện chính",
+        "makeMain": "Đặt làm nhân vật dẫn truyện chính",
+        "unsetMain": "Bỏ nhân vật dẫn truyện chính",
+        "mainSet": "Đã đặt làm nhân vật dẫn truyện chính",
+        "mainUnset": "Đã bỏ nhân vật dẫn truyện chính"
+      }
+    }
+  },
+  "timeOfDay": {
+    "none": "Không (giữ ánh sáng của ảnh bối cảnh, không đánh sáng lại)",
+    "dawn": "Sáng sớm",
+    "forenoon": "Buổi sáng",
+    "noon": "Giữa trưa",
+    "afternoon": "Xế chiều",
+    "day": "Ban ngày",
+    "dusk": "Hoàng hôn",
+    "night": "Ban đêm",
+    "scriptOriginal": "{{value}} (giá trị gốc trong kịch bản)"
+  },
+  "pipelineImport": {
+    "extractFrames": {
+      "title": "Bóc tách cú máy",
+      "subtitle": "Video → ffmpeg trích khung chính → (tuỳ chọn) backend Vision phân tích ngôn ngữ cú máy",
+      "sections": {
+        "videoFile": "File video",
+        "params": "Thiết lập trích xuất",
+        "postProcess": "Hậu xử lý"
+      },
+      "fields": {
+        "maxFrames": "Số khung tối đa",
+        "sceneThreshold": "Ngưỡng đổi cảnh"
+      },
+      "thresholdHint": "Ngưỡng càng cao = chỉ lấy mẫu khi hình đổi nhiều (cảnh dài: 0.2–0.3; MV cắt nhanh: từ 0.5)",
+      "analyzeShots": {
+        "label": "Dùng Vision phân tích ngôn ngữ cú máy của từng khung",
+        "hint": "Cỡ cảnh / góc máy / chuyển động máy / không khí / bảng màu · dùng năng lực Vision mặc định của backend"
+      },
+      "submit": "Bắt đầu bóc tách",
+      "submitting": "Đang xử lý",
+      "doneToast": "Bóc tách xong: đã thêm {{count}} khung vào canvas",
+      "progress": {
+        "uploading": "Đang tải video lên…",
+        "extracting": "ffmpeg đang trích khung hình (tối đa 60 giây)…",
+        "analyzing": "Vision đang phân tích {{count}} khung…",
+        "done": "Đã trích {{count}} khung",
+        "doneAnalyzed": "Đã trích {{count}} khung và phân tích xong cú máy"
+      },
+      "errors": {
+        "emptyResult": "Trích khung không ra gì — video có thể quá ngắn hoặc ở định dạng không hỗ trợ"
+      }
+    },
+    "picker": {
+      "choose": "Chọn một file video",
+      "formats": "Hỗ trợ mp4 / mov / webm và nhiều định dạng khác",
+      "replace": "Thay file",
+      "browse": "Duyệt file"
+    },
+    "progress": {
+      "failed": "Thất bại",
+      "completed": "Xong"
+    },
+    "errors": {
+      "noFile": "Chọn một file video trước đã"
+    },
+    "videoReference": {
+      "title": "Video tham chiếu",
+      "subtitleLine1": "Tải một đoạn phim / clip ngắn lên → trích 3-5 khung chính làm tham chiếu phong cách / bố cục / màu,",
+      "subtitleLine2": "rồi nối vào một GenNode làm ảnh tham chiếu để AI bắt được thứ ngôn ngữ hình ảnh đó.",
+      "sections": {
+        "video": "Video tham chiếu",
+        "frameCount": "Số khung cần trích"
+      },
+      "frameCount": "{{count}} khung",
+      "frameCountHint": "5-7 khung thường là đủ (nhiều hơn thì model mất tiêu điểm phong cách)",
+      "submit": "Nhập tham chiếu",
+      "doneToast": "Video tham chiếu: đã thêm {{count}} khung vào canvas",
+      "progress": {
+        "uploading": "Đang tải video lên...",
+        "extracting": "Đang trích {{count}} khung chính (tham chiếu bố cục / màu)...",
+        "done": "Xong — đã thêm {{count}} khung vào canvas làm tham chiếu"
+      },
+      "errors": {
+        "emptyResult": "Trích khung trả về kết quả rỗng"
+      }
+    },
+    "maskEditor": {
+      "title": "✏️ Trình sửa theo vùng tô",
+      "brush": "🖌 Cọ",
+      "eraser": "🧽 Tẩy",
+      "size": "Cỡ",
+      "loadBaseFailed": "Tải ảnh nền thất bại (cookie có thể đã hết hạn)",
+      "loadingBase": "Đang tải ảnh nền...",
+      "needPrompt": "Viết prompt mô tả vùng đã tô cần biến thành gì",
+      "needPaint": "Tô một vùng trước đã (cọ đỏ phủ tới đâu thì sửa tới đó)",
+      "promptPlaceholder": "Vùng đã tô cần biến thành gì? ví dụ tóc dài màu xanh / thêm một vệt nắng / xoá người qua đường...",
+      "hint": "Đỏ = vùng cần sửa · LingShan-G2 · có thể mất 30-60 giây",
+      "submit": "Áp dụng",
+      "submitting": "Đang xử lý...",
+      "progress": {
+        "building": "Đang dựng file mask...",
+        "uploading": "Đang tải mask lên...",
+        "submitting": "Đang gửi tác vụ inpaint...",
+        "running": "Đang xử lý (30-60 giây)..."
+      }
+    },
+    "compare": {
+      "title": "🔄 So sánh A/B",
+      "position": "Kéo thanh chia để so sánh; vị trí {{percent}}%",
+      "dragHandle": "Kéo để so sánh",
+      "hint": "Mẹo: kéo thanh chia, hoặc giữ ← / → để tinh chỉnh"
+    },
+    "createIdentity": {
+      "title": "Dựng tạo hình mới",
+      "subtitle": "Tạo một tạo hình nhân vật toàn cục mới từ ảnh đã chọn; tạo hình chuẩn hiện có vẫn giữ nguyên.",
+      "noPreview": "Không có xem trước",
+      "character": "Nhân vật",
+      "identityName": "Tên tạo hình",
+      "identityNamePlaceholder": "ví dụ thời cao tuổi, đồ đi làm, sau trận đánh",
+      "ageGroup": "Nhóm tuổi",
+      "ageUnspecified": "Không rõ tuổi",
+      "appearance": "Mô tả trang phục / phong cách",
+      "appearancePlaceholder": "Trang phục, phụ kiện và kiểu tóc của tạo hình này — không mô tả hành động.",
+      "facePrompt": "Prompt khuôn mặt ở cấp tạo hình (tuỳ chọn)",
+      "facePromptPlaceholder": "Chỉ điền khi tuổi thay đổi nhiều; nếu không thì chân dung nhân vật được dùng lại.",
+      "submit": "Dựng tạo hình",
+      "submitting": "Đang tạo...",
+      "created": "Đã dựng tạo hình: {{character}} / {{identity}}"
+    },
+    "import": {
+      "title": "Nhập asset vào canvas",
+      "project": "Dự án: {{project}}",
+      "loadFailed": "Tải thất bại",
+      "assetKinds": "Loại asset",
+      "kind": {
+        "identity": "🎭 Identity (ảnh tạo hình nhân vật)",
+        "portrait": "🖼 Portrait (chân dung nhân vật)",
+        "frame": "🎬 Frame (khung đầu của beat)",
+        "sketch": "✏️ Sketch (phác thảo)",
+        "directorRender": "📐 Asset ghép của đạo diễn"
+      },
+      "noCharacters": "Dự án này chưa có nhân vật nào",
+      "episodeBeat": "Tập / Beat",
+      "episodeLabel": "Tập:",
+      "selectAll": "Chọn tất cả",
+      "selectNone": "Bỏ chọn hết",
+      "willImport": "Đang nhập {{count}} ảnh",
+      "submit": "Nhập",
+      "submitting": "Đang nhập...",
+      "identityFallbackLabel": "tạo hình",
+      "portraitLabel": "chân dung",
+      "directorRenderLabel": "bản render đạo diễn"
+    }
+  },
+  "superchat": {
+    "spec": {
+      "characterFallback": "Nhân vật {{index}}",
+      "roleLabel": "Vai",
+      "descriptionLabel": "Mô tả"
+    }
+  },
+  "productSurface": {
+    "misconfigured": "Chưa cấu hình đầy đủ các tính năng khả dụng. Vui lòng liên hệ quản trị viên.",
+    "reload": "Tải lại",
+    "statusUnknown": "Chưa xác nhận được tính năng nào đang dùng được. Vui lòng thử lại sau.",
+    "unavailableTitle": "Tính năng không dùng được"
+  }
+}

--- a/frontend/public/locales/zh/translation.json
+++ b/frontend/public/locales/zh/translation.json
@@ -436,6 +436,7 @@
       "selectLanguage": "选择语言",
       "languageChinese": "中文",
       "languageEnglish": "English",
+      "languageVietnamese": "Tiếng Việt",
       "passwordDialog": {
         "title": "修改密码",
         "description": "修改成功后会退出所有设备，需要使用新密码重新登录。",

--- a/frontend/src/__tests__/i18n/locales-json.test.ts
+++ b/frontend/src/__tests__/i18n/locales-json.test.ts
@@ -14,21 +14,28 @@ function collectKeys(value: unknown, prefix = ""): string[] {
   );
 }
 
+function loadLocale(language: string): unknown {
+  return JSON.parse(readFileSync(`public/locales/${language}/translation.json`, "utf8"));
+}
+
 describe("locale translation files", () => {
-  it.each(["en", "zh"])("%s translation JSON is valid", (language) => {
+  it.each(["en", "zh", "vi"])("%s translation JSON is valid", (language) => {
     const content = readFileSync(`public/locales/${language}/translation.json`, "utf8");
 
     expect(() => JSON.parse(content)).not.toThrow();
   });
 
-  it("keeps zh and en translation key sets aligned", () => {
-    const zh = JSON.parse(readFileSync("public/locales/zh/translation.json", "utf8"));
-    const en = JSON.parse(readFileSync("public/locales/en/translation.json", "utf8"));
-    const zhKeys = new Set(collectKeys(zh));
+  // `en` is the reference key set. A locale may leave a value in English on
+  // purpose — prompt fragments, domain terms and product names all stay as they
+  // are — but it may never be missing a key, or i18next renders the raw key.
+  it.each(["zh", "vi"])("keeps %s aligned with the en key set", (language) => {
+    const en = loadLocale("en");
+    const other = loadLocale(language);
     const enKeys = new Set(collectKeys(en));
+    const otherKeys = new Set(collectKeys(other));
 
-    expect([...zhKeys].filter((key) => !enKeys.has(key)).sort()).toEqual([]);
-    expect([...enKeys].filter((key) => !zhKeys.has(key)).sort()).toEqual([]);
+    expect([...enKeys].filter((key) => !otherKeys.has(key)).sort()).toEqual([]);
+    expect([...otherKeys].filter((key) => !enKeys.has(key)).sort()).toEqual([]);
   });
 
   it("defines the Niu Lai accessory name and selection feedback", () => {

--- a/frontend/src/__tests__/lib/queries/release-notifications.test.tsx
+++ b/frontend/src/__tests__/lib/queries/release-notifications.test.tsx
@@ -74,7 +74,9 @@ describe("release notification query", () => {
     expect(seenLocale).toBe("zh");
   });
 
-  it("defaults missing and unknown locales to zh", async () => {
+  // Release notes exist in zh and en only. A locale we don't publish notes for
+  // gets English, not Chinese — `vi` used to land on Chinese release notes here.
+  it("defaults missing and unknown locales to en", async () => {
     const seenLocales: string[] = [];
     server.use(
       http.get("http://localhost:3000/api/v1/release-notifications", ({ request }) => {
@@ -85,8 +87,9 @@ describe("release notification query", () => {
 
     await fetchReleaseNotifications(undefined);
     await fetchReleaseNotifications("fr-FR");
+    await fetchReleaseNotifications("vi-VN");
 
-    expect(seenLocales.length).toBeGreaterThanOrEqual(2);
-    expect(seenLocales.every((locale) => locale === "zh")).toBe(true);
+    expect(seenLocales.length).toBeGreaterThanOrEqual(3);
+    expect(seenLocales.every((locale) => locale === "en")).toBe(true);
   });
 });

--- a/frontend/src/components/ingest/NovelFormatDialog.tsx
+++ b/frontend/src/components/ingest/NovelFormatDialog.tsx
@@ -17,6 +17,16 @@ import { ScrollArea } from "@/components/ui/scroll-area";
  *
  * 中英各一套：解析器两种格式都认（utils/screenplay_scene_parser.py），但样例是
  * 「照着抄」的模板，中文界面给中文制片格式、英文界面给 Fountain 格式，混着给等于没给。
+ *
+ * NOTE FOR TRANSLATORS — this applies to the `ingest.novelFormat.rule*`,
+ * `ingest.sceneHeaders.*` and `aiAssistant.formatCheck.recommended` strings too:
+ * the parser matches these keywords *literally*. It accepts the Chinese
+ * production formats and Fountain / Final Draft, and nothing else. Translate the
+ * explanation around them; never translate `第N集` / `EPISODE N`, `人物：` /
+ * `Characters:`, `内` / `外` / `INT.` / `EXT.`, or the time values
+ * (`深夜` / `NIGHT` / `DAY` / …). A localized guide whose keywords were
+ * translated reads fine and then fails every import made by someone who
+ * followed it.
  */
 // i18n-exempt-start —— 样例本身就是解析器认的制片格式，翻译过去就不是那个格式了
 const DRAMA_FORMAT_SPEC = [
@@ -128,7 +138,11 @@ const DRAMA_FORMAT_EXAMPLE_EN = [
 ].join("\n");
 // i18n-exempt-end
 
-/** 样例按界面语言取，不按剧本语言：这是「照着抄」的模板，跟着读的人走。 */
+/**
+ * 样例按界面语言取，不按剧本语言：这是「照着抄」的模板，跟着读的人走。
+ * Locales without their own sample set get the Fountain one, which is what the
+ * parser accepts for non-Chinese scripts — so this branch stays binary on purpose.
+ */
 const FORMAT_SAMPLES = {
   zh: {
     spec: DRAMA_FORMAT_SPEC,

--- a/frontend/src/components/layout/header.tsx
+++ b/frontend/src/components/layout/header.tsx
@@ -42,6 +42,7 @@ import { resetUserSessionState } from "@/lib/reset-region-state";
 import { useModelGatewayConfig } from "@/lib/queries/model-gateway";
 import { useOrgBranding } from "@/lib/queries/org-branding";
 import { useReleaseNotifications } from "@/lib/queries/release-notifications";
+import { normalize, SUPPORTED, type Supported } from "@/i18n/languages";
 import {
   useAnnouncementReadState,
   useAnnouncements,
@@ -110,9 +111,7 @@ export function Header({ ambientBackground = false }: { ambientBackground?: bool
     : t("app.logoHomeTooltip");
   const displayName = username ?? "User";
   const avatarInitial = displayName.slice(0, 1).toUpperCase();
-  const activeLanguage = (i18n.resolvedLanguage ?? i18n.language).startsWith("zh")
-    ? "zh"
-    : "en";
+  const activeLanguage = normalize(i18n.resolvedLanguage ?? i18n.language);
   const modelGatewayConfig = useModelGatewayConfig(ceRuntime);
   const releaseNotifications = useReleaseNotifications(i18n.resolvedLanguage ?? i18n.language);
   const releaseFeed = releaseNotifications.data?.data;
@@ -279,7 +278,7 @@ export function Header({ ambientBackground = false }: { ambientBackground?: bool
       ?.focus();
   }, [accountPanelOpen]);
 
-  const switchLanguage = (lang: "zh" | "en") => {
+  const switchLanguage = (lang: Supported) => {
     void i18n.changeLanguage(lang);
     setLanguage(lang);
   };
@@ -558,6 +557,14 @@ function useFloatingBubblePosition(
   return position;
 }
 
+// The account menu renders one row per entry in `SUPPORTED`, so adding a
+// locale means adding it there plus its label key here — no JSX to touch.
+const LANGUAGE_LABEL_KEYS: Record<Supported, string> = {
+  zh: "header.account.languageChinese",
+  en: "header.account.languageEnglish",
+  vi: "header.account.languageVietnamese",
+};
+
 function AccountPanel({
   activeLanguage,
   avatarInitial,
@@ -576,14 +583,14 @@ function AccountPanel({
   visible,
   t,
 }: {
-  activeLanguage: "zh" | "en";
+  activeLanguage: Supported;
   avatarInitial: string;
   avatarUrl: string | null;
   displayName: string;
   hasUnreadNotification: boolean;
   onChangeAvatar: () => void;
   onChangePassword?: () => void;
-  onLanguageChange: (lang: "zh" | "en") => void;
+  onLanguageChange: (lang: Supported) => void;
   onNotifications: () => void;
   onClose: () => void;
   onEnter: () => void;
@@ -594,9 +601,7 @@ function AccountPanel({
   t: (key: string) => string;
 }) {
   const [languageOpen, setLanguageOpen] = useState(false);
-  const activeLanguageLabel = activeLanguage === "zh"
-    ? t("header.account.languageChinese")
-    : t("header.account.languageEnglish");
+  const activeLanguageLabel = t(LANGUAGE_LABEL_KEYS[activeLanguage]);
 
   return (
     <div
@@ -651,16 +656,14 @@ function AccountPanel({
           />
           {languageOpen ? (
             <div className="ml-[30px] mr-1 space-y-0.5 pb-1">
-              <PreferenceOption
-                active={activeLanguage === "zh"}
-                label={t("header.account.languageChinese")}
-                onClick={() => onLanguageChange("zh")}
-              />
-              <PreferenceOption
-                active={activeLanguage === "en"}
-                label={t("header.account.languageEnglish")}
-                onClick={() => onLanguageChange("en")}
-              />
+              {SUPPORTED.map((language) => (
+                <PreferenceOption
+                  key={language}
+                  active={activeLanguage === language}
+                  label={t(LANGUAGE_LABEL_KEYS[language])}
+                  onClick={() => onLanguageChange(language)}
+                />
+              ))}
             </div>
           ) : null}
           {onLogout ? (

--- a/frontend/src/components/notifications/announcement-card.tsx
+++ b/frontend/src/components/notifications/announcement-card.tsx
@@ -74,15 +74,25 @@ export function AnnouncementCard({
   );
 }
 
+// `Intl` knows far more locales than the UI ships translations for, so pass the
+// resolved language straight through instead of collapsing everything that is
+// not Chinese into English. A malformed tag throws, so fall back rather than
+// take the notification list down with it.
+function relativeTimeFormat(locale: string): Intl.RelativeTimeFormat {
+  try {
+    return new Intl.RelativeTimeFormat(locale || "en", { numeric: "auto" });
+  } catch {
+    return new Intl.RelativeTimeFormat("en", { numeric: "auto" });
+  }
+}
+
 function formatRelativeTime(value: string | null | undefined, locale: string): string | undefined {
   if (!value) return undefined;
   const published = new Date(value);
   if (Number.isNaN(published.getTime())) return undefined;
   const diffMs = published.getTime() - Date.now();
   const absMs = Math.abs(diffMs);
-  const rtf = new Intl.RelativeTimeFormat(locale.startsWith("zh") ? "zh" : "en", {
-    numeric: "auto",
-  });
+  const rtf = relativeTimeFormat(locale);
   if (absMs < 60 * 60 * 1000) {
     return rtf.format(Math.round(diffMs / (60 * 1000)), "minute");
   }

--- a/frontend/src/i18n/index.ts
+++ b/frontend/src/i18n/index.ts
@@ -5,14 +5,9 @@ import { initReactI18next } from "react-i18next";
 import HttpBackend from "i18next-http-backend";
 import { useAppStore } from "@/stores/app-store";
 import { BUILD_ID } from "@/lib/app-version";
+import { SUPPORTED, normalize, type Supported } from "./languages";
 
-const SUPPORTED = ["zh", "en"] as const;
-type Supported = (typeof SUPPORTED)[number];
-
-export function normalize(lng: string | undefined): Supported {
-  const two = (lng ?? "").slice(0, 2).toLowerCase();
-  return (SUPPORTED as readonly string[]).includes(two) ? (two as Supported) : "zh";
-}
+export { SUPPORTED, normalize, type Supported };
 
 function initialLanguage(): Supported {
   if (typeof window !== "undefined") {
@@ -31,8 +26,8 @@ i18n
     lng: initialLanguage(),
     fallbackLng: "zh",
     supportedLngs: [...SUPPORTED],
-    // `zh-CN` / `en-US` collapse to `zh` / `en`, so the
-    // backend loader only has to serve two translation files.
+    // `zh-CN` / `en-US` / `vi-VN` collapse to `zh` / `en` / `vi`, so the
+    // backend loader only has to serve one translation file per language.
     load: "languageOnly",
     defaultNS: "translation",
     backend: {

--- a/frontend/src/i18n/languages.ts
+++ b/frontend/src/i18n/languages.ts
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: Elastic-2.0
+// Copyright (c) 2026 ClaymoreLab
+
+/**
+ * The supported UI languages, kept in a side-effect-free module.
+ *
+ * `./index` initializes i18next as an import side effect, so anything that only
+ * needs the language list (the account menu, for one) imports from here instead
+ * — otherwise every consumer's test has to stand up the full i18next runtime.
+ *
+ * Adding a locale: add the tag here, add `locales/<tag>/translation.json`, and
+ * add its label key to `LANGUAGE_LABEL_KEYS` in `components/layout/header.tsx`.
+ */
+export const SUPPORTED = ["zh", "en", "vi"] as const;
+export type Supported = (typeof SUPPORTED)[number];
+
+export function normalize(lng: string | undefined): Supported {
+  const two = (lng ?? "").slice(0, 2).toLowerCase();
+  return (SUPPORTED as readonly string[]).includes(two) ? (two as Supported) : "zh";
+}

--- a/frontend/src/lib/queries/release-notifications.ts
+++ b/frontend/src/lib/queries/release-notifications.ts
@@ -32,9 +32,13 @@ export interface ReleaseFeed {
 
 const RELEASE_FEED_STALE_TIME_MS = 60 * 60 * 1000;
 
+// Release notes only exist in `zh` and `en`. Anything else falls back to `en`
+// rather than `zh`: an unrecognized locale is far more likely to be a reader of
+// English than of Chinese, and this used to hand Chinese notes to every locale
+// that wasn't literally "en".
 export function normalizeReleaseLocale(locale: string | undefined): "zh" | "en" {
   const two = (locale ?? "").slice(0, 2).toLowerCase();
-  return two === "en" ? "en" : "zh";
+  return two === "zh" ? "zh" : "en";
 }
 
 export function releaseNotificationsQueryOptions(localeInput: string | undefined) {

--- a/license-inventory.csv
+++ b/license-inventory.csv
@@ -174,6 +174,7 @@ frontend/public/liexiaoren/skin/modal-secondary-button.png,Elastic-2.0,2026 Supe
 frontend/public/liexiaoren/skin/modal-title.png,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/public/liexiaoren/skin/poster.png,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/public/locales/en/translation.json,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
+frontend/public/locales/vi/translation.json,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/public/locales/zh/translation.json,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/public/login-cinematic/final-mark.png,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/public/login-cinematic/fonts/DingTalk_JinBuTi_Title.woff2,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
@@ -1268,6 +1269,7 @@ frontend/src/hooks/use-task-stream.ts,Elastic-2.0,2026 SuperTale contributors,RE
 frontend/src/hooks/use-transient-confirmation.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/hooks/use-view-toggles.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/i18n/index.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
+frontend/src/i18n/languages.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/index.css,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/lib/age-group.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/lib/api-errors.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation


### PR DESCRIPTION
Closes #489.

Adds the `vi` locale you green-lit, plus the two zh/en binary branches you asked me to fold in and the source comment about the format keywords. One extra fix came out of writing the locale — details in section 4.

Three commits, each independent and droppable.

---

## 1. `feat(i18n): add Vietnamese (vi) locale`

- `frontend/public/locales/vi/translation.json` — **5888 / 5888 keys**, exact parity with `en`
- `"vi"` in `SUPPORTED`
- `header.account.languageVietnamese` in `en` and `zh`
- parity test extended to every locale, not just `zh` vs `en`

Two small refactors came with it:

**The account menu no longer hardcodes two rows.** It maps over `SUPPORTED` with a `LANGUAGE_LABEL_KEYS` lookup, and `activeLanguage` goes through `normalize()` instead of `startsWith("zh") ? "zh" : "en"` (the third of the three binary branches from #489). Adding a fourth locale is now a tag plus a label key — no JSX.

**`SUPPORTED` / `normalize` moved to `i18n/languages.ts`.** `i18n/index.ts` initializes i18next as an import side effect, so importing it from `header.tsx` broke `header.test.tsx`, which mocks `react-i18next` without `initReactI18next`. A component that only needs the language list should not pull in the runtime. `index.ts` re-exports both, so existing imports are unaffected.

### What is deliberately left in English — 329 keys

Same reasoning as in #489, updated for what v2.0.2's extraction moved into the locale files:

| Group | Why |
|---|---|
| `nodeToolbar.*Prompt`, `lightEditor.prompt*` / `presetPrompts`, `node.imageEdit.suggest.*Prompt`, `episode.workbench.video.seedance2Guidance*Template` | Pure prompt content — composed into what goes to the image/video model, never rendered. Translating them measurably hurts output quality. The last group is newly extracted; `video-pane.tsx` says the guidance follows the UI language, so tell me if you'd rather have it in Vietnamese and I'll switch it. |
| `lightEditor.directions.*`, `multiAngleEditor.presets` / `zoomLevels` / `horizontalLabels` / `verticalLabels` | **These are dual-purpose and it's a real tradeoff, not a free win.** They render as visible labels (`LightEditorPanel.tsx:577`, `MultiAngleEditorPanel.tsx:228,258`) *and* get interpolated into the generated prompt (`LightEditorPanel.tsx:957`, `MultiAngleEditorPanel.tsx:515`). I chose prompt fidelity over a translated label, so a Vietnamese user sees "front" / "left" on those two panels. If you'd rather have the label translated, the fix is to split the key into a label and a prompt token rather than translating the shared one — happy to do that instead. |
| Domain terms — Model, Prompt, Render, Timeline, Keyframe, Upscale, Seed, Commit, canvas, node, asset, storyboard, beat | Vietnamese video/AI people use the English words; translating them reads worse than leaving them. |
| Product and proper nouns — SuperTale, Freezone, Director World, Shrimp Lens / Canvas / Pond / Feed, PlayCanvas, LingShan-G2, Grok Video Channel, HappyHorse | Names. |
| Slot and protocol identifiers quoted in UI copy — `scene_id`, `prop_id`, `identity_id`, `scene_master`, `prop_ref`, `selected_background`, `3GS`, `.sog`, GLB | They appear in the UI as the identifier the user has to type or match. |
| Screenplay-format keywords inside `ingest.novelFormat.*`, `ingest.formatCheck.*`, `aiAssistant.formatCheck.recommended` | See section 4. |

A few keys are identical to `en` simply because the Vietnamese happens to match (`Video`, `Album`, `FPV`, `Drone`, `Request ID`, the `", "` list separator). Those are in the 329 too.

---

## 2. `fix(i18n): fall back to English, not Chinese, for unpublished locales`

The other two binary branches from #489:

- `normalizeReleaseLocale` was `two === "en" ? "en" : "zh"` — every locale except literally `en` fetched **Chinese** release notes. Now only `zh` asks for Chinese.
- `formatRelativeTime` passed `startsWith("zh") ? "zh" : "en"` to `Intl`. The resolved language now goes straight through. Guarded with try/catch: `Intl.RelativeTimeFormat` throws on a structurally invalid tag, and a bad tag should not take the notification list down.

The existing test asserted the old behaviour (`defaults missing and unknown locales to zh`); it now asserts `en` and covers `vi-VN`.

---

## 3. Source comment about the format keywords

Added next to the format spec in `NovelFormatDialog.tsx`, naming the three key groups a translator will meet and stating that the parser matches the keywords literally. Also noted that the sample picker's `zh`-vs-`en` branch is binary **on purpose** — a locale without its own sample set should get the Fountain one — so a future reader doesn't "fix" it.

For the record, `Tập 1` and `Nhân vật: Ji-won` are what a Vietnamese writer would naturally type. The first fails to match an episode header. The second is worse: `parse_character_line` returns `["Nhân vật: Ji-won"]` — one character whose name is the whole line. It fails silently.

---

## 4. `fix(ingest): correct English screenplay-format guidance the parser rejects`

Not part of the original ask. I hit it while writing the Vietnamese format guide, because I copied your English one.

Three `en` strings teach a heading shape the parser does not accept. They were translated from the Chinese strings word for word, and `1-1 <location> <time> <int/ext>` only parses when the time and interior/exterior tokens are *Chinese*. Verified against `parse_scene_blocks` on current `main`:

```
EPISODE 1 / 1-1 City Cafe DAY INT     -> 1 block, location='' time='' int_ext=''
EPISODE 1 / INT. City Cafe - DAY      -> 1 block, location='City Cafe' time='日' int_ext='内'
EPISODE 1 / 1-1 苏鸾寝殿 深夜 内         -> 1 block, parses correctly
```

Affected:

- `aiAssistant.formatCheck.recommended` — the "standard script example" the assistant shows
- `ingest.formatCheck.issue.missingSceneHeaders.fix` — same example, in the fix hint
- `ingest.formatCheck.issue.sceneHeadersMissingTime.fix` — suggests `LATE NIGHT`, but `ENGLISH_TIME_TOKENS` is DAY / NIGHT / MORNING / AFTERNOON / EVENING / DAWN / DUSK. `INT. X - LATE NIGHT` does not match `INTERNATIONAL_SCENE_RE`, so the whole heading is lost — which `ingest.novelFormat.ruleTimeTokens` already warns about two screens away.

English-only; `zh` is correct as it stands. This is the trap from #489 turning out to be live rather than hypothetical, which is partly why the source comment in section 3 seems worth having.

---

## Verification

Everything CI runs, run locally on this branch:

| Check | Result |
|---|---|
| `scripts/check_frontend_i18n.py` | pass — 0 hardcoded Chinese, ratchet not moved |
| `scripts/lint_banned_words.py` | pass |
| `scripts/lint_ee_terms.py` | pass |
| `scripts/ce_allowlist.py` | pass |
| `scripts/check_dco.py` | pass — all 3 commits signed off |
| `pnpm build` (tsc -b + vite) | pass, `dist/locales/vi/translation.json` ships |
| `pnpm test` | 411 files, 2941 passed, **7 failed** |

Those 7 are pre-existing. On `upstream/main` with no changes the same run gives 2939 passed / **7 failed, identical tests**: 3 in `video-node-credit-contract`, 1 in `script-node-credit-contract`, 1 in `video-model-capabilities`, 2 in `auth-gating`. The auth-gating pair passes when its file runs alone, on both main and this branch — looks like a timeout under full-suite parallelism, not a real failure. My +2 passing are the extra parity case and the `vi-VN` assertion.

Locale integrity was checked mechanically, not by eye: key sets and key *order* identical to `en` across all three files; `{{...}}` / `<n>` / `$t()` placeholder multisets identical per key; no stray single braces; no key existing only as `_one` (Vietnamese resolves to the `other` category alone under `Intl.PluralRules`); and the `en`/`zh` diffs contain exactly one added key plus three changed `en` values, with every other value byte-identical to `upstream/main`.

Parser claims were checked by importing `novelvideo.utils.screenplay_scene_parser` and running `parse_scene_blocks` / `parse_character_line` / `ENGLISH_TIME_TOKENS` against the exact strings quoted above.

One convention worth stating so nobody "fixes" it piecemeal: the file uses old-style Vietnamese tone placement throughout — `hoà`, `khoá`, `xoá`, `tuỳ`, `huỷ`, `hoá` (190 occurrences, 0 of the modern `hòa` / `khóa` / `xóa` / `tùy` / `hủy`). Both are correct Vietnamese; this one is applied consistently. Happy to convert the whole file to the modern placement if you'd rather — it's one pass, but it should be all or nothing.

Terminology is likewise consistent rather than per-string: `cú máy` for shot, `khung đầu` for first frame, `bối cảnh` for scene-as-asset vs `cảnh` for scene-in-story, `ngữ cảnh cú máy` for shot context, `ứng viên` for candidate, `tạo hình` for identity, `phác thảo` for sketch, `luồng chính` for mainline, `dây chuyền` for pipeline.

@lywaterman
