### PR TITLE
fix: 同步工作流继续后的任务状态

### DIFF
--- a/frontend/src/__tests__/features/superchat/chat-task-status-bar.test.ts
+++ b/frontend/src/__tests__/features/superchat/chat-task-status-bar.test.ts
@@ -13,6 +13,8 @@ import {
   selectChatTaskItems,
   selectChatWorkflowRun,
   selectWorkflowActivityLabels,
+  shouldShowCancelAll,
+  workflowRunDisplayStatus,
   workflowRunStatusPollMs,
   workflowSettledCount,
   workflowStatusCounts,
@@ -317,6 +319,49 @@ describe("workflowRunStatusPollMs", () => {
       }),
     ])).toBe(60_000);
     expect(workflowRunStatusPollMs([])).toBe(60_000);
+  });
+
+  it("polls actively while an interrupted workflow is resuming", () => {
+    const interrupted = workflowRun({
+      status: "interrupted",
+      resumable: true,
+    });
+
+    expect(workflowRunStatusPollMs([interrupted], true)).toBe(5_000);
+  });
+});
+
+describe("workflowRunDisplayStatus", () => {
+  it("presents a resumable interrupted workflow as running during recovery", () => {
+    const interrupted = workflowRun({
+      status: "interrupted",
+      resumable: true,
+    });
+
+    expect(workflowRunDisplayStatus(interrupted, true)).toBe("running");
+    expect(workflowRunDisplayStatus(interrupted, false)).toBe("interrupted");
+  });
+
+  it("does not mask a terminal result that arrives while recovery is pending", () => {
+    const completed = workflowRun({
+      status: "completed",
+      resumable: false,
+    });
+
+    expect(workflowRunDisplayStatus(completed, true)).toBe("completed");
+  });
+});
+
+describe("shouldShowCancelAll", () => {
+  it("waits for a resumed workflow to become genuinely cancellable", () => {
+    const interrupted = workflowRun({
+      status: "interrupted",
+      resumable: true,
+    });
+
+    expect(workflowRunDisplayStatus(interrupted, true)).toBe("running");
+    expect(shouldShowCancelAll(0, interrupted, true)).toBe(false);
+    expect(shouldShowCancelAll(0, workflowRun(), false)).toBe(true);
   });
 });
 

--- a/frontend/src/__tests__/features/superchat/chat-task-status-bar.test.ts
+++ b/frontend/src/__tests__/features/superchat/chat-task-status-bar.test.ts
@@ -361,6 +361,7 @@ describe("shouldShowCancelAll", () => {
 
     expect(workflowRunDisplayStatus(interrupted, true)).toBe("running");
     expect(shouldShowCancelAll(0, interrupted, true)).toBe(false);
+    expect(shouldShowCancelAll(0, workflowRun(), true)).toBe(true);
     expect(shouldShowCancelAll(0, workflowRun(), false)).toBe(true);
   });
 });

