### PR TITLE
fix(backup): 文件备份与每日快照跳过已弃用的项目 Cognee 数据

### DIFF
--- a/license-inventory.csv
+++ b/license-inventory.csv
@@ -1562,6 +1562,7 @@ src/novelvideo/backup/__init__.py,Elastic-2.0,2026 SuperTale contributors,REUSE.
 src/novelvideo/backup/cli.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 src/novelvideo/backup/db_daily.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 src/novelvideo/backup/files_sync.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
+src/novelvideo/backup/scope.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 src/novelvideo/backup/wal_migrator.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 src/novelvideo/chat/__init__.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 src/novelvideo/chat/backend_sdk.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
@@ -1992,6 +1993,7 @@ tests/test_background_anchor_service.py,Elastic-2.0,2026 SuperTale contributors,
 tests/test_backup_db_daily.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_backup_files_sync.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_backup_restore_cli.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
+tests/test_backup_scope.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_backup_wal_migrator.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_batch_render_removed.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 tests/test_batch_render_video_actions_removed.py,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation

--- a/src/novelvideo/backup/db_daily.py
+++ b/src/novelvideo/backup/db_daily.py
@@ -7,17 +7,23 @@ import sqlite3
 import sys
 from pathlib import Path
 
+from novelvideo.backup.scope import is_deprecated_cognee_path
 from novelvideo.backup.wal_migrator import iter_sqlite_files
 
 SNAPSHOT_SUFFIX = ".snapshot"
 
 
 def snapshot_state_tree(state_dir: Path) -> tuple[int, int]:
-    """Create `<db>.snapshot` next to every SQLite database under state_dir."""
+    """Create `<db>.snapshot` next to every SQLite database under state_dir.
+
+    Deprecated Cognee stores are skipped; see novelvideo.backup.scope.
+    """
 
     ok = 0
     failed = 0
     for db_path in iter_sqlite_files(state_dir):
+        if is_deprecated_cognee_path(db_path.relative_to(state_dir)):
+            continue
         # Hermes owns its own SQLite settings; keep the top-level state.db daily
         # snapshot, but skip cache/session SQLite files in deeper subdirectories.
         if ".hermes" in db_path.parts and db_path.parent.name != ".hermes":

--- a/src/novelvideo/backup/files_sync.py
+++ b/src/novelvideo/backup/files_sync.py
@@ -13,6 +13,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import BinaryIO
 
+from novelvideo.backup.scope import DEPRECATED_COGNEE_FILTER_RULES, is_deprecated_cognee_path
 from novelvideo.freezone.canvas_lock import canvas_write_lock
 from novelvideo.freezone.paths import CANVAS_ID_RE
 
@@ -60,9 +61,11 @@ def _filter_text(*rules: str) -> str:
 RCLONE_FILTER = _filter_text(*_BASE_FILTER_RULES, "+ **")
 
 # The live-tree pass excludes hot state. Those files are copied from an immutable
-# per-run staging tree with HOT_SNAPSHOT_FILTER instead.
+# per-run staging tree with HOT_SNAPSHOT_FILTER instead. Deprecated Cognee stores are
+# skipped here only, so restore (RCLONE_FILTER) still reaches the copies in OSS.
 LIVE_SYNC_FILTER = _filter_text(
     *_BASE_FILTER_RULES,
+    *DEPRECATED_COGNEE_FILTER_RULES,
     *(f"- {pattern}" for pattern in _HOT_STATE_PATTERNS),
     "+ **",
 )
