### PR TITLE
fix: recognize ready workflow plan drafts

### DIFF
--- a/src/novelvideo/chat/service.py
+++ b/src/novelvideo/chat/service.py
@@ -798,10 +798,16 @@ def _codex_freezone_clarification_answered(event: Any) -> bool:
     return False
 
 
+_FREEZONE_WORKFLOW_DRAFT_PREPARE_TOOLS = {
+    "freezone_prepare_workflow_draft",
+    "freezone_prepare_workflow_plan_draft",
+}
+
+
 def _codex_freezone_ready_workflow_draft(event: Any) -> dict[str, Any] | None:
     """Return a successfully prepared workflow draft carried by a Codex event."""
 
-    if _codex_freezone_tool_name(event) != "freezone_prepare_workflow_draft":
+    if _codex_freezone_tool_name(event) not in _FREEZONE_WORKFLOW_DRAFT_PREPARE_TOOLS:
         return None
     status = str(getattr(event, "status", "") or "").strip().lower()
     if status not in {"completed", "success", "succeeded"} or getattr(event, "error", None):
@@ -7108,10 +7114,7 @@ async def _stream_assistant_reply_codex(
                     tool_name = _codex_freezone_tool_name(event)
                     if _codex_freezone_clarification_answered(event):
                         clarification_answered = True
-                    if tool_name in {
-                        "freezone_prepare_workflow_draft",
-                        "freezone_prepare_workflow_plan_draft",
-                    }:
+                    if tool_name in _FREEZONE_WORKFLOW_DRAFT_PREPARE_TOOLS:
                         workflow_draft_attempted = True
                     prepared_draft = _codex_freezone_ready_workflow_draft(event)
                     if prepared_draft is not None:

--- a/tests/test_chat_service_user_agent_scope.py
+++ b/tests/test_chat_service_user_agent_scope.py
@@ -1510,6 +1510,7 @@ def test_codex_clarification_requires_successful_answer(container, outcome):
         "failure",
         "blocked",
         "draft_ready",
+        "plan_draft_ready",
         "clarification_answered",
         "skill_saved",
     ],
@@ -1541,11 +1542,16 @@ async def test_codex_freezone_write_cannot_claim_success_without_tool_receipt(
                 thread_id="codex-thread",
                 turn_id="codex-turn",
             )
-            if tool_outcome == "draft_ready":
+            if tool_outcome in {"draft_ready", "plan_draft_ready"}:
+                draft_tool = (
+                    "freezone_prepare_workflow_plan_draft"
+                    if tool_outcome == "plan_draft_ready"
+                    else "freezone_prepare_workflow_draft"
+                )
                 yield SimpleNamespace(
                     type="tool_updated",
-                    text="[mcp:completed] dramaclaw.freezone_prepare_workflow_draft",
-                    name="dramaclaw.freezone_prepare_workflow_draft",
+                    text=f"[mcp:completed] dramaclaw.{draft_tool}",
+                    name=f"dramaclaw.{draft_tool}",
                     call_id="call-draft",
                     status="completed",
                     input={"intent": {"skill_id": "video-ad"}},
@@ -1705,7 +1711,7 @@ async def test_codex_freezone_write_cannot_claim_success_without_tool_receipt(
         assert "已创建" not in result["content"]
         assert result["content"] == "画布操作未完成：本轮没有执行画布写入，请重试。"
         assert assistant_deltas == [result["content"]]
-    elif tool_outcome == "draft_ready":
+    elif tool_outcome in {"draft_ready", "plan_draft_ready"}:
         assert result["content"] == (
             "工作流草稿已准备完成，等待你确认后创建画布节点；尚未执行生成。"
         )


### PR DESCRIPTION
## Summary

- recognize successful `freezone_prepare_workflow_plan_draft` results as ready workflow drafts
- share the supported prepare-tool set with the workflow-attempt tracking path
- preserve the existing canvas write receipt checks for actual writes and failures
- add end-of-turn regression coverage for both standard and formal Plan drafts

## Verification

- `75 passed` in the Codex Freezone/workflow-draft regression selection
- Ruff and diff checks passed

Closes #539