### PR TITLE
fix: support organization project storage lifecycle

### DIFF
--- a/src/novelvideo/api/routes/projects.py
+++ b/src/novelvideo/api/routes/projects.py
@@ -221,6 +221,9 @@ def _validated_owned_dirs(record: ProjectRecord) -> list[Path]:
     """
     validated = assert_owned_project_storage(
         owner_username=record.owner_username,
+        project_name=record.name,
+        storage_org_id=getattr(record, "storage_org_id", None),
+        storage_org_name=getattr(record, "storage_org_name", None),
         output_dir=record.output_dir,
         state_dir=record.state_dir,
         runtime_dir=record.runtime_dir,
@@ -1117,13 +1120,6 @@ async def purge_project(
         )
     if record.purged_at:
         raise HTTPException(status_code=400, detail="Project has already been purged.")
-    # Codex rollouts live under the home-node CODEX_HOME, outside the project
-    # directories quarantined below. Delete them before releasing the project.
-    await chat_service.delete_codex_project_threads(
-        str(user["username"]),
-        ctx.project_name,
-        project_state_dir=ctx.state_dir,
-    )
     try:
         quarantined_dirs = _quarantine_project_dirs(
             record,
@@ -1137,6 +1133,27 @@ async def purge_project(
             else "Project files could not be isolated. Nothing was permanently deleted."
         )
         raise HTTPException(status_code=500, detail=detail) from exc
+    # Codex rollouts live under the home-node CODEX_HOME, outside the project
+    # directories quarantined above. Validation and isolation must complete first:
+    # an invalid project path must never delete a valid Codex session.
+    original_state_dir = Path(record.state_dir).resolve(strict=False)
+    codex_state_dir = next(
+        (
+            quarantine
+            for original, quarantine in quarantined_dirs
+            if original == original_state_dir
+        ),
+        original_state_dir,
+    )
+    try:
+        await chat_service.delete_codex_project_threads(
+            str(user["username"]),
+            ctx.project_name,
+            project_state_dir=codex_state_dir,
+        )
+    except Exception:
+        _restore_quarantined_project_dirs(quarantined_dirs)
+        raise
     try:
         record = await registry.mark_project_purged(ctx.project_id)
     except Exception:

--- a/src/novelvideo/ports/project.py
+++ b/src/novelvideo/ports/project.py
@@ -35,6 +35,8 @@ class ProjectRecord:
     created_at: str = ""
     updated_at: str = ""
     purged_at: str | None = None
+    storage_org_id: str | None = None
+    storage_org_name: str | None = None
 
 
 @dataclass(frozen=True)

--- a/src/novelvideo/security/project_storage.py
+++ b/src/novelvideo/security/project_storage.py
@@ -4,14 +4,15 @@
 目的:即使数据库记录被篡改、旧迁移写坏路径、或程序缺陷导致路径异常,也绝不
 能移动或删除属于其他用户(或数据根、用户根等宽泛目录)的文件。
 
-规范布局: ``<root>/<owner_username>/<project>`` ,其中三类 root 分别是
-``config.OUTPUT_DIR`` / ``config.STATE_DIR`` / ``config.RUNTIME_DIR`` 。
+规范布局为 ``<root>/<owner_username>/<project>`` 或
+``<root>/_orgs/<organization>/<owner_username>/<project>`` ,其中三类 root
+分别是 ``config.OUTPUT_DIR`` / ``config.STATE_DIR`` / ``config.RUNTIME_DIR`` 。
 
 校验规则(任一不满足即拒绝,调用方必须放弃移动/删除任何目录):
 
-1. 路径规范化( ``resolve()`` )后必须恰好位于 ``<root>/<owner>/`` 下一层;
+1. 路径必须精确匹配项目记录中冻结的 owner、project 和 organization 范围;
 2. 三类目录各自只能落在对应的数据根内;
-3. owner 目录本身不能是符号链接,目标目录本身不能是符号链接
+3. root 之下的每一层存储边界都不能是符号链接
    (防止用可写目录里的软链接把删除引到别处);
 4. 路径不得等于数据根或 owner 用户根;
 5. 三个目录必须互不相同,且互不为对方的祖先。
@@ -20,6 +21,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+import os
 from pathlib import Path
 
 from novelvideo import config
@@ -50,36 +52,74 @@ def _roots() -> dict[str, Path]:
     }
 
 
-def _validate_one(kind: str, root: Path, owner_username: str, raw: Path) -> Path:
-    root_real = root.resolve(strict=False)
-    owner_dir = root / owner_username
-    # owner 目录本身若是软链接,resolve 会把它指到别处 —— 直接拒,不给软链接机会。
-    if owner_dir.is_symlink():
+def _safe_segment(value: str | None, *, label: str) -> str:
+    segment = (value or "").strip()
+    if (
+        not segment
+        or segment != value
+        or segment in {".", ".."}
+        or "/" in segment
+        or "\\" in segment
+    ):
+        raise ProjectStorageOwnershipError(f"invalid {label}: {value!r}")
+    return segment
+
+
+def _expected_suffix(
+    *,
+    owner_username: str,
+    project_name: str,
+    storage_org_id: str | None,
+    storage_org_name: str | None,
+) -> tuple[str, ...]:
+    owner = _safe_segment(owner_username, label="owner username")
+    project = _safe_segment(project_name, label="project name")
+    if storage_org_id is None and storage_org_name is None:
+        if owner == "_orgs":
+            raise ProjectStorageOwnershipError(
+                "personal project owner collides with reserved organization namespace"
+            )
+        return (owner, project)
+    if storage_org_id is None or storage_org_name is None:
         raise ProjectStorageOwnershipError(
-            f"{kind}: owner directory {owner_dir} is a symlink; refusing"
+            "organization storage id and name must either both be set or both be absent"
         )
-    owner_real = owner_dir.resolve(strict=False)
-    if owner_real.parent != root_real:
+    _safe_segment(storage_org_id, label="organization storage id")
+    org_name = _safe_segment(storage_org_name, label="organization storage name")
+    if owner == "_system":
         raise ProjectStorageOwnershipError(
-            f"{kind}: owner directory {owner_real} is not directly under root {root_real}"
+            "organization project owner collides with reserved system namespace"
+        )
+    return ("_orgs", org_name, owner, project)
+
+
+def _absolute_without_symlink_resolution(path: Path) -> Path:
+    return Path(os.path.abspath(os.fspath(path)))
+
+
+def _validate_one(kind: str, root: Path, suffix: tuple[str, ...], raw: Path) -> Path:
+    root_absolute = _absolute_without_symlink_resolution(root)
+    expected = root_absolute.joinpath(*suffix)
+    raw_absolute = _absolute_without_symlink_resolution(raw)
+    if raw_absolute != expected:
+        raise ProjectStorageOwnershipError(
+            f"{kind}: path {raw_absolute} does not match expected project path {expected}"
         )
 
-    # 叶子目录本身若是软链接,即便解析后落在 owner 内也拒绝:软链接可在两次操作
-    # 之间被换指向(TOCTOU),不作为可信边界。
-    if raw.is_symlink():
+    current = root_absolute
+    for segment in suffix:
+        current = current / segment
+        if current.is_symlink():
+            raise ProjectStorageOwnershipError(
+                f"{kind}: storage boundary {current} is a symlink; refusing"
+            )
+
+    root_real = root_absolute.resolve(strict=False)
+    real = raw_absolute.resolve(strict=False)
+    expected_real = root_real.joinpath(*suffix)
+    if real != expected_real:
         raise ProjectStorageOwnershipError(
-            f"{kind}: project directory {raw} is a symlink; refusing"
-        )
-    real = raw.resolve(strict=False)
-    if real == root_real:
-        raise ProjectStorageOwnershipError(f"{kind}: path equals data root {root_real}")
-    if real == owner_real:
-        raise ProjectStorageOwnershipError(
-            f"{kind}: path equals owner root {owner_real}"
-        )
-    if real.parent != owner_real:
-        raise ProjectStorageOwnershipError(
-            f"{kind}: path {real} is not directly under owner directory {owner_real}"
+            f"{kind}: resolved path {real} escaped expected project path {expected_real}"
         )
     return real
 
@@ -101,6 +141,9 @@ def _assert_disjoint(paths: dict[str, Path]) -> None:
 def assert_owned_project_storage(
     *,
     owner_username: str,
+    project_name: str,
+    storage_org_id: str | None = None,
+    storage_org_name: str | None = None,
     output_dir: str | Path,
     state_dir: str | Path,
     runtime_dir: str | Path,
@@ -110,16 +153,19 @@ def assert_owned_project_storage(
     调用方必须只在本函数成功返回后才移动/删除返回的路径,任一校验失败都不得
     对任何目录执行破坏性操作。
     """
