### PR TITLE
revert: 撤回 files-sync --checksum（#529），机械盘上全量读盘拖垮同盘服务

### DIFF
--- a/src/novelvideo/backup/files_sync.py
+++ b/src/novelvideo/backup/files_sync.py
@@ -114,7 +114,6 @@ def build_sync_cmd(
         "--backup-dir",
         history_dst,
         "--fast-list",
-        "--checksum",
         "--transfers",
         "8",
         "--skip-links",

--- a/tests/test_backup_files_sync.py
+++ b/tests/test_backup_files_sync.py
@@ -79,24 +79,6 @@ def test_build_sync_cmd_shape(tmp_path):
     assert "--local-no-check-updated" not in cmd
 
 
-def test_build_sync_cmd_compares_content_not_mtime(tmp_path):
-    cmd = build_sync_cmd(
-        src="/data/state",
-        dst="oss:dramaclaw-celery-backup/backup/ack/node-ack-a/state",
-        history_dst="oss:dramaclaw-celery-backup/backup/ack/node-ack-a/files-history/20260910T000000Z",
-        filter_file=tmp_path / "filter.txt",
-    )
-
-    # Default size+mtime comparison HEADs every object to read its mtime
-    # metadata (S3/OSS listings omit it); --checksum reuses the listed MD5 ETag.
-    assert "--checksum" in cmd
-    # These also skip the HEADs but silently drop changes: --update with server
-    # modtime skips edits landing between read and upload completion (and
-    # restored older versions); --size-only skips same-size edits.
-    for unsafe in ("--update", "--use-server-modtime", "--size-only"):
-        assert unsafe not in cmd
-
-
 def test_snapshot_reads_open_inode_when_atomic_replace_lands(monkeypatch, tmp_path):
     state_dir = tmp_path / "state"
     canvas_dir = state_dir / "user" / "project" / "freezone" / "canvases"


### PR DESCRIPTION
## PR 类型 / Type of PR
- [x] 🐞 Bug 修复 / Bug fix
- [ ] ✨ 新功能 / Feature
- [ ] 📝 文档 / Documentation
- [ ] 🧹 重构 / 清理 / Refactor or cleanup
- [ ] ⚙️ 构建 / CI / Build or CI
- [ ] ⚠️ 破坏性变更 / Breaking change

## 改动说明 / What this PR does and why

撤回 #529（files-sync 的 `rclone sync` 加 `--checksum`），恢复原有的 size+mtime 比对。

`--checksum` 让 rclone 每一轮都**读取全部源文件内容**计算 MD5。#529 验证时只在 SSD + 页缓存环境测了 MD5 吞吐，没有覆盖 state 位于机械盘的部署。上线后在这类部署上：

| state-sync 阶段 | #529 之前 | #529 之后 |
|---|---:|---:|
| 耗时（约 14.6 万个文件） | 73–76 s | 16m37s / 17m45s / 19m19s |
| 结果 | 成功 | 失败 / 失败 / 第 3 次尝试成功 |

扫描被拉长后，应用在此期间清理掉的文件会触发 `lstat` 错误，rclone 随即**整轮重试（最多 3 次），每次重试都再次全量读盘**，最终打满磁盘，拖慢同盘的 API。

## 关联 issue / Linked issues
Reverts #529

## 给 reviewer 的说明 / Notes for the reviewer

- 撤回后 `src/` 与 `tests/` 与 #529 之前（`c62b4099`）完全一致。
- 去掉 HEAD 请求的目标不变，后续改为另一种做法单独提 PR：rclone `hasher` 后端缓存 MD5（缓存命中时不读文件内容，实测无变化轮次读源 ≈0、HEAD ≈0）。它需要持久化且不在机械盘上的缓存目录，并在低峰期预热，否则首轮同样会全量读盘。
- `--update --use-server-modtime` 仍然不能用（会静默漏备份），理由见 #529。

## 面向用户的变更 / User-facing change
```release-note
Revert the files-sync --checksum change, which read every source file on each run and saturated spinning disks.
```

## 自检 / Checklist
- [x] 已自测 / Self-tested：`uv run pytest tests/test_backup_*.py`（38 passed）；代码树与 #529 前一致
- [x] 必要的文档已更新 / Docs updated where needed（N/A）
- [x] 提交信息清晰（建议 Conventional Commits）/ Clear commits (Conventional Commits suggested)
- [x] 每个 commit 都已 `git commit -s` 附 DCO 签署 / Every commit signed off with `git commit -s` (DCO)
- [x] 我已阅读并同意[贡献者协议](../CONTRIBUTING.md#贡献者协议) / I've read and agree to the [contributor terms](../CONTRIBUTING.md#贡献者协议)

https://claude.ai/code/session_01HFhZjQrh8FXBXNfXdywBtM