@@ -149,7 +152,9 @@ def sync_db_snapshots(
     snapshots = [
         snap
         for snap in sorted(state_dir.rglob(f"*{SNAPSHOT_SUFFIX}"))
-        if snap.is_file() and not snap.is_symlink()
+        if snap.is_file()
+        and not snap.is_symlink()
+        and not is_deprecated_cognee_path(snap.relative_to(state_dir))
     ]
     print(
         f"backup_stage_start stage=db-snapshots-sync files={len(snapshots)}",

--- a/src/novelvideo/backup/scope.py
+++ b/src/novelvideo/backup/scope.py
@@ -1,0 +1,27 @@
+"""Parts of the state/output trees that file backups deliberately leave out."""
+
+from __future__ import annotations
+
+from pathlib import PurePath
+
+# Cognee is deprecated. New backups skip each project's Cognee stores; copies already
+# in OSS are kept, and the restore filter (RCLONE_FILTER) can still reach them.
+DEPRECATED_COGNEE_DIRS = ("cognee_system", "cognee_data")
+
+# Projects live at <user>/<project>/ or, for organizations, _orgs/<org>/<user>/<project>/.
+_ORGS_DIR = "_orgs"
+
+DEPRECATED_COGNEE_FILTER_RULES = tuple(
+    rule
+    for name in DEPRECATED_COGNEE_DIRS
+    for rule in (f"- /*/*/{name}/**", f"- /{_ORGS_DIR}/*/*/*/{name}/**")
+)
+
+
+def is_deprecated_cognee_path(relative: str | PurePath) -> bool:
+    """Match a path relative to the tree root the way DEPRECATED_COGNEE_FILTER_RULES do."""
+
+    parts = PurePath(relative).parts
+    if len(parts) > 3 and parts[2] in DEPRECATED_COGNEE_DIRS:
+        return True
+    return len(parts) > 5 and parts[0] == _ORGS_DIR and parts[4] in DEPRECATED_COGNEE_DIRS

--- a/tests/test_backup_db_daily.py
+++ b/tests/test_backup_db_daily.py
@@ -19,14 +19,14 @@ def test_snapshot_in_place_all_dbs(tmp_path):
     state = tmp_path / "state"
     data = state / "u1" / "p1" / "data.db"
     _make_db(data, rows=3)
-    cognee = state / "u1" / "p1" / "cognee_system" / "databases" / "cognee_db"
-    _make_db(cognee, rows=2)
+    chat = state / "u1" / "p1" / "chat.db"
+    _make_db(chat, rows=2)
     (state / "u1" / "p1" / "project_config.json").write_text("{}", encoding="utf-8")
 
     ok, failed = snapshot_state_tree(state)
 
     assert ok == 2 and failed == 0
-    for src, rows in ((data, 3), (cognee, 2)):
+    for src, rows in ((data, 3), (chat, 2)):
         snap = src.with_name(src.name + ".snapshot")
         assert snap.exists()
         conn = sqlite3.connect(snap)
@@ -36,19 +36,37 @@ def test_snapshot_in_place_all_dbs(tmp_path):
         assert not snap.with_name(snap.name + ".tmp").exists()
 
 
+def test_snapshot_skips_deprecated_cognee_stores(tmp_path):
+    state = tmp_path / "state"
+    data = state / "u1" / "p1" / "data.db"
+    org_data = state / "_orgs" / "o" / "u1" / "p2" / "data.db"
+    cognee = state / "u1" / "p1" / "cognee_system" / "databases" / "cognee_db"
+    org_cognee = state / "_orgs" / "o" / "u1" / "p2" / "cognee_system" / "databases" / "cognee_db"
+    for db in (data, org_data, cognee, org_cognee):
+        _make_db(db)
+
+    ok, failed = snapshot_state_tree(state)
+
+    assert (ok, failed) == (2, 0)
+    for db in (data, org_data):
+        assert db.with_name(db.name + ".snapshot").exists()
+    for db in (cognee, org_cognee):
+        assert not db.with_name(db.name + ".snapshot").exists()
+
+
 def test_rerun_replaces_snapshot_and_skips_own_output(tmp_path):
     state = tmp_path / "state"
-    cognee = state / "u1" / "p1" / "cognee_system" / "databases" / "cognee_db"
-    _make_db(cognee, rows=1)
+    db = state / "u1" / "p1" / "data.db"
+    _make_db(db, rows=1)
 
     assert snapshot_state_tree(state) == (1, 0)
-    conn = sqlite3.connect(cognee)
+    conn = sqlite3.connect(db)
     conn.execute("INSERT INTO t VALUES (99)")
     conn.commit()
     conn.close()
 
     assert snapshot_state_tree(state) == (1, 0)
-    snap = cognee.with_name("cognee_db.snapshot")
+    snap = db.with_name("data.db.snapshot")
     conn = sqlite3.connect(snap)
     assert conn.execute("SELECT count(*) FROM t").fetchone()[0] == 2
     conn.close()
@@ -56,9 +74,9 @@ def test_rerun_replaces_snapshot_and_skips_own_output(tmp_path):
 
 def test_failed_snapshot_keeps_yesterday_and_no_tmp(tmp_path):
     state = tmp_path / "state"
-    bad = state / "u1" / "p1" / "cognee_system" / "databases" / "cognee_db"
+    bad = state / "u1" / "p1" / "data.db"
     bad.parent.mkdir(parents=True, exist_ok=True)
-    yesterday = bad.with_name("cognee_db.snapshot")
+    yesterday = bad.with_name("data.db.snapshot")
     yesterday.write_bytes(b"yesterday-good")
     bad.write_bytes(b"SQLite format 3\x00" + b"garbage" * 10)
 
@@ -66,7 +84,7 @@ def test_failed_snapshot_keeps_yesterday_and_no_tmp(tmp_path):
 
     assert ok == 0 and failed == 1
     assert yesterday.read_bytes() == b"yesterday-good"
-    assert not bad.with_name("cognee_db.snapshot.tmp").exists()
+    assert not bad.with_name("data.db.snapshot.tmp").exists()
 
 
 def test_main_empty_tree_is_success(tmp_path, monkeypatch):

--- a/tests/test_backup_files_sync.py
+++ b/tests/test_backup_files_sync.py
@@ -602,6 +602,36 @@ def test_db_snapshot_stage_logs_count_and_stops_on_failure(
     )
 
 
+def test_db_snapshot_stage_skips_deprecated_cognee_stores(monkeypatch, tmp_path):
+    state_dir = tmp_path / "state"
+    for rel in (
+        "u/p/data.db.snapshot",
+        "u/p/cognee_system/databases/cognee_db.snapshot",
+        "_orgs/o/u/p/chat.db.snapshot",
+        "_orgs/o/u/p/cognee_system/databases/cognee_db.snapshot",
+    ):
+        path = state_dir / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("s", encoding="utf-8")
+    calls = []
+    monkeypatch.setattr(files_sync_module, "_run", lambda cmd, env: calls.append(cmd) or 0)
+
+    assert (
+        files_sync_module.sync_db_snapshots(
+            state_dir,
+            "oss:bucket/state",
+            "oss:bucket/history/state",
+            {},
+        )
+        == 0
+    )
+
+    assert sorted(cmd[3] for cmd in calls) == [
+        "oss:bucket/state/_orgs/o/u/p/chat.db",
+        "oss:bucket/state/u/p/data.db",
+    ]
+
+
 def test_build_rclone_env(monkeypatch):
     monkeypatch.setenv("BACKUP_OSS_AK", "ak1")
     monkeypatch.setenv("BACKUP_OSS_SK", "sk1")

--- a/tests/test_backup_scope.py
+++ b/tests/test_backup_scope.py
@@ -1,0 +1,123 @@
+"""Backup scope: deprecated project Cognee stores are left out of new backups."""
+
+import shutil
+import subprocess
+
+import pytest
+
+from novelvideo.backup.files_sync import LIVE_SYNC_FILTER, RCLONE_FILTER, build_sync_cmd
+from novelvideo.backup.scope import is_deprecated_cognee_path
+
+_TREE = (
+    "u/p/data.db",
+    "u/p/project_config.json",
+    "u/p/graph-preview.json",
+    "u/p/freezone/canvases/c1.json",
+    "u/p/freezone/assets/a.txt",
+    "u/p/cognee_system/databases/cognee_db",
+    "u/p/cognee_system/lancedb/x.lance",
+    "u/p/cognee_data/raw.txt",
+    "u/p/nested/cognee_system/keep.txt",
+    "u/p/cognee_systemx/keep.txt",
+    "u/p/cognee/keep.txt",
+    "u/p/databases/keep.txt",
+    "_orgs/o/u/p/project_config.json",
+    "_orgs/o/u/p/cognee_system/lancedb/x.lance",
+    "_orgs/o/u/p/cognee_data/raw.txt",
+)
+
+needs_rclone = pytest.mark.skipif(shutil.which("rclone") is None, reason="rclone not installed")
+
+
+def _make_tree(root):
+    for rel in _TREE:
+        path = root / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("x", encoding="utf-8")
+
+
+def _listed(root, filter_text, tmp_path):
+    filter_file = tmp_path / "filter.txt"
+    filter_file.write_text(filter_text, encoding="utf-8")
+    out = subprocess.run(
+        ["rclone", "lsf", "-R", "--files-only", "--filter-from", str(filter_file), str(root)],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout
+    return set(out.split())
+
+
+@pytest.mark.parametrize(
+    ("rel", "expected"),
+    [
+        ("u/p/cognee_system/databases/cognee_db", True),
+        ("u/p/cognee_data/raw.txt", True),
+        ("_orgs/o/u/p/cognee_system/databases/cognee_db", True),
+        ("_orgs/o/u/p/cognee_data/raw.txt", True),
+        ("u/p/data.db", False),
+        ("u/p/project_config.json", False),
+        ("u/p/graph-preview.json", False),
+        ("u/p/freezone/canvases/c1.json", False),
+        ("u/p/nested/cognee_system/keep.txt", False),
+        ("u/cognee_system/keep.txt", False),
+        ("u/p/cognee_systemx/keep.txt", False),
+        ("u/p/cognee/keep.txt", False),
+        ("u/p/databases/keep.txt", False),
+        ("_orgs/o/u/p/data.db", False),
+    ],
+)
+def test_is_deprecated_cognee_path(rel, expected):
+    assert is_deprecated_cognee_path(rel) is expected
+
+
+@needs_rclone
+def test_live_sync_filter_skips_project_cognee_stores_only(tmp_path):
+    root = tmp_path / "state"
+    _make_tree(root)
+
+    assert _listed(root, LIVE_SYNC_FILTER, tmp_path) == {
+        "u/p/project_config.json",
+        "u/p/graph-preview.json",
+        "u/p/freezone/assets/a.txt",
+        "u/p/nested/cognee_system/keep.txt",
+        "u/p/cognee_systemx/keep.txt",
+        "u/p/cognee/keep.txt",
+        "u/p/databases/keep.txt",
+        "_orgs/o/u/p/project_config.json",
+    }
+
+
+@needs_rclone
+def test_restore_filter_still_reaches_existing_cognee_backups(tmp_path):
+    # Existing OSS copies are kept on purpose; restore must still be able to fetch them.
+    root = tmp_path / "state"
+    _make_tree(root)
+
+    listed = _listed(root, RCLONE_FILTER, tmp_path)
+
+    assert {"u/p/cognee_system/lancedb/x.lance", "_orgs/o/u/p/cognee_data/raw.txt"} <= listed
+
+
+@needs_rclone
+def test_sync_command_keeps_existing_copies_of_excluded_cognee_files(tmp_path):
+    src = tmp_path / "state"
+    _make_tree(src)
+    dst = tmp_path / "mirror"
+    kept = dst / "u/p/cognee_data/raw.txt"
+    kept.parent.mkdir(parents=True)
+    kept.write_text("old", encoding="utf-8")
+    filter_file = tmp_path / "live.filter"
+    filter_file.write_text(LIVE_SYNC_FILTER, encoding="utf-8")
+
+    cmd = build_sync_cmd(
+        src=str(src),
+        dst=str(dst),
+        history_dst=str(tmp_path / "history"),
+        filter_file=filter_file,
+    )
+    subprocess.run(cmd, check=True, capture_output=True)
+
+    assert kept.read_text(encoding="utf-8") == "old"
+    assert (dst / "u/p/project_config.json").exists()
+    assert not (dst / "u/p/cognee_system/lancedb/x.lance").exists()


### PR DESCRIPTION
## PR 类型 / Type of PR
- [x] 🐞 Bug 修复 / Bug fix
- [ ] ✨ 新功能 / Feature
- [ ] 📝 文档 / Documentation
- [ ] 🧹 重构 / 清理 / Refactor or cleanup
- [ ] ⚙️ 构建 / CI / Build or CI
- [ ] ⚠️ 破坏性变更 / Breaking change

## 改动说明 / What this PR does and why

Cognee 已弃用，但它在每个项目下的数据仍被文件备份反复扫描和比对。本 PR 让以下三处都跳过项目内的 `cognee_system/` 与 `cognee_data/`：

| 位置 | 改动 |
|---|---|
| files-sync live 同步 | `LIVE_SYNC_FILTER` 增加锚定层级的排除规则（output 同步复用同一份规则，旧布局下 output 里的同名目录一并跳过） |
| files-sync `.snapshot` 上传 | `sync_db_snapshots` 跳过 Cognee 目录下的快照 |
| db-daily | `snapshot_state_tree` 不再为 Cognee 库生成 `VACUUM INTO` 快照 |

在两个部署中实测，Cognee 目录下的文件占 state 文件数的 **38%–52%**，排除后每轮需比对的文件相应减少。

**范围刻意收窄：**
- 只匹配两种项目布局：`<user>/<project>/<dir>/` 与 `_orgs/<org>/<user>/<project>/<dir>/`；更深层的同名目录、`cognee*` 其他目录、任意 `databases/` 都不受影响。
- 恢复用的 `RCLONE_FILTER` 不变，sync 也不加 `--delete-excluded`：**OSS 上已有的 Cognee 副本保留，且仍能恢复**。
- `data.db`、`chat.db` 等其他 SQLite 照常生成每日快照。

rclone 过滤规则与 Python 路径判断集中在新模块 `novelvideo.backup.scope`，共用一份定义。

## 关联 issue / Linked issues
N/A

## 给 reviewer 的说明 / Notes for the reviewer

- 过滤规则用真实 `rclone lsf` / `rclone sync` 验证行为（未安装 rclone 时跳过），不只校验规则文本；其中一条直接执行 `build_sync_cmd` 生成的命令，确认目标端已有的 Cognee 副本不被覆盖或删除。
- 两个原有 db-daily 用例（重跑替换快照、失败时保留旧快照）原本用 `cognee_db` 作示例库；它们测的行为与 Cognee 无关，已改用普通库继续覆盖。
- 变异检查：以下每种改坏方式都会被测试拦住——判断函数丢掉 `_orgs` 分支、过滤规则丢掉 `_orgs` 条目、live 过滤未加排除、排除误加进恢复用基础规则、`.snapshot` 上传未跳过、db-daily 未跳过、sync 命令加 `--delete-excluded`。

## 面向用户的变更 / User-facing change
```release-note
Backups no longer scan or upload deprecated per-project Cognee stores; existing backup copies are kept and remain restorable.
```

## 自检 / Checklist
- [x] 已自测，`uv run pytest` 通过 / Self-tested, `uv run pytest` passes（4441 passed, 16 skipped）
- [x] 必要的文档已更新 / Docs updated where needed（N/A）
- [x] 提交信息清晰（建议 Conventional Commits）/ Clear commits (Conventional Commits suggested)
- [x] 每个 commit 都已 `git commit -s` 附 DCO 签署 / Every commit signed off with `git commit -s` (DCO)
- [x] 我已阅读并同意[贡献者协议](../CONTRIBUTING.md#贡献者协议) / I've read and agree to the [contributor terms](../CONTRIBUTING.md#贡献者协议)

验证命令 / Verification:
```bash
uv run pytest tests/test_backup_scope.py tests/test_backup_files_sync.py tests/test_backup_db_daily.py -q
uv run pytest -q
```

https://claude.ai/code/session_01HFhZjQrh8FXBXNfXdywBtM
