### PR TITLE
fix: 本地启动默认使用 CE，无需配置版本

### DIFF
--- a/src/novelvideo/model_gateway_settings.py
+++ b/src/novelvideo/model_gateway_settings.py
@@ -13,6 +13,7 @@ import os
 import sqlite3
 import tempfile
 import threading
+import time
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
@@ -135,18 +136,39 @@ def _settings_db_path() -> Path:
 def _connect() -> sqlite3.Connection:
     path = _settings_db_path()
     path.parent.mkdir(parents=True, exist_ok=True)
-    conn = sqlite3.connect(str(path), timeout=10, check_same_thread=False)
-    conn.row_factory = sqlite3.Row
-    configure_sqlite_connection(conn)
-    conn.execute("""
-        CREATE TABLE IF NOT EXISTS runtime_settings (
-            key TEXT PRIMARY KEY,
-            value TEXT NOT NULL,
-            updated_at TEXT NOT NULL
-        )
-        """)
-    conn.commit()
-    return conn
+    for attempt in range(3):
+        conn: sqlite3.Connection | None = None
+        try:
+            conn = sqlite3.connect(str(path), timeout=10, check_same_thread=False)
+            conn.row_factory = sqlite3.Row
+            configure_sqlite_connection(conn)
+            conn.execute("""
+                CREATE TABLE IF NOT EXISTS runtime_settings (
+                    key TEXT PRIMARY KEY,
+                    value TEXT NOT NULL,
+                    updated_at TEXT NOT NULL
+                )
+                """)
+            conn.commit()
+            return conn
+        except sqlite3.OperationalError as exc:
+            if conn is not None:
+                conn.close()
+            retryable = any(
+                marker in str(exc).lower()
+                for marker in (
+                    "database is locked",
+                    "database is busy",
+                )
+            )
+            if not retryable or attempt == 2:
+                raise
+            time.sleep(0.05 * (attempt + 1))
+        except Exception:
+            if conn is not None:
+                conn.close()
+            raise
+    raise RuntimeError("failed to open model gateway settings database")
 
 
 def _read_all() -> dict[str, str]:

--- a/src/novelvideo/ports/registry.py
+++ b/src/novelvideo/ports/registry.py
@@ -6,6 +6,8 @@ import os
 from importlib.metadata import entry_points
 from typing import Any
 
+from novelvideo.shared import runtime_env
+
 
 class PortNotRegistered(RuntimeError):
     def __init__(self, name: str) -> None:
@@ -57,8 +59,10 @@ def ensure_bootstrap() -> None:
     global _BOOTSTRAPPED
     if _BOOTSTRAPPED:
         return
+    edition = runtime_env.edition()
     dsn = os.environ.get("ST_CONTROL_PLANE_DSN", "").strip()
