### PR TITLE
feat: add LingShan G25 image models

### DIFF
--- a/src/novelvideo/official_media_models.json
+++ b/src/novelvideo/official_media_models.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "catalogVersion": "2026.09.02.1",
+  "catalogVersion": "2026.09.11.1",
   "name": "DramaClaw CE official media models",
   "mediaModels": {
     "LingShan-G2": {
@@ -11,6 +11,36 @@
       "enabled": true,
       "sortOrder": 10,
       "aliases": ["gpt-image-2", "huimeng_gpt_image2", "newapi_gpt_image2"],
+      "config": {
+        "request": {"endpoint": "images/generations", "parameters": []},
+        "ratioOptions": ["1:1", "16:9", "9:16", "4:3", "3:4", "3:2", "2:3", "4:5", "5:4", "21:9"],
+        "qualityOptions": ["low", "medium", "high"],
+        "resolutionOptions": ["1K", "2K", "4K"]
+      }
+    },
+    "LingShan-G25-Fast": {
+      "provider": "newapi",
+      "upstreamModel": "LingShan-G25-Fast",
+      "mediaType": "image",
+      "label": "LingShan G25 Fast",
+      "enabled": true,
+      "sortOrder": 11,
+      "aliases": [],
+      "config": {
+        "request": {"endpoint": "images/generations", "parameters": []},
+        "ratioOptions": ["1:1", "16:9", "9:16", "4:3", "3:4", "3:2", "2:3", "4:5", "5:4", "21:9"],
+        "qualityOptions": ["low", "medium", "high"],
+        "resolutionOptions": ["1K", "2K", "4K"]
+      }
+    },
+    "LingShan-G25-Pro": {
+      "provider": "newapi",
+      "upstreamModel": "LingShan-G25-Pro",
+      "mediaType": "image",
+      "label": "LingShan G25 Pro",
+      "enabled": true,
+      "sortOrder": 12,
+      "aliases": [],
       "config": {
         "request": {"endpoint": "images/generations", "parameters": []},
         "ratioOptions": ["1:1", "16:9", "9:16", "4:3", "3:4", "3:2", "2:3", "4:5", "5:4", "21:9"],

--- a/tests/test_model_gateway_settings.py
+++ b/tests/test_model_gateway_settings.py
@@ -3380,7 +3380,7 @@ def test_official_media_model_catalog_uses_ce_export_shape():
     images = get_official_media_model_catalog("image")
     videos = get_official_media_model_catalog("video")
 
-    assert len(images) == 6
+    assert len(images) == 8
     assert len(videos) == 11
     assert [entry["id"] for entry in videos[:2]] == [
         "wan3.0-video-prime",


### PR DESCRIPTION
## PR 类型 / Type of PR
- [ ] 🐞 Bug 修复 / Bug fix
- [x] ✨ 新功能 / Feature
- [ ] 📝 文档 / Documentation
- [ ] 🧹 重构 / 清理 / Refactor or cleanup
- [ ] ⚙️ 构建 / CI / Build or CI
- [ ] ⚠️ 破坏性变更 / Breaking change

## 改动说明 / What this PR does and why
- Add `LingShan-G25-Fast` and `LingShan-G25-Pro` to the bundled CE official media catalog.
- Reuse the existing LingShan G2 ratio, quality, resolution, and `images/generations` configuration.
- Bump the bundled catalog version to `2026.09.11.1`.

## 关联 issue / Linked issues
N/A

## 给 reviewer 的说明 / Notes for the reviewer
The runtime change is limited to `official_media_models.json`. The only test change updates the expected image-model count from 6 to 8. The new models intentionally have no compatibility aliases.

Focused verification:
- `python3 -m json.tool src/novelvideo/official_media_models.json`
- `pytest tests/test_model_gateway_settings.py -k official_media_model_catalog_uses_ce_export_shape`
- `pytest tests/test_publish_official_media_catalog.py`
- `git diff --check`

Result: 7 tests passed; JSON and diff checks passed.

## 面向用户的变更 / User-facing change
```release-note
Add LingShan G25 Fast and LingShan G25 Pro to the DramaClaw CE image model catalog.
```

## 自检 / Checklist
- [ ] 已自测，`uv run pytest` 通过 / Self-tested, `uv run pytest` passes
- [x] 必要的文档已更新 / Docs updated where needed (N/A: catalog-only model addition)
- [x] 提交信息清晰（建议 Conventional Commits）/ Clear commits (Conventional Commits suggested)
- [x] 每个 commit 都已 `git commit -s` 附 DCO 签署 / Every commit signed off with `git commit -s` (DCO)
- [x] 我已阅读并同意[贡献者协议](../CONTRIBUTING.md#贡献者协议) / I have read and agree to the contributor terms