### PR TITLE
feat(account): add first phone binding for password accounts

### DIFF
--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -438,6 +438,15 @@
       "languageChinese": "中文",
       "languageEnglish": "English",
       "languageVietnamese": "Tiếng Việt",
+      "phoneBinding": {
+        "title": "Bind phone number",
+        "description": "Verify your current password and phone to link it to this account. You can then sign in by code. The phone cannot be changed or unlinked.",
+        "submit": "Confirm binding",
+        "success": "Phone linked. Your existing account and password still work.",
+        "inUse": "This phone belongs to another account and cannot be linked. Accounts are not merged automatically.",
+        "alreadyBound": "This account already has a phone. Refresh the page.",
+        "error": "Could not link the phone. Try again."
+      },
       "passwordDialog": {
         "title": "Change password",
         "description": "Changing your password signs you out on every device. Sign in again with the new password.",
@@ -1838,6 +1847,7 @@
       "showcaseDescription": "Characters, storyboards, sound, and shots move forward in one production line"
     },
     "otp": {
+      "existingAccountHint": "Already have an account? Sign in with your account and password, then link your phone in the account menu to avoid creating another account.",
       "tab": "Verification code",
       "phone": "Phone number",
       "phonePlaceholder": "Enter phone number",

--- a/frontend/public/locales/vi/translation.json
+++ b/frontend/public/locales/vi/translation.json
@@ -438,6 +438,15 @@
       "languageChinese": "中文",
       "languageEnglish": "English",
       "languageVietnamese": "Tiếng Việt",
+      "phoneBinding": {
+        "title": "Liên kết số điện thoại",
+        "description": "Xác minh mật khẩu hiện tại và số điện thoại để liên kết với tài khoản này. Sau đó bạn có thể đăng nhập bằng mã. Không hỗ trợ đổi hoặc hủy liên kết số điện thoại.",
+        "submit": "Xác nhận liên kết",
+        "success": "Đã liên kết số điện thoại. Tài khoản và mật khẩu hiện tại vẫn sử dụng được.",
+        "inUse": "Số điện thoại này thuộc tài khoản khác nên không thể liên kết. Các tài khoản không được tự động hợp nhất.",
+        "alreadyBound": "Tài khoản này đã có số điện thoại. Hãy tải lại trang.",
+        "error": "Không thể liên kết số điện thoại. Vui lòng thử lại."
+      },
       "passwordDialog": {
         "title": "Đổi mật khẩu",
         "description": "Đổi mật khẩu sẽ đăng xuất bạn trên mọi thiết bị. Hãy đăng nhập lại bằng mật khẩu mới.",
@@ -1838,6 +1847,7 @@
       "showcaseDescription": "Nhân vật, storyboard, âm thanh và cú máy cùng tiến trên một dây chuyền"
     },
     "otp": {
+      "existingAccountHint": "Đã có tài khoản? Hãy đăng nhập bằng tài khoản và mật khẩu, rồi liên kết số điện thoại trong menu tài khoản để tránh tạo tài khoản khác.",
       "tab": "Mã xác minh",
       "phone": "Số điện thoại",
       "phonePlaceholder": "Nhập số điện thoại",

--- a/frontend/public/locales/zh/translation.json
+++ b/frontend/public/locales/zh/translation.json
@@ -438,6 +438,15 @@
       "languageChinese": "中文",
       "languageEnglish": "English",
       "languageVietnamese": "Tiếng Việt",
+      "phoneBinding": {
+        "title": "绑定手机号",
+        "description": "验证当前密码和手机号，绑定到现有账号。绑定后支持验证码登录，不支持换绑或解绑。",
+        "submit": "确认绑定",
+        "success": "手机号已绑定，原有账号和密码仍可使用。",
+        "inUse": "该手机号已属于其他账号，无法绑定。账号不会自动合并。",
+        "alreadyBound": "当前账号已绑定手机号，请刷新页面。",
+        "error": "绑定失败，请重试。"
+      },
       "passwordDialog": {
         "title": "修改密码",
         "description": "修改成功后会退出所有设备，需要使用新密码重新登录。",
@@ -1838,6 +1847,7 @@
       "showcaseDescription": "角色、分镜、声音与镜头，在同一条制作线上持续推进"
     },
     "otp": {
+      "existingAccountHint": "已有账号？请先用账号密码登录，再在账号菜单中绑定手机号，避免创建新账号。",
       "tab": "验证码登录",
       "phone": "手机号",
       "phonePlaceholder": "输入手机号",

--- a/frontend/src/__tests__/components/account/phone-binding-dialog.test.tsx
+++ b/frontend/src/__tests__/components/account/phone-binding-dialog.test.tsx
@@ -1,0 +1,162 @@
+// SPDX-License-Identifier: Elastic-2.0
+// Copyright (c) 2026 ClaymoreLab
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { PhoneBindingDialog } from "@/components/account/phone-binding-dialog";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+vi.mock("sonner", () => ({ toast: { success: vi.fn() } }));
+
+const challenge = {
+  verification_id: "A".repeat(26),
+  phone_masked: "138****8000",
+  expires_in_seconds: 300,
+};
+const reply = (data: unknown, status = 200) =>
+  new Response(JSON.stringify(data), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+
+describe("PhoneBindingDialog", () => {
+  beforeEach(() => vi.restoreAllMocks());
+
+  async function requestCode() {
+    fireEvent.change(
+      screen.getByLabelText("header.account.passwordDialog.current"),
+      { target: { value: "current-password" } },
+    );
+    fireEvent.change(screen.getByLabelText("auth.otp.phone"), {
+      target: { value: "13800138000" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "auth.otp.send" }));
+    await screen.findByLabelText("auth.otp.code");
+  }
+
+  it("binds via authenticated account endpoints without replacing the session", async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(reply({ ok: true, data: challenge }))
+      .mockResolvedValueOnce(
+        reply({
+          ok: true,
+          data: {
+            phone: "+8613800138000",
+            phone_masked: challenge.phone_masked,
+          },
+        }),
+      );
+    const onBound = vi.fn();
+    const onClose = vi.fn();
+    render(<PhoneBindingDialog onBound={onBound} onClose={onClose} />);
+    expect(
+      screen.getByRole("button", { name: "auth.otp.send" }),
+    ).toBeDisabled();
+    await requestCode();
+    fireEvent.change(screen.getByLabelText("auth.otp.code"), {
+      target: { value: "123456" },
+    });
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "header.account.phoneBinding.submit",
+      }),
+    );
+    await waitFor(() => expect(onBound).toHaveBeenCalledOnce());
+    expect(onClose).toHaveBeenCalledOnce();
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      1,
+      "/api/v1/account/phone/request",
+      expect.objectContaining({
+        credentials: "include",
+        body: JSON.stringify({
+          phone: "13800138000",
+          current_password: "current-password",
+        }),
+      }),
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      "/api/v1/account/phone/verify",
+      expect.objectContaining({
+        credentials: "include",
+        body: JSON.stringify({
+          phone: "13800138000",
+          current_password: "current-password",
+          code: "123456",
+          verification_id: challenge.verification_id,
+        }),
+      }),
+    );
+  });
+
+  it("keeps the existing account when a verified phone is already in use", async () => {
+    vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(reply({ ok: true, data: challenge }))
+      .mockResolvedValueOnce(reply({ detail: { code: "PHONE_IN_USE" } }, 409));
+    const onBound = vi.fn();
+    render(<PhoneBindingDialog onBound={onBound} onClose={vi.fn()} />);
+    await requestCode();
+    fireEvent.change(screen.getByLabelText("auth.otp.code"), {
+      target: { value: "123456" },
+    });
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "header.account.phoneBinding.submit",
+      }),
+    );
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "header.account.phoneBinding.inUse",
+    );
+    expect(onBound).not.toHaveBeenCalled();
+  });
+
+  it("invalidates the challenge when phone or password changes", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      reply({ ok: true, data: challenge }),
+    );
+    render(<PhoneBindingDialog onBound={vi.fn()} onClose={vi.fn()} />);
+    await requestCode();
+    fireEvent.change(screen.getByLabelText("auth.otp.phone"), {
+      target: { value: "13900139000" },
+    });
+    expect(screen.queryByLabelText("auth.otp.code")).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("button", {
+        name: "header.account.phoneBinding.submit",
+      }),
+    ).toBeDisabled();
+  });
+
+  it("reuses the verification idempotency key after a lost response", async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(reply({ ok: true, data: challenge }))
+      .mockRejectedValueOnce(new TypeError("network"))
+      .mockResolvedValueOnce(
+        reply({ ok: true, data: { phone: "+8613800138000" } }),
+      );
+    const onBound = vi.fn();
+    render(<PhoneBindingDialog onBound={onBound} onClose={vi.fn()} />);
+    await requestCode();
+    fireEvent.change(screen.getByLabelText("auth.otp.code"), {
+      target: { value: "123456" },
+    });
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "header.account.phoneBinding.submit",
+      }),
+    );
+    await screen.findByRole("alert");
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "header.account.phoneBinding.submit",
+      }),
+    );
+    await waitFor(() => expect(onBound).toHaveBeenCalledOnce());
+    expect(fetchMock.mock.calls[1][1]?.headers).toEqual(
+      fetchMock.mock.calls[2][1]?.headers,
+    );
+  });
+});

