### PR TITLE
fix(gateway): BrainClaw settings no longer switch the active gateway mode

### DIFF
--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -7097,8 +7097,8 @@
         "title": "BrainClaw by RelayClaw (Recommended)",
         "description": "BrainClaw handles text understanding, generation, structured output, tool calling, and vision tasks without per-feature mappings. It connects to RelayClaw by default; development setups may point it at a NewAPI-compatible endpoint that exposes BrainClaw. Image, video, audio, and Embedding still use the Local NewAPI settings below.",
         "model": "Fixed model",
-        "save": "Save & Enable BrainClaw",
-        "enabled": "RelayClaw BrainClaw is enabled.",
+        "save": "Save and use BrainClaw",
+        "enabled": "BrainClaw selected; it applies while Custom mode is active.",
         "missingEndpoint": "Enter the BrainClaw NewAPI URL.",
         "advancedEnabled": "Advanced custom LLM is enabled."
       },

--- a/frontend/public/locales/zh/translation.json
+++ b/frontend/public/locales/zh/translation.json
@@ -7097,8 +7097,8 @@
         "title": "虾脑 BrainClaw（推荐）",
         "description": "虾脑 BrainClaw 会统一处理文本理解、内容生成、结构化输出、工具调用和视觉理解请求，无需逐项维护模型映射。默认连接虾驿；开发联调时也可填写承载虾脑的 NewAPI 兼容地址和端口。图片、视频、音频和 Embedding 仍使用下方本地 NewAPI 配置。",
         "model": "固定模型",
-        "save": "保存并启用 BrainClaw",
-        "enabled": "已启用虾驿 BrainClaw。",
+        "save": "保存并选用 BrainClaw",
+        "enabled": "已选用虾驿 BrainClaw，自定义模式下生效。",
         "missingEndpoint": "请填写 BrainClaw NewAPI 地址。",
         "advancedEnabled": "已切换为高级自定义 LLM。"
       },

