### PR TITLE
fix: 修复文字 Skill 保存合同、失败回执与工作流确认重试

### DIFF
--- a/.hermes/plugins/freezone/__init__.py
+++ b/.hermes/plugins/freezone/__init__.py
@@ -3431,6 +3431,7 @@ def _dispatch_mcp_approved_frontend_commands(
     canvas: str,
     commands: list[Any],
     slim_result: bool,
+    workflow_confirmation: dict[str, Any] | None = None,
 ) -> str:
     if (
         canvas_command_bridge_key is None
@@ -3479,6 +3480,10 @@ def _dispatch_mcp_approved_frontend_commands(
         key = canvas_command_bridge_key(
             project_id=project, canvas_id=canvas, commands=commands
         )
+    if workflow_confirmation:
+        key += "-" + hashlib.sha256(
+            json.dumps(workflow_confirmation, sort_keys=True).encode()
+        ).hexdigest()[:24]
     bridge_root = os.environ.get("DRAMACLAW_CANVAS_COMMAND_BRIDGE_DIR", "").strip()
     # The worker launcher already gives each Hermes/Codex profile its
     # profile-scoped bridge directory (``.../freezone_freezone_main``). Do not
@@ -3493,6 +3498,7 @@ def _dispatch_mcp_approved_frontend_commands(
         commands=commands,
         envelope=envelope,
         bridge_dir=bridge_dir,
+        workflow_confirmation=workflow_confirmation,
     )
     if immediate_result is not None:
         return tool_result(
@@ -3558,6 +3564,7 @@ def _dispatch_frontend_canvas_commands(
     canvas: str,
     commands: list[Any],
     slim_result: bool,
+    workflow_confirmation: dict[str, Any] | None = None,
 ) -> str:
     if (
         canvas_command_bridge_key is None
@@ -3590,6 +3597,7 @@ def _dispatch_frontend_canvas_commands(
         canvas_id=canvas,
         commands=commands,
         envelope=envelope,
+        workflow_confirmation=workflow_confirmation,
     )
     try:
         timeout_seconds = max(
@@ -4208,6 +4216,7 @@ def _emit_canvas_commands(
     *,
     allow_dynamic_workflow_batch: bool = False,
     slim_result: bool = False,
+    workflow_confirmation: dict[str, Any] | None = None,
 ) -> str:
     if not isinstance(commands, list) or not commands:
         return _emit_command_error(
@@ -4270,12 +4279,14 @@ def _emit_canvas_commands(
             canvas=canvas,
             commands=commands,
             slim_result=slim_result,
+            workflow_confirmation=workflow_confirmation,
         )
     return _dispatch_frontend_canvas_commands(
         project=project,
         canvas=canvas,
         commands=commands,
         slim_result=slim_result,
+        workflow_confirmation=workflow_confirmation,
     )
 
 
@@ -5461,6 +5472,12 @@ def _handle_confirm_workflow_draft(args: dict[str, Any], **_: Any) -> str:
             built.get("commands"),
             allow_dynamic_workflow_batch=True,
             slim_result=True,
+            workflow_confirmation={
+                "draft_id": draft_id,
+                "task_id": confirmation_task_id,
+                "revision": payload.get("revision"),
+                "confirmation_started_at": payload.get("confirmation_started_at"),
+            },
         )
     except Exception:
         _finish_workflow_draft(

--- a/.hermes/plugins/freezone/__init__.py
+++ b/.hermes/plugins/freezone/__init__.py
@@ -7414,25 +7414,21 @@ _SKILL_STUDIO_RECIPE_SCHEMA = {
         "system_prompt": {
             "type": "string",
             "description": (
-                "Recipe 节点级 system_prompt 是 prompt/instruction generator，用来指导 Agent/LLM "
-                "根据用户目标、上游输出和参考素材，写出可送入对应节点的提示词/指令或 brief。"
-                "不要直接生成最终内容：text Recipe 不直接写正文成品，image/video/audio Recipe "
-                "不直接写最终图片、视频或音频描述成品，而是要求当前 LLM 输出给对应 "
-                "textGeneration/imageGeneration/videoGeneration/audioGeneration 节点使用的一条完整提示词/指令。"
-                "A Recipe system_prompt must never be the final downstream prompt itself. It must "
-                "instruct the current LLM how to transform upstream input into the downstream node "
-                "prompt/instruction, and should explicitly include: “重要：你的输出是一条提示词/指令，"
-                "将被送入下游 <node_type> 节点执行；不要自己生成最终内容。” "
+                "Recipe 节点级 system_prompt 必须按 output_kind 区分职责。"
+                "text Recipe 要求当前 LLM 直接输出最终交付文本（正文、脚本、大纲或摘要），"
+                "不能输出交给另一个 textGeneration 节点执行的二阶段指令。"
+                "image/video/audio Recipe 指导当前 LLM 根据用户目标、上游输出和参考素材，"
+                "写出送入对应节点的完整提示词/指令，而不是把固定的最终提示词作为 system_prompt。"
                 "必须包含【角色设定】、【输入来源】、【任务目标】、【输出结构要求】、"
-                "【质量标准】和【禁止事项/约束】。输出结构要求应描述下游 prompt/brief 必须包含的模块，"
-                "例如主体、场景、镜头、构图、风格、色彩、文本排版、连续性和负面约束。"
+                "【质量标准】和【禁止事项/约束】。文字 Recipe 的输出结构描述最终文本；"
+                "媒体 Recipe 的输出结构描述生成提示词中的主体、场景、构图、风格和负面约束。"
             ),
         },
         "must_have_items": {
             "type": "array",
             "description": (
                 "Required modules or sections that the Recipe output must contain. Prefer structural "
-                "items for the downstream prompt/brief, not only style adjectives."
+                "items for the final text (text Recipes) or downstream media prompt, not only style adjectives."
             ),
             "items": {"type": "string"},
         },

--- a/frontend/src/features/superchat/superchat-panel.tsx
+++ b/frontend/src/features/superchat/superchat-panel.tsx
@@ -14195,7 +14195,8 @@ export function SuperChatPanel({
       });
       if (!result.ok || !result.saved_to_catalog) {
         const errorText = result.errors?.find(Boolean) || result.message || "后端没有确认保存成功";
-        toast.error(`添加 Skill / Recipe 失败：${errorText}`);
+        const partiallySaved = Boolean(result.saved_skill_ids?.length || result.saved_recipe_ids?.length);
+        toast.error(partiallySaved && result.message ? result.message : `添加 Skill / Recipe 失败：${errorText}`);
         return false;
       }
       payload.saved_skill_ids = result.saved_skill_ids ?? payload.saved_skill_ids;

--- a/src/novelvideo/api/routes/chat.py
+++ b/src/novelvideo/api/routes/chat.py
@@ -780,13 +780,16 @@ async def _record_workflow_draft_canvas_result(
             return
         task_id = str(draft.get("task_id") or "")
         revision = int(draft.get("revision") or 0)
+        attempt_started_at = draft.get("confirmation_started_at")
+        if not task_id or attempt_started_at is None:
+            return
         task_state = await asyncio.to_thread(
             get_task_manager().get_task_for_project,
             project_ctx,
             "freezone_workflow_confirm",
             0,
             beat_num=None,
-            scope=f"{canvas_id}:{draft_id}:{revision}",
+            scope=f"{canvas_id}:{draft_id}:{revision}:{attempt_started_at}",
         )
         if (
             task_state is None
@@ -805,6 +808,7 @@ async def _record_workflow_draft_canvas_result(
             draft_id=draft_id,
             outcome="confirmed" if resolved.get("ok") else "ready",
             expected_task_id=task_id,
+            expected_confirmation_started_at=attempt_started_at,
         )
     except Exception:
         logger.exception(

--- a/src/novelvideo/api/routes/chat.py
+++ b/src/novelvideo/api/routes/chat.py
@@ -740,14 +740,40 @@ def _pending_workflow_draft_id(
     return identity if identity.startswith("workflow_draft_") else ""
 
 
+def _pending_workflow_confirmation(
+    username: str, payload: CanvasCommandToolResultIn,
+) -> dict[str, Any] | None:
+    """Capture server-side attempt ownership before the bridge is resolved."""
+    key = payload.bridge_key.strip()
+    if not key:
+        return None
+    directory = _bridge_dir_for_pending_key(username, payload)
+    pending = _load_pending_canvas_command(directory / f"{key}.pending.json")
+    if not isinstance(pending, dict):
+        return None
+    if (
+        pending.get("project_id") != payload.project_id
+        or pending.get("canvas_id") != payload.canvas_id
+    ):
+        return None
+    identity = pending.get("workflow_confirmation")
+    return dict(identity) if isinstance(identity, dict) else None
+
+
 async def _record_workflow_draft_canvas_result(
     *,
     user: dict[str, Any],
     payload: CanvasCommandToolResultIn,
     draft_id: str,
     resolved: dict[str, Any],
+    confirmation: dict[str, Any] | None = None,
 ) -> None:
-    if not draft_id:
+    if not draft_id or not confirmation or confirmation.get("draft_id") != draft_id:
+        return
+    task_id = str(confirmation.get("task_id") or "")
+    attempt_started_at = confirmation.get("confirmation_started_at")
+    revision = confirmation.get("revision")
+    if not task_id or attempt_started_at is None or not isinstance(revision, int):
         return
     project_id = str(payload.project_id or "").strip()
     canvas_id = str(payload.canvas_id or "").strip()
@@ -778,10 +804,11 @@ async def _record_workflow_draft_canvas_result(
         )
         if draft is None:
             return
-        task_id = str(draft.get("task_id") or "")
-        revision = int(draft.get("revision") or 0)
-        attempt_started_at = draft.get("confirmation_started_at")
-        if not task_id or attempt_started_at is None:
+        if (
+            draft.get("task_id") != task_id
+            or draft.get("confirmation_started_at") != attempt_started_at
+            or draft.get("revision") != revision
+        ):
             return
         task_state = await asyncio.to_thread(
             get_task_manager().get_task_for_project,
@@ -1416,12 +1443,14 @@ async def resolve_canvas_command_tool_result(
 ) -> dict[str, Any]:
     username = str(user["username"])
     workflow_draft_id = _pending_workflow_draft_id(username, payload)
+    confirmation = _pending_workflow_confirmation(username, payload)
     resolved = _resolve_canvas_command_tool_result_payload(payload, username=username)
     await _record_workflow_draft_canvas_result(
         user=user,
         payload=payload,
         draft_id=workflow_draft_id,
         resolved=resolved,
+        confirmation=confirmation,
     )
     if payload.cancelled or payload.canvas_apply_status == "cancelled_by_user":
         await _close_canvas_command_worker(username, payload)
@@ -1559,6 +1588,7 @@ async def _receive_bridge_results_during_turn(
         if event_type == "canvas.command.result":
             payload = CanvasCommandToolResultIn.model_validate(raw)
             workflow_draft_id = _pending_workflow_draft_id(username, payload)
+            confirmation = _pending_workflow_confirmation(username, payload)
             resolved = _resolve_canvas_command_tool_result_payload(
                 payload, username=username
             )
@@ -1567,6 +1597,7 @@ async def _receive_bridge_results_during_turn(
                 payload=payload,
                 draft_id=workflow_draft_id,
                 resolved=resolved,
+                confirmation=confirmation,
             )
             if payload.cancelled or payload.canvas_apply_status == "cancelled_by_user":
                 await _close_canvas_command_worker(username, payload)
@@ -2072,6 +2103,7 @@ def _load_pending_canvas_command(path: Any) -> dict[str, Any] | None:
         "project_id": payload.get("project_id"),
         "canvas_id": payload.get("canvas_id") or envelope.get("canvas_id"),
         "envelope": envelope,
+        "workflow_confirmation": payload.get("workflow_confirmation"),
     }
 
 

--- a/src/novelvideo/api/routes/chat.py
+++ b/src/novelvideo/api/routes/chat.py
@@ -1032,12 +1032,13 @@ def _resolve_skill_studio_tool_result_payload(
     if not key:
         raise HTTPException(status_code=400, detail="bridge_key is required")
     ok = payload.ok and payload.tool_call_status == "completed" and not payload.errors
-    draft_skill_ids, draft_recipe_ids = _skill_studio_draft_catalog_ids(payload.draft)
     saved_to_catalog = (
         payload.saved_to_catalog or payload.skill_studio_status == "catalog_saved"
     )
-    saved_skill_ids = payload.saved_skill_ids or draft_skill_ids
-    saved_recipe_ids = payload.saved_recipe_ids or draft_recipe_ids
+    save_requested = saved_to_catalog
+    saved_skill_ids: list[str] = []
+    saved_recipe_ids: list[str] = []
+    skill_studio_status = payload.skill_studio_status
     errors = list(payload.errors)
     cancelled = (
         payload.action == "cancel" or payload.skill_studio_status == "catalog_cancelled"
@@ -1066,6 +1067,17 @@ def _resolve_skill_studio_tool_result_payload(
                 logger.exception(
                     "failed to mark Freezone Hermes worker dirty after Skill Studio save"
                 )
+    if save_requested:
+        saved_to_catalog = ok
+        skill_studio_status = (
+            "catalog_saved"
+            if ok
+            else (
+                "catalog_partially_saved"
+                if saved_skill_ids or saved_recipe_ids
+                else "catalog_save_failed"
+            )
+        )
     if ok:
         if saved_to_catalog:
             agent_instruction = (
@@ -1112,10 +1124,22 @@ def _resolve_skill_studio_tool_result_payload(
             )
     else:
         agent_instruction = "Do not continue the Skill Studio flow; handle the frontend error or ask the user to retry."
-        message = (
-            payload.message
-            or "Frontend reported that the Skill Studio interaction failed."
-        )
+        if save_requested:
+            message = (
+                "Skill / Recipe 仅部分保存成功，请修正失败项后重试。"
+                if saved_skill_ids or saved_recipe_ids
+                else "Skill / Recipe 保存失败，未保存任何条目，请修正错误后重试。"
+            )
+            agent_instruction = (
+                "Catalog saving did not fully succeed. Report the errors and only the IDs "
+                "in saved_skill_ids / saved_recipe_ids as saved. Do not claim the draft "
+                "is ready to use or start its workflow. Keep the draft available for correction."
+            )
+        else:
+            message = (
+                payload.message
+                or "Frontend reported that the Skill Studio interaction failed."
+            )
     agent_visible_draft = (
         None if saved_to_catalog or cancelled or revision_started else payload.draft
     )
@@ -1123,8 +1147,10 @@ def _resolve_skill_studio_tool_result_payload(
         "ok": ok,
         "status": "skill_studio_frontend_result",
         "turn_id": payload.turn_id,
-        "tool_call_status": payload.tool_call_status,
-        "skill_studio_status": payload.skill_studio_status,
+        "tool_call_status": (
+            "failed" if save_requested and not ok else payload.tool_call_status
+        ),
+        "skill_studio_status": skill_studio_status,
         "action": payload.action,
         "selections": payload.selections,
         "draft": agent_visible_draft,

--- a/src/novelvideo/api/routes/freezone.py
+++ b/src/novelvideo/api/routes/freezone.py
@@ -14126,6 +14126,7 @@ async def claim_canvas_workflow_draft(
         raise HTTPException(400, str(exc)) from exc
     if draft is None:
         return error
+    attempt_started_at = draft["confirmation_started_at"]
     try:
         queued = await get_task_backend().enqueue_project_task(
             ctx,
@@ -14133,12 +14134,13 @@ async def claim_canvas_workflow_draft(
             product_surface="freezone_assistant",
             queue_kind="default",
             episode=0,
-            scope=f"{canvas_id}:{draft_id}:{revision}",
+            scope=f"{canvas_id}:{draft_id}:{revision}:{attempt_started_at}",
             payload={
                 "draft_id": draft_id,
                 "canvas_id": canvas_id,
                 "revision": revision,
-                "plan_digest": current_draft.get("plan_digest"),
+                "plan_digest": draft.get("plan_digest"),
+                "confirmation_started_at": attempt_started_at,
             },
         )
     except Exception:
@@ -14148,17 +14150,24 @@ async def claim_canvas_workflow_draft(
             canvas_id=canvas_id,
             draft_id=draft_id,
             outcome="ready",
+            expected_confirmation_started_at=attempt_started_at,
         )
         raise
     task_id = str(queued.task_state.task_id)
-    persisted = await asyncio.to_thread(
-        bind_workflow_draft_task,
-        project_dir=state_dir,
-        canvas_id=canvas_id,
-        draft_id=draft_id,
-        task_id=task_id,
-        root_task_id=task_id,
-    )
+    try:
+        persisted = await asyncio.to_thread(
+            bind_workflow_draft_task,
+            project_dir=state_dir,
+            canvas_id=canvas_id,
+            draft_id=draft_id,
+            task_id=task_id,
+            root_task_id=task_id,
+            expected_confirmation_started_at=attempt_started_at,
+        )
+    except ValueError as exc:
+        # A cancelled/replaced attempt must not bind a late enqueue response.
+        # Its runner carries the same attempt identity and cannot touch the replacement.
+        raise HTTPException(409, str(exc)) from exc
     if persisted is None:
         raise RuntimeError("workflow draft disappeared after durable task enqueue")
     return {"ok": True, "data": _workflow_draft_api_data(persisted)}

--- a/src/novelvideo/chat/service.py
+++ b/src/novelvideo/chat/service.py
@@ -998,18 +998,18 @@ Draft rules:
 - When Recipe craft conflicts with this turn's user request, confirmed inputs, or Skill constraints, use this priority order: user request > confirmed inputs > Skill constraints > Recipe craft > defaults.
 - Use snake_case Recipe fields directly: system_prompt, must_have_items, planning_prompt, result_summary, requires_source_media.
 - Do not ask the user for low-level fields such as id, category, action_keys, or system_prompt; infer them.
-- Recipe system_prompt is a prompt/instruction generator: it guides the current Agent/LLM to write
-  the prompt, brief, or instruction that will be sent to the corresponding textGeneration,
-  imageGeneration, videoGeneration, or audioGeneration node（送入对应节点）. 不要直接生成最终内容。
-  - For text Recipes, do not write the final copy/script/outline directly; instruct the current LLM
-    to produce a complete prompt/instruction for the textGeneration node that will generate that artifact.
-  - For image/video/audio Recipes, do not write the final image/video/audio prompt as the Recipe itself;
-    instruct the current LLM to transform upstream inputs into one complete downstream generation prompt.
-  - The system_prompt itself should say: output only the downstream node prompt/instruction, do not
-    execute the final content generation inside this step.
-- Recipe system_prompt must never be the final downstream prompt itself. It must instruct the current LLM how to transform upstream input into the downstream node prompt/instruction. It should explicitly include: “重要：你的输出是一条提示词/指令，将被送入下游 <node_type> 节点执行；不要自己生成最终内容。”
-- Recipe system_prompt must include concrete structured sections: 【角色设定】, 【输入来源】, 【任务目标】, 【输出结构要求】, 【质量标准】, and 【禁止事项/约束】. The output structure describes the modules that the downstream prompt/brief must contain, such as subject, scene, shot/composition, style, color, text/layout, continuity, and negative constraints.
-- Recipe must_have_items should usually be required modules/sections for the downstream prompt/brief, not only style adjectives. For an image Recipe, prefer items such as "主视觉描述", "文化元素提取", "构图与留白", "色彩与字体建议", "负面提示词/禁止事项".
+- Recipe output responsibilities depend on output_kind:
+  - For text Recipes, the current LLM must produce the final deliverable directly: the requested
+    copy, script, outline, summary, or other text. Do not generate instructions for a second LLM
+    or hand off to another textGeneration node. system_prompt describes how to produce that final text.
+  - For image/video/audio Recipes, the current LLM transforms upstream inputs into one complete
+    downstream generation prompt. The system_prompt describes how to write that prompt, not a fixed prompt.
+    Its output is a prompt for the corresponding imageGeneration, videoGeneration, or audioGeneration node.
+- Recipe system_prompt must include concrete structured sections: 【角色设定】, 【输入来源】,
+  【任务目标】, 【输出结构要求】, 【质量标准】, and 【禁止事项/约束】.
+  For text Recipes, output structure and must_have_items describe the final text itself.
+  For image/video/audio Recipes, they describe the downstream generation prompt, such as subject,
+  scene, composition, style, continuity, and negative constraints.
 - Recipe planning_prompt must be non-empty and describe this node's work in one short business sentence, usually "根据 X，生成/提取/改写 Y。". Do not explain scheduling mechanics, downstream nodes, workflow internals, or "when to schedule this Recipe" in this field.
 - Recipe result_summary must be non-empty and describe this node's business output in one short phrase or sentence, such as "3:4 竖版数码产品科技感详情图" or "家乡文化海报图片生成指令". Do not mention downstream execution, imageGeneration handoff, planner behavior, or workflow mechanics in this field.
 - For multi-step Skills, split planning/prompt-writing Recipes from terminal image/video generation Recipes when useful.

--- a/src/novelvideo/freezone/canvas_command_bridge.py
+++ b/src/novelvideo/freezone/canvas_command_bridge.py
@@ -202,6 +202,7 @@ def put_pending_canvas_command(
     commands: list[Any],
     envelope: dict[str, Any],
     bridge_dir: str | Path | None = None,
+    workflow_confirmation: dict[str, Any] | None = None,
 ) -> dict[str, Any] | None:
     """Publish once, replaying a durable result for an identical stable key.
 
@@ -240,6 +241,7 @@ def put_pending_canvas_command(
                 "canvas_id": canvas_id,
                 "commands": commands,
                 "envelope": envelope,
+                "workflow_confirmation": workflow_confirmation,
                 "request_fingerprint": fingerprint,
                 "created_at": time.time(),
             },

--- a/src/novelvideo/freezone/workflow_drafts.py
+++ b/src/novelvideo/freezone/workflow_drafts.py
@@ -515,6 +515,8 @@ def claim_workflow_draft_confirmation(
         payload.update(
             {
                 "status": "confirming",
+                "task_id": "",
+                "root_task_id": "",
                 "confirmation_started_at": now,
                 "updated_at": now,
             }
@@ -530,6 +532,7 @@ def bind_workflow_draft_task(
     draft_id: str,
     task_id: str,
     root_task_id: str,
+    expected_confirmation_started_at: float | None = None,
 ) -> dict[str, Any] | None:
     """Project the durable task identity onto its presentation draft."""
     _validate_scope(canvas_id, draft_id)
@@ -542,6 +545,11 @@ def bind_workflow_draft_task(
         payload = _read_draft(conn, canvas_id=canvas_id, draft_id=draft_id)
         if payload is None:
             return None
+        if expected_confirmation_started_at is not None and (
+            payload.get("confirmation_started_at") != expected_confirmation_started_at
+            or payload.get("status") != "confirming"
+        ):
+            raise ValueError("workflow draft confirmation attempt changed")
         existing = str(payload.get("task_id") or "")
         if existing and existing != clean_task_id:
             raise ValueError("workflow draft is bound to a different task")
@@ -559,6 +567,7 @@ def finish_workflow_draft_confirmation(
     draft_id: str,
     outcome: str,
     expected_task_id: str = "",
+    expected_confirmation_started_at: float | None = None,
 ) -> dict[str, Any] | None:
     _validate_scope(canvas_id, draft_id)
     if outcome not in CONFIRMATION_OUTCOMES:
@@ -568,6 +577,10 @@ def finish_workflow_draft_confirmation(
         payload = _read_draft(conn, canvas_id=canvas_id, draft_id=draft_id)
         if payload is None:
             return None
+        if expected_confirmation_started_at is not None and (
+            payload.get("confirmation_started_at") != expected_confirmation_started_at
+        ):
+            raise ValueError("workflow draft confirmation attempt changed")
         bound_task_id = str(payload.get("task_id") or "")
         if expected_task_id and expected_task_id != bound_task_id:
             raise ValueError("workflow draft confirmation task changed")

--- a/src/novelvideo/task_backend/runners/freezone.py
+++ b/src/novelvideo/task_backend/runners/freezone.py
@@ -151,6 +151,7 @@ async def _run_freezone_workflow_confirm_async(
     draft_id = str(payload.get("draft_id") or "").strip()
     revision = int(payload.get("revision") or 0)
     plan_digest = str(payload.get("plan_digest") or "").strip()
+    attempt_started_at = payload.get("confirmation_started_at")
     run_task_id = str(envelope.get("__run_task_id") or "").strip()
     if (
         not canvas_id
@@ -175,6 +176,10 @@ async def _run_freezone_workflow_confirm_async(
                 raise RuntimeError("workflow confirmation draft revision changed")
             if str(draft.get("plan_digest") or "") != plan_digest:
                 raise RuntimeError("workflow confirmation plan changed")
+            if attempt_started_at is not None and (
+                draft.get("confirmation_started_at") != attempt_started_at
+            ):
+                raise RuntimeError("workflow confirmation attempt changed")
             bound_task_id = str(draft.get("task_id") or "")
             if bound_task_id and bound_task_id != run_task_id:
                 raise RuntimeError(
@@ -209,6 +214,7 @@ async def _run_freezone_workflow_confirm_async(
                 draft_id=draft_id,
                 outcome="ready",
                 expected_task_id=run_task_id,
+                expected_confirmation_started_at=attempt_started_at,
             )
         except ValueError:
             # A newer confirmation task owns the draft; the old task may fail,

--- a/tests/test_api_freezone_workflow_runs.py
+++ b/tests/test_api_freezone_workflow_runs.py
@@ -53,6 +53,7 @@ def workflow_run_client(monkeypatch, tmp_path):
     }
     client = TestClient(app)
     client.state_dir = tmp_path
+    client.enqueued_tasks = ctx.enqueued_tasks
     return client
 
 
@@ -1065,3 +1066,52 @@ def test_workflow_run_list_cancels_orphaned_failed_record(
     assert listed["status"] == "cancelled"
     assert listed["resumable"] is False
     assert listed["metadata"]["cancel_reason"] == "workflow_nodes_deleted"
+
+
+def test_workflow_confirmation_can_retry_cancelled_attempt_without_duplicate_enqueue(
+    workflow_run_client,
+):
+    client = workflow_run_client
+    base = "/api/v1/projects/proj_demo/freezone/canvases/default/workflow-drafts"
+    draft = client.post(
+        base,
+        json={
+            "intent": {"skill_id": "video-ad", "user_goal": "广告"},
+            "compiled": {
+                "ok": True,
+                "skill_id": "video-ad",
+                "plan": {"nodes": [], "edges": [], "phases": []},
+            },
+        },
+    ).json()["data"]
+    url = f"{base}/{draft['draft_id']}"
+    first = client.post(url + "/claim", json={"revision": 1}).json()["data"]
+    assert (
+        client.post(
+            url + "/finish", json={"outcome": "ready", "task_id": first["task_id"]}
+        ).status_code
+        == 200
+    )
+    retry = client.post(url + "/claim", json={"revision": 1})
+    assert retry.status_code == 200
+    second = retry.json()["data"]
+    assert second["task_id"] != first["task_id"]
+    assert len(client.enqueued_tasks) == 2
+    assert client.enqueued_tasks[0]["scope"] != client.enqueued_tasks[1]["scope"]
+    duplicate = client.post(url + "/claim", json={"revision": 1}).json()
+    assert duplicate["status"] == "workflow_draft_confirmation_in_progress"
+    assert (
+        client.post(
+            url + "/finish", json={"outcome": "ready", "task_id": first["task_id"]}
+        ).status_code
+        == 400
+    )
+    assert (
+        client.post(
+            url + "/finish", json={"outcome": "confirmed", "task_id": second["task_id"]}
+        ).status_code
+        == 200
+    )
+    duplicate = client.post(url + "/claim", json={"revision": 1}).json()
+    assert duplicate["status"] == "workflow_draft_already_confirmed"
+    assert len(client.enqueued_tasks) == 2

--- a/tests/test_chat_route_prewarm.py
+++ b/tests/test_chat_route_prewarm.py
@@ -323,7 +323,9 @@ def test_canvas_command_tool_result_accepts_background_workflow(
 
 
 @pytest.mark.anyio
-@pytest.mark.parametrize("task_status", ["running", "completed", "reclaimed"])
+@pytest.mark.parametrize(
+    "task_status", ["running", "completed", "reclaimed", "reclaimed_before_read"]
+)
 async def test_late_canvas_result_completes_durable_workflow_draft(
     monkeypatch,
     tmp_path,
@@ -365,7 +367,7 @@ async def test_late_canvas_result_completes_durable_workflow_draft(
         task_id="task-1",
         root_task_id="task-1",
     )
-    if task_status != "reclaimed":
+    if task_status not in {"reclaimed", "reclaimed_before_read"}:
         finish_workflow_draft_confirmation(
             project_dir=tmp_path,
             canvas_id="canvas-a",
@@ -374,6 +376,19 @@ async def test_late_canvas_result_completes_durable_workflow_draft(
         )
 
     async def project_context(_user, _scope):
+        if task_status == "reclaimed_before_read":
+            finish_workflow_draft_confirmation(
+                project_dir=tmp_path, canvas_id="canvas-a", draft_id=draft["draft_id"],
+                outcome="ready", expected_task_id="task-1",
+            )
+            claim_workflow_draft_confirmation(
+                project_dir=tmp_path, canvas_id="canvas-a", draft_id=draft["draft_id"],
+                revision=1, now=claimed["confirmation_started_at"] + 1,
+            )
+            bind_workflow_draft_task(
+                project_dir=tmp_path, canvas_id="canvas-a", draft_id=draft["draft_id"],
+                task_id="task-2", root_task_id="task-2",
+            )
         return SimpleNamespace(state_dir=tmp_path)
 
     monkeypatch.setattr(chat_route, "_project_context_for_scope", project_context)
@@ -383,6 +398,8 @@ async def test_late_canvas_result_completes_durable_workflow_draft(
 
     def get_task(*_args, **kwargs):
         queried_scopes.append(kwargs["scope"])
+        if task_status == "reclaimed_before_read":
+            return SimpleNamespace(task_id="task-2", status="running")
         if kwargs["scope"] != expected_scope:
             return None
         if task_status == "reclaimed":
@@ -422,7 +439,11 @@ async def test_late_canvas_result_completes_durable_workflow_draft(
         user={"id": "u-admin", "username": "admin"},
         payload=payload,
         draft_id=draft["draft_id"],
-        resolved={"ok": True},
+        resolved={"ok": task_status != "reclaimed_before_read"},
+        confirmation={
+            "draft_id": draft["draft_id"], "task_id": "task-1", "revision": 1,
+            "confirmation_started_at": claimed["confirmation_started_at"],
+        },
     )
     stored, error = read_workflow_draft(
         project_dir=tmp_path,
@@ -432,21 +453,31 @@ async def test_late_canvas_result_completes_durable_workflow_draft(
 
     assert error is None
     assert stored is not None
-    assert queried_scopes == [expected_scope]
     assert stored["status"] == {
         "running": "confirmed", "completed": "submitted", "reclaimed": "confirming",
+        "reclaimed_before_read": "confirming",
     }[task_status]
-    if task_status == "reclaimed":
+    assert queried_scopes == (
+        [] if task_status == "reclaimed_before_read" else [expected_scope]
+    )
+    if task_status in {"reclaimed", "reclaimed_before_read"}:
         assert stored["task_id"] == "task-2"
         assert stored["confirmation_started_at"] == claimed["confirmation_started_at"] + 1
 
 
-def test_pending_canvas_result_recovers_workflow_draft_identity(
+@pytest.mark.anyio
+@pytest.mark.parametrize("transport", ["http", "websocket"])
+async def test_pending_canvas_result_recovers_workflow_draft_identity(
     monkeypatch,
     tmp_path,
+    transport,
 ) -> None:
     bridge_dir = tmp_path / "bridge"
     draft_id = "workflow_draft_late_result"
+    confirmation = {
+        "draft_id": draft_id, "task_id": "task-1", "revision": 1,
+        "confirmation_started_at": 123.0,
+    }
     put_pending_canvas_command(
         key="bridge-workflow",
         project_id="project-a",
@@ -468,6 +499,7 @@ def test_pending_canvas_result_recovers_workflow_draft_identity(
             ]
         },
         bridge_dir=bridge_dir,
+        workflow_confirmation=confirmation,
     )
     monkeypatch.setattr(
         chat_route,
@@ -483,6 +515,53 @@ def test_pending_canvas_result_recovers_workflow_draft_identity(
     )
 
     assert chat_route._pending_workflow_draft_id("admin", payload) == draft_id
+    assert chat_route._pending_workflow_confirmation("admin", payload) == confirmation
+    payload.canvas_id = "other-canvas"
+    assert chat_route._pending_workflow_confirmation("admin", payload) is None
+    payload.canvas_id = "canvas-a"
+    recorded = []
+
+    async def record(**kwargs):
+        recorded.append(kwargs)
+
+    def resolve(*args, **kwargs):
+        # The real resolver removes pending state. Ownership must be captured first.
+        (bridge_dir / "bridge-workflow.pending.json").unlink()
+        return {"ok": True}
+
+    monkeypatch.setattr(chat_route, "_record_workflow_draft_canvas_result", record)
+    monkeypatch.setattr(chat_route, "_resolve_canvas_command_tool_result_payload", resolve)
+    if transport == "http":
+        await chat_route.resolve_canvas_command_tool_result(payload, {"username": "admin"})
+    else:
+        class Socket:
+            async def receive_json(self):
+                if recorded:
+                    raise WebSocketDisconnect()
+                return {"type": "canvas.command.result", **payload.model_dump()}
+
+        await chat_route._receive_bridge_results_during_turn(
+            websocket=Socket(), user={"username": "admin"}, username="admin",
+        )
+    assert recorded[0]["confirmation"] == confirmation
+    assert recorded[0]["draft_id"] == draft_id
+
+
+@pytest.mark.anyio
+async def test_unbound_workflow_receipt_does_not_read_current_attempt(monkeypatch):
+    async def unexpected_read(*args):
+        pytest.fail("a legacy receipt must not borrow the current draft identity")
+
+    monkeypatch.setattr(chat_route, "_project_context_for_scope", unexpected_read)
+    await chat_route._record_workflow_draft_canvas_result(
+        user={"username": "admin"},
+        payload=chat_route.CanvasCommandToolResultIn(
+            bridge_key="legacy", project_id="project-a", canvas_id="canvas-a",
+            canvas_apply_status="cancelled_by_user",
+        ),
+        draft_id="workflow_draft_legacy",
+        resolved={"ok": False},
+    )
 
 
 def test_canvas_command_tool_result_reports_open_node_action_as_opened_panel(

--- a/tests/test_chat_route_prewarm.py
+++ b/tests/test_chat_route_prewarm.py
@@ -323,9 +323,11 @@ def test_canvas_command_tool_result_accepts_background_workflow(
 
 
 @pytest.mark.anyio
+@pytest.mark.parametrize("task_status", ["running", "completed", "reclaimed"])
 async def test_late_canvas_result_completes_durable_workflow_draft(
     monkeypatch,
     tmp_path,
+    task_status,
 ) -> None:
     from novelvideo.freezone.workflow_drafts import (
         bind_workflow_draft_task,
@@ -346,11 +348,15 @@ async def test_late_canvas_result_completes_durable_workflow_draft(
             "plan": {"nodes": [], "edges": [], "phases": []},
         },
     )
-    claim_workflow_draft_confirmation(
+    claimed, claim_error = claim_workflow_draft_confirmation(
         project_dir=tmp_path,
         canvas_id="canvas-a",
         draft_id=draft["draft_id"],
         revision=1,
+    )
+    assert claim_error is None
+    expected_scope = (
+        f"canvas-a:{draft['draft_id']}:1:{claimed['confirmation_started_at']}"
     )
     bind_workflow_draft_task(
         project_dir=tmp_path,
@@ -359,12 +365,13 @@ async def test_late_canvas_result_completes_durable_workflow_draft(
         task_id="task-1",
         root_task_id="task-1",
     )
-    finish_workflow_draft_confirmation(
-        project_dir=tmp_path,
-        canvas_id="canvas-a",
-        draft_id=draft["draft_id"],
-        outcome="submitted",
-    )
+    if task_status != "reclaimed":
+        finish_workflow_draft_confirmation(
+            project_dir=tmp_path,
+            canvas_id="canvas-a",
+            draft_id=draft["draft_id"],
+            outcome="submitted",
+        )
 
     async def project_context(_user, _scope):
         return SimpleNamespace(state_dir=tmp_path)
@@ -372,13 +379,34 @@ async def test_late_canvas_result_completes_durable_workflow_draft(
     monkeypatch.setattr(chat_route, "_project_context_for_scope", project_context)
     from novelvideo import task_state
 
+    queried_scopes = []
+
+    def get_task(*_args, **kwargs):
+        queried_scopes.append(kwargs["scope"])
+        if kwargs["scope"] != expected_scope:
+            return None
+        if task_status == "reclaimed":
+            # A retry wins between reading the draft and recording the receipt.
+            finish_workflow_draft_confirmation(
+                project_dir=tmp_path, canvas_id="canvas-a", draft_id=draft["draft_id"],
+                outcome="ready", expected_task_id="task-1",
+            )
+            claim_workflow_draft_confirmation(
+                project_dir=tmp_path, canvas_id="canvas-a", draft_id=draft["draft_id"],
+                revision=1, now=claimed["confirmation_started_at"] + 1,
+            )
+            bind_workflow_draft_task(
+                project_dir=tmp_path, canvas_id="canvas-a", draft_id=draft["draft_id"],
+                task_id="task-2", root_task_id="task-2",
+            )
+            return SimpleNamespace(task_id="task-1", status="running")
+        return SimpleNamespace(task_id="task-1", status=task_status)
+
     monkeypatch.setattr(
         task_state,
         "get_task_manager",
         lambda: SimpleNamespace(
-            get_task_for_project=lambda *_args, **_kwargs: SimpleNamespace(
-                task_id="task-1", status="running"
-            )
+            get_task_for_project=get_task,
         ),
     )
     payload = chat_route.CanvasCommandToolResultIn(
@@ -404,7 +432,13 @@ async def test_late_canvas_result_completes_durable_workflow_draft(
 
     assert error is None
     assert stored is not None
-    assert stored["status"] == "confirmed"
+    assert queried_scopes == [expected_scope]
+    assert stored["status"] == {
+        "running": "confirmed", "completed": "submitted", "reclaimed": "confirming",
+    }[task_status]
+    if task_status == "reclaimed":
+        assert stored["task_id"] == "task-2"
+        assert stored["confirmation_started_at"] == claimed["confirmation_started_at"] + 1
 
 
 def test_pending_canvas_result_recovers_workflow_draft_identity(

--- a/tests/test_chat_route_prewarm.py
+++ b/tests/test_chat_route_prewarm.py
@@ -1626,3 +1626,41 @@ async def test_freezone_prewarm_skips_unavailable_surface(monkeypatch) -> None:
 
     assert warmed is False
     assert calls == []
+
+
+@pytest.mark.parametrize("partial", [False, True])
+def test_catalog_save_error_overrides_frontend_success(monkeypatch, tmp_path, partial):
+    monkeypatch.setattr(chat_route, "_canvas_bridge_dir", lambda *a, **k: tmp_path)
+
+    def save(*, username, kind, payload):
+        if partial and kind == "recipes":
+            return payload
+        raise ValueError("injected save failure")
+
+    monkeypatch.setattr(chat_route, "save_user_agent_config_item", save)
+    payload = chat_route.SkillStudioToolResultIn(
+        bridge_key="failed-save",
+        turn_id="turn-a",
+        action="confirm_add",
+        skill_studio_status="catalog_saved",
+        saved_to_catalog=True,
+        saved_skill_ids=["invented"],
+        saved_recipe_ids=["invented"],
+        draft={"skill": {"id": "skill-a"}, "recipes": [{"id": "recipe-a"}]},
+        message="已保存为正式 Skill / Recipe，可立即使用",
+    )
+    result = chat_route._resolve_skill_studio_tool_result_payload(
+        payload, username="alice"
+    )
+    assert result["ok"] is False
+    assert result["saved_to_catalog"] is False
+    assert result["tool_call_status"] == "failed"
+    assert result["skill_studio_status"] == (
+        "catalog_partially_saved" if partial else "catalog_save_failed"
+    )
+    assert result["saved_skill_ids"] == []
+    assert result["saved_recipe_ids"] == (["recipe-a"] if partial else [])
+    assert "可立即使用" not in result["message"]
+    assert "部分" in result["message"] if partial else "未保存任何" in result["message"]
+    assert result["draft"] == payload.draft
+    assert result["errors"]

--- a/tests/test_chat_service_user_agent_scope.py
+++ b/tests/test_chat_service_user_agent_scope.py
@@ -3298,9 +3298,11 @@ def test_freezone_prompt_includes_skill_studio_contract_only_for_catalog_intent(
     assert "Do not claim the Skill or Recipe is saved" in prompt
     assert "Do not ask whether to\n  save the current draft" in prompt
     assert "save_now/save_current/confirm_save" in prompt
-    assert "prompt/instruction generator" in prompt
-    assert "不要直接生成最终内容" in prompt
-    assert "送入对应节点" in prompt
+    assert (
+        "For text Recipes, the current LLM must produce the final deliverable directly"
+        in prompt
+    )
+    assert "For image/video/audio Recipes" in prompt
     assert (
         "planning.planning_notes must start with an executable path summary" in prompt
     )
@@ -3308,11 +3310,8 @@ def test_freezone_prompt_includes_skill_studio_contract_only_for_catalog_intent(
     assert "Do not include workflow_templates" in prompt
     assert "complete dynamic freezone_workflow_plan.v1" in prompt
     assert "dynamic dependency rules" in prompt
-    assert (
-        "Recipe system_prompt must never be the final downstream prompt itself"
-        in prompt
-    )
-    assert "重要：你的输出是一条提示词/指令" in prompt
+    assert "For text Recipes, do not write the final" not in prompt
+    assert "不要自己生成最终内容" not in prompt
     assert "终端生成型" not in prompt
     assert "不要把所有 Recipe 都写成 prompt compiler" not in prompt
     assert "must not emit Freezone canvas commands" in prompt

--- a/tests/test_freezone_agent_config_store.py
+++ b/tests/test_freezone_agent_config_store.py
@@ -491,3 +491,53 @@ def test_user_agent_config_delete_missing_item_is_idempotent(
     )
 
     assert deleted is False
+
+
+def test_text_skill_studio_draft_saves_final_text_recipe_and_reference(
+    tmp_path, monkeypatch
+):
+    from novelvideo.api.routes import chat as chat_route
+
+    monkeypatch.setattr(agent_config_store, "OUTPUT_DIR", str(tmp_path))
+    monkeypatch.setattr(
+        agent_config_store, "BUILTIN_AGENT_CATALOG_DIR", tmp_path / "builtins"
+    )
+    monkeypatch.setattr(
+        chat_route, "_canvas_bridge_dir", lambda *a, **k: tmp_path / "bridge"
+    )
+    monkeypatch.setattr(
+        chat_route, "sync_freezone_hermes_workflow_skills", lambda *_: None
+    )
+    recipe = _recipe_payload("chinese-condense")
+    recipe["system_prompt"] = (
+        "【角色设定】中文编辑。【输入来源】用户原文。【任务目标】直接输出一句话摘要。"
+        "【输出结构要求】仅输出最终摘要。【质量标准】保留人物、时间、地点和事件。"
+        "【禁止事项/约束】不新增事实。"
+    )
+    skill = _skill_payload("chinese-condense-skill")
+    skill["allowed_recipe_ids"] = [recipe["id"]]
+    result = chat_route._resolve_skill_studio_tool_result_payload(
+        chat_route.SkillStudioToolResultIn(
+            bridge_key="condense-save",
+            turn_id="condense-turn",
+            action="confirm_add",
+            skill_studio_status="catalog_saved",
+            saved_to_catalog=True,
+            draft={"skill": skill, "recipes": [recipe]},
+        ),
+        username="alice",
+    )
+    assert result["ok"] is True
+    assert result["saved_skill_ids"] == [skill["id"]]
+    assert result["saved_recipe_ids"] == [recipe["id"]]
+    recipes = agent_config_store.list_user_agent_config_items("alice", "recipes")
+    skills = agent_config_store.list_user_agent_config_items("alice", "skills")
+    assert any(r["id"] == recipe["id"] for r in recipes)
+    assert next(s for s in skills if s["id"] == skill["id"])["allowed_recipe_ids"] == [
+        recipe["id"]
+    ]
+    recipe["system_prompt"] = "将被送入下游 textGeneration"
+    with pytest.raises(ValueError, match="final deliverable"):
+        agent_config_store.save_user_agent_config_item(
+            username="alice", kind="recipes", payload=recipe
+        )

--- a/tests/test_freezone_plugin.py
+++ b/tests/test_freezone_plugin.py
@@ -4863,6 +4863,43 @@ def test_canvas_command_schema_accepts_minimal_variants_and_rejects_union_shell(
         validator.validate({"commands": [union_shell]})
 
 
+@pytest.mark.parametrize("external_mcp", [False, True])
+def test_workflow_bridge_binds_original_confirmation_attempt(monkeypatch, external_mcp):
+    plugin = _load_plugin_module()
+    pending = []
+    monkeypatch.setenv("DRAMACLAW_EXTERNAL_MCP", "1" if external_mcp else "0")
+    monkeypatch.setattr(plugin, "put_pending_canvas_command", lambda **kw: pending.append(kw))
+    monkeypatch.setattr(
+        plugin, "wait_canvas_command_result",
+        lambda *args, **kwargs: {"ok": True, "applied": True},
+    )
+    dispatch = (
+        plugin._dispatch_mcp_approved_frontend_commands if external_mcp
+        else plugin._dispatch_frontend_canvas_commands
+    )
+    confirmation = {
+        "draft_id": "workflow_draft_a", "task_id": "task-1", "revision": 1,
+        "confirmation_started_at": 123.0,
+    }
+    for identity in [confirmation, confirmation, {
+        **confirmation, "task_id": "task-2", "confirmation_started_at": 124.0,
+    }]:
+        dispatch(
+            project="project-a", canvas="canvas-a", slim_result=True,
+            commands=[{
+                "type": "create_node", "node_type": "textAnnotationNode",
+                "data": {"workflowInstanceId": "workflow_draft_a"},
+            }],
+            workflow_confirmation=identity,
+        )
+    assert pending[0]["workflow_confirmation"] == confirmation
+    assert pending[2]["workflow_confirmation"]["task_id"] == "task-2"
+    assert "workflow_confirmation" not in pending[0]["envelope"]
+    if external_mcp:
+        assert pending[0]["key"] == pending[1]["key"]
+        assert pending[0]["key"] != pending[2]["key"]
+
+
 def test_freezone_mcp_default_create_node_uses_frontend_bridge(monkeypatch):
     plugin = _load_plugin_module()
     pending_commands = []

--- a/tests/test_freezone_plugin.py
+++ b/tests/test_freezone_plugin.py
@@ -4251,10 +4251,10 @@ def test_freezone_plugin_skill_studio_tool_schemas_expose_nested_contracts():
         "description"
     ]
     assert (
-        "must never be the final downstream prompt itself"
+        "text Recipe 要求当前 LLM 直接输出最终交付文本"
         in recipe_system_prompt_description
     )
-    assert "重要：你的输出是一条提示词/指令" in recipe_system_prompt_description
+    assert "二阶段指令" in recipe_system_prompt_description
     assert recipe_item["properties"]["output_kind"]["enum"] == [
         "text",
         "image",
@@ -4276,7 +4276,7 @@ def test_freezone_plugin_skill_studio_tool_schemas_expose_nested_contracts():
     ]
     assert "节点" in system_prompt_description
     assert "提示词/指令" in system_prompt_description
-    assert "不要直接生成最终内容" in system_prompt_description
+    assert "text Recipe 不直接写正文成品" not in system_prompt_description
     assert "送入对应节点" in system_prompt_description
     assert "终端生成型" not in system_prompt_description
     assert "不要把所有 Recipe 都写成 prompt compiler" not in system_prompt_description

--- a/tests/test_freezone_workflow_confirmation_task.py
+++ b/tests/test_freezone_workflow_confirmation_task.py
@@ -136,3 +136,51 @@ async def test_workflow_confirmation_task_recovers_confirmed_result_after_restar
     assert stored is not None
     assert stored["status"] == "confirmed"
     assert result["draft_id"] == draft["draft_id"]
+
+
+@pytest.mark.asyncio
+async def test_old_confirmation_runner_cannot_reset_new_unbound_attempt(tmp_path):
+    draft, envelope = _claimed_task(tmp_path)
+    envelope["payload"]["confirmation_started_at"] = 1000
+    finish_workflow_draft_confirmation(
+        project_dir=tmp_path,
+        canvas_id="default",
+        draft_id=draft["draft_id"],
+        outcome="ready",
+        expected_task_id="task-1",
+    )
+    retry, error = claim_workflow_draft_confirmation(
+        project_dir=tmp_path,
+        canvas_id="default",
+        draft_id=draft["draft_id"],
+        revision=1,
+        now=1001,
+    )
+    assert error is None
+    assert retry["task_id"] == ""
+    with pytest.raises(RuntimeError, match="attempt changed"):
+        await freezone_runner._run_freezone_workflow_confirm_async(
+            envelope, SimpleNamespace(state_dir=tmp_path)
+        )
+    stored, _ = read_workflow_draft(
+        project_dir=tmp_path, canvas_id="default", draft_id=draft["draft_id"]
+    )
+    assert stored["status"] == "confirming"
+    with pytest.raises(ValueError, match="attempt changed"):
+        bind_workflow_draft_task(
+            project_dir=tmp_path,
+            canvas_id="default",
+            draft_id=draft["draft_id"],
+            task_id="late-old-task",
+            root_task_id="late-old-task",
+            expected_confirmation_started_at=1000,
+        )
+    bound = bind_workflow_draft_task(
+        project_dir=tmp_path,
+        canvas_id="default",
+        draft_id=draft["draft_id"],
+        task_id="task-2",
+        root_task_id="task-2",
+        expected_confirmation_started_at=1001,
+    )
+    assert bound["task_id"] == "task-2"


### PR DESCRIPTION
文字 Skill 草稿可能遵循生成指令产出二阶段 Recipe，随后被最终文本合同拒绝；保存失败回执仍可能声称成功。工作流确认取消后，同一草稿重试还会沿用旧任务绑定。本 PR 修复三个独立问题。

- #505：生成系统提示及工具字段说明按 output_kind 区分职责：text Recipe 直接产出最终文本；媒体 Recipe 产出下游生成提示词。保留文字 Recipe 二阶段合同校验，并用固定草稿通过真实目录保存验证 Skill 引用可用。
- #506：保存结果仅采用后端实际保存 ID，明确 catalog_saved / catalog_save_failed / catalog_partially_saved。失败时覆盖客户端成功文案和状态，保留草稿供修正；前端对部分保存显示后端提示。
- #507：重新领取非活动草稿时原子清除旧任务绑定；使用持久化 confirmation_started_at 区分确认轮次及入队 scope。绑定与 runner 清理检查所属轮次，防止旧任务影响新尝试。活动/已提交/已确认草稿仍拒绝重复确认，过期入队绑定返回 409。

验证（基于 staging 7590fdfc）：
- 7 个后端相关测试文件：411 passed。
- 3 个前端相关测试文件：50 passed。
- TypeScript tsc -b、修改 Python 文件 Ruff 和 diff whitespace 检查通过。
- 未调用付费模型，未做真实浏览器端到端复现；生成内容采用固定样例验证。未修改计费规则或 CI 配置。

Closes #505
Closes #506
Closes #507