--- a/frontend/src/__tests__/components/layout/header.test.tsx
+++ b/frontend/src/__tests__/components/layout/header.test.tsx
@@ -8,7 +8,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { Header } from "@/components/layout/header";
 
-const runtimeState = vi.hoisted(() => ({ authRequired: true, isCe: false }));
+const runtimeState = vi.hoisted(() => ({ authRequired: true, isCe: false, phoneVisible: false }));
 const authState = vi.hoisted(() => ({ username: "local", logout: vi.fn() }));
 const resetUserSessionStateMock = vi.hoisted(() => vi.fn());
 const securityState = vi.hoisted(() => ({
@@ -32,6 +32,7 @@ vi.mock("@/lib/reset-region-state", () => ({
 vi.mock("@/lib/runtime-config", () => ({
   authRequired: () => runtimeState.authRequired,
   isCeRuntime: () => runtimeState.isCe,
+  phoneOtpEntryVisible: () => runtimeState.phoneVisible,
 }));
 
 vi.mock("@/lib/queries/model-gateway", () => ({
@@ -73,6 +74,7 @@ vi.mock("react-i18next", () => ({
         "header.account.changeAvatar": "Change avatar",
         "header.account.changePassword": "Change password",
         "header.account.setPassword": "Set password",
+        "header.account.phoneBinding.title": "Bind phone",
         "header.account.selectLanguage": "Select language",
         "header.account.languageChinese": "Chinese",
         "header.account.languageEnglish": "English",
@@ -147,6 +149,7 @@ describe("Header runtime gating", () => {
   beforeEach(() => {
     runtimeState.authRequired = true;
     runtimeState.isCe = false;
+    runtimeState.phoneVisible = false;
     authState.username = "local";
     authState.logout.mockReset();
     resetUserSessionStateMock.mockReset();
@@ -203,6 +206,24 @@ describe("Header runtime gating", () => {
 
     expect(await screen.findByText("138****8000")).toBeInTheDocument();
     expect(screen.getByText("Set password")).toBeInTheDocument();
+  });
+
+  it.each([false, true])("gates first phone binding on phone entry visibility (%s)", async (visible) => {
+    runtimeState.phoneVisible = visible;
+    securityState.data = { password_configured: true, phone: null, phone_masked: null };
+    renderHeader();
+    fireEvent.mouseEnter(screen.getByLabelText("Open account").parentElement!);
+    await screen.findByText("Log out");
+    expect(screen.queryByText("Bind phone") !== null).toBe(visible);
+  });
+
+  it("does not offer replacing an existing phone", async () => {
+    runtimeState.phoneVisible = true;
+    securityState.data = { password_configured: true, phone: "+8613800138000", phone_masked: "138****8000" };
+    renderHeader();
+    fireEvent.mouseEnter(screen.getByLabelText("Open account").parentElement!);
+    await screen.findByText("Log out");
+    expect(screen.queryByText("Bind phone")).not.toBeInTheDocument();
   });
 
   it("moves the announcement entry from the header actions into the account panel", async () => {

--- a/frontend/src/components/account/phone-binding-dialog.tsx
+++ b/frontend/src/components/account/phone-binding-dialog.tsx
@@ -1,0 +1,240 @@
+// SPDX-License-Identifier: Elastic-2.0
+// Copyright (c) 2026 ClaymoreLab
+import { useEffect, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  AuthApiError,
+  bindAccountPhone,
+  newAuthIdempotencyKey,
+  type OtpChallenge,
+} from "@/lib/auth-api";
+
+export function PhoneBindingDialog({
+  onClose,
+  onBound,
+}: {
+  onClose: () => void;
+  onBound: () => void;
+}) {
+  const { t } = useTranslation();
+  const [phone, setPhone] = useState("");
+  const [password, setPassword] = useState("");
+  const [code, setCode] = useState("");
+  const [challenge, setChallenge] = useState<OtpChallenge | null>(null);
+  const [busy, setBusy] = useState(false);
+  const busyRef = useRef(false);
+  const [cooldown, setCooldown] = useState(0);
+  const [error, setError] = useState<string | null>(null);
+  const requestKey = useRef(newAuthIdempotencyKey());
+  const verifyKey = useRef(newAuthIdempotencyKey());
+  const alive = useRef(true);
+  useEffect(() => {
+    alive.current = true;
+    return () => {
+      alive.current = false;
+    };
+  }, []);
+  useEffect(() => {
+    if (cooldown <= 0) return;
+    const timer = window.setTimeout(
+      () => setCooldown((value) => Math.max(0, value - 1)),
+      1000,
+    );
+    return () => window.clearTimeout(timer);
+  }, [cooldown]);
+
+  function showError(exc: unknown) {
+    let key = "header.account.phoneBinding.error";
+    if (exc instanceof AuthApiError) {
+      if (exc.code === "CURRENT_PASSWORD_INCORRECT")
+        key = "header.account.passwordDialog.currentIncorrect";
+      else if (exc.code === "PHONE_IN_USE")
+        key = "header.account.phoneBinding.inUse";
+      else if (exc.code === "PHONE_ALREADY_BOUND")
+        key = "header.account.phoneBinding.alreadyBound";
+      else if (exc.status === 429) key = "auth.otp.rateLimited";
+      else if (exc.status === 400 || exc.status === 422)
+        key = "auth.otp.invalidPhone";
+      else if (
+        exc.status === 401 ||
+        exc.status === 410 ||
+        exc.code === "OTP_CHALLENGE_CONSUMED"
+      )
+        key = "auth.otp.invalidCode";
+      else if (exc.status === 503) key = "auth.otp.unavailable";
+    }
+    setError(t(key));
+  }
+
+  async function sendCode() {
+    if (busyRef.current || cooldown > 0 || !phone.trim() || !password) return;
+    busyRef.current = true;
+    setBusy(true);
+    setError(null);
+    try {
+      const result = (await bindAccountPhone(
+        "request",
+        { phone, current_password: password },
+        requestKey.current,
+      )) as OtpChallenge;
+      if (!alive.current) return;
+      setChallenge(result);
+      setCode("");
+      setCooldown(60);
+      requestKey.current = newAuthIdempotencyKey();
+      verifyKey.current = newAuthIdempotencyKey();
+      toast.success(t("auth.otp.sent", { phone: result.phone_masked }));
+    } catch (exc) {
+      if (alive.current) showError(exc);
+    } finally {
+      busyRef.current = false;
+      if (alive.current) setBusy(false);
+    }
+  }
+
+  async function submit(event: React.FormEvent) {
+    event.preventDefault();
+    if (busyRef.current || !challenge || !/^\d{6}$/.test(code)) return;
+    busyRef.current = true;
+    setBusy(true);
+    setError(null);
+    try {
+      await bindAccountPhone(
+        "verify",
+        {
+          phone,
+          current_password: password,
+          code,
+          verification_id: challenge.verification_id,
+        },
+        verifyKey.current,
+      );
+      if (!alive.current) return;
+      toast.success(t("header.account.phoneBinding.success"));
+      onBound();
+      onClose();
+    } catch (exc) {
+      if (alive.current) showError(exc);
+    } finally {
+      busyRef.current = false;
+      if (alive.current) setBusy(false);
+    }
+  }
+
+  function resetChallenge() {
+    setChallenge(null);
+    setCode("");
+    setError(null);
+    requestKey.current = newAuthIdempotencyKey();
+    verifyKey.current = newAuthIdempotencyKey();
+  }
+
+  return (
+    <Dialog
+      open
+      onOpenChange={(open) => {
+        if (!open && !busyRef.current) onClose();
+      }}
+    >
+      <DialogContent className="max-w-sm">
+        <DialogHeader>
+          <DialogTitle>{t("header.account.phoneBinding.title")}</DialogTitle>
+          <DialogDescription>
+            {t("header.account.phoneBinding.description")}
+          </DialogDescription>
+        </DialogHeader>
+        <form onSubmit={submit} className="space-y-4">
+          <label className="block space-y-1.5 text-sm">
+            <span>{t("header.account.passwordDialog.current")}</span>
+            <Input
+              type="password"
+              autoComplete="current-password"
+              maxLength={512}
+              value={password}
+              disabled={busy}
+              onChange={(event) => {
+                setPassword(event.target.value);
+                resetChallenge();
+              }}
+            />
+          </label>
+          <label className="block space-y-1.5 text-sm">
+            <span>{t("auth.otp.phone")}</span>
+            <Input
+              type="tel"
+              autoComplete="tel"
+              maxLength={32}
+              value={phone}
+              disabled={busy}
+              onChange={(event) => {
+                setPhone(event.target.value);
+                resetChallenge();
+              }}
+            />
+          </label>
+          <Button
+            type="button"
+            variant="outline"
+            disabled={busy || cooldown > 0 || !phone.trim() || !password}
+            onClick={() => void sendCode()}
+          >
+            {cooldown > 0
+              ? t("auth.otp.resendIn", { seconds: cooldown })
+              : t(challenge ? "auth.otp.resend" : "auth.otp.send")}
+          </Button>
+          {challenge ? (
+            <label className="block space-y-1.5 text-sm">
+              <span>{t("auth.otp.code")}</span>
+              <Input
+                inputMode="numeric"
+                autoComplete="one-time-code"
+                maxLength={6}
+                value={code}
+                disabled={busy}
+                onChange={(event) =>
+                  setCode(event.target.value.replace(/\D/g, ""))
+                }
+              />
+            </label>
+          ) : null}
+          {error ? (
+            <p role="alert" className="text-sm text-destructive">
+              {error}
+            </p>
+          ) : null}
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              disabled={busy}
+              onClick={onClose}
+            >
+              {t("common.cancel")}
+            </Button>
+            <Button
+              type="submit"
+              disabled={busy || !challenge || !/^\d{6}$/.test(code)}
+            >
+              {t(
+                busy
+                  ? "auth.otp.verifying"
+                  : "header.account.phoneBinding.submit",
+              )}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/components/layout/header.tsx
+++ b/frontend/src/components/layout/header.tsx
@@ -20,6 +20,7 @@ import {
 import { Button } from "@/components/ui/button";
 import { AvatarUploadDialog } from "@/components/account/avatar-upload-dialog";
 import { PasswordChangeDialog } from "@/components/account/password-change-dialog";
+import { PhoneBindingDialog } from "@/components/account/phone-binding-dialog";
 import {
   Tooltip,
   TooltipContent,
@@ -37,7 +38,7 @@ import {
 import { useQueryClient } from "@tanstack/react-query";
 import { useAuthStore } from "@/stores/auth-store";
 import { useAppStore } from "@/stores/app-store";
-import { authRequired, isCeRuntime } from "@/lib/runtime-config";
+import { authRequired, isCeRuntime, phoneOtpEntryVisible } from "@/lib/runtime-config";
 import { resetUserSessionState } from "@/lib/reset-region-state";
 import { useModelGatewayConfig } from "@/lib/queries/model-gateway";
 import { useOrgBranding } from "@/lib/queries/org-branding";
@@ -69,6 +70,7 @@ export function Header({ ambientBackground = false }: { ambientBackground?: bool
   const [releaseNotificationStateVersion, setReleaseNotificationStateVersion] = useState(0);
   const [avatarDialogOpen, setAvatarDialogOpen] = useState(false);
   const [passwordDialogOpen, setPasswordDialogOpen] = useState(false);
+  const [phoneBindingOpen, setPhoneBindingOpen] = useState(false);
   const [accountPanelOpen, setAccountPanelOpen] = useState(false);
   const [accountPanelVisible, setAccountPanelVisible] = useState(false);
   const [settingsWarningBubbleDismissed, setSettingsWarningBubbleDismissed] = useState(false);
@@ -112,6 +114,8 @@ export function Header({ ambientBackground = false }: { ambientBackground?: bool
     : t("app.logoHomeTooltip");
   const accountSecurity = useAccountSecurity(!ceRuntime && showLogout && Boolean(username));
   const passwordConfigured = accountSecurity.data?.password_configured ?? true;
+  const canBindPhone = !ceRuntime && showLogout && phoneOtpEntryVisible()
+    && accountSecurity.data?.phone === null && accountSecurity.data?.password_configured === true;
   const displayName = accountSecurity.data?.phone_masked ?? storedDisplayName ?? username ?? "User";
   const avatarInitial = displayName.slice(0, 1).toUpperCase();
   const activeLanguage = normalize(i18n.resolvedLanguage ?? i18n.language);
@@ -446,6 +450,10 @@ export function Header({ ambientBackground = false }: { ambientBackground?: bool
               hasUnreadNotification={hasUnreadNotification}
               onChangeAvatar={openAvatarDialog}
               onChangePassword={showLogout ? openPasswordDialog : undefined}
+              onBindPhone={canBindPhone ? () => {
+                closeAccountPanelNow();
+                setPhoneBindingOpen(true);
+              } : undefined}
               onLanguageChange={switchLanguage}
               onNotifications={openNotifications}
               onClose={scheduleCloseAccountPanel}
@@ -486,6 +494,11 @@ export function Header({ ambientBackground = false }: { ambientBackground?: bool
         onPasswordChanged={handlePasswordChanged}
         passwordConfigured={passwordConfigured}
       />
+      {phoneBindingOpen && canBindPhone ? <PhoneBindingDialog
+        key={username}
+        onClose={() => setPhoneBindingOpen(false)}
+        onBound={() => { void accountSecurity.refetch(); }}
+      /> : null}
       {ceRuntime ? <SettingsDialog open={settingsOpen} onOpenChange={setSettingsOpen} /> : null}
       {settingsWarningBubble
         ? createPortal(
@@ -578,6 +591,7 @@ function AccountPanel({
   hasUnreadNotification,
   onChangeAvatar,
   onChangePassword,
+  onBindPhone,
   onLanguageChange,
   onNotifications,
   onClose,
@@ -596,6 +610,7 @@ function AccountPanel({
   hasUnreadNotification: boolean;
   onChangeAvatar: () => void;
   onChangePassword?: () => void;
+  onBindPhone?: () => void;
   onLanguageChange: (lang: Supported) => void;
   onNotifications: () => void;
   onClose: () => void;
@@ -636,6 +651,11 @@ function AccountPanel({
           </span>
         </div>
         <div className="space-y-0.5">
+          {onBindPhone ? <AccountMenuRow
+            icon={<KeyRound className="size-3.5" />}
+            label={t("header.account.phoneBinding.title")}
+            onClick={onBindPhone}
+          /> : null}
           <AccountMenuRow
             icon={<Bell className="size-3.5" />}
             label={t("header.notifications")}

--- a/frontend/src/components/login/login-card.tsx
+++ b/frontend/src/components/login/login-card.tsx
@@ -375,7 +375,7 @@ function OtpLoginForm({ needsRegion }: { needsRegion: boolean }) {
           {error}
         </p>
       ) : (
-        <p className={styles.otpHint}>{t("auth.otp.autoRegisterHint")}</p>
+        <p className={styles.otpHint}>{t("auth.otp.autoRegisterHint")} {t("auth.otp.existingAccountHint")}</p>
       )}
 
       <button

--- a/frontend/src/lib/auth-api.ts
+++ b/frontend/src/lib/auth-api.ts
@@ -50,6 +50,27 @@ export function newAuthIdempotencyKey(): string {
   return `web:${crypto.randomUUID()}`;
 }
 
+export async function bindAccountPhone(
+  action: "request" | "verify",
+  input: {
+    phone: string;
+    current_password: string;
+    verification_id?: string;
+    code?: string;
+  },
+  idempotencyKey: string,
+): Promise<OtpChallenge | { phone: string; phone_masked: string }> {
+  const response = await fetch(`/api/v1/account/phone/${action}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", "Idempotency-Key": idempotencyKey },
+    credentials: "include",
+    body: JSON.stringify(input),
+    signal: regionAbortController().signal,
+  });
+  if (!response.ok) throw await authError(response, "Phone binding failed");
+  return (await response.json()).data;
+}
+
 export async function requestOtp(
   phone: string,
   idempotencyKey: string,

--- a/license-inventory.csv
+++ b/license-inventory.csv
@@ -291,6 +291,7 @@ frontend/src/__tests__/api/style-templates-shape.test.ts,Elastic-2.0,2026 SuperT
 frontend/src/__tests__/api/task-poll-timeout.test.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/__tests__/components/account/avatar-upload-dialog.test.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/__tests__/components/account/password-change-dialog.test.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
+frontend/src/__tests__/components/account/phone-binding-dialog.test.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/__tests__/components/assets/asset-panels-rename.test.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/__tests__/components/assets/asset-tabs-beats-contract.test.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/__tests__/components/assets/character-image-source-select.test.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
@@ -714,6 +715,7 @@ frontend/src/commands/image.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.tom
 frontend/src/components/GlobalErrorDialog.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/components/account/avatar-upload-dialog.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/components/account/password-change-dialog.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
+frontend/src/components/account/phone-binding-dialog.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/components/app-update-available.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/components/app-update-required.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/components/assets/asset-beat-references.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation


### PR DESCRIPTION
## Summary

- Add first phone binding for existing password accounts, using the current password and SMS verification.
- Show the account-menu entry only in authenticated EE, when the existing phone-entry visibility flag is enabled and the account has a password but no phone.
- Never offer replacing/unlinking a phone or merging accounts; retain the existing session and refresh account security after success.
- Tell existing users to sign in with their password before linking a phone, to avoid creating another account.
- Include Chinese, English, Vietnamese copy and license inventory entries.

## Backend contract / deployment

Requires the paired authentication-backend rollout first:

- `POST /api/v1/account/phone/request`: `{phone,current_password}` plus `Idempotency-Key`; returns the existing OTP challenge shape.
- `POST /api/v1/account/phone/verify`: adds `{verification_id,code}`; returns `{ok:true,data:{phone,phone_masked}}`.
- Existing `GET /api/v1/account/security` is unchanged. No new runtime flag or environment variable.
- Backend also enables platform entitlement for future phone signups without granting credits or changing existing users.

## Validation

- `pnpm build`: passed.
- `pnpm test --run`: 419 files / 3006 tests passed.
- Frontend i18n hardcoded-copy check: passed.
- License inventory coverage test: passed.
- New tests cover successful binding, occupied phone, challenge reset, lost-response retry, hidden entry and already-bound accounts.

Real SMS delivery was not exercised; automated tests do not send billable messages.