-    edition = os.environ.get("ST_EDITION", "").strip().lower()
+    if edition not in {"ce", "ee"}:
+        raise RuntimeError("ST_EDITION 无效：仅支持 ce 或 ee")
     if dsn and edition == "ce":
         raise RuntimeError(
             "ST_CONTROL_PLANE_DSN 与 ST_EDITION=ce 同时设置(矛盾配置):"
@@ -82,4 +86,4 @@ def ensure_bootstrap() -> None:
         register_local_ports()
         _BOOTSTRAPPED = True
         return
-    raise RuntimeError("缺 ST_CONTROL_PLANE_DSN 且未显式 ST_EDITION=ce，拒绝启动")
+    raise RuntimeError("ST_EDITION=ee 但缺 ST_CONTROL_PLANE_DSN，拒绝启动")

--- a/src/novelvideo/shared/runtime_env.py
+++ b/src/novelvideo/shared/runtime_env.py
@@ -17,8 +17,16 @@ def task_backend() -> str:
 
 
 def edition() -> str:
+    """Resolve CE by default; a control-plane DSN selects EE when unspecified.
+
+    Preserve explicit values so bootstrap can reject conflicting or invalid
+    configuration instead of silently falling back to a different edition.
+    """
     _load_env()
-    return os.environ.get("ST_EDITION", "").strip().lower()
+    configured = os.environ.get("ST_EDITION", "").strip().lower()
+    if configured:
+        return configured
+    return "ee" if os.environ.get("ST_CONTROL_PLANE_DSN", "").strip() else "ce"
 
 
 def is_ce() -> bool:

--- a/tests/ports/test_registry.py
+++ b/tests/ports/test_registry.py
@@ -58,10 +58,17 @@ def test_egress_operation_accessor_uses_the_stable_registry_name() -> None:
     assert get_egress_operation_port() is implementation
 
 
-def test_ensure_bootstrap_registers_local_ports_for_explicit_ce(monkeypatch) -> None:
+@pytest.mark.parametrize("edition", [None, "", "  ", "ce"])
+def test_ensure_bootstrap_registers_local_ports_for_ce(monkeypatch, edition) -> None:
+    from novelvideo.shared import runtime_env
+
+    monkeypatch.setattr(runtime_env, "load_project_dotenv", lambda **kwargs: None)
     registry = _registry()
     monkeypatch.delenv("ST_CONTROL_PLANE_DSN", raising=False)
-    monkeypatch.setenv("ST_EDITION", "ce")
+    if edition is None:
+        monkeypatch.delenv("ST_EDITION", raising=False)
+    else:
+        monkeypatch.setenv("ST_EDITION", edition)
     monkeypatch.setenv("ST_TASK_ENVELOPE_ACTIVE_KEY_ID", "registry-test-v1")
     monkeypatch.setenv(
         "ST_TASK_ENVELOPE_KEYRING_B64_JSON",
@@ -280,14 +287,24 @@ def test_ensure_bootstrap_requires_credit_quote_for_ee(monkeypatch) -> None:
     assert "credit_quote" in str(exc.value)
 
 
-def test_ensure_bootstrap_requires_explicit_ce_without_control_plane(
+def test_ensure_bootstrap_requires_control_plane_for_explicit_ee(
     monkeypatch,
 ) -> None:
     registry = _registry()
     monkeypatch.delenv("ST_CONTROL_PLANE_DSN", raising=False)
-    monkeypatch.delenv("ST_EDITION", raising=False)
+    monkeypatch.setenv("ST_EDITION", "ee")
 
-    with pytest.raises(RuntimeError, match="ST_EDITION=ce"):
+    with pytest.raises(RuntimeError, match="ST_CONTROL_PLANE_DSN"):
+        registry.ensure_bootstrap()
+
+
+@pytest.mark.parametrize("dsn", ["", "postgresql://example"])
+def test_ensure_bootstrap_rejects_unknown_edition(monkeypatch, dsn) -> None:
+    registry = _registry()
+    monkeypatch.setenv("ST_CONTROL_PLANE_DSN", dsn)
+    monkeypatch.setenv("ST_EDITION", "cee")
+
+    with pytest.raises(RuntimeError, match="ST_EDITION"):
         registry.ensure_bootstrap()
 
 

--- a/tests/ports/test_tasks.py
+++ b/tests/ports/test_tasks.py
@@ -725,7 +725,9 @@ def test_local_bootstrap_bad_signing_config_registers_zero_ports(monkeypatch):
     from novelvideo.task_backend.signing import TaskEnvelopeSigningConfigError
 
     monkeypatch.setattr(registry, "_PORTS", {})
-    monkeypatch.delenv("ST_TASK_ENVELOPE_ACTIVE_KEY_ID", raising=False)
+    # Missing config is valid in default CE (a local key is generated).
+    # A partially supplied keyring must still fail before any port is registered.
+    monkeypatch.setenv("ST_TASK_ENVELOPE_ACTIVE_KEY_ID", "incomplete-keyring")
     monkeypatch.delenv("ST_TASK_ENVELOPE_KEYRING_B64_JSON", raising=False)
 
     with pytest.raises(TaskEnvelopeSigningConfigError):

--- a/tests/test_api_config_runtime.py
+++ b/tests/test_api_config_runtime.py
@@ -2,14 +2,19 @@ from __future__ import annotations
 
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
+import pytest
 
 
-def test_runtime_config_includes_stable_instance_id(monkeypatch) -> None:
+@pytest.mark.parametrize("edition", [None, "", "ce"])
+def test_runtime_config_includes_stable_instance_id(monkeypatch, edition) -> None:
     from novelvideo.api.routes import config
     from novelvideo.shared import runtime_env
 
     monkeypatch.setattr(runtime_env, "load_project_dotenv", lambda override=False: None)
-    monkeypatch.setenv("ST_EDITION", "ce")
+    if edition is None:
+        monkeypatch.delenv("ST_EDITION", raising=False)
+    else:
+        monkeypatch.setenv("ST_EDITION", edition)
     monkeypatch.delenv("ST_CONTROL_PLANE_DSN", raising=False)
 
     app = FastAPI()

--- a/tests/test_freezone_ai_staging_prop_egress.py
+++ b/tests/test_freezone_ai_staging_prop_egress.py
@@ -274,6 +274,8 @@ def test_c1_05b_platform_passes_the_real_gate(client, monkeypatch) -> None:
     from novelvideo.director_world import staging_prop_ai
 
     _use_authz(monkeypatch, _StubAuthz(kind="platform"))
+    # This is the deployment-owned platform credential path, not CE SQLite.
+    monkeypatch.setenv("ST_EDITION", "ee")
     monkeypatch.setenv("MODEL_API_KEY", "platform-key")
     monkeypatch.setenv("NEWAPI_API_KEY", "platform-key")
 

--- a/tests/test_freezone_image_backend.py
+++ b/tests/test_freezone_image_backend.py
@@ -534,7 +534,7 @@ async def test_freezone_video_omni_gen_rejects_happyhorse_model(
         )
 
     assert exc.value.status_code == 400
-    assert "HappyHorse video does not support omni reference mode" in str(exc.value.detail)
+    assert "does not support omni reference mode" in str(exc.value.detail)
 
 
 def _audio_reference(project_dir: Path, name: str) -> dict[str, str]:
@@ -8105,6 +8105,13 @@ async def test_freezone_image_models_returns_selection_keys(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     _patch_freezone_project(monkeypatch, tmp_path, project="58")
+
+    # Selection keys are the fallback when no scoped model catalog is available.
+    # Default CE has an official catalog and must not be mistaken for this path.
+    async def no_catalog(_media_type: str, *, requester_user_id: str):
+        return None
+
+    monkeypatch.setattr(freezone_routes, "_scoped_media_model_catalog", no_catalog)
 
     result = await freezone_routes.freezone_image_models(
         project="58",

--- a/tests/test_model_gateway_settings.py
+++ b/tests/test_model_gateway_settings.py
@@ -7,6 +7,8 @@ import os
 from pathlib import Path
 
 import pytest
+
+
 import respx
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
@@ -64,6 +66,36 @@ from novelvideo.newapi_provisioner import (
     update_provider_channel_credentials,
     upsert_channel,
 )
+
+
+@pytest.mark.parametrize("failures", [1, 3])
+def test_settings_initialization_retries_lock_and_closes_connections(
+    monkeypatch, tmp_path, failures
+):
+    import sqlite3
+    from novelvideo import model_gateway_settings as settings
+
+    monkeypatch.setattr(settings, "_settings_db_path", lambda: tmp_path / "settings.db")
+    configure = settings.configure_sqlite_connection
+    connections = []
+
+    def contend_on_journal_mode(conn):
+        connections.append(conn)
+        if len(connections) <= failures:
+            raise sqlite3.OperationalError("database is locked")
+        configure(conn)
+
+    monkeypatch.setattr(settings, "configure_sqlite_connection", contend_on_journal_mode)
+    if failures == 1:
+        assert settings._read_all() == {}
+        assert len(connections) == 2
+    else:
+        with pytest.raises(sqlite3.OperationalError, match="database is locked"):
+            settings._read_all()
+        assert len(connections) == 3
+    for conn in connections:
+        with pytest.raises(sqlite3.ProgrammingError, match="closed"):
+            conn.execute("SELECT 1")
 
 
 def _newer_bundled_catalog_version(offset: int = 1) -> str:

--- a/tests/test_openapi_edition_contract.py
+++ b/tests/test_openapi_edition_contract.py
@@ -15,12 +15,14 @@ def _run_json(code: str, *, env_updates: dict[str, str]) -> dict:
     env["NOVELVIDEO_STATE_DIR"] = tempfile.mkdtemp(prefix="ce-openapi-state-")
     proc = subprocess.run(
         [sys.executable, "-c", code],
-        check=True,
+        check=False,
         capture_output=True,
         text=True,
         cwd=REPO_ROOT,
         env=env,
+        timeout=60,
     )
+    assert proc.returncode == 0, proc.stderr
     return json.loads(proc.stdout)
 
 
@@ -95,3 +97,52 @@ print(json.dumps({"status_code": response.status_code, "body": response.json()})
     assert result["body"]["data"]["edition"] == "ce"
     assert result["body"]["data"]["auth_required"] is False
     assert result["body"]["data"]["instance_id"]
+
+
+def test_default_ce_starts_and_serves_config_without_edition_settings(tmp_path) -> None:
+    result = _run_json(
+        """
+import json
+import os
+from unittest.mock import AsyncMock, patch
+from fastapi.testclient import TestClient
+import novelvideo.env
+import dotenv
+
+# A fresh install must not inherit the developer's .env or shell edition.
+novelvideo.env.load_project_dotenv = lambda **kwargs: None
+dotenv.load_dotenv = lambda *args, **kwargs: False
+for key in ("ST_EDITION", "ST_CONTROL_PLANE_DSN"):
+    os.environ.pop(key, None)
+
+from novelvideo.api.app import create_app
+from novelvideo.ports.registry import get_port
+with patch("novelvideo.official_media_catalog_remote.run_official_media_catalog_updater", new=AsyncMock()):
+    app = create_app()
+    # Exercise the real lifespan, including bootstrap and the local lifecycle.
+    with TestClient(app) as client:
+        response = client.get("/api/v1/config")
+        paths = app.openapi()["paths"]
+        result = {
+            "status_code": response.status_code,
+            "data": response.json()["data"],
+            "lifecycle": type(get_port("lifecycle")).__name__,
+            "has_ee_users_route": "/api/v1/users/search" in paths,
+        }
+print(json.dumps(result), end="")
+""",
+        env_updates={
+            "NOVELVIDEO_DATA_ROOT": str(tmp_path),
+            "NOVELVIDEO_OUTPUT_DIR": str(tmp_path / "output"),
+            "NOVELVIDEO_RUNTIME_DIR": str(tmp_path / "runtime"),
+            "ST_EDITION": "",
+            "ST_CONTROL_PLANE_DSN": "",
+            "ST_TASK_ENVELOPE_ACTIVE_KEY_ID": "",
+            "ST_TASK_ENVELOPE_KEYRING_B64_JSON": "",
+        },
+    )
+    assert result["status_code"] == 200
+    assert result["data"]["edition"] == "ce"
+    assert result["data"]["auth_required"] is False
+    assert result["lifecycle"] == "NoOpLifecycle"
+    assert result["has_ee_users_route"] is False

--- a/tests/test_p0g4t_service_operation_exclusion.py
+++ b/tests/test_p0g4t_service_operation_exclusion.py
@@ -24,7 +24,9 @@ from novelvideo.service_operation_gate import (
         ("ce", "", True),
         ("ee", "postgresql://organization-dsn-canary", False),
         ("ce", "postgresql://contradictory-dsn-canary", False),
-        ("", "", False),
+        ("", "", True),
+        ("ee", "", False),
+        ("", "postgresql://organization-dsn-canary", False),
     ],
 )
 def test_service_operation_gate_allows_only_effective_ce_local(

--- a/tests/test_runtime_env.py
+++ b/tests/test_runtime_env.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import os
 
+import pytest
+
 
 def test_preserve_st_env_restores_changed_and_added_st_keys(monkeypatch) -> None:
     from novelvideo.shared.env_guard import preserve_st_env
@@ -38,7 +40,7 @@ def test_cookie_secure_defaults_true_and_parses_boolean_values(monkeypatch) -> N
         assert cookie_secure() is False
 
 
-def test_is_ce_effective_requires_ce_without_control_plane_dsn(monkeypatch) -> None:
+def test_is_ce_effective_defaults_to_ce_without_control_plane_dsn(monkeypatch) -> None:
     import novelvideo.shared.runtime_env as runtime_env
 
     monkeypatch.setattr(runtime_env, "load_project_dotenv", lambda override=False: None)
@@ -47,7 +49,7 @@ def test_is_ce_effective_requires_ce_without_control_plane_dsn(monkeypatch) -> N
         ("", "ce", True),
         (" postgresql://example ", "ce", False),
         ("postgresql://example", "", False),
-        ("", "", False),
+        ("", "", True),
     )
     for dsn, edition, expected in cases:
         if dsn:
@@ -60,3 +62,32 @@ def test_is_ce_effective_requires_ce_without_control_plane_dsn(monkeypatch) -> N
             monkeypatch.delenv("ST_EDITION", raising=False)
 
         assert runtime_env.is_ce_effective() is expected
+
+
+@pytest.mark.parametrize(
+    ("configured_edition", "dsn", "expected"),
+    [
+        (None, None, "ce"),
+        ("", "", "ce"),
+        ("  ", "  ", "ce"),
+        (" CE ", None, "ce"),
+        (None, "postgresql://example", "ee"),
+        ("", "postgresql://example", "ee"),
+        ("ee", None, "ee"),
+        ("ee", "postgresql://example", "ee"),
+    ],
+)
+def test_runtime_edition_defaults_and_explicit_selection(
+    monkeypatch, configured_edition, dsn, expected
+) -> None:
+    from novelvideo.shared import runtime_env
+
+    monkeypatch.setattr(runtime_env, "load_project_dotenv", lambda **kwargs: None)
+    for key, value in (("ST_EDITION", configured_edition), ("ST_CONTROL_PLANE_DSN", dsn)):
+        if value is None:
+            monkeypatch.delenv(key, raising=False)
+        else:
+            monkeypatch.setenv(key, value)
+
+    assert runtime_env.edition() == expected
+    assert runtime_env.is_ce_effective() is (expected == "ce")

--- a/tests/test_screenplay_normalizer.py
+++ b/tests/test_screenplay_normalizer.py
@@ -8,6 +8,19 @@ from novelvideo.cognee.screenplay_normalizer import (
 )
 
 
+@pytest.fixture
+def per_scene_enrichment(monkeypatch):
+    from novelvideo.cognee import pipeline
+
+    # These normalization tests supply per-scene enrichment below. An empty
+    # batch selects that fallback without creating a real model client.
+    monkeypatch.setattr(
+        pipeline,
+        "_create_scene_build_agent",
+        lambda *args, **kwargs: _FakeAgent(pipeline.SceneEnrichmentList(scenes=[])),
+    )
+
+
 def test_normalize_time_of_day_maps_classical_terms_to_closed_choices():
     assert normalize_time_of_day("亥时") == "夜晚"
     assert normalize_time_of_day("三更") == "夜晚"
@@ -378,6 +391,7 @@ async def test_headings_the_parser_cannot_resolve_go_to_the_model_in_one_batch()
 
 
 @pytest.mark.asyncio
+@pytest.mark.usefixtures("per_scene_enrichment")
 async def test_extract_scenes_from_script_prefers_ai_normalized_blocks(monkeypatch):
     from novelvideo.cognee import pipeline
     from novelvideo.models import NovelScene
@@ -442,6 +456,7 @@ async def test_extract_scenes_from_script_prefers_ai_normalized_blocks(monkeypat
 
 
 @pytest.mark.asyncio
+@pytest.mark.usefixtures("per_scene_enrichment")
 async def test_extract_scenes_from_script_falls_back_when_ai_returns_partial_blocks(
     monkeypatch,
 ):
@@ -498,6 +513,7 @@ async def test_extract_scenes_from_script_falls_back_when_ai_returns_partial_blo
 
 
 @pytest.mark.asyncio
+@pytest.mark.usefixtures("per_scene_enrichment")
 async def test_extract_scenes_from_script_falls_back_when_ai_returns_empty(monkeypatch):
     from novelvideo.cognee import pipeline
     from novelvideo.models import NovelScene
@@ -530,6 +546,7 @@ async def test_extract_scenes_from_script_falls_back_when_ai_returns_empty(monke
 
 
 @pytest.mark.asyncio
+@pytest.mark.usefixtures("per_scene_enrichment")
 async def test_extract_scenes_from_script_falls_back_when_ai_merges_distinct_locations(
     monkeypatch,
 ):

--- a/tests/test_structured_builders.py
+++ b/tests/test_structured_builders.py
@@ -489,8 +489,23 @@ async def test_extraction_is_bounded_but_not_serial():
 
 
 @pytest.fixture
-async def structured_store(tmp_path):
+async def structured_store(tmp_path, monkeypatch):
     from novelvideo.sqlite_store import SQLiteStore
+    from novelvideo import structured_extraction
+
+    # Build/replay tests exercise extraction evidence and persistence. Optional
+    # appearance enrichment must not construct a real credentialed model.
+    class EmptyAppearanceAgent:
+        async def run(self, _prompt):
+            return SimpleNamespace(
+                output=structured_extraction.CharacterAppearanceList(characters=[])
+            )
+
+    monkeypatch.setattr(
+        structured_extraction,
+        "_create_character_appearance_agent",
+        lambda agent=None: agent if agent is not None else EmptyAppearanceAgent(),
+    )
 
     state_dir = tmp_path / "user" / "structured"
     state_dir.mkdir(parents=True)
@@ -2801,4 +2816,3 @@ def test_describe_output_failure_includes_retry_prompts():
     assert "Exceeded maximum output retries (2)" in text
     assert "final_result" in text
     assert "Field required" in text
-

--- a/tests/test_task_envelope_local_signing_key.py
+++ b/tests/test_task_envelope_local_signing_key.py
@@ -43,7 +43,15 @@ def _load_local(**kwargs):
     return load_or_create_local_signing_config(**kwargs)
 
 
-def test_ce_generates_and_persists_a_usable_keyring(ce_env):
+@pytest.mark.parametrize("edition", [None, "", "ce"])
+def test_ce_generates_and_persists_a_usable_keyring(ce_env, monkeypatch, edition):
+    from novelvideo.shared import runtime_env
+
+    monkeypatch.setattr(runtime_env, "load_project_dotenv", lambda **kwargs: None)
+    if edition is None:
+        monkeypatch.delenv("ST_EDITION", raising=False)
+    else:
+        monkeypatch.setenv("ST_EDITION", edition)
     config = _load_local()
 
     assert config.active_key_id in config.keyring
@@ -98,8 +106,6 @@ def test_explicit_env_config_wins_over_the_generated_file(ce_env, monkeypatch):
 @pytest.mark.parametrize(
     ("edition", "dsn"),
     [
-        (None, None),
-        ("", None),
         ("ee", None),
         ("ce", "postgresql://control-plane/db"),
         (None, "postgresql://control-plane/db"),

--- a/tests/test_video_prompt_language.py
+++ b/tests/test_video_prompt_language.py
@@ -37,10 +37,8 @@ def test_global_video_optimizer_applies_language_to_system_and_task(
 
     monkeypatch.setattr(module, "Agent", FactoryAgent)
     monkeypatch.setattr(
-        module,
-        "get_newapi_text_pydantic_model",
+        "novelvideo.config.get_newapi_text_pydantic_model",
         lambda *_args, **_kwargs: object(),
-        raising=False,
     )
 
     # The factory's system instruction must agree with the per-request task.


### PR DESCRIPTION
## PR 类型 / Type of PR
- [x] 🐞 Bug 修复 / Bug fix

## 改动说明 / What this PR does and why

用户按本地安装说明执行 `uv run novelvideo api --port 8780`，未配置版本或控制面 DSN 时，API 会拒绝启动；单独调用 config handler 也会报告 EE。本次将未配置时的运行版本默认设为 CE，启动检查复用后端版本解析，`/api/v1/config` 返回 `edition: "ce"`、`auth_required: false`，前端无需额外版本配置。

首次并发初始化 CE SQLite 设置库时，对短暂 locked/busy 冲突进行最多三次尝试并关闭失败连接，避免并行启动在 WAL 初始化阶段失败。全量测试另以四个 worker 共用全新的临时数据目录验证。

有控制面 DSN 且未指定版本时仍选择 EE；显式 EE 缺 DSN、CE 与 DSN 冲突或版本值无效时仍拒绝启动。默认 CE 自动生成和复用本地任务签名密钥。

## 关联 issue / Linked issues
Closes #502

## 给 reviewer 的说明 / Notes for the reviewer

目标分支为 `main`；从 main 创建的干净分支，替代 #508，未包含 staging 功能。无数据库迁移、模型供应商配置或合规依赖变化。

新增真实 FastAPI lifespan 回归测试，在禁用开发者 dotenv 注入并移除版本/DSN 环境变量后，验证启动成功、config 返回免登录 CE、本地 lifecycle 生效且不暴露企业用户路由。测试仅替换会访问远端的模型目录更新任务。

验证（本地 Python 3.12）：

```bash
.venv/bin/python -m pytest -n 4 -q --tb=short
.venv/bin/ruff check --output-format=concise .
.venv/bin/python scripts/check_ce_port_closure.py
.venv/bin/python scripts/check_backend_i18n.py
```

全量结果：4394 passed、16 skipped；857 条现有依赖/接口弃用警告。

另已对全部变更文件运行 pre-commit（gitleaks 与禁用词 lint）。默认 CE 下媒体目录生效后，媒体回退测试显式模拟无目录场景，视频不支持 omni 的测试兼容目录校验返回的错误文案。构建与剧本规范化测试在 agent 工厂边界模拟可选模型补全，语言测试修正 mock 目标，平台凭据测试显式选择 EE，避免依赖开发者本地模型密钥。

## 面向用户的变更 / User-facing change
```release-note
本地启动默认使用社区版，无需设置版本或企业配置，修复直接运行 API 时因缺少 ST_EDITION 而启动失败的问题。
```

## 自检 / Checklist
- [x] 已自测，pytest 全量通过 / Full pytest suite passes
- [x] 必要的文档已更新 / Docs updated where needed（现有文档已声明默认 CE，本次实现与其对齐）
- [x] 提交信息清晰（建议 Conventional Commits）/ Clear commits (Conventional Commits suggested)
- [x] 每个 commit 都已 `git commit -s` 附 DCO 签署 / Every commit signed off with `git commit -s` (DCO)
- [ ] 我已阅读并同意[贡献者协议](../CONTRIBUTING.md#贡献者协议) / I've read and agree to the contributor terms
