### PR TITLE
chore: release v2.0.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "supertale-ce"
-version = "2.0.3"
+version = "2.0.4"
 description = "SuperTale Community Edition API and video pipeline"
 readme = "README.md"
 requires-python = ">=3.11,<3.13"

--- a/src/novelvideo/release-notes.md
+++ b/src/novelvideo/release-notes.md
@@ -1,33 +1,32 @@
 ---
-version: 2.0.3
+version: 2.0.4
 attention: medium
 ---
-# v2.0.3
+# v2.0.4
 
 ## User-facing Highlights (zh)
 
-- **自部署组合更加完整**: Docker 源码版会同时构建 DramaClaw、虾画前端和同级目录中的 dramaclaw-gateway；镜像版继续提供直接拉取已发布镜像的独立入口，社区用户可以更清楚地选择开发或稳定部署方式。
-- **自定义模型配置补齐角色构建**: 自定义模式现在可以正确映射 DC-character-builder-LLM，使用自定义模型网关时角色提取不再因缺少模型映射而失败。
-- **跨项目复制素材更可靠**: 在虾画中跨项目粘贴节点时，图片和视频素材由后端完成复制，并在迁移结束前暂停自动保存，减少引用丢失或保存到旧地址的问题。
-- **失败原因更容易定位**: 项目分享会明确提示用户不存在、已加入或邀请冲突等原因；角色提取重试耗尽时，日志会保留真正的失败原因，方便排查模型输出问题。
-- **社区文档覆盖更多语言**: README 新增越南语和泰语版本，并重新梳理源码开发、镜像部署、模型网关和许可证说明。
+- **新增越南语界面**: DramaClaw 现已提供完整的越南语界面，并修正英文剧本格式指引和多语言回退逻辑，让更多社区用户可以直接使用熟悉的语言完成创作。
+- **支持可选手机号验证码登录**: 部署方启用对应入口后，用户可以通过手机号和验证码登录并设置密码；登录能力默认受开关控制，不影响现有部署。
+- **跨项目媒体引用更安全**: 虾画会识别来自其他项目的图片和视频引用，阻止无效引用继续写入，并为历史遗留引用提供复制到当前项目的一键修复入口。
+- **本地 CE 启动更省配置**: 本地启动现在默认使用社区版，不再要求额外声明版本；并发初始化配置时也会自动重试。
+- **画布任务计费参数更加准确**: 画布主线生成任务会携带完整的模型计费参数，减少预估与实际结算不一致的情况。
 
 ## User-facing Highlights (en)
 
-- **A more complete self-hosted stack**: The source Docker entry point now builds DramaClaw, the XiaHua frontend, and a sibling dramaclaw-gateway checkout together, while the release entry point remains dedicated to published images. Community users can choose development or stable deployment more clearly.
-- **Character building works in Custom mode**: Custom model configurations can now map DC-character-builder-LLM, preventing character extraction failures caused by a missing model mapping when using a custom gateway.
-- **More reliable cross-project asset copying**: When nodes are pasted across XiaHua projects, image and video assets are copied by the backend and autosave pauses until migration finishes, reducing broken or stale references.
-- **Clearer failure details**: Project sharing now distinguishes missing users, existing members, and invitation conflicts. Character extraction logs also preserve the actual cause after output retries are exhausted.
-- **More accessible community documentation**: Vietnamese and Thai READMEs are now available, with clearer guidance for source development, image-based deployment, model gateways, and licensing.
+- **Vietnamese interface support**: DramaClaw now includes a complete Vietnamese interface, along with corrected English screenplay guidance and safer language fallback behavior.
+- **Optional phone OTP sign-in**: When enabled by the deployment operator, users can sign in with a phone number and verification code and set a password. The entry remains gated and does not affect existing deployments by default.
+- **Safer cross-project media references**: XiaHua detects image and video references that belong to another project, prevents new invalid references from being saved, and offers one-click repair for legacy references by copying them into the current project.
+- **Simpler local CE startup**: Local startup now defaults to the Community Edition without requiring an explicit edition setting, with automatic retries for concurrent settings initialization.
+- **More accurate canvas task billing**: Mainline canvas generation tasks now include complete model-pricing inputs, reducing differences between estimated and settled usage.
 
 ## Fixes
 