-    owner = (owner_username or "").strip()
-    if not owner or "/" in owner or "\\" in owner or owner in (".", ".."):
-        raise ProjectStorageOwnershipError(
-            f"invalid owner username for storage validation: {owner_username!r}"
-        )
+    suffix = _expected_suffix(
+        owner_username=owner_username,
+        project_name=project_name,
+        storage_org_id=storage_org_id,
+        storage_org_name=storage_org_name,
+    )
     roots = _roots()
     validated = {
-        "output": _validate_one("output", roots["output"], owner, Path(output_dir)),
-        "state": _validate_one("state", roots["state"], owner, Path(state_dir)),
-        "runtime": _validate_one("runtime", roots["runtime"], owner, Path(runtime_dir)),
+        "output": _validate_one("output", roots["output"], suffix, Path(output_dir)),
+        "state": _validate_one("state", roots["state"], suffix, Path(state_dir)),
+        "runtime": _validate_one(
+            "runtime", roots["runtime"], suffix, Path(runtime_dir)
+        ),
     }
     _assert_disjoint(validated)
     return ValidatedProjectStorage(

--- a/tests/test_project_lifecycle_storage.py
+++ b/tests/test_project_lifecycle_storage.py
@@ -1,4 +1,5 @@
 from dataclasses import replace
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
@@ -16,8 +17,18 @@ def _patch_roots(monkeypatch, tmp_path) -> None:
 
 
 def _record(
-    tmp_path, *, status: str = "active", owner: str = "alice"
+    tmp_path,
+    *,
+    status: str = "active",
+    owner: str = "alice",
+    storage_org_id: str | None = None,
+    storage_org_name: str | None = None,
 ) -> ProjectRecord:
+    relative = (
+        ("_orgs", storage_org_name, owner, "demo")
+        if storage_org_name
+        else (owner, "demo")
+    )
     return ProjectRecord(
         id="01PROJECT",
         owner_type="user",
@@ -25,10 +36,12 @@ def _record(
         owner_username=owner,
         name="demo",
         home_node_id="local",
-        output_dir=str(tmp_path / "output" / owner / "demo"),
-        state_dir=str(tmp_path / "state" / owner / "demo"),
-        runtime_dir=str(tmp_path / "runtime" / owner / "demo"),
+        output_dir=str(tmp_path / "output" / Path(*relative)),
+        state_dir=str(tmp_path / "state" / Path(*relative)),
+        runtime_dir=str(tmp_path / "runtime" / Path(*relative)),
         status=status,
+        storage_org_id=storage_org_id,
+        storage_org_name=storage_org_name,
     )
 
 
@@ -52,17 +65,25 @@ def _context(record: ProjectRecord) -> ProjectContext:
 
 
 @pytest.mark.asyncio
-async def test_create_project_does_not_reuse_orphaned_same_name_data(monkeypatch, tmp_path):
+@pytest.mark.parametrize("storage_org", [None, ("org_01HXYZ", "acme")])
+async def test_create_project_does_not_reuse_orphaned_same_name_data(
+    monkeypatch, tmp_path, storage_org
+):
     from novelvideo.api.routes import projects
 
     _patch_roots(monkeypatch, tmp_path)
-    record = _record(tmp_path)
-    old_canvas = tmp_path / "state" / "alice" / "demo" / "freezone" / "canvases"
+    storage_org_id, storage_org_name = storage_org or (None, None)
+    record = _record(
+        tmp_path,
+        storage_org_id=storage_org_id,
+        storage_org_name=storage_org_name,
+    )
+    old_canvas = Path(record.state_dir) / "freezone" / "canvases"
     old_canvas.mkdir(parents=True)
     (old_canvas / "default.json").write_text('{"old": true}', encoding="utf-8")
-    (tmp_path / "state" / "alice" / "demo" / "data.db").write_bytes(b"old workflow db")
-    (tmp_path / "output" / "alice" / "demo").mkdir(parents=True)
-    (tmp_path / "runtime" / "alice" / "demo").mkdir(parents=True)
+    (Path(record.state_dir) / "data.db").write_bytes(b"old workflow db")
+    Path(record.output_dir).mkdir(parents=True)
+    Path(record.runtime_dir).mkdir(parents=True)
 
     class Registry:
         async def create_project(self, **_kwargs):
@@ -141,7 +162,14 @@ async def test_purge_detaches_files_before_releasing_project_name(monkeypatch, t
     async def emit_audit(**_kwargs):
         calls.append("audit")
 
-    async def delete_codex_threads(*_args, **_kwargs):
+    async def delete_codex_threads(*_args, **kwargs):
+        assert all(
+            not projects.Path(path).exists()
+            for path in (record.output_dir, record.state_dir, record.runtime_dir)
+        )
+        isolated_state = projects.Path(kwargs["project_state_dir"])
+        assert isolated_state.exists()
+        assert isolated_state.name.startswith(".demo.purging-")
         calls.append("codex")
         return 1
 
@@ -198,6 +226,58 @@ async def test_purge_restores_files_when_registry_purge_fails(monkeypatch, tmp_p
         assert not list(path.parent.glob(".demo.purging-*"))
 
 
+@pytest.mark.asyncio
+async def test_organization_purge_restores_files_when_codex_cleanup_fails(
+    monkeypatch, tmp_path
+):
+    from novelvideo.api.routes import projects
+
+    _patch_roots(monkeypatch, tmp_path)
+    record = _record(
+        tmp_path,
+        status="deleted",
+        storage_org_id="org_01HXYZ",
+        storage_org_name="acme",
+    )
+    for raw_path in (record.output_dir, record.state_dir, record.runtime_dir):
+        path = projects.Path(raw_path)
+        path.mkdir(parents=True)
+        (path / "retained.txt").write_text("old", encoding="utf-8")
+    ctx = _context(record)
+
+    class Registry:
+        async def get_project(self, _project_id):
+            return record
+
+        async def mark_project_purged(self, _project_id):
+            raise AssertionError("registry purge must not run after Codex cleanup fails")
+
+    async def resolve_context(**_kwargs):
+        return ctx
+
+    async def delete_codex_threads(*_args, **kwargs):
+        isolated_state = projects.Path(kwargs["project_state_dir"])
+        assert isolated_state.exists()
+        assert isolated_state.name.startswith(".demo.purging-")
+        raise RuntimeError("Codex unavailable")
+
+    monkeypatch.setattr(projects, "resolve_project_context", resolve_context)
+    monkeypatch.setattr(projects, "get_project_registry", lambda: Registry())
+    monkeypatch.setattr(
+        projects.chat_service,
+        "delete_codex_project_threads",
+        delete_codex_threads,
+    )
+
+    with pytest.raises(RuntimeError, match="Codex unavailable"):
+        await projects.purge_project("01PROJECT", user={"username": "alice"})
+
+    for raw_path in (record.output_dir, record.state_dir, record.runtime_dir):
+        path = projects.Path(raw_path)
+        assert (path / "retained.txt").read_text(encoding="utf-8") == "old"
+        assert not list(path.parent.glob(".demo.purging-*"))
+
+
 # --------------------------------------------------------------------------- #
 # 存储归属校验器:用户操作必须互相隔离,绝不移动/删除他人目录                     #
 # --------------------------------------------------------------------------- #
@@ -206,6 +286,9 @@ async def test_purge_restores_files_when_registry_purge_fails(monkeypatch, tmp_p
 def _valid_dirs(tmp_path, owner="alice"):
     return dict(
         owner_username=owner,
+        project_name="demo",
+        storage_org_id=None,
+        storage_org_name=None,
         output_dir=str(tmp_path / "output" / owner / "demo"),
         state_dir=str(tmp_path / "state" / owner / "demo"),
         runtime_dir=str(tmp_path / "runtime" / owner / "demo"),
@@ -218,6 +301,139 @@ def test_validator_accepts_owned_dirs(monkeypatch, tmp_path):
     _patch_roots(monkeypatch, tmp_path)
     validated = assert_owned_project_storage(**_valid_dirs(tmp_path))
     assert validated.state_dir == (tmp_path / "state" / "alice" / "demo").resolve()
+
+
+def test_validator_rejects_personal_owner_that_collides_with_org_namespace(
+    monkeypatch, tmp_path
+):
+    from novelvideo.security import (
+        ProjectStorageOwnershipError,
+        assert_owned_project_storage,
+    )
+
+    _patch_roots(monkeypatch, tmp_path)
+
+    with pytest.raises(ProjectStorageOwnershipError):
+        assert_owned_project_storage(**_valid_dirs(tmp_path, owner="_orgs"))
+
+
+def test_validator_accepts_owned_organization_dirs(monkeypatch, tmp_path):
+    from novelvideo.security import assert_owned_project_storage
+
+    _patch_roots(monkeypatch, tmp_path)
+    args = _valid_dirs(tmp_path)
+    suffix = Path("_orgs", "acme", "alice", "demo")
+    args.update(
+        storage_org_id="org_01HXYZ",
+        storage_org_name="acme",
+        output_dir=str(tmp_path / "output" / suffix),
+        state_dir=str(tmp_path / "state" / suffix),
+        runtime_dir=str(tmp_path / "runtime" / suffix),
+    )
+
+    validated = assert_owned_project_storage(**args)
+
+    assert validated.state_dir == (tmp_path / "state" / suffix).resolve()
+
+
+@pytest.mark.parametrize(
+    ("storage_org_id", "storage_org_name"),
+    [
+        (None, "acme"),
+        ("org_01HXYZ", None),
+        ("", ""),
+        (" ", " "),
+    ],
+)
+def test_validator_rejects_incomplete_or_empty_organization_metadata(
+    monkeypatch, tmp_path, storage_org_id, storage_org_name
+):
+    from novelvideo.security import (
+        ProjectStorageOwnershipError,
+        assert_owned_project_storage,
+    )
+
+    _patch_roots(monkeypatch, tmp_path)
+    args = _valid_dirs(tmp_path)
+    args.update(
+        storage_org_id=storage_org_id,
+        storage_org_name=storage_org_name,
+    )
+
+    with pytest.raises(ProjectStorageOwnershipError):
+        assert_owned_project_storage(**args)
+
+
+def test_validator_rejects_different_organization_even_when_all_paths_match(
+    monkeypatch, tmp_path
+):
+    from novelvideo.security import (
+        ProjectStorageOwnershipError,
+        assert_owned_project_storage,
+    )
+
+    _patch_roots(monkeypatch, tmp_path)
+    args = _valid_dirs(tmp_path)
+    wrong_suffix = Path("_orgs", "other-org", "alice", "demo")
+    args.update(
+        storage_org_id="org_01HXYZ",
+        storage_org_name="acme",
+        output_dir=str(tmp_path / "output" / wrong_suffix),
+        state_dir=str(tmp_path / "state" / wrong_suffix),
+        runtime_dir=str(tmp_path / "runtime" / wrong_suffix),
+    )
+
+    with pytest.raises(ProjectStorageOwnershipError):
+        assert_owned_project_storage(**args)
+
+
+def test_validator_rejects_symlinked_organization_directory(monkeypatch, tmp_path):
+    from novelvideo.security import (
+        ProjectStorageOwnershipError,
+        assert_owned_project_storage,
+    )
+
+    _patch_roots(monkeypatch, tmp_path)
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    org_root = tmp_path / "state" / "_orgs"
+    org_root.mkdir(parents=True)
+    (org_root / "acme").symlink_to(outside, target_is_directory=True)
+    args = _valid_dirs(tmp_path)
+    suffix = Path("_orgs", "acme", "alice", "demo")
+    args.update(
+        storage_org_id="org_01HXYZ",
+        storage_org_name="acme",
+        output_dir=str(tmp_path / "output" / suffix),
+        state_dir=str(tmp_path / "state" / suffix),
+        runtime_dir=str(tmp_path / "runtime" / suffix),
+    )
+
+    with pytest.raises(ProjectStorageOwnershipError):
+        assert_owned_project_storage(**args)
+
+
+def test_validator_rejects_organization_owner_that_collides_with_system_namespace(
+    monkeypatch, tmp_path
+):
+    from novelvideo.security import (
+        ProjectStorageOwnershipError,
+        assert_owned_project_storage,
+    )
+
+    _patch_roots(monkeypatch, tmp_path)
+    args = _valid_dirs(tmp_path, owner="_system")
+    suffix = Path("_orgs", "acme", "_system", "demo")
+    args.update(
+        storage_org_id="org_01HXYZ",
+        storage_org_name="acme",
+        output_dir=str(tmp_path / "output" / suffix),
+        state_dir=str(tmp_path / "state" / suffix),
+        runtime_dir=str(tmp_path / "runtime" / suffix),
+    )
+
+    with pytest.raises(ProjectStorageOwnershipError):
+        assert_owned_project_storage(**args)
 
 
 def test_validator_rejects_other_users_directory(monkeypatch, tmp_path):
@@ -340,8 +556,16 @@ async def test_purge_refuses_when_record_points_at_other_user(monkeypatch, tmp_p
     async def resolve_context(**_kwargs):
         return ctx
 
+    async def delete_codex_threads(*_args, **_kwargs):
+        raise AssertionError("ownership validation must happen before Codex deletion")
+
     monkeypatch.setattr(projects, "resolve_project_context", resolve_context)
     monkeypatch.setattr(projects, "get_project_registry", lambda: Registry())
+    monkeypatch.setattr(
+        projects.chat_service,
+        "delete_codex_project_threads",
+        delete_codex_threads,
+    )
 
     with pytest.raises(projects.HTTPException) as exc_info:
         await projects.purge_project("01PROJECT", user={"username": "alice"})


### PR DESCRIPTION
## PR 类型 / Type of PR

- [x] 🐞 Bug 修复 / Bug fix
- [ ] ✨ 新功能 / Feature
- [ ] 📝 文档 / Documentation
- [ ] 🧹 重构 / 清理 / Refactor or cleanup
- [ ] ⚙️ 构建 / CI / Build or CI
- [ ] ⚠️ 破坏性变更 / Breaking change

## 改动说明 / What this PR does and why

修复 staging 中组织项目路径被个人项目目录安全检查误判的问题，同时调整永久删除顺序。

- 精确支持个人路径 root/username/project
- 精确支持组织路径 root/_orgs/org/username/project
- 组织范围必须来自项目记录中的可信 storage_org_id 和 storage_org_name
- 校验 root 以下每层符号链接，继续拒绝跨用户、跨组织和路径穿越
- 永久删除先校验并隔离项目目录，再删除 Codex 会话
- Codex 清理失败时恢复已隔离目录

## 关联 PR / Linked PR

- EE 配套变更：https://github.com/claymorelab/SuperTale/pull/217

## 给 reviewer 的说明 / Notes for the reviewer

本 PR 保证目录归属校验失败时不会先删除 Codex 会话。数据库、文件系统和 Codex 没有共享事务；Codex 已删除后若数据库提交失败，完整的可重试 purge 状态机仍需后续独立改造。

EE 与 CE 必须配套发布；建议先部署 EE，再部署 CE。

## 面向用户的变更 / User-facing change

```release-note
修复组织成员和管理员无法创建或永久删除组织项目的问题。
```

## 自检 / Checklist

- [x] 已自测，相关 pytest 通过
- [x] 文档无需更新 / N/A
- [x] 提交信息清晰
- [x] commit 已附 DCO 签署
- [ ] 我已阅读并同意贡献者协议