### PR TITLE
fix: 按模型能力统一 Freezone 生成参数

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -194,6 +194,8 @@ FREEZONE_STORY_SCRIPT_MODEL=DC-freezone-story-script-writer-LLM
 
 # Freezone / Recipe 编译为可执行提示词。
 FREEZONE_RECIPE_COMPILER_MODEL=DC-freezone-recipe-compiler-LLM
+# Recipe 编译模型始终启用推理；可选 low/high/max，默认 low。
+FREEZONE_RECIPE_COMPILER_REASONING_EFFORT=low
 # 单节点编译等待上限；超时后使用确定性 fallback，不阻断工作流。
 FREEZONE_RECIPE_COMPILER_TIMEOUT_SECONDS=30
 # 同批 Recipe 提示词的最大并发编译数（范围 1-8）。

--- a/.hermes/plugins/freezone/__init__.py
+++ b/.hermes/plugins/freezone/__init__.py
@@ -827,6 +827,9 @@ def _handle_request_user_clarification(args: dict[str, Any], **_: Any) -> str:
             }
         )
     questions = normalized_questions
+    answers = args.get("answers")
+    if not isinstance(answers, dict):
+        answers = {}
     if not questions:
         return tool_result(
             {
@@ -899,6 +902,7 @@ def _handle_request_user_clarification(args: dict[str, Any], **_: Any) -> str:
             "title": str(args.get("title") or "").strip(),
             "description": str(args.get("description") or "").strip(),
             "questions": questions,
+            "answers": answers,
             "allow_recommended": bool(args.get("allow_recommended", False)),
             "allow_skip": bool(args.get("allow_skip", True)),
         },
@@ -8038,6 +8042,29 @@ TOOLS = (
                     "type": "array",
                     "description": "High-level user-facing questions. Ask only the questions needed for the next decision; use one focused question when the next step depends on one answer, or group closely related choices when they should be answered together. Each question should usually have 2-5 options, but generation model questions must include every exact option from the live node schema.",
                     "items": _SKILL_STUDIO_QUESTION_SCHEMA,
+                },
+                "answers": {
+                    "type": "object",
+                    "description": "Previously confirmed answers used as context for dependent generation fields, such as image_model or video_model when the model question is not repeated on this card.",
+                    "additionalProperties": {
+                        "anyOf": [
+                            {"type": "string"},
+                            {"type": "array", "items": {"type": "string"}},
+                            {
+                                "type": "object",
+                                "properties": {
+                                    "option_ids": {
+                                        "type": "array",
+                                        "items": {"type": "string"},
+                                    },
+                                    "option_id": {"type": "string"},
+                                    "custom_text": {"type": "string"},
+                                    "customText": {"type": "string"},
+                                },
+                                "additionalProperties": False,
+                            },
+                        ]
+                    },
                 },
                 "allow_recommended": {
                     "type": "boolean",

--- a/.hermes/plugins/freezone/__init__.py
+++ b/.hermes/plugins/freezone/__init__.py
@@ -717,11 +717,11 @@ def _emit_clarification_event(
         timeout_seconds = max(
             1,
             int(
-                os.environ.get("DRAMACLAW_CLARIFICATION_RESULT_TIMEOUT_SECONDS", "600")
+                os.environ.get("DRAMACLAW_CLARIFICATION_RESULT_TIMEOUT_SECONDS", "240")
             ),
         )
     except ValueError:
-        timeout_seconds = 600
+        timeout_seconds = 240
     resolved = wait_clarification_result(key, timeout_seconds=timeout_seconds)
     if resolved is not None:
         return tool_result(resolved)
@@ -765,6 +765,68 @@ def _handle_request_user_clarification(args: dict[str, Any], **_: Any) -> str:
         ).strip("-")
         clarification_id = f"clarify_{safe_context or 'default'}_{uuid.uuid4().hex[:8]}"
     questions = _safe_list(args.get("questions"))
+    generation_question_aliases = {
+        "image_count": "image_variants_per_node",
+        "video_count": "video_variants_per_node",
+    }
+    generation_question_titles = {
+        "image_model": "图片模型",
+        "image_aspect_ratio": "图片比例",
+        "image_resolution": "图片分辨率",
+        "image_quality": "图片画质",
+        "image_variants_per_node": "图片生成数量",
+        "video_model": "视频模型",
+        "video_aspect_ratio": "视频比例",
+        "video_resolution": "视频分辨率",
+        "video_duration_seconds": "视频时长",
+        "video_generate_audio": "视频声音",
+        "video_variants_per_node": "视频生成数量",
+    }
+    server_managed_question_ids = {"thinking_level"}
+    questions = [
+        question
+        for question in questions
+        if not (
+            isinstance(question, dict)
+            and str(question.get("id") or "").strip().lower()
+            in server_managed_question_ids
+        )
+    ]
+    generation_option_sources = {
+        "image_model": "image_models",
+        "image_aspect_ratio": "selected_image_model_ratios",
+        "image_resolution": "selected_image_model_resolutions",
+        "image_quality": "selected_image_model_qualities",
+        "image_variants_per_node": "image_variant_counts",
+        "video_model": "video_models",
+        "video_aspect_ratio": "selected_video_model_ratios",
+        "video_resolution": "selected_video_model_resolutions",
+        "video_duration_seconds": "selected_video_model_durations",
+        "video_generate_audio": "selected_video_model_audio",
+        "video_variants_per_node": "video_variant_counts",
+    }
+    normalized_questions: list[Any] = []
+    for question in questions:
+        if not isinstance(question, dict):
+            normalized_questions.append(question)
+            continue
+        question_id = str(question.get("id") or "").strip().lower()
+        question_id = generation_question_aliases.get(question_id, question_id)
+        if question_id not in generation_option_sources:
+            normalized_questions.append(question)
+            continue
+        normalized_questions.append(
+            {
+                **question,
+                "id": question_id,
+                "title": str(question.get("title") or "").strip()
+                or generation_question_titles[question_id],
+                "options": _safe_list(question.get("options")),
+                "mode": str(question.get("mode") or "single").strip() or "single",
+                "options_source": generation_option_sources[question_id],
+            }
+        )
+    questions = normalized_questions
     if not questions:
         return tool_result(
             {
@@ -2992,6 +3054,73 @@ def _generation_parameter_value_present(field: str, value: Any) -> bool:
     return isinstance(value, str) and bool(value.strip())
 
 
+def _generation_catalog_entry(
+    project: str,
+    node_type: str,
+    model: Any,
+    cache: dict[str, list[dict[str, Any]] | None],
+) -> dict[str, Any] | None:
+    """Return the live model entry used to decide conditional parameters.
+
+    An unavailable catalog deliberately returns ``None`` so preflight keeps its
+    conservative legacy requirements. Only an authoritative matching entry may
+    remove a model-dependent field such as image quality.
+    """
+    media_type = "image" if node_type == "imageGenNode" else "video"
+    model_id = str(model or "").strip().casefold()
+    if not model_id:
+        return None
+    if media_type not in cache:
+        response = _request(
+            "GET",
+            f"/projects/{quote(project, safe='')}/freezone/{media_type}/models",
+        )
+        raw_entries = response.get("data") if response.get("ok", True) else None
+        cache[media_type] = (
+            [entry for entry in raw_entries if isinstance(entry, dict)]
+            if isinstance(raw_entries, list)
+            else None
+        )
+    for entry in cache[media_type] or []:
+        identifiers = {
+            str(entry.get(key) or "").strip().casefold()
+            for key in ("id", "apiModel", "api_model", "catalogId", "label")
+        }
+        if model_id in identifiers:
+            return entry
+    return None
+
+
+def _generation_parameter_fields_for_model(
+    project: str,
+    node_type: str,
+    data: dict[str, Any],
+    catalog_cache: dict[str, list[dict[str, Any]] | None],
+) -> tuple[str, ...] | None:
+    fields = _GENERATION_PARAMETER_FIELDS.get(node_type)
+    if fields is None:
+        return None
+    entry = _generation_catalog_entry(
+        project,
+        node_type,
+        data.get("model"),
+        catalog_cache,
+    )
+    if entry is None:
+        return fields
+    conditional_fields: set[str] = set()
+    if node_type == "imageGenNode":
+        quality_options = entry.get("qualityOptions")
+        if not (
+            isinstance(quality_options, list)
+            and any(str(value).strip() for value in quality_options)
+        ):
+            conditional_fields.add("quality")
+    elif node_type == "videoNode" and entry.get("supportsGenerateAudio") is False:
+        conditional_fields.add("generateAudio")
+    return tuple(field for field in fields if field not in conditional_fields)
+
+
 def _use_frontend_default_for_recommended_models(commands: list[Any]) -> None:
     """Resolve a symbolic recommendation through the frontend's live default.
 
@@ -3101,17 +3230,26 @@ def _generation_parameters_required_result(
             for item in missing
         }
     )
-    required_choices = {
-        "image": ["model", "aspect_ratio", "resolution", "quality", "count"],
-        "video": [
-            "model",
-            "aspect_ratio",
-            "resolution",
-            "duration_seconds",
-            "generate_audio",
-            "count",
-        ],
+    portable_fields = {
+        "model": "model",
+        "aspectRatio": "aspect_ratio",
+        "size": "resolution",
+        "quality": "quality",
+        "durationSec": "duration_seconds",
+        "generateAudio": "generate_audio",
+        "count": "count",
     }
+    required_choices: dict[str, list[str]] = {}
+    for item in missing:
+        media_type = "image" if item["node_type"] == "imageGenNode" else "video"
+        choices = required_choices.setdefault(media_type, [])
+        for field in item.get("fields") or []:
+            portable = portable_fields.get(str(field), str(field))
+            # Video stores its resolution in data.quality.
+            if media_type == "video" and field == "quality":
+                portable = "resolution"
+            if portable not in choices:
+                choices.append(portable)
     return {
         "ok": False,
         "status": "clarification_required",
@@ -3119,9 +3257,7 @@ def _generation_parameters_required_result(
         "error": "image/video generation parameters require user clarification",
         "media_types": media_types,
         "missing_parameters": missing,
-        "required_choices": {
-            media_type: required_choices[media_type] for media_type in media_types
-        },
+        "required_choices": required_choices,
         "clarification": {
             "title": "确认图片和视频生成参数",
             "allow_recommended": True,
@@ -3143,8 +3279,6 @@ def _external_generation_parameter_preflight(
     canvas: str,
     commands: list[Any],
 ) -> dict[str, Any] | None:
-    if not _external_mcp_agent_enabled():
-        return None
     execution_commands = [
         command
         for command in commands
@@ -3187,6 +3321,7 @@ def _external_generation_parameter_preflight(
     else:
         nodes, edges = {}, []
     missing_by_node: dict[str, dict[str, Any]] = {}
+    catalog_cache: dict[str, list[dict[str, Any]] | None] = {}
     for raw_command in commands:
         if not isinstance(raw_command, dict):
             continue
@@ -3230,17 +3365,17 @@ def _external_generation_parameter_preflight(
             node_type = str(node.get("type") or node.get("node_type") or "").strip()
             if expected_type is not None and node_type != expected_type:
                 continue
-            required_fields = _GENERATION_PARAMETER_FIELDS.get(node_type)
+            data = node.get("data") if isinstance(node.get("data"), dict) else {}
+            required_fields = _generation_parameter_fields_for_model(
+                project,
+                node_type,
+                data,
+                catalog_cache,
+            )
             if required_fields is None:
                 continue
-            data = node.get("data") if isinstance(node.get("data"), dict) else {}
-            # Workflow graph approval is the single image/video parameter
-            # confirmation point. Re-running the workflow must reuse the
-            # persisted node configuration instead of opening another
-            # clarification card. Runtime capability preflight still runs
-            # below the write boundary and can reject unsupported values.
-            if data.get("workflowConfigConfirmed") is True:
-                continue
+            # Reuse complete persisted choices, but a confirmation marker alone
+            # cannot substitute for missing generation parameters.
             if command_type == "run_workflow" and not raw_command.get("regenerate"):
                 output_key = "imageUrl" if node_type == "imageGenNode" else "videoUrl"
                 if isinstance(data.get(output_key), str) and data[output_key].strip():
@@ -3509,11 +3644,11 @@ def _dispatch_mcp_approved_frontend_commands(
         timeout_seconds = max(
             1,
             int(
-                os.environ.get("DRAMACLAW_CANVAS_COMMAND_RESULT_TIMEOUT_SECONDS", "300")
+                os.environ.get("DRAMACLAW_CANVAS_COMMAND_RESULT_TIMEOUT_SECONDS", "600")
             ),
         )
     except ValueError:
-        timeout_seconds = 300
+        timeout_seconds = 600
     timeout_result = {
         "ok": False,
         "tool_call_status": "failed",
@@ -3596,11 +3731,11 @@ def _dispatch_frontend_canvas_commands(
         timeout_seconds = max(
             1,
             int(
-                os.environ.get("DRAMACLAW_CANVAS_COMMAND_RESULT_TIMEOUT_SECONDS", "75")
+                os.environ.get("DRAMACLAW_CANVAS_COMMAND_RESULT_TIMEOUT_SECONDS", "600")
             ),
         )
     except ValueError:
-        timeout_seconds = 75
+        timeout_seconds = 600
     timeout_result = {
         "ok": False,
         "tool_call_status": "failed",
@@ -7133,7 +7268,7 @@ _SKILL_STUDIO_QUESTION_SCHEMA = {
         },
         "title": {
             "type": "string",
-            "description": "User-facing question title.",
+            "description": "User-facing question title. Optional for canonical image/video generation question ids; the server supplies a localized title.",
         },
         "description": {
             "type": "string",
@@ -7141,7 +7276,12 @@ _SKILL_STUDIO_QUESTION_SCHEMA = {
         },
         "options": {
             "type": "array",
-            "description": "2-4 selectable options.",
+            "description": (
+                "Usually 2-4 selectable options. For image_model, video_model, and other "
+                "generation-parameter questions backed by a live node schema, this may be omitted; "
+                "the frontend resolves every exact live option from options_source. If options are "
+                "provided, never shorten the catalog to a recommended subset."
+            ),
             "items": _SKILL_STUDIO_OPTION_SCHEMA,
         },
         "mode": {
@@ -7158,8 +7298,25 @@ _SKILL_STUDIO_QUESTION_SCHEMA = {
             "type": "boolean",
             "description": "Whether the frontend should allow a free-form custom answer for this question.",
         },
+        "options_source": {
+            "type": "string",
+            "enum": [
+                "image_models",
+                "selected_image_model_ratios",
+                "selected_image_model_resolutions",
+                "selected_image_model_qualities",
+                "image_variant_counts",
+                "video_models",
+                "selected_video_model_ratios",
+                "selected_video_model_resolutions",
+                "selected_video_model_durations",
+                "selected_video_model_audio",
+                "video_variant_counts",
+            ],
+            "description": "Server-managed live option source. The clarification tool adds this automatically for canonical image/video generation parameter questions.",
+        },
     },
-    "required": ["id", "title", "options"],
+    "required": ["id"],
 }
 
 _SKILL_STUDIO_DRAFT_OUTLINE_STAGE_SCHEMA = {
@@ -7859,7 +8016,7 @@ TOOLS = (
         "freezone_request_user_clarification",
         _schema(
             "freezone_request_user_clarification",
-            "Ask the user structured clarification questions in the Freezone frontend and wait for their submitted answers. Use for user choices before continuing the current chat or workflow, including Skill Studio setup questions. For image/video generation, never combine fields into a recommended-settings preset: use one question per missing field, inspect the live node schema, and expose exact resolution values such as 480P/720P when supported. The submitted answers only mean the user completed the choices; decide the next step from the current context. This tool does not write canvas nodes or save catalog files.",
+            "Ask the user structured clarification questions in the Freezone frontend and wait for their submitted answers. Use for user choices before continuing the current chat or workflow, including Skill Studio setup questions. For image/video generation, never combine fields into a recommended-settings preset: use one canonical question id per missing field. For canonical generation ids, title and options may be omitted because the server supplies localized titles and the frontend resolves the complete live catalog. The submitted answers only mean the user completed the choices; decide the next step from the current context. This tool does not write canvas nodes or save catalog files.",
             {
                 "clarification_id": {
                     "type": "string",
@@ -7879,7 +8036,7 @@ TOOLS = (
                 },
                 "questions": {
                     "type": "array",
-                    "description": "High-level user-facing questions. Ask only the questions needed for the next decision; use one focused question when the next step depends on one answer, or group closely related choices when they should be answered together. Each question should usually have 2-5 options.",
+                    "description": "High-level user-facing questions. Ask only the questions needed for the next decision; use one focused question when the next step depends on one answer, or group closely related choices when they should be answered together. Each question should usually have 2-5 options, but generation model questions must include every exact option from the live node schema.",
                     "items": _SKILL_STUDIO_QUESTION_SCHEMA,
                 },
                 "allow_recommended": {

--- a/agent-kit/skills/dramaclaw-workflows/SKILL.md
+++ b/agent-kit/skills/dramaclaw-workflows/SKILL.md
@@ -14,6 +14,10 @@ Build one coherent workflow transaction, not a sequence of standalone canvas edi
   canvas data must be refreshed, call `freezone_get_canvas_ontology` instead of inventing a
   `canvas://` resource. MCP clients must use only resource URIs returned by `resources/list` or
   `resources/templates/list`.
+- The Skill package/server display name does not determine a host's MCP registration key. Use the
+  exact `server` returned by the host. In DramaClaw's Codex adapter, filesystem-backed Skill files
+  are read from `dramaclaw`; workflow catalog resources use `dramaclaw_workflows` (underscore).
+  Never call `resources/read` with an inferred `dramaclaw-workflows` server key.
 - Use the portable `dramaclaw-workflows` MCP server for catalog discovery and deterministic
   compilation when it is available. Use the authorized DramaClaw MCP server for draft persistence,
   approval, canvas commit, and execution. Tool names are host-neutral; call them through the MCP
@@ -63,6 +67,9 @@ The image/video choices are:
 - Image: model preference, aspect ratio, resolution/quality, and variants per node.
 - Video: model or generation mode, aspect ratio, resolution, duration, sound generation, and output
   variants per node.
+- Provider thinking/reasoning level is server-managed. Never ask the user to choose
+  `thinking_level`, reasoning effort, or low/medium/high thinking options, and never add such a
+  question from a live model parameter schema.
 
 Do not include audio voice-source selection in this preliminary clarification. Never ask the user
 to choose system voice versus custom voice. A speech node uses an already selected custom

--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -878,7 +878,36 @@
       "canvasExecuting": "Executing...",
       "canvasConfirmExecution": "Confirm execution",
       "canvasTimeoutCancelled": "The canvas operation timed out and was cancelled without being applied.",
-      "canvasManuallyCancelled": "The canvas operation was manually cancelled without being applied."
+      "canvasManuallyCancelled": "The canvas operation was manually cancelled without being applied.",
+      "canvasRetryPrompt": "Recheck and continue the unfinished canvas operation. Preserve completed results, verify existing nodes and run state, then complete generation parameters before requesting approval again.",
+      "canvasRetryDisplay": "Recheck and continue the unfinished canvas operation",
+      "generationParams": {
+        "autoRatio": "Auto ratio",
+        "imageQuality": "Image quality",
+        "quality": {
+          "low": "Low quality",
+          "medium": "Standard quality",
+          "high": "High quality"
+        },
+        "imageCount": "{{count}} image",
+        "imageCount_other": "{{count}} images",
+        "videoCount": "{{count}} video",
+        "videoCount_other": "{{count}} videos",
+        "durationSeconds": "{{count}} second",
+        "durationSeconds_other": "{{count}} seconds",
+        "generateAudio": "Generate audio",
+        "muteAudio": "Do not generate audio",
+        "audioOn": "Audio",
+        "audioOff": "Muted"
+      },
+      "clarification": {
+        "skipped": "Skipped",
+        "submitted": "Submitted",
+        "skippedQuestions": "Questions skipped",
+        "submittedAnswers": "Submitted answers · {{count}}",
+        "noAnswersSkipped": "These questions were skipped.",
+        "noAnswersSubmitted": "No specific options were submitted."
+      }
     },
     "workflowRecovery": {
       "safetyReviewFailed": "Some nodes did not pass safety review",

--- a/frontend/public/locales/zh/translation.json
+++ b/frontend/public/locales/zh/translation.json
@@ -890,8 +890,11 @@
           "high": "高画质"
         },
         "imageCount": "{{count}} 张",
+        "imageCount_other": "{{count}} 张",
         "videoCount": "{{count}} 个",
+        "videoCount_other": "{{count}} 个",
         "durationSeconds": "{{count}} 秒",
+        "durationSeconds_other": "{{count}} 秒",
         "generateAudio": "生成声音",
         "muteAudio": "不生成声音",
         "audioOn": "有声",

--- a/frontend/public/locales/zh/translation.json
+++ b/frontend/public/locales/zh/translation.json
@@ -878,7 +878,33 @@
       "canvasExecuting": "执行中...",
       "canvasConfirmExecution": "确认执行",
       "canvasTimeoutCancelled": "画布操作因等待超时已取消，没有应用到画布。",
-      "canvasManuallyCancelled": "画布操作已手动取消，没有应用到画布。"
+      "canvasManuallyCancelled": "画布操作已手动取消，没有应用到画布。",
+      "canvasRetryPrompt": "请重新检查并继续刚才未完成的画布操作。先核对已有节点和运行状态，保留已完成结果；补齐生成参数后再提交新的审批。",
+      "canvasRetryDisplay": "重新检查并继续未完成的画布操作",
+      "generationParams": {
+        "autoRatio": "自动比例",
+        "imageQuality": "图片画质",
+        "quality": {
+          "low": "低画质",
+          "medium": "标准画质",
+          "high": "高画质"
+        },
+        "imageCount": "{{count}} 张",
+        "videoCount": "{{count}} 个",
+        "durationSeconds": "{{count}} 秒",
+        "generateAudio": "生成声音",
+        "muteAudio": "不生成声音",
+        "audioOn": "有声",
+        "audioOff": "静音"
+      },
+      "clarification": {
+        "skipped": "已跳过",
+        "submitted": "已提交",
+        "skippedQuestions": "已跳过问题",
+        "submittedAnswers": "已提交回答 · {{count}} 个",
+        "noAnswersSkipped": "本次问题已跳过。",
+        "noAnswersSubmitted": "本次未提交具体选项。"
+      }
     },
     "workflowRecovery": {
       "safetyReviewFailed": "有节点未通过安全审核",

--- a/frontend/src/__tests__/features/canvas/image-node-generation-matrix.test.tsx
+++ b/frontend/src/__tests__/features/canvas/image-node-generation-matrix.test.tsx
@@ -54,6 +54,7 @@ vi.mock("@/api/ops", async (importOriginal) => ({
       providerId: "huimeng",
       apiModel: "test_image_api",
       label: "测试模型",
+      qualityOptions: ["low", "medium", "high"],
     },
   ]),
   listFreezoneStyleTemplates: vi.fn(async () => []),
@@ -147,7 +148,19 @@ describe("图片节点：三种参考图形态的提交载荷", () => {
       // 画布 id 从 URL 取，后端按它归档产物。
       canvasId: "canvas-7",
       nodeId: "img-1",
+      quality: "medium",
     });
+  });
+
+  it("只有节点显式设置画质时才下发 quality", async () => {
+    useCanvasStore.getState().setCanvasData(
+      [imageGenNode({ quality: "high" })],
+      [],
+    );
+
+    await submitAndSettle();
+
+    expect(payloads()[0]).toMatchObject({ quality: "high" });
   });
 
   it("图生图 —— 单张上游图", async () => {

--- a/frontend/src/__tests__/features/canvas/media-model-parameter-chip.test.ts
+++ b/frontend/src/__tests__/features/canvas/media-model-parameter-chip.test.ts
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: Elastic-2.0
+// Copyright (c) 2026 ClaymoreLab
+import { describe, expect, it } from 'vitest';
+
+import type { MediaModelParameterDefinition } from '@/api/ops';
+import {
+  filterMediaModelParamsForMode,
+  userSelectableMediaModelParameters,
+} from '@/features/canvas/ui/MediaModelParameterChip';
+
+const parameters: MediaModelParameterDefinition[] = [
+  {
+    key: 'thinking_level',
+    label: '思考等级',
+    control: 'select',
+    requestPath: 'thinking_level',
+    options: ['low', 'medium', 'high'],
+    default: 'low',
+  },
+  {
+    key: 'style',
+    label: '风格',
+    control: 'select',
+    requestPath: 'style',
+    options: ['natural', 'vivid'],
+    default: 'natural',
+  },
+];
+
+describe('media model parameter visibility', () => {
+  it('keeps thinking level server managed', () => {
+    expect(userSelectableMediaModelParameters(parameters).map((item) => item.key)).toEqual([
+      'style',
+    ]);
+  });
+
+  it('does not resubmit a stored thinking level override', () => {
+    expect(
+      filterMediaModelParamsForMode(
+        parameters,
+        { thinking_level: 'high', style: 'vivid' },
+        'text_to_image',
+      ),
+    ).toEqual({ style: 'vivid' });
+  });
+});

--- a/frontend/src/__tests__/features/freezone/canvas-chat-commands.test.ts
+++ b/frontend/src/__tests__/features/freezone/canvas-chat-commands.test.ts
@@ -3915,6 +3915,11 @@ describe("canvas chat commands", () => {
     expect(shouldIncludeCanvasSummary("基于当前画布搭一个流程")).toBe(true);
     expect(shouldIncludeCanvasSummary("加一个图片节点")).toBe(true);
     expect(shouldIncludeCanvasSummary("我想做个公益短片没思路")).toBe(true);
+    expect(
+      shouldIncludeCanvasSummary("重新选择图片模型", {
+        hasFocusedNodeContext: true,
+      }),
+    ).toBe(false);
   });
 
   it("keeps text node references free of legacy semantic guidance", () => {

--- a/frontend/src/__tests__/features/superchat/freezone-selection-attachment.test.tsx
+++ b/frontend/src/__tests__/features/superchat/freezone-selection-attachment.test.tsx
@@ -30,6 +30,29 @@ const apiMocks = vi.hoisted(() => ({
   post: vi.fn(() => Promise.resolve()),
 }));
 
+const imageModelMocks = vi.hoisted(() => ({
+  result: {
+    models: [
+      {
+        id: "existing-model",
+        providerId: "newapi",
+        apiModel: "existing-model",
+        label: "支持画质模型",
+        qualityOptions: ["low", "medium", "high"],
+      },
+      {
+        id: "seedream-4.5",
+        providerId: "newapi",
+        apiModel: "seedream-4.5",
+        label: "Seedream 4.5",
+      },
+    ],
+    isLoading: false,
+    isFallback: false,
+    error: null,
+  },
+}));
+
 function getFreezoneComposerTextbox(): HTMLElement {
   return screen.getByRole("textbox", {
     name: "想画什么、改哪里，直接告诉虾画",
@@ -95,6 +118,11 @@ vi.mock("@/lib/api", () => ({
   api: {
     post: apiMocks.post,
   },
+}));
+
+vi.mock("@/features/canvas/hooks/useFreezoneImageModels", () => ({
+  useFreezoneImageModels: () => imageModelMocks.result,
+  getFreezoneImageModelsSnapshot: () => imageModelMocks.result,
 }));
 
 vi.mock("@/api/projects", () => ({
@@ -1036,7 +1064,7 @@ describe("SuperChatPanel Freezone selection attachment state", () => {
     );
   });
 
-  it("lets image generation approvals edit node image parameters before applying", async () => {
+  it("hides and omits image quality after switching to a model without that capability", async () => {
     const node = {
       id: "image-node-1",
       type: "imageGenNode",
@@ -1101,9 +1129,11 @@ describe("SuperChatPanel Freezone selection attachment state", () => {
     });
 
     expect(await screen.findByLabelText("图片模型")).toBeInTheDocument();
+    expect(screen.getByLabelText("图片画质")).toBeInTheDocument();
+    fireEvent.change(screen.getByLabelText("图片模型"), { target: { value: "seedream-4.5" } });
+    await waitFor(() => expect(screen.queryByLabelText("图片画质")).not.toBeInTheDocument());
     fireEvent.change(screen.getByLabelText("图片比例"), { target: { value: "9:16" } });
     fireEvent.change(screen.getByLabelText("图片分辨率"), { target: { value: "2K" } });
-    fireEvent.change(screen.getByLabelText("图片画质"), { target: { value: "high" } });
     fireEvent.change(screen.getByLabelText("图片数量"), { target: { value: "2" } });
     fireEvent.click(screen.getByRole("button", { name: "确认执行" }));
 
@@ -1112,7 +1142,7 @@ describe("SuperChatPanel Freezone selection attachment state", () => {
         json: expect.objectContaining({
           turn_id: "turn-a",
           event: expect.objectContaining({
-            type: "canvas_command_result",
+            type: "canvas_command_approval_resolution",
             bridge_key: "bridge-image",
             envelopes: [
               expect.objectContaining({
@@ -1121,10 +1151,9 @@ describe("SuperChatPanel Freezone selection attachment state", () => {
                     type: "update_node_data",
                     node_id: node.id,
                     data: {
-                      model: "existing-model",
+                      model: "seedream-4.5",
                       aspectRatio: "9:16",
                       size: "2K",
-                      quality: "high",
                       count: 2,
                     },
                   },
@@ -1532,7 +1561,7 @@ describe("SuperChatPanel Freezone selection attachment state", () => {
                   ],
                 },
               ],
-              received_at: Date.now() - 61_000,
+              received_at: Date.now() - 301_000,
             },
           ],
         },
@@ -1650,7 +1679,7 @@ describe("SuperChatPanel Freezone selection attachment state", () => {
     await waitFor(() => expect(screen.queryByText("待确认的画布操作")).not.toBeInTheDocument());
   });
 
-  it("retries a timed-out canvas command from its persisted result", async () => {
+  it("starts an agent recovery turn instead of replaying a timed-out command", async () => {
     const envelopes = [
       {
         schema_version: "canvas_chat_commands.v1" as const,
@@ -1726,8 +1755,10 @@ describe("SuperChatPanel Freezone selection attachment state", () => {
     fireEvent.click(screen.getByRole("button", { name: "重新执行" }));
 
     await waitFor(() => {
-      expect(useCanvasStore.getState().nodes).toHaveLength(1);
-      expect(useCanvasStore.getState().nodes[0]?.data.title).toBe("恢复创建的图片节点");
+      expect(superChatMocks.send).toHaveBeenCalledWith(
+        expect.stringContaining("先核对已有节点和运行状态"), [], "重新检查并继续未完成的画布操作",
+      );
+      expect(useCanvasStore.getState().nodes).toHaveLength(0);
     });
   });
 
@@ -1850,7 +1881,7 @@ describe("SuperChatPanel Freezone selection attachment state", () => {
               ],
             },
           ],
-          receivedAt: Date.now() - 61_000,
+          receivedAt: Date.now() - 301_000,
         },
       }));
     });
@@ -1929,7 +1960,7 @@ describe("SuperChatPanel Freezone selection attachment state", () => {
     });
 
     expect(await screen.findByText("待确认的画布操作")).toBeInTheDocument();
-    expect(screen.getByText(/(?:59|60)s 后自动取消/)).toBeInTheDocument();
+    expect(screen.getByText(/(?:299|300)s 后自动取消/)).toBeInTheDocument();
   });
 
   it("shows a cancelled feedback when a stale canvas approval remains in message parts", () => {

--- a/frontend/src/__tests__/features/superchat/freezone-selection-attachment.test.tsx
+++ b/frontend/src/__tests__/features/superchat/freezone-selection-attachment.test.tsx
@@ -80,6 +80,12 @@ vi.mock("react-i18next", () => ({
         "freezone.chat.currentSelection": "当前选中",
         "freezone.chat.usedThisTurn": "本轮会使用",
         "freezone.chat.canvasCommandsCancelled": "已取消画布操作",
+        "freezone.chat.canvasRetryPrompt": "请重新检查并继续刚才未完成的画布操作。先核对已有节点和运行状态，保留已完成结果；补齐生成参数后再提交新的审批。",
+        "freezone.chat.canvasRetryDisplay": "重新检查并继续未完成的画布操作",
+        "freezone.chat.generationParams.imageQuality": "图片画质",
+        "freezone.chat.generationParams.generateAudio": "生成音频",
+        "freezone.chat.generationParams.audioOn": "有声",
+        "freezone.chat.generationParams.audioOff": "静音",
       };
       const template = translations[key]
         ?? (typeof options?.defaultValue === "string" ? options.defaultValue : key);

--- a/frontend/src/__tests__/features/superchat/use-superchat.test.ts
+++ b/frontend/src/__tests__/features/superchat/use-superchat.test.ts
@@ -52,8 +52,11 @@ import {
   canvasApprovalRequiresAudioVoiceChoiceForTest,
   canvasApprovalRequiresManualUiActionForTest,
   canvasApprovalRequiresHumanReviewConfirmationForTest,
+  clarificationQuestionsWithLiveModelCatalogsForTest,
   imageApprovalInitialParamsForTest,
   imageApprovalParamGroupsForTest,
+  imageQualityOptionsForApprovalForTest,
+  normalizeImageQualityForApprovalForTest,
   textApprovalInitialParamsForTest,
   videoApprovalInitialParamsForTest,
   videoApprovalParamGroupsForTest,
@@ -96,6 +99,7 @@ import {
   skillStudioEventsFromUiEventsForTest,
   visibleCanvasContextActivitiesForMessageForTest,
   visibleAssistantOrderedPartsForMessageForTest,
+  visibleAssistantClarificationTimelineItemsForTest,
   visibleSkillStudioEventsForMessageForTest,
 } from "@/features/superchat/superchat-panel";
 import type { ChatMessage, ChatMessagePart, ChatRole } from "@/features/superchat/types";
@@ -2093,6 +2097,53 @@ describe("Skill Studio question response", () => {
     ]);
   });
 
+  it("hides unanswered fields from submitted clarification summaries", () => {
+    const items = visibleAssistantClarificationTimelineItemsForTest(
+      [
+        {
+          id: "image_model",
+          title: "图片模型",
+          options: [{ id: "newapi_nanobanana2", label: "LingShan NB 2" }],
+        },
+        {
+          id: "image_quality",
+          title: "图片画质",
+          options: [
+            { id: "low", label: "低画质" },
+            { id: "medium", label: "标准画质" },
+            { id: "high", label: "高画质" },
+          ],
+        },
+      ],
+      { image_model: { option_ids: ["newapi_nanobanana2"] } },
+    );
+
+    expect(items).toEqual([
+      {
+        key: "image_model",
+        title: "图片模型",
+        summary: "LingShan NB 2",
+        answered: true,
+      },
+    ]);
+  });
+
+  it("keeps submitted option ids visible when dynamic labels are unavailable", () => {
+    const items = visibleAssistantClarificationTimelineItemsForTest(
+      [{ id: "image_resolution", title: "图片分辨率", options: [] }],
+      { image_resolution: { option_ids: ["1K"] } },
+    );
+
+    expect(items).toEqual([
+      {
+        key: "image_resolution",
+        title: "图片分辨率",
+        summary: "1K",
+        answered: true,
+      },
+    ]);
+  });
+
   it("builds a bridge tool result payload instead of a new chat message", () => {
     const payload = buildSkillStudioQuestionToolResultForTest(
       {
@@ -3035,6 +3086,162 @@ describe("Skill Studio draft response", () => {
 });
 
 describe("Canvas command approval image params", () => {
+  it("replaces a shortened image-model clarification with the complete live catalog", () => {
+    const questions = clarificationQuestionsWithLiveModelCatalogsForTest(
+      [{
+        id: "image_model",
+        title: "图片模型",
+        options: [{ id: "seedream-4.5", label: "Seedream 4.5", description: "快速" }],
+      }],
+      [
+        { id: "newapi_gpt_image2", label: "LingShan G2", apiModel: "LingShan-G2" },
+        { id: "seedream-catalog-id", label: "Seedream 4.5", apiModel: "seedream-4.5" },
+      ],
+      [],
+    );
+
+    expect(questions[0]?.options).toEqual([
+      { id: "newapi_gpt_image2", label: "LingShan G2" },
+      { id: "seedream-catalog-id", label: "Seedream 4.5", description: "快速" },
+    ]);
+  });
+
+  it("resolves a tool-declared video model source from the complete live catalog", () => {
+    const questions = clarificationQuestionsWithLiveModelCatalogsForTest(
+      [{
+        id: "preferred_model",
+        title: "视频模型",
+        options_source: "video_models",
+        options: [{ id: "video-fast", label: "快速模型", description: "速度优先" }],
+      }],
+      [],
+      [
+        { id: "video-quality", label: "高质量模型", apiModel: "video-quality-v1" },
+        { id: "video-fast", label: "快速模型", apiModel: "video-fast-v1" },
+      ],
+    );
+
+    expect(questions[0]?.options).toEqual([
+      { id: "video-quality", label: "高质量模型" },
+      { id: "video-fast", label: "快速模型", description: "速度优先" },
+    ]);
+  });
+
+  it("derives dependent generation options from the selected live model", () => {
+    const questions = clarificationQuestionsWithLiveModelCatalogsForTest(
+      [
+        { id: "image_model", title: "图片模型", options: [] },
+        { id: "image_aspect_ratio", title: "图片比例", options: [{ id: "1:1", label: "1:1" }] },
+        { id: "image_resolution", title: "图片分辨率", options: [] },
+        { id: "image_quality", title: "图片画质", options: [] },
+        { id: "video_model", title: "视频模型", options: [] },
+        { id: "video_resolution", title: "视频分辨率", options: [] },
+        { id: "video_duration_seconds", title: "视频时长", options: [] },
+        { id: "video_generate_audio", title: "生成声音", options: [] },
+      ],
+      [{
+        id: "image-a",
+        label: "图片 A",
+        ratioOptions: ["1:1", "16:9"],
+        resolutionOptions: ["1K", "2K"],
+        qualityOptions: ["low", "medium", "high"],
+      }],
+      [{
+        id: "video-a",
+        label: "视频 A",
+        resolutionOptions: ["480P", "720P"],
+        minDuration: 4,
+        maxDuration: 6,
+        supportsGenerateAudio: false,
+      }],
+      {
+        image_model: { option_ids: ["image-a"] },
+        video_model: { option_ids: ["video-a"] },
+      },
+    );
+
+    expect(questions.find((question) => question.id === "image_aspect_ratio")?.options)
+      .toEqual([{ id: "1:1", label: "1:1" }, { id: "16:9", label: "16:9" }]);
+    expect(questions.find((question) => question.id === "image_resolution")?.options)
+      .toEqual([{ id: "1K", label: "1K" }, { id: "2K", label: "2K" }]);
+    expect(questions.find((question) => question.id === "image_quality")?.options)
+      .toEqual([
+        { id: "low", label: "low" },
+        { id: "medium", label: "medium" },
+        { id: "high", label: "high" },
+      ]);
+    expect(questions.find((question) => question.id === "video_resolution")?.options)
+      .toEqual([{ id: "480P", label: "480P" }, { id: "720P", label: "720P" }]);
+    expect(questions.find((question) => question.id === "video_duration_seconds")?.options)
+      .toEqual([
+        { id: "4", label: "4 seconds" },
+        { id: "5", label: "5 seconds" },
+        { id: "6", label: "6 seconds" },
+      ]);
+    expect(questions.find((question) => question.id === "video_generate_audio")?.options)
+      .toEqual([]);
+  });
+
+  it("keeps tool-provided options when the model was already fixed outside the card", () => {
+    const questions = clarificationQuestionsWithLiveModelCatalogsForTest(
+      [{
+        id: "image_resolution",
+        title: "图片分辨率",
+        options_source: "selected_image_model_resolutions",
+        options: [{ id: "2K", label: "2K" }],
+      }],
+      [{ id: "image-a", label: "图片 A", resolutionOptions: ["1K", "2K"] }],
+      [],
+    );
+
+    expect(questions[0]?.options).toEqual([{ id: "2K", label: "2K" }]);
+  });
+
+  it("derives missing-field options from an already confirmed model answer", () => {
+    const questions = clarificationQuestionsWithLiveModelCatalogsForTest(
+      [
+        {
+          id: "image_resolution",
+          title: "图片分辨率",
+          options_source: "selected_image_model_resolutions",
+          options: [],
+        },
+        {
+          id: "video_duration_seconds",
+          title: "视频时长",
+          options_source: "selected_video_model_durations",
+          options: [],
+        },
+      ],
+      [{ id: "image-a", label: "图片 A", resolutionOptions: ["1K", "2K"] }],
+      [{ id: "video-a", label: "视频 A", minDuration: 4, maxDuration: 5 }],
+      {
+        image_model: { option_ids: ["image-a"] },
+        video_model: { option_ids: ["video-a"] },
+      },
+    );
+
+    expect(questions[0]?.options).toEqual([
+      { id: "1K", label: "1K" },
+      { id: "2K", label: "2K" },
+    ]);
+    expect(questions[1]?.options).toEqual([
+      { id: "4", label: "4 seconds" },
+      { id: "5", label: "5 seconds" },
+    ]);
+  });
+
+  it("derives image quality only from the selected model capability", () => {
+    expect(imageQualityOptionsForApprovalForTest({
+      qualityOptions: ["low", "medium", "high"],
+    })).toEqual(["low", "medium", "high"]);
+    expect(normalizeImageQualityForApprovalForTest(
+      "high",
+      ["low", "medium", "high"],
+    )).toBe("high");
+    expect(normalizeImageQualityForApprovalForTest("medium", [])).toBeNull();
+  });
+
   it("updates image node data before running generate_image", () => {
     const approval = {
       id: "approval-a",
@@ -3134,23 +3341,43 @@ describe("Canvas command approval image params", () => {
       }],
     };
 
-    expect(imageApprovalInitialParamsForTest(approval as never, [], "fallback-image")).toMatchObject({
+    expect(imageApprovalInitialParamsForTest(
+      approval as never,
+      [],
+      "fallback-image",
+      [{
+        id: "image-model",
+        ratioOptions: ["1:1"],
+        resolutionOptions: ["4K"],
+      }],
+    )).toMatchObject({
       nodeId: "image-a",
       nodeIds: ["image-a"],
       model: "image-model",
-      aspectRatio: "9:16",
+      aspectRatio: "1:1",
+      size: "4K",
     });
     expect(videoApprovalInitialParamsForTest(
       approval as never,
       [],
       [],
-      [{ id: "video-model", minDuration: 5, maxDuration: 15 }],
+      [{
+        id: "video-model",
+        ratioOptions: ["1:1"],
+        resolutionOptions: ["480P"],
+        minDuration: 4,
+        maxDuration: 6,
+        supportsGenerateAudio: false,
+      }],
       "fallback-video",
     )).toMatchObject({
       nodeId: "video-a",
       nodeIds: ["video-a"],
       model: "video-model",
-      durationSec: 10,
+      aspectRatio: "1:1",
+      quality: "480P",
+      durationSec: 6,
+      generateAudio: false,
     });
     expect(textApprovalInitialParamsForTest(approval as never, [])).toEqual({
       nodeIds: ["text-a"],
@@ -3223,7 +3450,7 @@ describe("Canvas command approval image params", () => {
       model: "seedream-4.5",
       aspectRatio: "16:9",
       size: "2K",
-      quality: "low",
+      quality: null,
       count: 1,
     });
 
@@ -3237,7 +3464,6 @@ describe("Canvas command approval image params", () => {
           model: "seedream-4.5",
           aspectRatio: "16:9",
           size: "2K",
-          quality: "low",
           count: 1,
         },
       },

--- a/frontend/src/features/canvas/ui/MediaModelParameterChip.tsx
+++ b/frontend/src/features/canvas/ui/MediaModelParameterChip.tsx
@@ -13,16 +13,26 @@ interface Props {
   onChange: (values: Record<string, unknown>) => void;
 }
 
+const SERVER_MANAGED_PARAMETER_KEYS = new Set(["thinking_level"]);
+
+export function userSelectableMediaModelParameters(
+  parameters: MediaModelParameterDefinition[] | undefined,
+  mode?: string,
+): MediaModelParameterDefinition[] {
+  const normalizedMode = mode ? MODE_ALIASES[mode] ?? mode : "";
+  return (parameters ?? []).filter((item) => {
+    if (SERVER_MANAGED_PARAMETER_KEYS.has(item.key)) return false;
+    if (!item.modes?.length) return true;
+    return Boolean(mode && (item.modes.includes(mode) || item.modes.includes(normalizedMode)));
+  });
+}
+
 export function MediaModelParameterChip({ parameters, values = {}, mode, onChange }: Props) {
   const { t } = useTranslation();
   const [open, setOpen] = useState(false);
   const rootRef = useRef<HTMLDivElement>(null);
   const visible = useMemo(
-    () => (parameters ?? []).filter((item) => {
-      if (!item.modes?.length) return true;
-      const normalizedMode = mode ? MODE_ALIASES[mode] ?? mode : "";
-      return Boolean(mode && (item.modes.includes(mode) || item.modes.includes(normalizedMode)));
-    }),
+    () => userSelectableMediaModelParameters(parameters, mode),
     [mode, parameters],
   );
 
@@ -117,8 +127,7 @@ export function filterMediaModelParamsForMode(
 ): Record<string, unknown> {
   const normalizedMode = MODE_ALIASES[mode] ?? mode;
   const allowed = new Set(
-    (parameters ?? [])
-      .filter((item) => !item.modes?.length || item.modes.includes(normalizedMode))
+    userSelectableMediaModelParameters(parameters, normalizedMode)
       .map((item) => item.key),
   );
   return Object.fromEntries(

--- a/frontend/src/features/canvas/ui/ModelParamsControls.tsx
+++ b/frontend/src/features/canvas/ui/ModelParamsControls.tsx
@@ -292,18 +292,11 @@ export const ModelParamsControls = memo(({
     ? 'text-[10px] leading-none text-text-muted/80'
     : 'text-text-muted/80';
   const extraParamSchema = selectedModel.extraParamsSchema ?? [];
-  const inlineExtraParamSchema = useMemo(
-    () =>
-      extraParamSchema.filter(
-        (definition) => definition.key === 'thinking_level' && definition.type === 'enum'
-      ),
-    [extraParamSchema]
-  );
   const panelExtraParamSchema = useMemo(
     () => extraParamSchema.filter((definition) => definition.key !== 'thinking_level'),
     [extraParamSchema]
   );
-  const hasOtherParamsPanel = showWebSearchToggle || inlineExtraParamSchema.length > 0;
+  const hasOtherParamsPanel = showWebSearchToggle;
 
   useEffect(() => {
     const animationDurationMs = 200;
@@ -806,50 +799,6 @@ export const ModelParamsControls = memo(({
                   </div>
                 </label>
               )}
-
-              {inlineExtraParamSchema.map((definition) => {
-                const translatedLabel = resolveTranslatedText(t, definition.labelKey, definition.label);
-                const translatedDescription = definition.description || definition.descriptionKey
-                  ? resolveTranslatedText(
-                    t,
-                    definition.descriptionKey,
-                    definition.description
-                  )
-                  : '';
-                const resolvedValue = resolveExtraParamValue(
-                  definition.key,
-                  extraParams,
-                  selectedModel.defaultExtraParams,
-                  definition.defaultValue
-                );
-
-                return (
-                  <div
-                    key={definition.key}
-                    className="space-y-2 rounded-lg border border-[rgba(255,255,255,0.08)] bg-bg-dark/65 p-3"
-                  >
-                    <div>
-                      <div className="text-xs font-medium text-text-dark">{translatedLabel}</div>
-                      {translatedDescription && (
-                        <div className="mt-0.5 text-[11px] leading-4 text-text-muted">
-                          {translatedDescription}
-                        </div>
-                      )}
-                    </div>
-                    <UiSelect
-                      value={String(resolvedValue ?? '')}
-                      onChange={(event) => onExtraParamChange?.(definition.key, event.target.value)}
-                      className="h-9 text-sm"
-                    >
-                      {(definition.options ?? []).map((option) => (
-                        <option key={option.value} value={option.value}>
-                          {resolveTranslatedText(t, option.labelKey, option.label)}
-                        </option>
-                      ))}
-                    </UiSelect>
-                  </div>
-                );
-              })}
             </div>
           </UiPanel>
         )

--- a/frontend/src/features/freezone/chatNodeReferences.ts
+++ b/frontend/src/features/freezone/chatNodeReferences.ts
@@ -302,6 +302,7 @@ function nodeTextReference(
 function nodeReferenceItem(
   node: CanvasNode,
   context?: { nodes?: readonly CanvasNode[]; edges?: readonly CanvasEdge[] },
+  options: { includeActionCatalog?: boolean } = {},
 ): CanvasNodeReferenceItem {
   const textReference = nodeTextReference(node);
   return {
@@ -318,7 +319,10 @@ function nodeReferenceItem(
     candidate_origin:
       (node.data as { candidate_origin?: unknown }).candidate_origin ?? null,
     position: { x: node.position.x, y: node.position.y },
-    action_catalog: buildAgentCanvasNodeActionCatalog(node, context),
+    action_catalog:
+      options.includeActionCatalog === false
+        ? ({} as CanvasNodeActionCatalog & Record<string, unknown>)
+        : buildAgentCanvasNodeActionCatalog(node, context),
   };
 }
 
@@ -616,9 +620,9 @@ export function shouldIncludeCanvasSummary(
   text: string,
   options: { hasFocusedNodeContext?: boolean } = {},
 ): boolean {
-  void options;
   const trimmed = text.trim();
   if (!trimmed) return false;
+  if (options.hasFocusedNodeContext) return false;
   return true;
 }
 
@@ -759,7 +763,7 @@ export function buildCanvasNodeReferenceAttachment(
   nodes: CanvasNode[],
   edges: CanvasEdge[] = [],
   allNodes: CanvasNode[] = nodes,
-  options: { displayNodes?: CanvasNode[] } = {},
+  options: { displayNodes?: CanvasNode[]; includeActionCatalog?: boolean } = {},
 ): ChatAttachment | null {
   const referencedNodes = nodes.filter((node) => node.id);
   if (referencedNodes.length === 0) return null;
@@ -781,10 +785,10 @@ export function buildCanvasNodeReferenceAttachment(
     project,
     canvas_id: canvasId,
     display_nodes: displayNodes.map((node) =>
-      nodeReferenceItem(node, actionContext),
+      nodeReferenceItem(node, actionContext, options),
     ),
     nodes: referencedNodes.map((node) =>
-      nodeReferenceItem(node, actionContext),
+      nodeReferenceItem(node, actionContext, options),
     ),
     edges: referencedEdges.map((edge) => edgeReferenceItem(edge, nodeById)),
   };

--- a/frontend/src/features/superchat/superchat-panel.tsx
+++ b/frontend/src/features/superchat/superchat-panel.tsx
@@ -2399,6 +2399,12 @@ function imageApprovalParamGroups(
   approval: PendingCanvasCommandApproval,
   canvasNodes: CanvasNode[],
   fallbackModel: string,
+  models: readonly {
+    id: string;
+    ratioOptions?: string[];
+    resolutionOptions?: string[];
+    qualityOptions?: string[];
+  }[] = [],
 ): CanvasApprovalImageParams[] {
   const nodeIds = imageGenerateCommandNodeIds(approval.envelopes);
   const textValue = (value: unknown, fallback: string) =>
@@ -2406,13 +2412,24 @@ function imageApprovalParamGroups(
   const groups = new Map<string, CanvasApprovalImageParams>();
   for (const nodeId of nodeIds) {
     const nodeData = approvalNodeData(approval, canvasNodes, nodeId);
+    const model = textValue(nodeData?.model, fallbackModel);
+    const selectedModel = models.find((item) => item.id === model);
+    const aspectOptions = clarificationCapabilityOptions(
+      selectedModel?.ratioOptions,
+      CANVAS_APPROVAL_IMAGE_ASPECT_RATIO_OPTIONS,
+    );
+    const sizeOptions = clarificationCapabilityOptions(
+      selectedModel?.resolutionOptions,
+      CANVAS_APPROVAL_IMAGE_SIZE_OPTIONS,
+    );
+    const qualityOptions = imageQualityOptionsForApproval(selectedModel);
     const params: CanvasApprovalImageParams = {
       nodeId,
       nodeIds: [nodeId],
-      model: textValue(nodeData?.model, fallbackModel),
-      aspectRatio: textValue(nodeData?.aspectRatio, "16:9"),
-      size: textValue(nodeData?.size, "2K"),
-      quality: textValue(nodeData?.quality, "medium"),
+      model,
+      aspectRatio: normalizeApprovalStringOption(nodeData?.aspectRatio, aspectOptions, "16:9"),
+      size: normalizeApprovalStringOption(nodeData?.size, sizeOptions, "2K"),
+      quality: normalizeImageQualityForApproval(nodeData?.quality, qualityOptions),
       count: typeof nodeData?.count === "number" && CANVAS_APPROVAL_IMAGE_COUNT_OPTIONS.includes(nodeData.count as 1 | 2 | 4)
         ? nodeData.count
         : 1,
@@ -2435,8 +2452,44 @@ function imageApprovalInitialParams(
   approval: PendingCanvasCommandApproval,
   canvasNodes: CanvasNode[],
   fallbackModel: string,
+  models: readonly {
+    id: string;
+    ratioOptions?: string[];
+    resolutionOptions?: string[];
+    qualityOptions?: string[];
+  }[] = [],
 ): CanvasApprovalImageParams | null {
-  return imageApprovalParamGroups(approval, canvasNodes, fallbackModel)[0] ?? null;
+  return imageApprovalParamGroups(approval, canvasNodes, fallbackModel, models)[0] ?? null;
+}
+
+function imageQualityOptionsForApproval(
+  model: { qualityOptions?: string[] } | null | undefined,
+): readonly string[] {
+  return (model?.qualityOptions ?? []).map((item) => item.trim()).filter(Boolean);
+}
+
+function normalizeImageQualityForApproval(
+  value: unknown,
+  options: readonly string[],
+): string | null {
+  if (options.length === 0) return null;
+  const requested = typeof value === "string" ? value.trim() : "";
+  return options.find((option) => option.toLowerCase() === requested.toLowerCase())
+    ?? options.find((option) => option.toLowerCase() === "medium")
+    ?? options[0]
+    ?? null;
+}
+
+function normalizeApprovalStringOption(
+  value: unknown,
+  options: readonly string[],
+  preferred: string,
+): string {
+  const requested = typeof value === "string" ? value.trim() : "";
+  return options.find((option) => option.toLowerCase() === requested.toLowerCase())
+    ?? options.find((option) => option.toLowerCase() === preferred.toLowerCase())
+    ?? options[0]
+    ?? preferred;
 }
 
 function resolutionToVideoQuality(value: string): VideoGenQuality | null {
@@ -2603,8 +2656,10 @@ function videoApprovalParamGroups(
     id: string;
     label?: string;
     resolutionOptions?: string[];
+    ratioOptions?: string[];
     minDuration?: number | null;
     maxDuration?: number | null;
+    supportsGenerateAudio?: boolean;
   }>,
   fallbackModel: string,
 ): CanvasApprovalVideoParams[] {
@@ -2620,7 +2675,10 @@ function videoApprovalParamGroups(
     const model = selectedModel?.id ?? rawModel;
     const qualityOptions = videoQualityOptionsForApproval(selectedModel);
     const durationBounds = videoDurationBoundsForApproval(selectedModel);
-    const aspectRatio = textValue(nodeData?.aspectRatio, "16:9");
+    const aspectOptions = clarificationCapabilityOptions(
+      selectedModel?.ratioOptions,
+      VIDEO_GENERATION_ASPECT_RATIOS,
+    );
     const requiresHumanReviewConfirmation = (
       isSeedance20ApprovalModel(model)
       && approvalVideoHasImageInput(approval, canvasNodes, canvasEdges, nodeId, nodeData)
@@ -2630,12 +2688,12 @@ function videoApprovalParamGroups(
       nodeId,
       nodeIds: [nodeId],
       model,
-      aspectRatio: (VIDEO_GENERATION_ASPECT_RATIOS as readonly string[]).includes(aspectRatio)
-        ? aspectRatio
-        : "16:9",
+      aspectRatio: normalizeApprovalStringOption(nodeData?.aspectRatio, aspectOptions, "16:9"),
       quality: normalizeVideoQualityForApproval(nodeData?.quality, qualityOptions),
       durationSec: clampVideoDurationForApproval(nodeData?.durationSec, durationBounds),
-      generateAudio: Boolean(nodeData?.generateAudio),
+      generateAudio: selectedModel?.supportsGenerateAudio === false
+        ? false
+        : Boolean(nodeData?.generateAudio),
       humanReview: requiresHumanReviewConfirmation || Boolean(nodeData?.humanReview),
       requiresHumanReviewConfirmation,
       count: isCanvasApprovalVideoCount(nodeData?.count) ? nodeData.count : 1,
@@ -2664,8 +2722,10 @@ function videoApprovalInitialParams(
     id: string;
     label?: string;
     resolutionOptions?: string[];
+    ratioOptions?: string[];
     minDuration?: number | null;
     maxDuration?: number | null;
+    supportsGenerateAudio?: boolean;
   }>,
   fallbackModel: string,
 ): CanvasApprovalVideoParams | null {
@@ -2871,7 +2931,7 @@ function amendCanvasApprovalWithImageParams(
     model: params.model,
     aspectRatio: params.aspectRatio,
     size: params.size,
-    quality: params.quality,
+    ...(params.quality ? { quality: params.quality } : {}),
     count: params.count,
   };
   return amendCanvasApprovalWithGenerationData(
@@ -3017,6 +3077,9 @@ export const amendCanvasApprovalWithAudioParamsForTest = amendCanvasApprovalWith
 export const imageApprovalInitialParamsForTest = imageApprovalInitialParams;
 export const videoApprovalInitialParamsForTest = videoApprovalInitialParams;
 export const imageApprovalParamGroupsForTest = imageApprovalParamGroups;
+export const imageQualityOptionsForApprovalForTest = imageQualityOptionsForApproval;
+export const normalizeImageQualityForApprovalForTest = normalizeImageQualityForApproval;
+export const clarificationQuestionsWithLiveModelCatalogsForTest = clarificationQuestionsWithLiveModelCatalogs;
 export const videoApprovalParamGroupsForTest = videoApprovalParamGroups;
 export const textApprovalInitialParamsForTest = textApprovalInitialParams;
 export const audioApprovalInitialParamsForTest = audioApprovalInitialParams;
@@ -3062,23 +3125,30 @@ function CanvasApprovalImageParamSelect({
 }
 
 function CanvasApprovalVideoConfigChip({
+  aspectOptions,
   disabled,
   durationBounds,
   onChange,
   params,
   qualityOptions,
+  supportsGenerateAudio,
 }: {
+  aspectOptions: readonly string[];
   disabled?: boolean;
   durationBounds: { min: number; max: number };
   onChange: (patch: Partial<CanvasApprovalVideoParams>) => void;
   params: CanvasApprovalVideoParams;
   qualityOptions: readonly VideoGenQuality[];
+  supportsGenerateAudio: boolean;
 }) {
+  const { t } = useTranslation();
   const triggerRef = useRef<HTMLButtonElement>(null);
   const popoverRef = useRef<HTMLDivElement>(null);
   const [isOpen, setIsOpen] = useState(false);
   const [popoverStyle, setPopoverStyle] = useState<CSSProperties>({});
-  const audioLabel = params.generateAudio ? "有声" : "静音";
+  const audioLabel = params.generateAudio
+    ? t("freezone.chat.generationParams.audioOn")
+    : t("freezone.chat.generationParams.audioOff");
 
   const updatePopoverPosition = useCallback(() => {
     const rect = triggerRef.current?.getBoundingClientRect();
@@ -3148,7 +3218,7 @@ function CanvasApprovalVideoConfigChip({
         >
           <div className="mb-1.5 text-[11px] font-medium text-muted-foreground">比例</div>
           <div className="mb-3 grid grid-cols-4 gap-1.5">
-            {VIDEO_GENERATION_ASPECT_RATIOS.map((ratio) => {
+            {aspectOptions.map((ratio) => {
               const isActive = params.aspectRatio === ratio;
               return (
                 <button
@@ -3205,28 +3275,34 @@ function CanvasApprovalVideoConfigChip({
             className="mb-3 w-full"
           />
 
-          <div className="mb-1.5 text-[11px] font-medium text-muted-foreground">生成音频</div>
-          <div className="flex items-center justify-between rounded-md bg-white/[0.06] px-2.5 py-1.5">
-            <span className="text-xs font-medium text-foreground">{audioLabel}</span>
-            <button
-              type="button"
-              role="switch"
-              aria-checked={params.generateAudio}
-              aria-label="生成音频"
-              onClick={() => onChange({ generateAudio: !params.generateAudio })}
-              className={cn(
-                "relative h-5 w-9 rounded-full transition-colors",
-                params.generateAudio ? "bg-white/35" : "bg-white/15",
-              )}
-            >
-              <span
-                className={cn(
-                  "absolute top-0.5 size-4 rounded-full bg-white transition-transform",
-                  params.generateAudio ? "translate-x-4" : "translate-x-0.5",
-                )}
-              />
-            </button>
-          </div>
+          {supportsGenerateAudio ? (
+            <>
+              <div className="mb-1.5 text-[11px] font-medium text-muted-foreground">
+                {t("freezone.chat.generationParams.generateAudio")}
+              </div>
+              <div className="flex items-center justify-between rounded-md bg-white/[0.06] px-2.5 py-1.5">
+                <span className="text-xs font-medium text-foreground">{audioLabel}</span>
+                <button
+                  type="button"
+                  role="switch"
+                  aria-checked={params.generateAudio}
+                  aria-label={t("freezone.chat.generationParams.generateAudio")}
+                  onClick={() => onChange({ generateAudio: !params.generateAudio })}
+                  className={cn(
+                    "relative h-5 w-9 rounded-full transition-colors",
+                    params.generateAudio ? "bg-white/35" : "bg-white/15",
+                  )}
+                >
+                  <span
+                    className={cn(
+                      "absolute top-0.5 size-4 rounded-full bg-white transition-transform",
+                      params.generateAudio ? "translate-x-4" : "translate-x-0.5",
+                    )}
+                  />
+                </button>
+              </div>
+            </>
+          ) : null}
         </div>,
         document.body,
       )}
@@ -3258,8 +3334,13 @@ function CanvasCommandApprovalCard({
   const fallbackImageModel = imageModels.models[0]?.id ?? "";
   const fallbackVideoModel = videoModels.models[0]?.id ?? "";
   const initialImageParams = useMemo(
-    () => imageApprovalParamGroups(approval, canvasNodes, fallbackImageModel),
-    [approval, canvasNodes, fallbackImageModel],
+    () => imageApprovalParamGroups(
+      approval,
+      canvasNodes,
+      fallbackImageModel,
+      imageModels.models,
+    ),
+    [approval, canvasNodes, fallbackImageModel, imageModels.models],
   );
   const initialVideoParams = useMemo(
     () => videoApprovalParamGroups(
@@ -3360,10 +3441,29 @@ function CanvasCommandApprovalCard({
     return options;
   }, [imageModels.models]);
   const updateImageParams = useCallback((index: number, patch: Partial<CanvasApprovalImageParams>) => {
-    setImageParams((current) => current.map((params, paramsIndex) => (
-      paramsIndex === index ? { ...params, ...patch } : params
-    )));
-  }, []);
+    setImageParams((current) => current.map((params, paramsIndex) => {
+      if (paramsIndex !== index) return params;
+      const next = { ...params, ...patch };
+      const model = imageModels.models.find((item) => item.id === next.model);
+      const aspectOptions = clarificationCapabilityOptions(
+        model?.ratioOptions,
+        CANVAS_APPROVAL_IMAGE_ASPECT_RATIO_OPTIONS,
+      );
+      const sizeOptions = clarificationCapabilityOptions(
+        model?.resolutionOptions,
+        CANVAS_APPROVAL_IMAGE_SIZE_OPTIONS,
+      );
+      return {
+        ...next,
+        aspectRatio: normalizeApprovalStringOption(next.aspectRatio, aspectOptions, "16:9"),
+        size: normalizeApprovalStringOption(next.size, sizeOptions, "2K"),
+        quality: normalizeImageQualityForApproval(
+          next.quality,
+          imageQualityOptionsForApproval(model),
+        ),
+      };
+    }));
+  }, [imageModels.models]);
   const videoModelOptionsFor = useCallback((params: CanvasApprovalVideoParams) => {
     const options = videoModels.models.map((model) => ({ value: model.id, label: model.label ?? model.id }));
     if (params.model && !options.some((option) => option.value === params.model)) {
@@ -3378,10 +3478,16 @@ function CanvasCommandApprovalCard({
       const model = videoModels.models.find((item) => item.id === next.model) ?? videoModels.models[0];
       const qualityOptions = videoQualityOptionsForApproval(model);
       const durationBounds = videoDurationBoundsForApproval(model);
+      const aspectOptions = clarificationCapabilityOptions(
+        model?.ratioOptions,
+        VIDEO_GENERATION_ASPECT_RATIOS,
+      );
       return {
         ...next,
+        aspectRatio: normalizeApprovalStringOption(next.aspectRatio, aspectOptions, "16:9"),
         quality: normalizeVideoQualityForApproval(next.quality, qualityOptions),
         durationSec: clampVideoDurationForApproval(next.durationSec, durationBounds),
+        generateAudio: model?.supportsGenerateAudio === false ? false : next.generateAudio,
       };
     }));
   }, [videoModels.models]);
@@ -3461,9 +3567,22 @@ function CanvasCommandApprovalCard({
           </button>
         </div>
       )}
-      {imageParams.map((imageParam, imageParamIndex) => (
-        <div key={`${imageParam.nodeId}:${imageParam.model}`} className="border-t border-amber-400/10 px-3 py-1.5">
-          <div className="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1">
+      {imageParams.map((imageParam, imageParamIndex) => {
+        const selectedImageModel = imageModels.models.find(
+          (model) => model.id === imageParam.model,
+        );
+        const imageAspectOptions = clarificationCapabilityOptions(
+          selectedImageModel?.ratioOptions,
+          CANVAS_APPROVAL_IMAGE_ASPECT_RATIO_OPTIONS,
+        );
+        const imageSizeOptions = clarificationCapabilityOptions(
+          selectedImageModel?.resolutionOptions,
+          CANVAS_APPROVAL_IMAGE_SIZE_OPTIONS,
+        );
+        const imageQualityOptions = imageQualityOptionsForApproval(selectedImageModel);
+        return (
+          <div key={`${imageParam.nodeId}:${imageParam.model}`} className="border-t border-amber-400/10 px-3 py-1.5">
+            <div className="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1">
             <span className="inline-flex items-center gap-1 text-[11px] font-medium text-foreground">
               <Image className="size-3" />图片
               {(imageParam.nodeIds?.length ?? 1) > 1 ? ` ×${imageParam.nodeIds?.length}` : ""}
@@ -3482,7 +3601,7 @@ function CanvasCommandApprovalCard({
               disabled={isExecuting}
               value={imageParam.aspectRatio}
               onChange={(value) => updateImageParams(imageParamIndex, { aspectRatio: value })}
-              options={CANVAS_APPROVAL_IMAGE_ASPECT_RATIO_OPTIONS.map((option) => ({
+              options={imageAspectOptions.map((option) => ({
                 value: option,
                 label: option === "auto" ? "自动比例" : option,
               }))}
@@ -3493,16 +3612,20 @@ function CanvasCommandApprovalCard({
               disabled={isExecuting}
               value={imageParam.size}
               onChange={(value) => updateImageParams(imageParamIndex, { size: value })}
-              options={CANVAS_APPROVAL_IMAGE_SIZE_OPTIONS.map((option) => ({ value: option, label: option }))}
+              options={imageSizeOptions.map((option) => ({ value: option, label: option }))}
             />
-            <span className="h-4 w-px bg-white/[0.12]" />
-            <CanvasApprovalImageParamSelect
-              ariaLabel="图片画质"
-              disabled={isExecuting}
-              value={imageParam.quality}
-              onChange={(value) => updateImageParams(imageParamIndex, { quality: value })}
-              options={CANVAS_APPROVAL_IMAGE_QUALITY_OPTIONS.map((option) => ({ value: option, label: option }))}
-            />
+            {imageQualityOptions.length > 0 ? (
+              <>
+                <span className="h-4 w-px bg-white/[0.12]" />
+                <CanvasApprovalImageParamSelect
+                  ariaLabel={t("freezone.chat.generationParams.imageQuality")}
+                  disabled={isExecuting}
+                  value={imageParam.quality ?? imageQualityOptions[0]}
+                  onChange={(value) => updateImageParams(imageParamIndex, { quality: value })}
+                  options={imageQualityOptions.map((option) => ({ value: option, label: option }))}
+                />
+              </>
+            ) : null}
             <span className="h-4 w-px bg-white/[0.12]" />
             <CanvasApprovalImageParamSelect
               ariaLabel="图片数量"
@@ -3511,14 +3634,19 @@ function CanvasCommandApprovalCard({
               onChange={(value) => updateImageParams(imageParamIndex, { count: Number(value) })}
               options={CANVAS_APPROVAL_IMAGE_COUNT_OPTIONS.map((option) => ({ value: String(option), label: `${option} 张` }))}
             />
+            </div>
           </div>
-        </div>
-      ))}
+        );
+      })}
       {videoParams.map((videoParam, videoParamIndex) => {
         const selectedVideoModel = videoModels.models.find((model) => model.id === videoParam.model)
           ?? videoModels.models[0];
         const videoQualityOptions = videoQualityOptionsForApproval(selectedVideoModel);
         const videoDurationBounds = videoDurationBoundsForApproval(selectedVideoModel);
+        const videoAspectOptions = clarificationCapabilityOptions(
+          selectedVideoModel?.ratioOptions,
+          VIDEO_GENERATION_ASPECT_RATIOS,
+        );
         return (
         <div key={`${videoParam.nodeId}:${videoParam.model}`} className="border-t border-amber-400/10 px-3 py-1">
           <div className="flex min-w-0 flex-wrap items-center gap-x-1.5 gap-y-0.5">
@@ -3536,11 +3664,13 @@ function CanvasCommandApprovalCard({
             />
             <span className="h-3.5 w-px bg-white/[0.12]" />
             <CanvasApprovalVideoConfigChip
+              aspectOptions={videoAspectOptions}
               disabled={isExecuting}
               durationBounds={videoDurationBounds}
               onChange={(patch) => updateVideoParams(videoParamIndex, patch)}
               params={videoParam}
               qualityOptions={videoQualityOptions}
+              supportsGenerateAudio={selectedVideoModel?.supportsGenerateAudio !== false}
             />
             <span className="h-3.5 w-px bg-white/[0.12]" />
             <CanvasApprovalImageParamSelect
@@ -3928,9 +4058,248 @@ type SkillStudioQuestionSelections = Record<string, string | string[] | SkillStu
 
 type AssistantClarificationQuestion = SkillStudioQuestion & {
   mode?: "single" | "multiple";
+  options_source?: ClarificationOptionsSource;
 };
 
 type AssistantClarificationAnswers = SkillStudioQuestionSelections;
+
+type ClarificationCatalogModel = {
+  id: string;
+  label?: string;
+  apiModel?: string;
+  catalogId?: string;
+  resolutionOptions?: string[];
+  ratioOptions?: string[];
+  qualityOptions?: string[];
+  minDuration?: number | null;
+  maxDuration?: number | null;
+  supportsGenerateAudio?: boolean;
+};
+
+type ClarificationOptionsSource =
+  | "image_models"
+  | "selected_image_model_ratios"
+  | "selected_image_model_resolutions"
+  | "selected_image_model_qualities"
+  | "image_variant_counts"
+  | "video_models"
+  | "selected_video_model_ratios"
+  | "selected_video_model_resolutions"
+  | "selected_video_model_durations"
+  | "selected_video_model_audio"
+  | "video_variant_counts";
+
+const CLARIFICATION_SOURCE_BY_QUESTION_ID: Record<string, ClarificationOptionsSource> = {
+  image_model: "image_models",
+  image_aspect_ratio: "selected_image_model_ratios",
+  image_resolution: "selected_image_model_resolutions",
+  image_quality: "selected_image_model_qualities",
+  image_variants_per_node: "image_variant_counts",
+  video_model: "video_models",
+  video_aspect_ratio: "selected_video_model_ratios",
+  video_resolution: "selected_video_model_resolutions",
+  video_duration_seconds: "selected_video_model_durations",
+  video_generate_audio: "selected_video_model_audio",
+  video_variants_per_node: "video_variant_counts",
+};
+
+const normalizedClarificationId = (value: unknown) =>
+  String(value ?? "").trim().toLowerCase().replace(/-/g, "_");
+
+function clarificationSelectedValue(
+  questions: AssistantClarificationQuestion[],
+  answers: AssistantClarificationAnswers,
+  questionId: string,
+): string {
+  const questionIndex = questions.findIndex(
+    (question) => normalizedClarificationId(question.id) === questionId,
+  );
+  if (questionIndex < 0) {
+    const directAnswer = Object.entries(answers).find(
+      ([answerKey]) => normalizedClarificationId(answerKey) === questionId,
+    )?.[1];
+    const selection = normalizedSkillStudioQuestionSelection(directAnswer);
+    return selection.optionIds[0]?.trim() || selection.customText.trim();
+  }
+  const question = questions[questionIndex];
+  const selection = normalizedSkillStudioQuestionSelection(
+    answers[skillStudioQuestionKey(question, questionIndex)],
+  );
+  return selection.optionIds[0]?.trim() || selection.customText.trim();
+}
+
+function clarificationSelectedModel(
+  questions: AssistantClarificationQuestion[],
+  answers: AssistantClarificationAnswers,
+  questionId: "image_model" | "video_model",
+  models: readonly ClarificationCatalogModel[],
+): ClarificationCatalogModel | null {
+  const selected = clarificationSelectedValue(questions, answers, questionId).toLowerCase();
+  if (!selected) return null;
+  return models.find((model) =>
+    [model.id, model.apiModel, model.catalogId, model.label]
+      .some((identifier) => String(identifier ?? "").trim().toLowerCase() === selected),
+  ) ?? null;
+}
+
+function clarificationOptions(
+  values: readonly (string | number | boolean)[],
+  existingOptions: SkillStudioQuestionOption[],
+  labelFor: (value: string | number | boolean) => string = String,
+): SkillStudioQuestionOption[] {
+  const normalized = (value: unknown) => String(value ?? "").trim().toLowerCase();
+  return values.map((value) => {
+    const id = String(value);
+    const existing = existingOptions.find((option) =>
+      normalized(option.id) === normalized(id) || normalized(option.label) === normalized(id),
+    );
+    return {
+      id,
+      label: labelFor(value),
+      ...(existing?.description ? { description: existing.description } : {}),
+    };
+  });
+}
+
+function clarificationCapabilityOptions(
+  configured: readonly string[] | null | undefined,
+  fallback: readonly string[],
+): readonly string[] {
+  const values = (configured ?? []).map((value) => value.trim()).filter(Boolean);
+  return values.length > 0 ? values : fallback;
+}
+
+function clarificationQuestionsWithLiveModelCatalogs(
+  questions: AssistantClarificationQuestion[],
+  imageModels: readonly ClarificationCatalogModel[],
+  videoModels: readonly ClarificationCatalogModel[],
+  answers: AssistantClarificationAnswers = {},
+  t?: TFunction,
+): AssistantClarificationQuestion[] {
+  const selectedImageModel = clarificationSelectedModel(
+    questions, answers, "image_model", imageModels,
+  );
+  const selectedVideoModel = clarificationSelectedModel(
+    questions, answers, "video_model", videoModels,
+  );
+  const hasImageModelQuestion = questions.some(
+    (question) => normalizedClarificationId(question.id) === "image_model",
+  );
+  const hasVideoModelQuestion = questions.some(
+    (question) => normalizedClarificationId(question.id) === "video_model",
+  );
+  return questions.map((question) => {
+    const questionId = normalizedClarificationId(question.id);
+    const source = question.options_source ?? CLARIFICATION_SOURCE_BY_QUESTION_ID[questionId];
+    const existingOptions = question.options ?? [];
+    const normalized = (value: unknown) => String(value ?? "").trim().toLowerCase();
+    if (source === "image_models" || source === "video_models") {
+      const models = source === "image_models" ? imageModels : videoModels;
+      if (!models.length) return question;
+      return {
+        ...question,
+        options_source: source,
+        options: models.map((model) => {
+          const identifiers = [model.id, model.apiModel, model.catalogId, model.label]
+            .map(normalized)
+            .filter(Boolean);
+          const existing = existingOptions.find((option) => {
+            const optionId = normalized(option.id);
+            const optionLabel = normalized(option.label).replace(/\s*\(recommended\)\s*$/, "");
+            return identifiers.includes(optionId) || identifiers.includes(optionLabel);
+          });
+          return {
+            id: model.id,
+            label: model.label ?? model.id,
+            ...(existing?.description ? { description: existing.description } : {}),
+          };
+        }),
+      };
+    }
+    let values: readonly (string | number | boolean)[] | null = null;
+    let labelFor: (value: string | number | boolean) => string = String;
+    if (source?.startsWith("selected_image_model_") && !selectedImageModel) {
+      return hasImageModelQuestion
+        ? { ...question, options_source: source, options: [], allow_custom: false }
+        : question;
+    }
+    if (source?.startsWith("selected_video_model_") && !selectedVideoModel) {
+      return hasVideoModelQuestion
+        ? { ...question, options_source: source, options: [], allow_custom: false }
+        : question;
+    }
+    if (source === "selected_image_model_ratios") {
+      values = clarificationCapabilityOptions(
+        selectedImageModel?.ratioOptions,
+        CANVAS_APPROVAL_IMAGE_ASPECT_RATIO_OPTIONS,
+      );
+      labelFor = (value) => value === "auto"
+        ? String(t?.("freezone.chat.generationParams.autoRatio") ?? "Auto")
+        : String(value);
+    } else if (source === "selected_image_model_resolutions") {
+      values = clarificationCapabilityOptions(
+        selectedImageModel?.resolutionOptions,
+        CANVAS_APPROVAL_IMAGE_SIZE_OPTIONS,
+      );
+    } else if (source === "selected_image_model_qualities") {
+      values = selectedImageModel?.qualityOptions?.filter(Boolean) ?? [];
+      labelFor = (value) => String(t?.(
+        `freezone.chat.generationParams.quality.${String(value).toLowerCase()}`,
+        { defaultValue: String(value) },
+      ) ?? value);
+    } else if (source === "image_variant_counts") {
+      values = CANVAS_APPROVAL_IMAGE_COUNT_OPTIONS;
+      labelFor = (value) => String(t?.("freezone.chat.generationParams.imageCount", {
+        count: Number(value),
+      }) ?? `${value} images`);
+    } else if (source === "selected_video_model_ratios") {
+      values = clarificationCapabilityOptions(
+        selectedVideoModel?.ratioOptions,
+        VIDEO_GENERATION_ASPECT_RATIOS,
+      );
+      labelFor = (value) => value === "auto"
+        ? String(t?.("freezone.chat.generationParams.autoRatio") ?? "Auto")
+        : String(value);
+    } else if (source === "selected_video_model_resolutions") {
+      values = clarificationCapabilityOptions(
+        selectedVideoModel?.resolutionOptions,
+        CANVAS_APPROVAL_VIDEO_QUALITY_OPTIONS,
+      );
+    } else if (source === "selected_video_model_durations") {
+      if (selectedVideoModel) {
+        const min = Number(selectedVideoModel.minDuration);
+        const max = Number(selectedVideoModel.maxDuration);
+        const start = Number.isFinite(min) && min > 0 ? Math.ceil(min) : CANVAS_APPROVAL_VIDEO_DURATION_MIN;
+        const end = Number.isFinite(max) && max >= start ? Math.floor(max) : CANVAS_APPROVAL_VIDEO_DURATION_MAX;
+        values = Array.from({ length: end - start + 1 }, (_, index) => start + index);
+        labelFor = (value) => String(t?.("freezone.chat.generationParams.durationSeconds", {
+          count: Number(value),
+        }) ?? `${value} seconds`);
+      } else values = [];
+    } else if (source === "selected_video_model_audio") {
+      values = selectedVideoModel && selectedVideoModel.supportsGenerateAudio !== false
+        ? [true, false]
+        : [];
+      labelFor = (value) => String(t?.(
+        value === true
+          ? "freezone.chat.generationParams.generateAudio"
+          : "freezone.chat.generationParams.muteAudio",
+      ) ?? (value === true ? "Generate audio" : "Mute audio"));
+    } else if (source === "video_variant_counts") {
+      values = CANVAS_APPROVAL_VIDEO_COUNT_OPTIONS;
+      labelFor = (value) => String(t?.("freezone.chat.generationParams.videoCount", {
+        count: Number(value),
+      }) ?? `${value} videos`);
+    }
+    if (values === null) return question;
+    return {
+      ...question,
+      options_source: source,
+      options: clarificationOptions(values, existingOptions, labelFor),
+      allow_custom: false,
+    };
+  });
+}
 
 type AssistantClarificationUiEvent = {
   type: "assistant.clarification.request";
@@ -5393,9 +5762,11 @@ function selectedSkillStudioOptionLabel(
 ): string {
   const selection = normalizedSkillStudioQuestionSelection(selections[skillStudioQuestionKey(question, questionIndex)]);
   const selectedLabels = selection.optionIds
-    .map((optionId) => findSkillStudioOption(question, optionId))
-    .filter((option): option is SkillStudioQuestionOption => Boolean(option))
-    .map(formatSkillStudioOption);
+    .map((optionId) => {
+      const option = findSkillStudioOption(question, optionId);
+      return option ? formatSkillStudioOption(option) : optionId.trim();
+    })
+    .filter(Boolean);
   const customText = selection.customText.trim();
   const parts = [...selectedLabels, ...(customText ? [`补充：${customText}`] : [])];
   return parts.length > 0 ? parts.join("；") : "未选择";
@@ -5436,6 +5807,32 @@ function buildSkillStudioQuestionTimelineItems(
 }
 
 export const buildSkillStudioQuestionTimelineItemsForTest = buildSkillStudioQuestionTimelineItems;
+
+function visibleAssistantClarificationTimelineItems(
+  questions: AssistantClarificationQuestion[],
+  answers: AssistantClarificationAnswers,
+  action?: string,
+): SkillStudioQuestionTimelineItem[] {
+  if (action === "skip") return [];
+  if (action === "recommended") {
+    return buildSkillStudioQuestionTimelineItems(questions, answers, action)
+      .filter((item) => item.answered);
+  }
+  return questions
+    .map((question, index) => ({ question, index }))
+    .filter(({ question, index }) =>
+      skillStudioSelectionHasAnswer(answers[skillStudioQuestionKey(question, index)]),
+    )
+    .map(({ question, index }) => ({
+      key: skillStudioQuestionKey(question, index),
+      title: question.title || `问题 ${index + 1}`,
+      summary: selectedSkillStudioOptionLabel(question, index, answers),
+      answered: true,
+    }));
+}
+
+export const visibleAssistantClarificationTimelineItemsForTest =
+  visibleAssistantClarificationTimelineItems;
 
 export function buildSkillStudioQuestionResponseForTest(
   event: Extract<SkillStudioUiEvent, { type: "skill_studio.questions" }>,
@@ -5497,7 +5894,9 @@ export function buildAssistantClarificationResponseForTest(
 
   const answerLines = (event.questions ?? [])
     .map((question, index) => ({ question, index }))
-    .filter(({ question }) => (question.options ?? []).length > 0 || skillStudioQuestionAllowsCustom(question))
+    .filter(({ question, index }) =>
+      skillStudioSelectionHasAnswer(answers[skillStudioQuestionKey(question, index)]),
+    )
     .map(({ question, index }) =>
       `${question.title || `问题 ${index + 1}`}\n${selectedSkillStudioOptionLabel(question, index, answers)}`,
     );
@@ -6183,15 +6582,22 @@ function SkillStudioQuestionsCard({
 }
 
 function AssistantClarificationSummaryCard({ event }: { event: AssistantClarificationUiEvent }) {
+  const { t } = useTranslation();
   const questions = Array.isArray(event.questions) ? event.questions : [];
   const answers = event.answers && typeof event.answers === "object" ? event.answers : {};
-  const timelineItems = buildSkillStudioQuestionTimelineItems(questions, answers);
-  const answeredCount = timelineItems.filter((item) => item.answered).length;
+  const timelineItems = visibleAssistantClarificationTimelineItems(
+    questions,
+    answers,
+    event.action,
+  );
+  const answeredCount = timelineItems.length;
   const skipped = event.skipped === true || event.action === "skip";
-  const statusLabel = skipped ? "已跳过" : "已提交";
+  const statusLabel = skipped
+    ? t("freezone.chat.clarification.skipped")
+    : t("freezone.chat.clarification.submitted");
   const countLabel = skipped
-    ? `已跳过问题 · ${timelineItems.length} 个`
-    : `已提交回答 · ${answeredCount} / ${timelineItems.length} 个`;
+    ? t("freezone.chat.clarification.skippedQuestions")
+    : t("freezone.chat.clarification.submittedAnswers", { count: answeredCount });
   return (
     <div className="rounded-2xl border border-white/[0.07] bg-white/[0.025] px-3 py-3 text-sm shadow-[0_14px_40px_rgba(0,0,0,0.16)] backdrop-blur-sm">
       <div className="mb-3 flex items-center justify-between gap-3">
@@ -6241,7 +6647,9 @@ function AssistantClarificationSummaryCard({ event }: { event: AssistantClarific
         ))}
         {timelineItems.length === 0 && (
           <div className="rounded-xl border border-white/[0.06] bg-black/10 px-3 py-2 text-xs text-muted-foreground">
-            已提交，未包含可展示的问题配置。
+            {skipped
+              ? t("freezone.chat.clarification.noAnswersSkipped")
+              : t("freezone.chat.clarification.noAnswersSubmitted")}
           </div>
         )}
       </div>
@@ -6256,7 +6664,11 @@ function AssistantClarificationInputCard({
   event: AssistantClarificationUiEvent;
   onSubmit?: (event: AssistantClarificationUiEvent, answers: AssistantClarificationAnswers) => Promise<boolean>;
 }) {
-  const questions = Array.isArray(event.questions) ? event.questions : [];
+  const { t } = useTranslation();
+  const params = useParams({ strict: false }) as { project?: string };
+  const imageModelCatalog = useFreezoneImageModels(params.project);
+  const videoModelCatalog = useFreezoneVideoModels(params.project);
+  const eventQuestions = Array.isArray(event.questions) ? event.questions : [];
   const eventIdentity = assistantClarificationEventIdentity(event);
   const [answers, setAnswers] = useState<AssistantClarificationAnswers>(() =>
     event.answers && typeof event.answers === "object" ? event.answers : {},
@@ -6266,6 +6678,30 @@ function AssistantClarificationInputCard({
     setAnswers(event.answers && typeof event.answers === "object" ? event.answers : {});
     setActiveQuestionPosition(0);
   }, [eventIdentity]);
+  const questions = useMemo(
+    () => clarificationQuestionsWithLiveModelCatalogs(
+      eventQuestions,
+      !imageModelCatalog.isLoading && !imageModelCatalog.isFallback
+        ? imageModelCatalog.models
+        : [],
+      !videoModelCatalog.isLoading && !videoModelCatalog.isFallback
+        ? videoModelCatalog.models
+        : [],
+      answers,
+      t,
+    ),
+    [
+      answers,
+      eventQuestions,
+      imageModelCatalog.isFallback,
+      imageModelCatalog.isLoading,
+      imageModelCatalog.models,
+      videoModelCatalog.isFallback,
+      videoModelCatalog.isLoading,
+      videoModelCatalog.models,
+      t,
+    ],
+  );
   const selectableQuestions = questions
     .map((question, index) => ({ question, index }))
     .filter(({ question }) => (question.options ?? []).length > 0 || skillStudioQuestionAllowsCustom(question));
@@ -6289,10 +6725,21 @@ function AssistantClarificationInputCard({
 	          ? currentSelection.optionIds.filter((candidate) => candidate !== optionKey)
           : [...currentSelection.optionIds, optionKey]
         : [optionKey];
-      return {
+	      const nextAnswers = {
         ...current,
 	        [questionKey]: skillStudioSelectionForMode(question, optionIds, currentSelection.customText),
 	      };
+	      const questionId = normalizedClarificationId(question.id);
+	      if (questionId === "image_model") {
+	        for (const key of ["image_aspect_ratio", "image_resolution", "image_quality"]) {
+	          delete nextAnswers[key];
+	        }
+	      } else if (questionId === "video_model") {
+	        for (const key of ["video_aspect_ratio", "video_resolution", "video_duration_seconds", "video_generate_audio"]) {
+	          delete nextAnswers[key];
+	        }
+	      }
+	      return nextAnswers;
 	    });
 	    if (selectionMode === "single" && activeQuestionPosition < selectableQuestions.length - 1) {
 	      setActiveQuestionPosition((position) => Math.min(position + 1, selectableQuestions.length - 1));
@@ -6310,8 +6757,8 @@ function AssistantClarificationInputCard({
   }, []);
   const submitAnswers = useCallback(() => {
     if (!onSubmit || !canSubmit) return;
-    void onSubmit(event, answers);
-  }, [answers, canSubmit, event, onSubmit]);
+    void onSubmit({ ...event, questions }, answers);
+  }, [answers, canSubmit, event, onSubmit, questions]);
   const activeQuestion = activeItem?.question;
   const activeQuestionIndex = activeItem?.index ?? 0;
   const activeQuestionKey = activeQuestion ? skillStudioQuestionKey(activeQuestion, activeQuestionIndex) : "";
@@ -10143,7 +10590,6 @@ type CanvasCommandFeedback = Pick<CanvasChatCommandApplyResult, "applied" | "ope
 };
 
 const CANVAS_APPROVAL_IMAGE_SIZE_OPTIONS = ["1K", "2K", "4K"] as const;
-const CANVAS_APPROVAL_IMAGE_QUALITY_OPTIONS = ["low", "medium", "high"] as const;
 const CANVAS_APPROVAL_IMAGE_ASPECT_RATIO_OPTIONS = [
   "auto",
   "1:1",
@@ -10188,7 +10634,7 @@ type CanvasApprovalImageParams = {
   model: string;
   aspectRatio: string;
   size: string;
-  quality: string;
+  quality: string | null;
   count: number;
 };
 
@@ -10279,7 +10725,7 @@ type CanvasCommandSurfaceEvent =
     };
 
 const CANVAS_COMMAND_EXECUTION_MODE_STORAGE_KEY = "freezone.canvasCommandExecutionMode";
-const CANVAS_COMMAND_APPROVAL_TIMEOUT_MS = 60_000;
+const CANVAS_COMMAND_APPROVAL_TIMEOUT_MS = 300_000;
 
 const DIRECTOR_RUN_MODE_OPTIONS: ReadonlyArray<{
   value: DirectorRunMode;
@@ -11902,7 +12348,7 @@ export function SuperChatPanel({
       selectedFreezoneNodes,
       canvasEdges,
       canvasNodes,
-      { displayNodes: selectedFreezoneNodes },
+      { displayNodes: selectedFreezoneNodes, includeActionCatalog: false },
     );
   }, [
     canvasEdges,
@@ -11930,7 +12376,7 @@ export function SuperChatPanel({
       mentioned,
       canvasEdges,
       canvasNodes,
-      { displayNodes: mentioned },
+      { displayNodes: mentioned, includeActionCatalog: false },
     );
   }, [
     canvasEdges,
@@ -12972,27 +13418,18 @@ export function SuperChatPanel({
 
   const handleRetryCanvasCommandFeedback = useCallback((
     feedback: CanvasCommandFeedback,
-    messageId: string,
-    turnId?: string,
+    _messageId: string,
+    _turnId?: string,
   ) => {
     if (!feedback.envelopes?.length) return;
-    const receivedAt = Date.now();
-    const retryKey = `retry:${feedback.key}:${receivedAt}`;
-    handleApplyCanvasCommandApproval({
-      id: retryKey,
-      key: retryKey,
-      messageId,
-      turnId: turnId ?? null,
-      bridgeKey: null,
-      agentId: effectiveFreezoneAgentId,
-      anchorTextPrefix: feedback.anchorTextPrefix ?? null,
-      surfaceOrder: receivedAt,
-      receivedAt,
-      envelopes: feedback.envelopes,
-      commandCount: feedback.envelopes.reduce((sum, envelope) => sum + envelope.commands.length, 0),
-      plans: feedback.plans ?? canvasCommandPlansFromEnvelopes(feedback.envelopes),
-    });
-  }, [effectiveFreezoneAgentId, handleApplyCanvasCommandApproval]);
+    // A settled bridge result is immutable. Start a new agent turn so retry
+    // gets a fresh tool identity, parameter preflight and an attributable receipt.
+    void chat.send(
+      t("freezone.chat.canvasRetryPrompt"),
+      [],
+      t("freezone.chat.canvasRetryDisplay"),
+    );
+  }, [chat, t]);
 
   useEffect(() => {
     if (canvasCommandExecutionMode !== "auto_execute") return;

--- a/license-inventory.csv
+++ b/license-inventory.csv
@@ -528,6 +528,7 @@ frontend/src/__tests__/features/canvas/image-gen-prompt.test.ts,Elastic-2.0,2026
 frontend/src/__tests__/features/canvas/image-gen-stale-error-banner.test.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/__tests__/features/canvas/image-multi-angle-application.test.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/__tests__/features/canvas/image-node-generation-matrix.test.tsx,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
+frontend/src/__tests__/features/canvas/media-model-parameter-chip.test.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/__tests__/features/canvas/image-node-resize-min.test.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/__tests__/features/canvas/image-outpaint-application.test.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation
 frontend/src/__tests__/features/canvas/image-relight-application.test.ts,Elastic-2.0,2026 SuperTale contributors,REUSE.toml aggregate annotation

--- a/src/novelvideo/agent_skills/dramaclaw-workflows/SKILL.md
+++ b/src/novelvideo/agent_skills/dramaclaw-workflows/SKILL.md
@@ -14,6 +14,10 @@ Build one coherent workflow transaction, not a sequence of standalone canvas edi
   canvas data must be refreshed, call `freezone_get_canvas_ontology` instead of inventing a
   `canvas://` resource. MCP clients must use only resource URIs returned by `resources/list` or
   `resources/templates/list`.
+- The Skill package/server display name does not determine a host's MCP registration key. Use the
+  exact `server` returned by the host. In DramaClaw's Codex adapter, filesystem-backed Skill files
+  are read from `dramaclaw`; workflow catalog resources use `dramaclaw_workflows` (underscore).
+  Never call `resources/read` with an inferred `dramaclaw-workflows` server key.
 - Use the portable `dramaclaw-workflows` MCP server for catalog discovery and deterministic
   compilation when it is available. Use the authorized DramaClaw MCP server for draft persistence,
   approval, canvas commit, and execution. Tool names are host-neutral; call them through the MCP
@@ -63,6 +67,9 @@ The image/video choices are:
 - Image: model preference, aspect ratio, resolution/quality, and variants per node.
 - Video: model or generation mode, aspect ratio, resolution, duration, sound generation, and output
   variants per node.
+- Provider thinking/reasoning level is server-managed. Never ask the user to choose
+  `thinking_level`, reasoning effort, or low/medium/high thinking options, and never add such a
+  question from a live model parameter schema.
 
 Do not include audio voice-source selection in this preliminary clarification. Never ask the user
 to choose system voice versus custom voice. A speech node uses an already selected custom

--- a/src/novelvideo/api/routes/freezone.py
+++ b/src/novelvideo/api/routes/freezone.py
@@ -8578,6 +8578,33 @@ async def _scoped_media_model_catalog(
         raise HTTPException(503, "媒体模型目录暂不可用，请稍后重试") from None
 
 
+_SERVER_MANAGED_MEDIA_MODEL_PARAMETER_KEYS = frozenset({"thinking_level"})
+
+
+def _public_media_model_catalog(
+    catalog: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Hide provider tuning owned by the server from canvas model controls."""
+    result: list[dict[str, Any]] = []
+    for entry in catalog:
+        public_entry = dict(entry)
+        request = entry.get("request")
+        if isinstance(request, dict):
+            public_request = dict(request)
+            parameters = request.get("parameters")
+            if isinstance(parameters, list):
+                public_request["parameters"] = [
+                    dict(parameter)
+                    for parameter in parameters
+                    if isinstance(parameter, dict)
+                    and str(parameter.get("key") or "")
+                    not in _SERVER_MANAGED_MEDIA_MODEL_PARAMETER_KEYS
+                ]
+            public_entry["request"] = public_request
+        result.append(public_entry)
+    return result
+
+
 def _media_model_unavailable(
     media_type: str, catalog: list[dict[str, Any]]
 ) -> HTTPException:
@@ -8769,10 +8796,14 @@ async def _resolve_catalog_request(
         defined_keys = {
             str(parameter["key"]) for parameter in full_schema.get("parameters") or []
         }
+        server_managed_keys = (
+            defined_keys & _SERVER_MANAGED_MEDIA_MODEL_PARAMETER_KEYS
+        )
         filtered_params = {
             key: value
             for key, value in (model_params or {}).items()
-            if key in active_keys or key not in defined_keys
+            if key not in server_managed_keys
+            and (key in active_keys or key not in defined_keys)
         }
         if media_type == "image" and entry.get("qualityOptions"):
             schema = {**schema, "includeQuality": True}
@@ -8990,7 +9021,11 @@ async def freezone_video_models(
     )
     return {
         "ok": True,
-        "data": get_freezone_video_model_options() if catalog is None else catalog,
+        "data": (
+            get_freezone_video_model_options()
+            if catalog is None
+            else _public_media_model_catalog(catalog)
+        ),
     }
 
 
@@ -9008,7 +9043,7 @@ async def freezone_image_models(
         requester_user_id=ctx.requester_user_id,
     )
     if catalog is not None:
-        return {"ok": True, "data": catalog}
+        return {"ok": True, "data": _public_media_model_catalog(catalog)}
     options = image_generation_selection_options()
     data = []
     for key, label in options.items():

--- a/src/novelvideo/api/routes/projects.py
+++ b/src/novelvideo/api/routes/projects.py
@@ -269,6 +269,27 @@ def _quarantine_project_dirs(
     仅在 ``record`` 的三类目录全部通过归属校验后才移动;任一目录不属于
     ``record.owner_username`` 时抛出,不移动任何目录。
     """
+    recorded_dirs = (
+        Path(record.output_dir),
+        Path(record.state_dir),
+        Path(record.runtime_dir),
+    )
+    # Some migrated registry rows retain paths from a retired storage root
+    # after all three project directories have already been removed. There is
+    # no filesystem tree to move in that case, so allow the caller to purge the
+    # stale registry row. Use lstat rather than exists so broken symlinks still
+    # count as filesystem entries and continue through strict ownership checks.
+    all_missing = True
+    for recorded_dir in recorded_dirs:
+        try:
+            recorded_dir.lstat()
+        except FileNotFoundError:
+            continue
+        all_missing = False
+        break
+    if all_missing:
+        return []
+
     quarantined: list[tuple[Path, Path]] = []
     token = uuid.uuid4().hex
     try:

--- a/src/novelvideo/freezone/agent_workflows/catalog.py
+++ b/src/novelvideo/freezone/agent_workflows/catalog.py
@@ -2178,7 +2178,8 @@ def validate_agent_workflow_plan(
         recipe_pipeline = (
             (catalog.get("recipePipeline") or []) if isinstance(catalog, dict) else []
         )
-        stage = _text(node.get("stage")) if isinstance(node, dict) else ""
+        data_stage = data.get("stage") if isinstance(data, dict) else None
+        stage = _text(node.get("stage") or data_stage) if isinstance(node, dict) else ""
         requires_recipe = node_type in {
             "imageGenNode",
             "videoNode",

--- a/src/novelvideo/freezone/agent_workflows/graph.py
+++ b/src/novelvideo/freezone/agent_workflows/graph.py
@@ -257,7 +257,12 @@ def build_workflow_graph_commands(args: dict[str, Any]) -> dict[str, Any]:
             node["node_type"],
             audio_uses_upstream_text=node["plan_id"] in audio_prompt_target_plan_ids,
         )
-        raw_stage = str(raw_node.get("stage") or "").strip().lower()
+        raw_data = raw_node.get("data")
+        raw_stage = str(
+            raw_node.get("stage")
+            or (raw_data.get("stage") if isinstance(raw_data, dict) else "")
+            or ""
+        ).strip().lower()
         if node["node_type"] in TEXTUAL_NODE_TYPES and raw_stage in USER_INPUT_STAGES:
             data.setdefault("workflowCatalogRole", "user_input")
         # Plain text with no role is inferred per edge, as in the frontend.
@@ -511,6 +516,9 @@ def _node_data(
 ) -> dict[str, Any]:
     data = node.get("data")
     result = dict(data) if isinstance(data, dict) else {}
+    # ``data.stage`` is accepted as an agent compatibility input but stage is
+    # workflow metadata, not canvas node data.
+    result.pop("stage", None)
     label = node.get("label") or node.get("title") or node.get("name")
     description = (
         node.get("description") or node.get("responsibility") or node.get("purpose")

--- a/src/novelvideo/freezone/recipe_runtime.py
+++ b/src/novelvideo/freezone/recipe_runtime.py
@@ -41,6 +41,8 @@ _MAX_NODE_PROMPT_CHARS = 12_000
 _MAX_UPSTREAM_CHARS = 16_000
 _MAX_CONFIRMED_INPUTS_CHARS = 8_000
 _MAX_SKILL_CONSTRAINTS_CHARS = 12_000
+_DEFAULT_RECIPE_COMPILER_REASONING_EFFORT = "low"
+_RECIPE_COMPILER_REASONING_EFFORTS = frozenset({"low", "high", "max"})
 _prompt_cache: OrderedDict[str, str] = OrderedDict()
 _prompt_inflight: dict[str, asyncio.Task["RecipeModelCompilation"]] = {}
 
@@ -83,6 +85,23 @@ class RecipeModelCompilation:
     prompt: str
     model_call_id: str
     executed_at: float
+
+
+def _recipe_compiler_reasoning_effort() -> str:
+    value = (
+        os.environ.get(
+            "FREEZONE_RECIPE_COMPILER_REASONING_EFFORT",
+            _DEFAULT_RECIPE_COMPILER_REASONING_EFFORT,
+        ).strip()
+        or _DEFAULT_RECIPE_COMPILER_REASONING_EFFORT
+    ).lower()
+    if value not in _RECIPE_COMPILER_REASONING_EFFORTS:
+        supported = ", ".join(sorted(_RECIPE_COMPILER_REASONING_EFFORTS))
+        raise RecipeRuntimeError(
+            "unsupported FREEZONE_RECIPE_COMPILER_REASONING_EFFORT="
+            f"{value!r}; expected one of: {supported}"
+        )
+    return value
 
 
 def _model_compilation(value: RecipeModelCompilation | str) -> RecipeModelCompilation:
@@ -297,9 +316,11 @@ async def _run_recipe_compiler(task: str) -> RecipeModelCompilation:
     )
     response = await agent.run(
         task,
-        # Recipe compilation is a bounded text transformation. Keep reasoning
-        # disabled without depending on the removed legacy text-settings helper.
-        model_settings={"openai_reasoning_effort": "none"},
+        # The compiler route uses an always-reasoning model. Keep this at the
+        # lowest supported effort by default because compilation is bounded.
+        model_settings={
+            "openai_reasoning_effort": _recipe_compiler_reasoning_effort()
+        },
     )
     compiled = str(response.output or "").strip()
     if not compiled:

--- a/src/novelvideo/freezone/workflow_plan.py
+++ b/src/novelvideo/freezone/workflow_plan.py
@@ -91,7 +91,8 @@ def _node_type_value(node: dict[str, Any]) -> str:
 
 
 def _node_stage_value(node: dict[str, Any]) -> str:
-    return str(node.get("stage") or "").strip()
+    data = node.get("data") if isinstance(node.get("data"), dict) else {}
+    return str(node.get("stage") or data.get("stage") or "").strip()
 
 
 def _edge_link_type_value(edge: dict[str, Any]) -> str:

--- a/src/novelvideo/freezone/workflow_schema.py
+++ b/src/novelvideo/freezone/workflow_schema.py
@@ -178,7 +178,9 @@ def _catalog_schema(*, recipe_required: bool = False) -> dict[str, Any]:
     return schema
 
 
-def _node_data_schema(*, recipe_required: bool = False) -> dict[str, Any]:
+def _node_data_schema(
+    *, recipe_required: bool = False, resource_stage_allowed: bool = False
+) -> dict[str, Any]:
     return {
         "type": "object",
         "description": (
@@ -193,7 +195,14 @@ def _node_data_schema(*, recipe_required: bool = False) -> dict[str, Any]:
             "text": {"type": "string"},
             "prompt": {"type": "string"},
             "description": {"type": "string"},
-            "stage": False,
+            # Compatibility input for agent-authored resource text nodes. The
+            # compiler moves this to the portable top-level stage and removes
+            # it from emitted canvas node data. Executable nodes stay strict.
+            "stage": (
+                {"type": "string", "enum": ["input", "resource", "asset"]}
+                if resource_stage_allowed
+                else False
+            ),
             "model": {"type": "string"},
             "aspectRatio": {"type": "string"},
             "size": {"type": "string"},
@@ -258,12 +267,24 @@ def _resource_text_node_schema() -> dict[str, Any]:
         {
             "node_type": {"type": "string", "enum": ["textAnnotationNode"]},
             "stage": {"type": "string", "enum": ["input", "resource", "asset"]},
+            "data": _node_data_schema(resource_stage_allowed=True),
         }
     )
     return {
         "type": "object",
         "properties": properties,
-        "required": ["id", "node_type", "stage"],
+        "required": ["id", "node_type", "data"],
+        "anyOf": [
+            {"required": ["stage"]},
+            {
+                "properties": {
+                    "data": {
+                        "type": "object",
+                        "required": ["stage"],
+                    }
+                }
+            },
+        ],
         "additionalProperties": False,
     }
 
@@ -283,6 +304,9 @@ def _group_schema() -> dict[str, Any]:
     return {
         "type": "object",
         "properties": {
+            # Agent hosts often attach a logical group id. Canvas group
+            # commands do not need it, so the compiler accepts and discards it.
+            "id": {"type": "string"},
             "label": {"type": "string"},
             "node_ids": {
                 "type": "array",

--- a/tests/test_freezone_image_backend.py
+++ b/tests/test_freezone_image_backend.py
@@ -8124,6 +8124,61 @@ async def test_freezone_image_models_prefers_ee_catalog(
     assert result == {"ok": True, "data": catalog}
 
 
+def test_freezone_image_request_defaults_quality_to_medium() -> None:
+    request = freezone_routes.FreezoneGenRequest(prompt="test")
+
+    assert request.quality == "medium"
+
+
+@pytest.mark.asyncio
+async def test_freezone_image_models_hides_server_managed_thinking_level(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_freezone_project(monkeypatch, tmp_path, project="58")
+    catalog = [
+        {
+            "id": "custom-image",
+            "providerId": "fal",
+            "apiModel": "nano-banana-2",
+            "request": {
+                "endpoint": "images/generations",
+                "parameters": [
+                    {
+                        "key": "thinking_level",
+                        "control": "select",
+                        "requestPath": "thinking_level",
+                        "options": ["low", "medium", "high"],
+                        "default": "low",
+                    },
+                    {
+                        "key": "style",
+                        "control": "select",
+                        "requestPath": "style",
+                        "options": ["natural", "vivid"],
+                        "default": "natural",
+                    },
+                ],
+            },
+        }
+    ]
+
+    async def fake_catalog(media_type: str) -> list[dict[str, object]]:
+        assert media_type == "image"
+        return catalog
+
+    monkeypatch.setattr(freezone_routes, "_ee_media_model_catalog", fake_catalog)
+
+    result = await freezone_routes.freezone_image_models(
+        project="58",
+        user={"username": "admin"},
+    )
+
+    parameters = result["data"][0]["request"]["parameters"]
+    assert [parameter["key"] for parameter in parameters] == ["style"]
+    assert len(catalog[0]["request"]["parameters"]) == 2
+
+
 def test_ce_media_catalog_overlay_preserves_unconfigured_defaults() -> None:
     defaults = [
         {
@@ -8240,6 +8295,52 @@ async def test_image_catalog_pixel_floor_is_added_to_execution_schema(
     assert schema["minPixels"] == 3_686_400
     assert values == {}
     assert entry is catalog[0]
+
+
+@pytest.mark.asyncio
+async def test_catalog_request_uses_default_for_server_managed_thinking_level(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    catalog = [
+        {
+            "id": "custom-image-id",
+            "providerId": "fal",
+            "apiModel": "nano-banana-2",
+            "request": {
+                "endpoint": "images/generations",
+                "parameters": [
+                    {
+                        "key": "thinking_level",
+                        "control": "select",
+                        "requestPath": "thinking_level",
+                        "options": ["low", "medium", "high"],
+                        "default": "low",
+                    },
+                    {
+                        "key": "style",
+                        "control": "select",
+                        "requestPath": "style",
+                        "options": ["natural", "vivid"],
+                        "default": "natural",
+                    },
+                ],
+            },
+        }
+    ]
+
+    async def fake_catalog(media_type: str) -> list[dict[str, object]]:
+        assert media_type == "image"
+        return catalog
+
+    monkeypatch.setattr(freezone_routes, "_ee_media_model_catalog", fake_catalog)
+
+    _schema, values, _entry = await freezone_routes._resolve_catalog_request(
+        "image",
+        "custom-image-id",
+        {"thinking_level": "high", "style": "vivid"},
+    )
+
+    assert values == {"thinking_level": "low", "style": "vivid"}
 
 
 @pytest.mark.asyncio

--- a/tests/test_freezone_plugin.py
+++ b/tests/test_freezone_plugin.py
@@ -2579,6 +2579,32 @@ def test_generation_clarification_fills_titles_live_sources_and_legacy_count_ali
     assert all(question["mode"] == "single" for question in questions)
 
 
+def test_generation_clarification_preserves_confirmed_model_context(monkeypatch):
+    plugin = _load_plugin_module()
+    handlers = {name: handler for name, _schema, handler in plugin.TOOLS}
+    schemas = {name: schema for name, schema, _handler in plugin.TOOLS}
+    captured = {}
+
+    def fake_emit(project, canvas, event):
+        captured.update({"project": project, "canvas": canvas, "event": event})
+        return "shown"
+
+    monkeypatch.setattr(plugin, "_emit_clarification_event", fake_emit)
+    result = handlers["freezone_request_user_clarification"](
+        {
+            "questions": [{"id": "image_resolution"}],
+            "answers": {"image_model": {"option_ids": ["image-a"]}},
+        }
+    )
+
+    assert result == "shown"
+    assert captured["event"]["answers"] == {"image_model": {"option_ids": ["image-a"]}}
+    answers_schema = schemas["freezone_request_user_clarification"]["parameters"][
+        "properties"
+    ]["answers"]
+    assert answers_schema["type"] == "object"
+
+
 def test_external_generation_clarification_accepts_separate_resolution_question(
     monkeypatch,
 ):

--- a/tests/test_freezone_plugin.py
+++ b/tests/test_freezone_plugin.py
@@ -697,6 +697,99 @@ def test_external_generation_preflight_accepts_confirmed_image_and_video_paramet
         "_request",
         lambda *_args, **_kwargs: {"ok": True, "data": {"nodes": [], "edges": []}},
     )
+
+
+def test_generation_preflight_does_not_require_quality_for_model_without_quality_options(
+    monkeypatch,
+):
+    plugin = _load_plugin_module()
+
+    def fake_request(method, path, **_kwargs):
+        assert method == "GET"
+        assert path == "/projects/project-a/freezone/image/models"
+        return {
+            "ok": True,
+            "data": [
+                {
+                    "id": "newapi_nanobanana2",
+                    "label": "LingShan NB 2",
+                    "ratioOptions": ["16:9"],
+                    "resolutionOptions": ["1K"],
+                }
+            ],
+        }
+
+    monkeypatch.setattr(plugin, "_request", fake_request)
+    commands = [
+        {
+            "type": "create_node",
+            "client_id": "image",
+            "node_type": "imageGenNode",
+            "data": {
+                "model": "newapi_nanobanana2",
+                "aspectRatio": "16:9",
+                "size": "1K",
+                "count": 1,
+            },
+        },
+        {
+            "type": "run_node_action",
+            "node_id": "image",
+            "action": "generate_image",
+        },
+    ]
+
+    assert (
+        plugin._external_generation_parameter_preflight(
+            "project-a", "canvas-a", commands
+        )
+        is None
+    )
+
+
+def test_generation_preflight_keeps_quality_for_model_with_quality_options(
+    monkeypatch,
+):
+    plugin = _load_plugin_module()
+    monkeypatch.setattr(
+        plugin,
+        "_request",
+        lambda *_args, **_kwargs: {
+            "ok": True,
+            "data": [
+                {
+                    "id": "quality-model",
+                    "qualityOptions": ["low", "medium", "high"],
+                }
+            ],
+        },
+    )
+    commands = [
+        {
+            "type": "create_node",
+            "client_id": "image",
+            "node_type": "imageGenNode",
+            "data": {
+                "model": "quality-model",
+                "aspectRatio": "16:9",
+                "size": "2K",
+                "count": 1,
+            },
+        },
+        {
+            "type": "run_node_action",
+            "node_id": "image",
+            "action": "generate_image",
+        },
+    ]
+
+    result = plugin._external_generation_parameter_preflight(
+        "project-a", "canvas-a", commands
+    )
+
+    assert result is not None
+    assert result["missing_parameters"][0]["fields"] == ["quality"]
+    assert result["required_choices"] == {"image": ["quality"]}
     commands = [
         {
             "type": "create_node",
@@ -738,25 +831,17 @@ def test_external_generation_preflight_accepts_confirmed_image_and_video_paramet
     )
 
 
-def test_hermes_generation_path_does_not_enable_external_parameter_preflight(
-    monkeypatch,
-):
+@pytest.mark.parametrize("confirmed", [False, True])
+def test_hermes_generation_checks_parameters_before_approval(monkeypatch, confirmed):
     plugin = _load_plugin_module()
     monkeypatch.delenv("DRAMACLAW_EXTERNAL_MCP", raising=False)
-    monkeypatch.setattr(
-        plugin,
-        "_request",
-        lambda *_args, **_kwargs: pytest.fail("Hermes preflight must not read canvas"),
+    monkeypatch.setattr(plugin, "_request", lambda *_args, **_kwargs: {
+        "ok": True, "data": {"nodes": [{"id": "image", "type": "imageGenNode", "data": {"workflowConfigConfirmed": confirmed}}], "edges": []},
+    })
+    result = plugin._external_generation_parameter_preflight(
+        "project-a", "canvas-a", [{"type": "run_workflow", "scope": "canvas"}],
     )
-
-    assert (
-        plugin._external_generation_parameter_preflight(
-            "project-a",
-            "canvas-a",
-            [{"type": "run_workflow", "scope": "canvas"}],
-        )
-        is None
-    )
+    assert result["code"] == "generation_parameters_required"
 
 
 def test_dynamic_workflow_plan_is_rejected_before_canvas_bridge():
@@ -2405,11 +2490,93 @@ def test_external_generation_clarification_rejects_bundled_settings(monkeypatch)
     assert result["code"] == "generation_parameter_questions_invalid"
     assert "video_resolution" in result["required_question_ids"]["video"]
     assert "image_variants_per_node" in result["required_question_ids"]["image"]
+    assert "image_quality" in result["required_question_ids"]["image"]
     assert "video_variants_per_node" in result["required_question_ids"]["video"]
     assert "image_count" not in result["required_question_ids"]["image"]
     assert "video_count" not in result["required_question_ids"]["video"]
     assert "480P" in result["agent_instruction"]
     assert emitted == []
+
+
+def test_external_generation_clarification_filters_server_managed_thinking_question(
+    monkeypatch,
+):
+    plugin = _load_plugin_module()
+    handlers = {name: handler for name, _schema, handler in plugin.TOOLS}
+    monkeypatch.setenv("DRAMACLAW_EXTERNAL_MCP", "1")
+    emitted = []
+    monkeypatch.setattr(
+        plugin,
+        "_emit_clarification_event",
+        lambda _project, _canvas, event: emitted.append(event) or "shown",
+    )
+
+    result = handlers["freezone_request_user_clarification"](
+        {
+            "questions": [
+                {"id": "image_model", "title": "图片模型", "options": [{"id": "m"}]},
+                {"id": "video_model", "title": "视频模型", "options": [{"id": "v"}]},
+                {"id": "image_quality", "title": "图片画质", "options": [{"id": "low"}]},
+                {"id": "thinking_level", "title": "思考等级", "options": [{"id": "low"}]},
+            ]
+        }
+    )
+
+    assert result == "shown"
+    assert [question["id"] for question in emitted[0]["questions"]] == [
+        "image_model",
+        "video_model",
+        "image_quality",
+    ]
+    assert emitted[0]["questions"][0]["options_source"] == "image_models"
+    assert emitted[0]["questions"][1]["options_source"] == "video_models"
+    assert (
+        emitted[0]["questions"][2]["options_source"]
+        == "selected_image_model_qualities"
+    )
+
+
+def test_generation_clarification_fills_titles_live_sources_and_legacy_count_aliases(
+    monkeypatch,
+):
+    plugin = _load_plugin_module()
+    handlers = {name: handler for name, _schema, handler in plugin.TOOLS}
+    captured = {}
+
+    def fake_emit(project, canvas, event):
+        captured.update({"project": project, "canvas": canvas, "event": event})
+        return "shown"
+
+    monkeypatch.setattr(plugin, "_emit_clarification_event", fake_emit)
+    result = handlers["freezone_request_user_clarification"](
+        {
+            "questions": [
+                {"id": "image_model"},
+                {"id": "image_quality"},
+                {"id": "image_count"},
+            ]
+        }
+    )
+
+    assert result == "shown"
+    questions = captured["event"]["questions"]
+    assert [question["id"] for question in questions] == [
+        "image_model",
+        "image_quality",
+        "image_variants_per_node",
+    ]
+    assert [question["title"] for question in questions] == [
+        "图片模型",
+        "图片画质",
+        "图片生成数量",
+    ]
+    assert [question["options_source"] for question in questions] == [
+        "image_models",
+        "selected_image_model_qualities",
+        "image_variant_counts",
+    ]
+    assert all(question["options"] == [] for question in questions)
+    assert all(question["mode"] == "single" for question in questions)
 
 
 def test_external_generation_clarification_accepts_separate_resolution_question(
@@ -4097,7 +4264,25 @@ def test_freezone_plugin_skill_studio_tool_schemas_expose_nested_contracts():
         in clarification_schema["properties"]["clarification_id"]["description"]
     )
     assert "skill_studio_session_id" in clarification_schema["properties"]
-    assert clarification_question_item["required"] == ["id", "title", "options"]
+    assert clarification_question_item["required"] == ["id"]
+    assert clarification_question_item["properties"]["options_source"]["enum"] == [
+        "image_models",
+        "selected_image_model_ratios",
+        "selected_image_model_resolutions",
+        "selected_image_model_qualities",
+        "image_variant_counts",
+        "video_models",
+        "selected_video_model_ratios",
+        "selected_video_model_resolutions",
+        "selected_video_model_durations",
+        "selected_video_model_audio",
+        "video_variant_counts",
+    ]
+    assert (
+        "every exact live option"
+        in clarification_question_item["properties"]["options"]["description"]
+    )
+    assert "title and options may be omitted" in clarification_description
     assert clarification_option_item["required"] == ["id", "label"]
     assert "Do not include Recipe drafts inside skill" in skill_schema["description"]
     patch_field_description = patch_schema["properties"]["patch"]["description"]
@@ -5118,6 +5303,34 @@ def test_freezone_plugin_register_call_exposes_node_tools_on_hermes_acp():
     assert by_name["freezone_emit_canvas_command"]["toolset"] == "hermes-acp"
     assert len(calls) == len(plugin.TOOLS)
 
+def test_external_skill_import_submits_background_task_without_canvas_write(monkeypatch):
+    import base64
+    module = _load_plugin_module()
+    monkeypatch.setenv('DRAMACLAW_PROJECT', 'project')
+    calls = []
+    monkeypatch.setattr(module, '_request', lambda method, path, **kwargs: calls.append((method, path, kwargs)) or {'ok': True, 'data': {'batch_id': 'b', 'items': []}})
+    result = module._handle_import_external_skill({'project_id': 'p/a', 'name': 'SKILL.md', 'markdown': '# 文案'})
+    if isinstance(result, str):
+        result = json.loads(result)
+    assert calls[0][0:2] == ('POST', '/projects/p%2Fa/freezone/skill-imports')
+    assert base64.b64decode(calls[0][2]['body']['files'][0]['content_base64']).decode() == '# 文案'
+    assert result['status'] == 'skill_import_submitted'
+    assert result['batch_id'] == 'b'
+    schema = next(schema for name, schema, _handler in module.TOOLS if name == 'freezone_import_external_skill')
+    Draft202012Validator(schema['output_schema']).validate(result)
+
+
+def test_external_skill_import_result_is_available_for_skill_studio(monkeypatch):
+    module = _load_plugin_module()
+    monkeypatch.setattr(module, '_request', lambda *args, **kwargs: {'ok': True, 'data': {'id': 'i', 'status': 'ready', 'bundle': {'skill': {'id': 'ad'}, 'recipes': []}}})
+    result = module._handle_get_skill_import({'project_id': 'p', 'import_id': 'i'})
+    if isinstance(result, str):
+        result = json.loads(result)
+    assert result['import_result']['bundle']['skill']['id'] == 'ad'
+    assert 'Skill Studio' in result['agent_instruction']
+    schema = next(schema for name, schema, _handler in module.TOOLS if name == 'freezone_get_skill_import')
+    Draft202012Validator(schema['output_schema']).validate(result)
+
 
 @pytest.mark.parametrize("requested", [True, "false", 1])
 def test_confirm_draft_cannot_expand_execution_policy(monkeypatch, requested):
@@ -5329,32 +5542,3 @@ def test_observation_timeout_only_retries_read(monkeypatch):
     result = plugin._handle_observe_workflow_run({"run_id": "run_1"})
     assert result["next_action"] == "observe_same_run"
     assert result["retryable"] is True
-
-
-def test_external_skill_import_submits_background_task_without_canvas_write(monkeypatch):
-    import base64
-    module = _load_plugin_module()
-    monkeypatch.setenv('DRAMACLAW_PROJECT', 'project')
-    calls = []
-    monkeypatch.setattr(module, '_request', lambda method, path, **kwargs: calls.append((method, path, kwargs)) or {'ok': True, 'data': {'batch_id': 'b', 'items': []}})
-    result = module._handle_import_external_skill({'project_id': 'p/a', 'name': 'SKILL.md', 'markdown': '# 文案'})
-    if isinstance(result, str):
-        result = json.loads(result)
-    assert calls[0][0:2] == ('POST', '/projects/p%2Fa/freezone/skill-imports')
-    assert base64.b64decode(calls[0][2]['body']['files'][0]['content_base64']).decode() == '# 文案'
-    assert result['status'] == 'skill_import_submitted'
-    assert result['batch_id'] == 'b'
-    schema = next(schema for name, schema, _handler in module.TOOLS if name == 'freezone_import_external_skill')
-    Draft202012Validator(schema['output_schema']).validate(result)
-
-
-def test_external_skill_import_result_is_available_for_skill_studio(monkeypatch):
-    module = _load_plugin_module()
-    monkeypatch.setattr(module, '_request', lambda *args, **kwargs: {'ok': True, 'data': {'id': 'i', 'status': 'ready', 'bundle': {'skill': {'id': 'ad'}, 'recipes': []}}})
-    result = module._handle_get_skill_import({'project_id': 'p', 'import_id': 'i'})
-    if isinstance(result, str):
-        result = json.loads(result)
-    assert result['import_result']['bundle']['skill']['id'] == 'ad'
-    assert 'Skill Studio' in result['agent_instruction']
-    schema = next(schema for name, schema, _handler in module.TOOLS if name == 'freezone_get_skill_import')
-    Draft202012Validator(schema['output_schema']).validate(result)

--- a/tests/test_project_lifecycle_storage.py
+++ b/tests/test_project_lifecycle_storage.py
@@ -288,6 +288,9 @@ def test_quarantine_rejects_nonexistent_path_outside_owner_roots(monkeypatch, tm
         _record(tmp_path),
         state_dir=str(tmp_path / "outside" / "alice" / "demo"),
     )
+    # Any remaining project tree keeps strict validation enabled for every
+    # registered path, including missing paths outside the configured roots.
+    projects.Path(record.output_dir).mkdir(parents=True)
     assert not projects.Path(record.state_dir).exists()
 
     with pytest.raises(ProjectStorageOwnershipError):
@@ -298,6 +301,34 @@ def test_quarantine_rejects_nonexistent_path_outside_owner_roots(monkeypatch, tm
         )
 
     assert not projects.Path(record.state_dir).exists()
+
+
+def test_quarantine_allows_registry_only_purge_when_all_legacy_dirs_are_missing(
+    monkeypatch,
+    tmp_path,
+):
+    from novelvideo.api.routes import projects
+
+    _patch_roots(monkeypatch, tmp_path / "current")
+    legacy_root = tmp_path / "retired-root"
+    record = ProjectRecord(
+        id="01LEGACY",
+        owner_type="user",
+        owner_id="local",
+        owner_username="alice",
+        name="demo",
+        home_node_id="local",
+        output_dir=str(legacy_root / "output" / "alice" / "demo"),
+        state_dir=str(legacy_root / "state" / "alice" / "demo"),
+        runtime_dir=str(legacy_root / "runtime" / "alice" / "demo"),
+        status="deleted",
+    )
+
+    assert projects._quarantine_project_dirs(
+        record,
+        project_id=record.id,
+        reason="purging",
+    ) == []
 
 
 def test_validator_rejects_nested_dirs(monkeypatch, tmp_path):

--- a/tests/test_recipe_runtime.py
+++ b/tests/test_recipe_runtime.py
@@ -108,8 +108,24 @@ def test_recipe_compiler_uses_the_dedicated_brainclaw_profile(monkeypatch):
     assert result.executed_at > 0
     assert captured["brainclaw_profile"] is BrainClawProfile.FREEZONE_RECIPE_COMPILATION
     assert captured["run_kwargs"] == {
-        "model_settings": {"openai_reasoning_effort": "none"}
+        "model_settings": {"openai_reasoning_effort": "low"}
     }
+
+
+def test_recipe_compiler_reasoning_effort_is_configurable(monkeypatch):
+    monkeypatch.setenv("FREEZONE_RECIPE_COMPILER_REASONING_EFFORT", "HIGH")
+
+    assert recipe_runtime._recipe_compiler_reasoning_effort() == "high"
+
+
+def test_recipe_compiler_reasoning_effort_rejects_unsupported_value(monkeypatch):
+    monkeypatch.setenv("FREEZONE_RECIPE_COMPILER_REASONING_EFFORT", "none")
+
+    with pytest.raises(
+        recipe_runtime.RecipeRuntimeError,
+        match="expected one of: high, low, max",
+    ):
+        recipe_runtime._recipe_compiler_reasoning_effort()
 
 
 def test_build_recipe_compiler_task_checks_output_kind():

--- a/tests/test_workflow_mcp.py
+++ b/tests/test_workflow_mcp.py
@@ -141,6 +141,57 @@ async def test_graph_compile_accepts_canonical_plan_fields():
 
 
 @pytest.mark.asyncio
+async def test_graph_compile_normalizes_agent_resource_aliases():
+    arguments = {
+        "plan": {
+            "schema_version": "freezone_workflow_plan.v1",
+            "skill": {"id": "video-tutorial", "version": 1},
+            "nodes": [
+                {
+                    "id": "input",
+                    "node_type": "textAnnotationNode",
+                    "data": {
+                        "stage": "input",
+                        "title": "用户需求",
+                        "prompt": "用户提供的固定文案",
+                        "workflowCatalog": {},
+                    },
+                },
+                {
+                    "id": "image",
+                    "node_type": "imageGenNode",
+                    "data": {
+                        "prompt": "未来城市雨夜",
+                        "workflowCatalog": {"recipeId": "general-image"},
+                    },
+                },
+            ],
+            "edges": [
+                {"source": "input", "target": "image", "link_type": "prompt_for"}
+            ],
+            "groups": [
+                {"id": "episode-1", "label": "第一集", "node_ids": ["input", "image"]}
+            ],
+        }
+    }
+    graph_tool = next(
+        tool
+        for tool in await workflow_mcp.list_tools()
+        if tool.name == "workflow_graph_compile"
+    )
+    Draft202012Validator(graph_tool.inputSchema).validate(arguments)
+
+    result = await workflow_mcp.call_tool("workflow_graph_compile", arguments)
+
+    payload = _result_payload(result)
+    assert payload["ok"] is True, payload
+    assert payload["commands"][0]["data"]["content"] == "用户提供的固定文案"
+    assert payload["commands"][0]["data"]["workflowCatalogRole"] == "user_input"
+    assert "stage" not in payload["commands"][0]["data"]
+    assert any(command["type"] == "group_nodes" for command in payload["commands"])
+
+
+@pytest.mark.asyncio
 async def test_every_workflow_tool_validates_its_real_call_result(monkeypatch):
     monkeypatch.setattr(workflow_mcp, "search_catalog", lambda **_kwargs: [])
     monkeypatch.setattr(

--- a/tests/test_workflow_plan.py
+++ b/tests/test_workflow_plan.py
@@ -1532,10 +1532,21 @@ def test_workflow_plan_schema_rejects_extra_node_type_alias():
         Draft202012Validator(workflow_plan_json_schema()).validate(plan)
 
 
-def test_workflow_plan_schema_rejects_data_stage_compatibility_path():
+def test_workflow_plan_schema_accepts_data_stage_compatibility_path():
     plan = _dynamic_plan(image_count=1)
     input_node = plan["nodes"][0]
     input_node["data"]["stage"] = input_node.pop("stage")
+
+    Draft202012Validator(workflow_plan_json_schema()).validate(plan)
+
+    result = validate_workflow_plan(plan)
+
+    assert result["ok"] is True
+
+
+def test_workflow_plan_schema_rejects_data_stage_on_executable_node():
+    plan = _dynamic_plan(image_count=1)
+    plan["nodes"][1]["data"]["stage"] = "input"
 
     with pytest.raises(ValidationError):
         Draft202012Validator(workflow_plan_json_schema()).validate(plan)


### PR DESCRIPTION
## 目的

统一画布图片/视频生成参数与实时模型能力，修复模型列表不完整、无画质能力模型仍要求选择画质，以及参数确认信息冗余等问题。

## 主要改动

- 参数卡读取完整的图片和视频模型目录
- 按模型能力动态提供比例、分辨率、画质、时长、声音与生成数量
- 不支持画质的图片模型不展示、不补问也不提交画质字段
- 中文化 low / medium / high 画质标签
- 已提交确认卡只显示实际选择的参数
- 优化当前节点上下文，减少重复画布摘要和参数卡重试等待
- 加强工作流预检、Recipe 运行结果及项目存储边界校验
- 同步 Freezone 插件、Agent Skill 说明和测试覆盖

## 验证

- `pnpm exec vitest run ...`：5 个测试文件、400 项测试通过
- `pnpm exec tsc --noEmit`：通过
- `.venv/bin/python -m pytest ...`：498 项测试通过
