### PR TITLE
fix: preserve user confirmation waits past stream idle timeout

### DIFF
--- a/src/novelvideo/chat/backend_sdk.py
+++ b/src/novelvideo/chat/backend_sdk.py
@@ -46,6 +46,20 @@ _CODEX_LIFECYCLE_ONLY_EVENTS = {
     "egress_submitted",
 }
 
+# These MCP tools intentionally keep the App Server turn open while a durable
+# frontend card waits for the user. Their own bridge timeout reports a
+# recoverable ``pending_user_input`` result, so the generic runtime idle guard
+# must not interrupt them first.
+_CODEX_USER_INPUT_TOOL_NAMES = {
+    "freezone_request_user_clarification",
+    "freezone_finish_agent_catalog_draft",
+}
+
+
+def _codex_tool_waits_for_user_input(name: str | None) -> bool:
+    normalized = str(name or "").strip()
+    return normalized.rsplit(".", 1)[-1] in _CODEX_USER_INPUT_TOOL_NAMES
+
 
 @dataclass(slots=True)
 class ChatBackendEvent:
@@ -1830,14 +1844,22 @@ class CodexThread:
         idle_deadline = started_at + CODEX_STREAM_IDLE_TIMEOUT
         total_deadline = started_at + CODEX_STREAM_TOTAL_TIMEOUT
         saw_runtime_progress = False
+        user_input_calls: set[str] = set()
         timed_out = False
 
         try:
             while True:
-                deadline = min(
-                    total_deadline,
-                    idle_deadline if saw_runtime_progress else first_progress_deadline,
-                )
+                if user_input_calls:
+                    deadline = total_deadline
+                else:
+                    deadline = min(
+                        total_deadline,
+                        (
+                            idle_deadline
+                            if saw_runtime_progress
+                            else first_progress_deadline
+                        ),
+                    )
                 remaining = deadline - loop.time()
                 try:
                     if remaining <= 0:
@@ -1848,7 +1870,9 @@ class CodexThread:
                 except asyncio.TimeoutError:
                     timed_out = True
                     now = loop.time()
-                    if now >= total_deadline:
+                    if user_input_calls:
+                        timeout_kind = "user-input"
+                    elif now >= total_deadline:
                         timeout_kind = "total"
                     elif saw_runtime_progress:
                         timeout_kind = "idle"
@@ -1878,8 +1902,13 @@ class CodexThread:
                                 exc_info=True,
                             )
 
+                    timeout_message = (
+                        "等待用户确认超时，请重新提交确认卡。"
+                        if timeout_kind == "user-input"
+                        else "Codex App Server 响应超时，请重试。"
+                    )
                     timeout_error = {
-                        "message": "Codex App Server 响应超时，请重试。",
+                        "message": timeout_message,
                         "kind": timeout_kind,
                     }
                     yield ChatBackendEvent(
@@ -1901,7 +1930,7 @@ class CodexThread:
                         thread_id=self.id,
                         turn_id=current_turn_id,
                         disposition="timeout",
-                        text="Codex App Server 响应超时，请重试。",
+                        text=timeout_message,
                         error=timeout_error,
                     )
                     break
@@ -1914,6 +1943,19 @@ class CodexThread:
                         total_deadline,
                         loop.time() + CODEX_STREAM_IDLE_TIMEOUT,
                     )
+                if event.type == "tool_started" and _codex_tool_waits_for_user_input(
+                    event.name
+                ):
+                    user_input_calls.add(event.call_id or str(event.name))
+                elif event.type == "tool_updated":
+                    call_key = event.call_id or str(event.name)
+                    status = str(event.status or "").strip().lower()
+                    if call_key in user_input_calls and status not in {
+                        "inprogress",
+                        "pending",
+                        "running",
+                    }:
+                        user_input_calls.discard(call_key)
                 yield event
                 if event.type == "complete":
                     break