-- 修复自定义模式无法映射角色构建模型的问题 (#491).
-- 修复角色提取重试耗尽后只记录通用错误、无法定位真实原因的问题 (#492).
-- 修复项目分享失败时提示不明确的问题 (#479).
+- 修正英文剧本格式指引、多语言回退和越南语手机号登录文案 (#500, #516).
+- 修复跨项目媒体引用可能导致素材无法访问或画布保存异常的问题 (#513).
+- 修复本地启动必须额外配置版本，以及并发初始化配置可能失败的问题 (#511).
+- 修复画布主线任务缺少模型计费参数的问题 (#497).
 
 ## Improvements
 
-- 跨项目粘贴改由后端复制素材，并在迁移期间暂停自动保存 (#493).
-- 将源码开发和镜像部署拆分为清晰的 Docker Compose 入口，并默认集成同级 dramaclaw-gateway (#476, #482).
-- 重构 README 的产品、部署、网关和许可证说明，新增越南语与泰语文档 (#481, #483, #484, #486, #495).
+- 新增受部署开关控制的手机号验证码登录和密码设置能力 (#471).

--- a/tests/test_release_feed.py
+++ b/tests/test_release_feed.py
@@ -114,7 +114,7 @@ def test_built_wheel_contains_parseable_release_notes_artifact(tmp_path: Path) -
 def test_project_version_is_single_source_of_truth() -> None:
     pyproject = tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))
 
-    assert pyproject["project"]["version"] == "2.0.3"
+    assert pyproject["project"]["version"] == "2.0.4"
     assert importlib.metadata.version("supertale-ce") == pyproject["project"]["version"]
     assert "__version__" not in Path("src/novelvideo/__init__.py").read_text(encoding="utf-8")
 

--- a/uv.lock
+++ b/uv.lock
@@ -3428,7 +3428,7 @@ wheels = [
 
 [[package]]
 name = "supertale-ce"
-version = "2.0.3"
+version = "2.0.4"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## PR 类型 / Type of PR
- [ ] 🐞 Bug 修复 / Bug fix
- [ ] ✨ 新功能 / Feature
- [x] 📝 文档 / Documentation
- [ ] 🧹 重构 / 清理 / Refactor or cleanup
- [x] ⚙️ 构建 / CI / Build or CI
- [ ] ⚠️ 破坏性变更 / Breaking change

## 改动说明 / What this PR does and why

准备 DramaClaw v2.0.4 发布：

- 将项目版本和锁文件版本更新为 `2.0.4`；
- 更新版本单一真源测试；
- 重写包内中英文 release notes，覆盖 v2.0.3 之后合入的用户可见变更。

## 关联 issue / Linked issues

N/A

## 给 reviewer 的说明 / Notes for the reviewer

请重点核对中英文 highlights 是否准确覆盖 v2.0.3 至当前 `main` 的变更，以及版本号在 `pyproject.toml`、`uv.lock`、测试和包内 notes 中是否一致。

验证：

```bash
UV_CACHE_DIR=/Users/newyue/claymorelab/.uv-cache /private/tmp/dramaclaw-release-v2.0.4-venv/bin/python -m pytest tests/test_release_feed.py
# 12 passed
```

## 面向用户的变更 / User-facing change

```release-note
v2.0.4 adds Vietnamese UI support, optional phone OTP sign-in, safer cross-project media references, simpler local CE startup, and more accurate canvas task billing.
```

## 自检 / Checklist
- [ ] 已自测，`uv run pytest` 通过 / Self-tested, `uv run pytest` passes
- [x] 必要的文档已更新 / Docs updated where needed
- [x] 提交信息清晰（建议 Conventional Commits）/ Clear commits (Conventional Commits suggested)
- [x] 每个 commit 都已 `git commit -s` 附 DCO 签署 / Every commit signed off with `git commit -s` (DCO)
- [ ] 我已阅读并同意[贡献者协议](../CONTRIBUTING.md#贡献者协议) / I've read and agree to the [contributor terms](../CONTRIBUTING.md#贡献者协议)
