### PR TITLE
fix(backup): files-sync 改用 --checksum 比对，去掉逐对象 HEAD

### DIFF
--- a/src/novelvideo/backup/files_sync.py
+++ b/src/novelvideo/backup/files_sync.py
@@ -114,6 +114,7 @@ def build_sync_cmd(
         "--backup-dir",
         history_dst,
         "--fast-list",
+        "--checksum",
         "--transfers",
         "8",
         "--skip-links",

--- a/tests/test_backup_files_sync.py
+++ b/tests/test_backup_files_sync.py
@@ -79,6 +79,24 @@ def test_build_sync_cmd_shape(tmp_path):
     assert "--local-no-check-updated" not in cmd
 
 
+def test_build_sync_cmd_compares_content_not_mtime(tmp_path):
+    cmd = build_sync_cmd(
+        src="/data/state",
+        dst="oss:dramaclaw-celery-backup/backup/ack/node-ack-a/state",
+        history_dst="oss:dramaclaw-celery-backup/backup/ack/node-ack-a/files-history/20260910T000000Z",
+        filter_file=tmp_path / "filter.txt",
+    )
+
+    # Default size+mtime comparison HEADs every object to read its mtime
+    # metadata (S3/OSS listings omit it); --checksum reuses the listed MD5 ETag.
+    assert "--checksum" in cmd
+    # These also skip the HEADs but silently drop changes: --update with server
+    # modtime skips edits landing between read and upload completion (and
+    # restored older versions); --size-only skips same-size edits.
+    for unsafe in ("--update", "--use-server-modtime", "--size-only"):
+        assert unsafe not in cmd
+
+
 def test_snapshot_reads_open_inode_when_atomic_replace_lands(monkeypatch, tmp_path):
     state_dir = tmp_path / "state"
     canvas_dir = state_dir / "user" / "project" / "freezone" / "canvases"


### PR DESCRIPTION
## PR 类型 / Type of PR
- [x] 🐞 Bug 修复 / Bug fix
- [ ] ✨ 新功能 / Feature
- [ ] 📝 文档 / Documentation
- [ ] 🧹 重构 / 清理 / Refactor or cleanup
- [ ] ⚙️ 构建 / CI / Build or CI
- [ ] ⚠️ 破坏性变更 / Breaking change

## 改动说明 / What this PR does and why

`files-sync` 的 `rclone sync` 加上 `--checksum`。

rclone 默认按「大小 + mtime」判断文件是否变化。在 S3/OSS 上，mtime 存在对象的自定义元数据里，列表接口不返回，所以**每比对一个大小相同的对象都要额外发一次 `HeadObject`**。files-sync 每轮对整棵 state 树跑两遍（hot 快照 + live），HEAD 请求量随文件数 × 运行频率线性增长，是备份桶请求费的主要来源。

`--checksum` 改用列表结果里已有的 MD5 ETag 比对，不再逐对象 HEAD。备份频率和 RPO 不变。

`build_snapshot_copyto_cmd` 不改：单对象 `copyto` 本身就要 HEAD 目标对象，加 `--checksum` 不减少请求。

## 关联 issue / Linked issues
N/A

## 给 reviewer 的说明 / Notes for the reviewer

**实测**（rclone v1.69.3 与 v1.75.0 结果一致）：

| 场景 | 默认 | `--checksum` |
|---|---:|---:|
| MinIO，2,001 个文件稳态同步，HEAD 次数 | 2,003 | 3 |
| 阿里云 OSS，1,377 个真实对象 dry-run，HEAD 次数 | 1,378 | **1** |
| OSS dry-run 判定需重传 / 删除 | 0 / 0 | 0 / 0 |

OSS 返回的 ETag 是大写十六进制，rclone 能正常识别为 MD5（1,377/1,377 个对象均有 MD5）。

**为什么不用 `--update --use-server-modtime`**：它同样能免 HEAD，但改为比较「本地 mtime vs 服务端上传时间」，会**静默漏备份**。复现（MinIO，2,001 个文件，三种模式各自独立目标）：

| 场景 | 默认 | `--update --use-server-modtime` | `--checksum` |
|---|---|---|---|
| 正常修改 50 个文件 | ✅ | ✅ | ✅ |
| 修改发生在读取后、上传完成前（20 个） | ✅ | ❌ 跳过，后续轮次也不补 | ✅ |
| 恢复较旧版本（mtime 更早，10 个） | ✅ | ❌ 跳过 | ✅ |
| 删除 | ✅ | ✅ | ✅ |
| 最终 `rclone check` 与源不一致 | 0 | **30** | 0 |

hot 快照是先拷贝、若干分钟后才上传，第二种情况的窗口恰好落在改动最频繁的文件上。`--size-only` 会漏掉大小不变的修改，同样不用。新测试把这三个参数列为禁止项。

**代价**：每轮需在本地对参与比对的文件计算 MD5（实测约 500–670 MB/s）；大于 upload cutoff（默认 200 MiB）的分片对象仍需一次 HEAD 读取 md5 元数据。

## 面向用户的变更 / User-facing change
```release-note
Backup files-sync now compares files by checksum, eliminating one HEAD request per object on every run against S3-compatible storage.
```

## 自检 / Checklist
- [x] 已自测，`uv run pytest` 通过 / Self-tested, `uv run pytest` passes（4423 passed, 16 skipped）
- [x] 必要的文档已更新 / Docs updated where needed（N/A）
- [x] 提交信息清晰（建议 Conventional Commits）/ Clear commits (Conventional Commits suggested)
- [x] 每个 commit 都已 `git commit -s` 附 DCO 签署 / Every commit signed off with `git commit -s` (DCO)
- [x] 我已阅读并同意[贡献者协议](../CONTRIBUTING.md#贡献者协议) / I've read and agree to the [contributor terms](../CONTRIBUTING.md#贡献者协议)

验证命令 / Verification:
```bash
uv run pytest tests/test_backup_files_sync.py -q   # 含新增 test_build_sync_cmd_compares_content_not_mtime
uv run pytest -q                                   # 4423 passed, 16 skipped
pre-commit run --files src/novelvideo/backup/files_sync.py tests/test_backup_files_sync.py
```

https://claude.ai/code/session_01HFhZjQrh8FXBXNfXdywBtM