--- a/tests/test_codex_app_server.py
+++ b/tests/test_codex_app_server.py
@@ -1162,6 +1162,145 @@ async def test_codex_stream_times_out_after_runtime_becomes_idle(monkeypatch, tm
 
 
 @pytest.mark.asyncio
+async def test_codex_stream_does_not_idle_timeout_while_waiting_for_user_input(
+    monkeypatch, tmp_path
+):
+    from openai_codex.generated import v2_all as v2
+    from openai_codex.models import Notification
+
+    delay = threading.Event()
+    interrupt_calls = []
+    started_tool = {
+        "type": "mcpToolCall",
+        "id": "call-confirm",
+        "server": "dramaclaw",
+        "tool": "freezone_finish_agent_catalog_draft",
+        "arguments": {"skill_studio_session_id": "studio-1"},
+        "status": "inProgress",
+    }
+    completed_tool = {
+        **started_tool,
+        "status": "completed",
+        "result": {
+            "content": [{"type": "text", "text": "confirmed"}],
+            "structuredContent": {
+                "status": "skill_studio_frontend_result",
+                "action": "confirm",
+            },
+        },
+    }
+
+    class FakeTurn:
+        id = "turn-confirm"
+
+        def stream(self):
+            yield Notification(
+                method="turn/started",
+                payload=v2.TurnStartedNotification.model_validate(
+                    {
+                        "threadId": "thread-confirm",
+                        "turn": {
+                            "id": self.id,
+                            "items": [],
+                            "status": "inProgress",
+                        },
+                    }
+                ),
+            )
+            yield Notification(
+                method="item/started",
+                payload=v2.ItemStartedNotification.model_validate(
+                    {
+                        "threadId": "thread-confirm",
+                        "turnId": self.id,
+                        "startedAtMs": 1,
+                        "item": started_tool,
+                    }
+                ),
+            )
+            delay.wait(timeout=0.1)
+            yield Notification(
+                method="item/completed",
+                payload=v2.ItemCompletedNotification.model_validate(
+                    {
+                        "threadId": "thread-confirm",
+                        "turnId": self.id,
+                        "completedAtMs": 2,
+                        "item": completed_tool,
+                    }
+                ),
+            )
+            yield Notification(
+                method="item/agentMessage/delta",
+                payload=v2.AgentMessageDeltaNotification.model_validate(
+                    {
+                        "threadId": "thread-confirm",
+                        "turnId": self.id,
+                        "itemId": "message-confirm",
+                        "delta": "已确认",
+                    }
+                ),
+            )
+            yield Notification(
+                method="turn/completed",
+                payload=v2.TurnCompletedNotification.model_validate(
+                    {
+                        "threadId": "thread-confirm",
+                        "turn": {
+                            "id": self.id,
+                            "items": [],
+                            "status": "completed",
+                        },
+                    }
+                ),
+            )
+
+        def interrupt(self):
+            interrupt_calls.append(self.id)
+            delay.set()
+
+    class FakeThread:
+        id = "thread-confirm"
+
+    @contextmanager
+    def fake_shared_codex(_config):
+        yield object()
+
+    monkeypatch.setattr(codex_app_server, "shared_codex", fake_shared_codex)
+    monkeypatch.setattr(
+        backend_sdk,
+        "_start_or_resume_codex_thread",
+        lambda *_args, **_kwargs: FakeThread(),
+    )
+    monkeypatch.setattr(
+        backend_sdk, "_start_codex_turn", lambda *_args, **_kwargs: FakeTurn()
+    )
+    monkeypatch.setattr(backend_sdk, "CODEX_STREAM_FIRST_PROGRESS_TIMEOUT", 1.0)
+    monkeypatch.setattr(backend_sdk, "CODEX_STREAM_IDLE_TIMEOUT", 0.03)
+    monkeypatch.setattr(backend_sdk, "CODEX_STREAM_TOTAL_TIMEOUT", 0.5)
+
+    thread = CodexThread(
+        codex_bin=None,
+        cwd=tmp_path,
+        env={},
+        model="DC-codex-agent-LLM",
+        model_provider="dramaclaw_gateway",
+        developer_instructions="Use DramaClaw MCP only.",
+        config_overrides=(),
+        thread_config={},
+        turn_metadata={},
+        thread_id=None,
+    )
+    events = [event async for event in thread.stream("Create a skill")]
+
+    assert interrupt_calls == []
+    assert events[-1].type == "complete"
+    assert events[-1].text == "已确认"
+    assert events[-2].type == "egress_disposition"
+    assert events[-2].disposition == "completed"
+
+
+@pytest.mark.asyncio
 async def test_codex_stream_enforces_total_deadline_despite_continuous_progress(
     monkeypatch, tmp_path
 ):


### PR DESCRIPTION
## Summary

- track Codex MCP calls that are explicitly waiting for frontend user input
- suspend the generic 300-second stream idle deadline while those calls remain active
- retain the overall turn deadline and report a user-confirmation-specific timeout if it is reached
- resume the normal idle deadline after the interactive tool completes

## Verification

- `PYTHONPATH=src .venv/bin/python -m pytest -q tests/test_codex_app_server.py` (25 passed, 1 deselected)
- `black --check` and `ruff check` on changed files

Closes #535