--- a/frontend/src/features/superchat/chat-task-status-bar.tsx
+++ b/frontend/src/features/superchat/chat-task-status-bar.tsx
@@ -238,9 +238,8 @@ export function shouldShowCancelAll(
   run: FreezoneWorkflowRun | null,
   resuming: boolean,
 ): boolean {
-  return !resuming && (
-    activeStandaloneTaskCount > 0 || run?.status === "running"
-  );
+  if (resuming && run?.status !== "running") return false;
+  return activeStandaloneTaskCount > 0 || run?.status === "running";
 }
 
 export function resolveWorkflowRunDisplayCompletion(
@@ -809,7 +808,7 @@ export function ChatTaskStatusBar({
     }
   };
   const cancelAll = async () => {
-    if (resuming) return;
+    if (resuming && workflowRun?.status !== "running") return;
     const workflowActive = workflowRun?.status === "running";
     const count = activeStandaloneTasks.length + (workflowActive ? 1 : 0);
     if (count === 0 || cancelling) return;

--- a/frontend/src/features/superchat/chat-task-status-bar.tsx
+++ b/frontend/src/features/superchat/chat-task-status-bar.tsx
@@ -209,8 +209,9 @@ export function selectChatWorkflowRun(
 
 export function workflowRunStatusPollMs(
   runs: readonly FreezoneWorkflowRun[],
+  resuming = false,
 ): number {
-  return runs.some((run) => run.status === "running")
+  return resuming || runs.some((run) => run.status === "running")
     ? WORKFLOW_RUN_ACTIVE_POLL_MS
     : WORKFLOW_RUN_IDLE_POLL_MS;
 }
@@ -221,6 +222,24 @@ export function isStatusBarWorkflowContinuable(
   return Boolean(
     run?.resumable &&
     (run.status === "failed" || run.status === "interrupted"),
+  );
+}
+
+export function workflowRunDisplayStatus(
+  run: FreezoneWorkflowRun | null,
+  resuming: boolean,
+): FreezoneWorkflowRun["status"] | null {
+  if (resuming && isStatusBarWorkflowContinuable(run)) return "running";
+  return run?.status ?? null;
+}
+
+export function shouldShowCancelAll(
+  activeStandaloneTaskCount: number,
+  run: FreezoneWorkflowRun | null,
+  resuming: boolean,
+): boolean {
+  return !resuming && (
+    activeStandaloneTaskCount > 0 || run?.status === "running"
   );
 }
 
@@ -540,6 +559,7 @@ export function ChatTaskStatusBar({
       RECENT_COMPLETED_MS
       ? null
       : resolvedWorkflowRun;
+  const workflowDisplayStatus = workflowRunDisplayStatus(workflowRun, resuming);
   const existingNodeIds = useMemo(
     () => new Set(nodes.map((node) => node.id)),
     [nodes],
@@ -576,7 +596,7 @@ export function ChatTaskStatusBar({
   const [workflowActivityIndex, setWorkflowActivityIndex] = useState(0);
   const hasTerminalItems =
     taskItems.some(({ task }) => isTerminal(task)) ||
-    Boolean(workflowRun && workflowRun.status !== "running");
+    Boolean(workflowDisplayStatus && workflowDisplayStatus !== "running");
 
   const refreshWorkflowRuns = useCallback(async () => {
     if (scope !== "canvas" || !projectId || !canvasId) {
@@ -635,10 +655,10 @@ export function ChatTaskStatusBar({
     if (!projectId || !canvasId) return;
     const timer = window.setInterval(
       () => void refreshWorkflowRuns(),
-      workflowRunStatusPollMs(workflowRuns),
+      workflowRunStatusPollMs(workflowRuns, resuming),
     );
     return () => window.clearInterval(timer);
-  }, [canvasId, projectId, refreshWorkflowRuns, workflowRuns]);
+  }, [canvasId, projectId, refreshWorkflowRuns, resuming, workflowRuns]);
 
   useEffect(() => {
     if (!hasTerminalItems) return;
@@ -687,7 +707,7 @@ export function ChatTaskStatusBar({
     return t(`taskCenter.chatStatus.workflowPhase.${action.phase ?? "waiting_dependencies"}`);
   };
   const summary = workflowRun
-    ? workflowRun.status === "completed"
+    ? workflowDisplayStatus === "completed"
       ? t("taskCenter.chatStatus.workflowCompletedShort", {
           completed: workflowSettledCount(workflowActions),
           total: workflowActions.length,
@@ -697,19 +717,19 @@ export function ChatTaskStatusBar({
             completed: workflowCounts.completed,
             total: workflowActions.length,
           }),
-          workflowRun.status === "interrupted"
+          workflowDisplayStatus === "interrupted"
             ? t("taskCenter.chatStatus.interruptedShort")
-            : workflowRun.status === "failed"
+            : workflowDisplayStatus === "failed"
               ? t("taskCenter.chatStatus.stoppedShort")
               : null,
           workflowCounts.inProgress > 0
-            && workflowRun.status === "running"
+            && workflowDisplayStatus === "running"
             ? t("taskCenter.chatStatus.inProgressShort", {
                 count: workflowCounts.inProgress,
               })
             : null,
           workflowCounts.waiting > 0
-            && workflowRun.status === "running"
+            && workflowDisplayStatus === "running"
             ? t("taskCenter.chatStatus.waitingShort", {
                 count: workflowCounts.waiting,
               })
@@ -789,6 +809,7 @@ export function ChatTaskStatusBar({
     }
   };
   const cancelAll = async () => {
+    if (resuming) return;
     const workflowActive = workflowRun?.status === "running";
     const count = activeStandaloneTasks.length + (workflowActive ? 1 : 0);
     if (count === 0 || cancelling) return;
@@ -899,13 +920,18 @@ export function ChatTaskStatusBar({
     ? taskItems.filter(({ task }) => !linkedWorkflowTaskKeys.has(task.task_key))
     : taskItems;
   const waitingBatchItems = chatTaskBatchWaitingItems(detailItems);
-  const hasActiveStatus = activeItems.length > 0 || workflowRun?.status === "running";
+  const hasActiveStatus = activeItems.length > 0 || workflowDisplayStatus === "running";
+  const showCancelAll = shouldShowCancelAll(
+    activeStandaloneTasks.length,
+    workflowRun,
+    resuming,
+  );
   const hasFailedStatus =
     failedCount > 0 ||
     Boolean(
-      workflowRun &&
-      workflowRun.status !== "running" &&
-      workflowRun.status !== "completed",
+      workflowDisplayStatus &&
+      workflowDisplayStatus !== "running" &&
+      workflowDisplayStatus !== "completed",
     );
 
   return (
@@ -966,7 +992,7 @@ export function ChatTaskStatusBar({
                 : t("taskCenter.chatStatus.resume")}
           </Button>
         ) : null}
-        {hasActiveStatus ? (
+        {showCancelAll ? (
           <Button
             type="button"
             size="sm"


### PR DESCRIPTION
暂停后的工作流点击“继续”时，恢复动作已经执行，但任务状态栏仍按旧运行记录显示“已暂停”。本次调整在恢复请求执行期间派生为运行中状态，并保持 5 秒轮询；若请求失败，界面会回到原暂停状态，若服务端返回完成状态则立即展示完成。

验证：

- `vitest run src/__tests__/features/superchat/chat-task-status-bar.test.ts`：30 passed
- `tsc -b --pretty false`：通过
- `pnpm build:ce`：通过