--- a/src/novelvideo/api/routes/model_gateway.py
+++ b/src/novelvideo/api/routes/model_gateway.py
@@ -666,7 +666,7 @@ async def save_official_gateway_config(body: OfficialGatewayBody) -> dict[str, A
 async def save_custom_brainclaw_config(
     body: BrainClawGatewayBody,
 ) -> dict[str, Any]:
-    """Save the RelayClaw key and activate mixed custom-media/BrainClaw LLM."""
+    """Save the BrainClaw endpoint for Custom mode (does not switch the active mode)."""
     try:
         require_ce_gateway_management()
     except PermissionError as exc:
@@ -697,7 +697,6 @@ async def save_custom_brainclaw_config(
     save_relayclaw_brainclaw_key(
         api_key=api_key,
         base_url=base_url,
-        activate=True,
     )
     runtime = refresh_model_gateway_runtime()
     return {

--- a/src/novelvideo/model_gateway_settings.py
+++ b/src/novelvideo/model_gateway_settings.py
@@ -236,22 +236,25 @@ def set_model_gateway_mode(mode: str) -> None:
 
 
 def set_custom_llm_mode(mode: str) -> None:
-    normalized = normalize_custom_llm_mode(mode)
-    _write_many(
-        {
-            "custom_llm_mode": normalized,
-            "model_gateway_mode": MODE_CUSTOM,
-        }
-    )
+    """Choose how Custom mode routes LLM traffic.
+
+    This is a setting *inside* Custom mode: it only matters while
+    ``model_gateway_mode`` is ``custom``, and choosing it never activates
+    Custom mode. Official and Hybrid always use BrainClaw and ignore it.
+    """
+    _write_many({"custom_llm_mode": normalize_custom_llm_mode(mode)})
 
 
 def save_relayclaw_brainclaw_key(
     *,
     api_key: str = "",
     base_url: str = "",
-    activate: bool = True,
 ) -> None:
-    """Persist the BrainClaw LLM endpoint without changing official credentials."""
+    """Persist the BrainClaw LLM endpoint and select BrainClaw for Custom mode.
+
+    Like :func:`set_custom_llm_mode`, this does not change the active gateway
+    mode; activating Custom stays with the explicit enable action.
+    """
     values = {"custom_llm_mode": CUSTOM_LLM_MODE_RELAYCLAW_BRAINCLAW}
     clean_api_key = str(api_key or "").strip()
     clean_base_url = normalize_relay_base_url(base_url)
@@ -259,8 +262,6 @@ def save_relayclaw_brainclaw_key(
         values["brainclaw_newapi_api_key"] = clean_api_key
     if clean_base_url:
         values["brainclaw_newapi_base_url"] = clean_base_url
-    if activate:
-        values["model_gateway_mode"] = MODE_CUSTOM
     _write_many(values)
 
 

--- a/tests/test_brainclaw_contract.py
+++ b/tests/test_brainclaw_contract.py
@@ -21,6 +21,7 @@ from novelvideo.brainclaw_contract import (
     merge_brainclaw_headers,
 )
 from novelvideo.model_gateway_settings import (
+    get_model_gateway_settings,
     CUSTOM_LLM_MODE_ADVANCED,
     CUSTOM_LLM_MODE_RELAYCLAW_BRAINCLAW,
     get_effective_llm_config,
@@ -58,7 +59,7 @@ def test_mixed_mode_routes_llm_to_relayclaw_without_changing_media(
 ):
     _isolate_settings_db(monkeypatch, tmp_path)
     _configure_custom_media()
-    save_relayclaw_brainclaw_key(api_key="sk-relay-secret", activate=True)
+    save_relayclaw_brainclaw_key(api_key="sk-relay-secret")
 
     llm = get_effective_llm_config()
     media = get_effective_newapi_config()
@@ -77,7 +78,7 @@ def test_cognee_legacy_llm_and_embedding_ignore_brainclaw_selector(
 ):
     _isolate_settings_db(monkeypatch, tmp_path)
     _configure_custom_media()
-    save_relayclaw_brainclaw_key(api_key="sk-relay-secret", activate=True)
+    save_relayclaw_brainclaw_key(api_key="sk-relay-secret")
 
     from novelvideo.cognee import config as cognee_config
 
@@ -394,7 +395,7 @@ def test_recipe_variant_header_requires_recipe_text_profile():
 def test_effective_text_defaults_force_brainclaw_for_mixed_mode(monkeypatch, tmp_path):
     _isolate_settings_db(monkeypatch, tmp_path)
     _configure_custom_media()
-    save_relayclaw_brainclaw_key(api_key="sk-relay-secret", activate=True)
+    save_relayclaw_brainclaw_key(api_key="sk-relay-secret")
 
     assert config.get_effective_newapi_text_model_name(
         "FREEZONE_VISION_MODEL",
@@ -416,7 +417,7 @@ def test_brainclaw_factory_forces_model_and_central_profile_headers(
 ):
     _isolate_settings_db(monkeypatch, tmp_path)
     _configure_custom_media()
-    save_relayclaw_brainclaw_key(api_key="sk-relay-secret", activate=True)
+    save_relayclaw_brainclaw_key(api_key="sk-relay-secret")
     captured: dict[str, object] = {}
 
     def fake_model(model_name, **kwargs):
@@ -444,7 +445,7 @@ def test_brainclaw_factory_forces_model_and_central_profile_headers(
 def test_brainclaw_factory_emits_trusted_recipe_variant_header(monkeypatch, tmp_path):
     _isolate_settings_db(monkeypatch, tmp_path)
     _configure_custom_media()
-    save_relayclaw_brainclaw_key(api_key="sk-relay-secret", activate=True)
+    save_relayclaw_brainclaw_key(api_key="sk-relay-secret")
     captured: dict[str, object] = {}
 
     monkeypatch.setattr(
@@ -473,7 +474,7 @@ def test_brainclaw_factory_emits_trusted_recipe_variant_header(monkeypatch, tmp_
 def test_hermes_brainclaw_has_no_fixed_profile(monkeypatch, tmp_path):
     _isolate_settings_db(monkeypatch, tmp_path)
     _configure_custom_media()
-    save_relayclaw_brainclaw_key(api_key="sk-relay-secret", activate=True)
+    save_relayclaw_brainclaw_key(api_key="sk-relay-secret")
 
     from novelvideo.chat import hermes_workspace
 
@@ -558,8 +559,8 @@ def test_custom_brainclaw_endpoint_does_not_replace_official_gateway(
     save_relayclaw_brainclaw_key(
         api_key="sk-local-secret",
         base_url="http://127.0.0.1:8317",
-        activate=True,
     )
+    set_model_gateway_mode("custom")
 
     custom_llm = get_effective_llm_config()
     assert custom_llm.base_url == "http://127.0.0.1:8317/v1"
@@ -582,7 +583,6 @@ def test_custom_llm_mode_accepts_dedicated_brainclaw_without_official_key(
     save_relayclaw_brainclaw_key(
         api_key="sk-local-secret",
         base_url="http://127.0.0.1:8317",
-        activate=False,
     )
     monkeypatch.setattr(
         model_gateway,
@@ -602,3 +602,30 @@ def test_custom_llm_mode_accepts_dedicated_brainclaw_without_official_key(
     assert response.json()["data"]["llmEffective"]["baseUrl"] == (
         "http://127.0.0.1:8317/v1"
     )
+
+
+def test_brainclaw_settings_never_switch_the_active_gateway_mode(monkeypatch, tmp_path):
+    """BrainClaw is a setting inside Custom mode; touching it must not activate Custom."""
+    _isolate_settings_db(monkeypatch, tmp_path)
+    save_official_newapi_key(api_key="sk-official-secret")  # activates Official
+
+    save_relayclaw_brainclaw_key(api_key="sk-local-secret", base_url="http://127.0.0.1:8317")
+    assert get_model_gateway_settings().get("model_gateway_mode") == "official"
+    llm = get_effective_llm_config()
+    assert llm.mode == "official"
+    assert llm.base_url == OFFICIAL_NEWAPI_BASE_URL
+    assert llm.api_key == "sk-official-secret"
+
+    set_custom_llm_mode(CUSTOM_LLM_MODE_ADVANCED)
+    assert get_model_gateway_settings().get("model_gateway_mode") == "official"
+    assert get_effective_llm_config().mode == "official"
+
+    # Only the explicit enable action activates Custom, and then the saved
+    # BrainClaw endpoint / sub-mode applies.
+    set_model_gateway_mode("custom")
+    assert get_effective_llm_config().mode == CUSTOM_LLM_MODE_ADVANCED
+    set_custom_llm_mode(CUSTOM_LLM_MODE_RELAYCLAW_BRAINCLAW)
+    custom_llm = get_effective_llm_config()
+    assert custom_llm.mode == CUSTOM_LLM_MODE_RELAYCLAW_BRAINCLAW
+    assert custom_llm.base_url == "http://127.0.0.1:8317/v1"
+    assert custom_llm.api_key == "sk-local-secret"


### PR DESCRIPTION
## Why

The BrainClaw / Advanced choice is a setting *inside* Custom mode. Official and Hybrid always route LLM traffic to BrainClaw and never read it (`get_effective_llm_config` only consults `custom_llm_mode` and `brainclaw_newapi_*` when `model_gateway_mode == custom`). But two code paths also wrote `model_gateway_mode = custom`:

- `POST /custom/brainclaw/config` called `save_relayclaw_brainclaw_key(activate=True)`.
- `set_custom_llm_mode()` wrote the mode unconditionally, so clicking the **Advanced** tab did too.

A user running Official who opened the Custom tab and clicked Advanced, or saved a BrainClaw endpoint, had their whole gateway silently switched to Custom with no prompt. Activating a mode should only happen through the explicit enable actions (`/official/enable`, `/custom/enable`, `/hybrid/enable`), as the docs already say.

## What

- `model_gateway_settings.py`: `set_custom_llm_mode()` and `save_relayclaw_brainclaw_key()` write only their own keys; the `activate` parameter is removed.
- `api/routes/model_gateway.py`: `/custom/brainclaw/config` no longer activates Custom; docstring updated.
- i18n (zh/en): "Save & Enable BrainClaw" → "Save and use BrainClaw"; the success toast says it applies while Custom mode is active.
- `tests/test_brainclaw_contract.py`: `activate=` dropped from calls; the one test that relied on the side effect now calls `set_model_gateway_mode("custom")` explicitly; new test asserts that saving BrainClaw config or switching the sub-mode while Official is active leaves Official active and effective, and that the saved values apply once Custom is enabled.

Behaviour in Custom mode is unchanged: the saved endpoint/key and the sub-mode apply exactly as before.

## Verification

- `tests/test_brainclaw_contract.py` + `tests/test_model_gateway_settings.py`: 133 passed.
- Frontend `locales-json` + `settings-dialog` tests: 39 passed. ruff and banned-words lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NQrE65FQLj4endsbo3Wdsw